### PR TITLE
feat(fetch/nvd/api): use ErrorPropagatedRetryPolicy

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -149,7 +149,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Fetch
-        run: vuls-data-update fetch ${{ matrix.target }} --dir vuls-data-raw-${{ matrix.target }} --api-key ${{ secrets.NVD_API_KEY }} --concurrency 5
+        run: vuls-data-update fetch ${{ matrix.target }} --dir vuls-data-raw-${{ matrix.target }} --api-key ${{ secrets.NVD_API_KEY }} --concurrency 5 --wait 0
 
       - name: Split Large Files
         run: find vuls-data-raw-${{ matrix.target }} -name "*.json" -size +50M | xargs -I {} sh -c "split -a 3 -d -b 50m {} {}. && rm {}"

--- a/pkg/fetch/nvd/api/cpe/cpe.go
+++ b/pkg/fetch/nvd/api/cpe/cpe.go
@@ -134,22 +134,18 @@ func Fetch(opts ...Option) error {
 	log.Printf("[INFO] Fetch NVD CPE API. dir: %s", options.dir)
 
 	checkRetry := func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-		// do not retry on context.Canceled or context.DeadlineExceeded
-		if ctx.Err() != nil {
-			return false, ctx.Err()
+		if shouldRetry, err := retryablehttp.ErrorPropagatedRetryPolicy(ctx, resp, err); shouldRetry {
+			return shouldRetry, err
 		}
-		if err != nil {
-			return false, errors.Wrap(err, "http client Do")
-		}
+
 		// NVD JSON API returns 403 in rate limit excesses, should retry.
 		// Also, the API returns 408 infreqently.
 		switch resp.StatusCode {
 		case http.StatusForbidden, http.StatusRequestTimeout:
-			log.Printf("[INFO] HTTP %d happened, may retry", resp.StatusCode)
-			return true, nil
+			return true, fmt.Errorf("unexpected HTTP status %s", resp.Status)
+		default:
+			return false, nil
 		}
-
-		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 	}
 
 	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientCheckRetry(checkRetry))

--- a/pkg/fetch/nvd/api/cve/cve.go
+++ b/pkg/fetch/nvd/api/cve/cve.go
@@ -132,22 +132,18 @@ func Fetch(opts ...Option) error {
 	log.Printf("[INFO] Fetch NVD CVE API. dir: %s", options.dir)
 
 	checkRetry := func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-		// do not retry on context.Canceled or context.DeadlineExceeded
-		if ctx.Err() != nil {
-			return false, ctx.Err()
+		if shouldRetry, err := retryablehttp.ErrorPropagatedRetryPolicy(ctx, resp, err); shouldRetry {
+			return shouldRetry, err
 		}
-		if err != nil {
-			return false, errors.Wrap(err, "http client Do")
-		}
+
 		// NVD JSON API returns 403 in rate limit excesses, should retry.
 		// Also, the API returns 408 infreqently.
 		switch resp.StatusCode {
 		case http.StatusForbidden, http.StatusRequestTimeout:
-			log.Printf("[INFO] HTTP %d happened, may retry", resp.StatusCode)
-			return true, nil
+			return true, fmt.Errorf("unexpected HTTP status %s", resp.Status)
+		default:
+			return false, nil
 		}
-
-		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 	}
 
 	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientCheckRetry(checkRetry))

--- a/pkg/fetch/util/http/http.go
+++ b/pkg/fetch/util/http/http.go
@@ -117,7 +117,7 @@ func NewClient(opts ...ClientOption) *Client {
 		retryWaitMin: 1 * time.Second,
 		retryWaitMax: 30 * time.Second,
 		retryMax:     4,
-		checkRetry:   retryablehttp.DefaultRetryPolicy,
+		checkRetry:   retryablehttp.ErrorPropagatedRetryPolicy,
 		backoff:      retryablehttp.DefaultBackoff,
 	}
 


### PR DESCRIPTION
## before
```console
$ go run cmd/vuls-data-update/main.go fetch nvd-api-cve --concurrency 5 --wait 0 --retry 1
2023/11/24 17:43:04 [INFO] Fetch NVD CVE API. dir: /home/mainek00n/.cache/vuls-data-update/nvd/api/cve
1 / 116 [>_____________________________] 0.86% 0 p/s ETA 157503h49m45.512230912sGET https://services.nvd.nist.gov/rest/json/cves/2.0?resultsPerPage=2000&startIndex=10000 giving up after 2 attempt(s)
http request, url: https://services.nvd.nist.gov/rest/json/cves/2.0?resultsPerPage=2000&startIndex=10000
github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http.(*Client).Do
...
```

## after
```console
$ go run cmd/vuls-data-update/main.go fetch nvd-api-cve --concurrency 5 --wait 0 --retry 1
2023/11/24 17:43:04 [INFO] Fetch NVD CVE API. dir: /home/mainek00n/.cache/vuls-data-update/nvd/api/cve
1 / 116 [>_____________________________] 0.86% 0 p/s ETA 157503h49m45.512230912sGET https://services.nvd.nist.gov/rest/json/cves/2.0?resultsPerPage=2000&startIndex=10000 giving up after 2 attempt(s): unexpected HTTP status 503 Service Unavailable
http request, url: https://services.nvd.nist.gov/rest/json/cves/2.0?resultsPerPage=2000&startIndex=10000
github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http.(*Client).Do
...
```