### PR TITLE
fix(types/.../range): get major version in redhat

### DIFF
--- a/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range/range.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range/range.go
@@ -305,12 +305,12 @@ func (t RangeType) Compare(family ecosystemTypes.Ecosystem, v1, v2 string) (int,
 func extractRedHatMajorVersion(v string) string {
 	_, rhs, ok := strings.Cut(v, ".el")
 	if ok {
-		return strings.Split(rhs, "_")[0]
+		return strings.Split(strings.Split(rhs, ".")[0], "_")[0]
 	}
 
 	_, rhs, ok = strings.Cut(v, ".module+el")
 	if ok {
-		return strings.Split(rhs, "_")[0]
+		return strings.Split(strings.Split(rhs, ".")[0], "_")[0]
 	}
 
 	return ""

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range/range_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range/range_test.go
@@ -352,6 +352,16 @@ func TestRangeType_Compare(t *testing.T) {
 			want: -1,
 		},
 		{
+			name: "redhat v1: el8, v2: el8_10",
+			rt:   affectedrangeTypes.RangeTypeRPM,
+			args: args{
+				family: ecosystemTypes.EcosystemTypeRedHat,
+				v1:     "0.0.1-0.0.2.el8_0",
+				v2:     "0.0.1-0.0.1.el8.1",
+			},
+			want: +1,
+		},
+		{
 			name: "redhat v1: module+el8, v2: module+el8_10",
 			rt:   affectedrangeTypes.RangeTypeRPM,
 			args: args{


### PR DESCRIPTION
```console
[root@d552512c6ad4 /]# rpmdev-vercmp "" "0.0.1" "0.0.2.el8_0" "" "0.0.1" "0.0.1.el8.1"
0.0.1-0.0.2.el8_0 > 0.0.1-0.0.1.el8.1
```