### PR TITLE
fix(extract/redhat/oval/v2): priority of duplicated vendor status

### DIFF
--- a/pkg/extract/redhat/oval/v2/testdata/fixtures/v2/8/rhel-8-including-unpatched/definitions/oval%3Acom.redhat.cve%3Adef%3A20074559.json
+++ b/pkg/extract/redhat/oval/v2/testdata/fixtures/v2/8/rhel-8-including-unpatched/definitions/oval%3Acom.redhat.cve%3Adef%3A20074559.json
@@ -31,6 +31,12 @@
 			"affected": {
 				"resolution": [
 					{
+						"state": "Affected",
+						"component": [
+							"python27:2.7/python2-debug"
+						]
+					},
+					{
 						"state": "Will not fix",
 						"component": [
 							"python27:2.7/python2-debug",

--- a/pkg/extract/redhat/oval/v2/testdata/golden/data/CVE/2007/CVE-2007-4559.json
+++ b/pkg/extract/redhat/oval/v2/testdata/golden/data/CVE/2007/CVE-2007-4559.json
@@ -210,7 +210,7 @@
 											"vulnerable": true,
 											"fix_status": {
 												"class": "unfixed",
-												"vendor": "Will not fix"
+												"vendor": "Affected"
 											},
 											"package": {
 												"type": "binary",


### PR DESCRIPTION
https://github.com/vulsio/vuls-data-raw-redhat-ovalv2/blob/209f9b9ba7a7d3b8e17b6e9e4fb96dd6a82be981/7/rhel-7-including-unpatched/definitions/oval%3Acom.redhat.cve%3Adef%3A201712153.json#L32-L85