### PR TITLE
fix(ci/extract*): merge split files

### DIFF
--- a/.github/workflows/extract-nightly.yml
+++ b/.github/workflows/extract-nightly.yml
@@ -158,6 +158,9 @@ jobs:
           repository: vulsio/vuls-data-raw-${{ matrix.target }}
           path: vuls-data-raw-${{ matrix.target }}
 
+      - name: Merge Split Files
+        run: find vuls-data-raw-${{ matrix.target }} -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
+
       - name: Check out extracted repository
         uses: actions/checkout@v4
         with:
@@ -227,11 +230,17 @@ jobs:
           repository: vulsio/vuls-data-raw-${{ matrix.target }}
           path: vuls-data-raw-${{ matrix.target }}
 
+      - name: Merge Split Files
+        run: find vuls-data-raw-${{ matrix.target }} -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
+
       - name: Check out vulsio/vuls-data-raw-redhat-repository-to-cpe repository
         uses: actions/checkout@v4
         with:
           repository: vulsio/vuls-data-raw-redhat-repository-to-cpe
           path: vuls-data-raw-redhat-repository-to-cpe
+
+      - name: Merge Split Files
+        run: find vuls-data-raw-redhat-repository-to-cpe -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
 
       - name: Check out extracted repository
         uses: actions/checkout@v4
@@ -310,11 +319,17 @@ jobs:
           repository: vulsio/vuls-data-raw-nvd-api-cve
           path: vuls-data-raw-nvd-api-cve
 
+      - name: Merge Split Files
+        run: find vuls-data-raw-nvd-api-cve -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
+
       - name: Check out raw repository, CPEMATCH
         uses: actions/checkout@v4
         with:
           repository: vulsio/vuls-data-raw-nvd-api-cpematch
           path: vuls-data-raw-nvd-api-cpematch
+
+      - name: Merge Split Files
+        run: find vuls-data-raw-nvd-api-cpematch -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
 
       - name: Check out extracted repository
         uses: actions/checkout@v4
@@ -448,6 +463,9 @@ jobs:
           repository: vulsio/vuls-data-raw-redhat-ovalv2
           path: vuls-data-raw-redhat-ovalv2
 
+      - name: Merge Split Files
+        run: find vuls-data-raw-redhat-ovalv2 -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
+
       - name: remove unnecessary streams
         run: |
           rm -rf vuls-data-raw-redhat-ovalv2/5
@@ -461,6 +479,9 @@ jobs:
         with:
           repository: vulsio/vuls-data-raw-redhat-repository-to-cpe
           path: vuls-data-raw-redhat-repository-to-cpe
+
+      - name: Merge Split Files
+        run: find vuls-data-raw-redhat-repository-to-cpe -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
 
       - name: replace empty repository-to-cpe data
         run: |

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -158,6 +158,9 @@ jobs:
           repository: vulsio/vuls-data-raw-${{ matrix.target }}
           path: vuls-data-raw-${{ matrix.target }}
 
+      - name: Merge Split Files
+        run: find vuls-data-raw-${{ matrix.target }} -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
+
       - name: Check out extracted repository
         uses: actions/checkout@v4
         with:
@@ -235,11 +238,17 @@ jobs:
           repository: vulsio/vuls-data-raw-${{ matrix.target }}
           path: vuls-data-raw-${{ matrix.target }}
 
+      - name: Merge Split Files
+        run: find vuls-data-raw-${{ matrix.target }} -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
+
       - name: Check out vulsio/vuls-data-raw-redhat-repository-to-cpe repository
         uses: actions/checkout@v4
         with:
           repository: vulsio/vuls-data-raw-redhat-repository-to-cpe
           path: vuls-data-raw-redhat-repository-to-cpe
+
+      - name: Merge Split Files
+        run: find vuls-data-raw-redhat-repository-to-cpe -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
 
       - name: Check out extracted repository
         uses: actions/checkout@v4
@@ -310,11 +319,17 @@ jobs:
           repository: vulsio/vuls-data-raw-nvd-api-cve
           path: vuls-data-raw-nvd-api-cve
 
+      - name: Merge Split Files
+        run: find vuls-data-raw-nvd-api-cve -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
+
       - name: Check out raw repository, CPEMATCH
         uses: actions/checkout@v4
         with:
           repository: vulsio/vuls-data-raw-nvd-api-cpematch
           path: vuls-data-raw-nvd-api-cpematch
+
+      - name: Merge Split Files
+        run: find vuls-data-raw-nvd-api-cpematch -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
 
       - name: Check out extracted repository
         uses: actions/checkout@v4
@@ -448,6 +463,9 @@ jobs:
           repository: vulsio/vuls-data-raw-redhat-ovalv2
           path: vuls-data-raw-redhat-ovalv2
 
+      - name: Merge Split Files
+        run: find vuls-data-raw-redhat-ovalv2 -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
+
       - name: remove unnecessary streams
         run: |
           rm -rf vuls-data-raw-redhat-ovalv2/5
@@ -461,6 +479,9 @@ jobs:
         with:
           repository: vulsio/vuls-data-raw-redhat-repository-to-cpe
           path: vuls-data-raw-redhat-repository-to-cpe
+
+      - name: Merge Split Files
+        run: find vuls-data-raw-redhat-repository-to-cpe -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done
 
       - name: replace empty repository-to-cpe data
         run: |


### PR DESCRIPTION
```console
$ find vuls-data-raw-redhat-vex -name "*.json.*"
vuls-data-raw-redhat-vex/2023/CVE-2023-39325.json.000
vuls-data-raw-redhat-vex/2023/CVE-2023-39325.json.001

$ find vuls-data-raw-redhat-vex -name "*.json.*" | sed -r 's/(.*)\.json\.[0-9]+/\1.json/' | sort -u | while read -r base; do cat "$base".* > "$base" && rm -f "$base".*; done

$ git -C vuls-data-raw-redhat-vex status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    2023/CVE-2023-39325.json.000
	deleted:    2023/CVE-2023-39325.json.001

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	2023/CVE-2023-39325.json

no changes added to commit (use "git add" and/or "git commit -a")
```