### PR TITLE
fix(extract/redhat/vex): add pkg:generic to pass thru

### DIFF
--- a/pkg/extract/redhat/vex/testdata/fixtures/vex/2025/CVE-2025-29891.json
+++ b/pkg/extract/redhat/vex/testdata/fixtures/vex/2025/CVE-2025-29891.json
@@ -1,0 +1,679 @@
+{
+	"document": {
+		"aggregate_severity": {
+			"namespace": "https://access.redhat.com/security/updates/classification/",
+			"text": "Moderate"
+		},
+		"category": "csaf_vex",
+		"csaf_version": "2.0",
+		"distribution": {
+			"text": "Copyright © Red Hat, Inc. All rights reserved.",
+			"tlp": {
+				"label": "WHITE",
+				"url": "https://www.first.org/tlp/"
+			}
+		},
+		"lang": "en",
+		"notes": [
+			{
+				"category": "legal_disclaimer",
+				"text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+				"title": "Terms of Use"
+			}
+		],
+		"publisher": {
+			"category": "vendor",
+			"contact_details": "https://access.redhat.com/security/team/contact/",
+			"issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+			"name": "Red Hat Product Security",
+			"namespace": "https://www.redhat.com"
+		},
+		"references": [
+			{
+				"category": "self",
+				"summary": "Canonical URL",
+				"url": "https://security.access.redhat.com/data/csaf/v2/vex/2025/cve-2025-29891.json"
+			}
+		],
+		"title": "camel-http: org.apache.camel: Apache Camel: Camel Message Header Injection through request parameters",
+		"tracking": {
+			"current_release_date": "2025-03-17T03:48:49+00:00",
+			"generator": {
+				"date": "2025-03-17T03:48:49+00:00",
+				"engine": {
+					"name": "Red Hat SDEngine",
+					"version": "4.4.1"
+				}
+			},
+			"id": "CVE-2025-29891",
+			"initial_release_date": "2025-03-12T14:42:59.644000+00:00",
+			"revision_history": [
+				{
+					"date": "2025-03-12T14:42:59.644000+00:00",
+					"number": "1",
+					"summary": "Initial version"
+				},
+				{
+					"date": "2025-03-17T03:48:38.398173+00:00",
+					"number": "2",
+					"summary": "Current version"
+				},
+				{
+					"date": "2025-03-17T03:48:49+00:00",
+					"number": "3",
+					"summary": "Last generated version"
+				}
+			],
+			"status": "final",
+			"version": "3"
+		}
+	},
+	"product_tree": {
+		"branches": [
+			{
+				"branches": [
+					{
+						"branches": [
+							{
+								"category": "product_name",
+								"name": "Red Hat build of Apache Camel 4 for Quarkus 3",
+								"product": {
+									"name": "Red Hat build of Apache Camel 4 for Quarkus 3",
+									"product_id": "red_hat_build_of_apache_camel_4_for_quarkus_3",
+									"product_identification_helper": {
+										"cpe": "cpe:/a:redhat:camel_quarkus:3"
+									}
+								}
+							}
+						],
+						"category": "product_family",
+						"name": "Red Hat build of Apache Camel 4 for Quarkus 3"
+					},
+					{
+						"branches": [
+							{
+								"category": "product_name",
+								"name": "Red Hat build of Apache Camel for Spring Boot 4",
+								"product": {
+									"name": "Red Hat build of Apache Camel for Spring Boot 4",
+									"product_id": "red_hat_build_of_apache_camel_for_spring_boot_4",
+									"product_identification_helper": {
+										"cpe": "cpe:/a:redhat:camel_spring_boot:4"
+									}
+								}
+							}
+						],
+						"category": "product_family",
+						"name": "Red Hat build of Apache Camel for Spring Boot 4"
+					},
+					{
+						"branches": [
+							{
+								"category": "product_name",
+								"name": "Red Hat Fuse 7",
+								"product": {
+									"name": "Red Hat Fuse 7",
+									"product_id": "red_hat_fuse_7",
+									"product_identification_helper": {
+										"cpe": "cpe:/a:redhat:jboss_fuse:7"
+									}
+								}
+							}
+						],
+						"category": "product_family",
+						"name": "Red Hat Fuse 7"
+					},
+					{
+						"branches": [
+							{
+								"category": "product_name",
+								"name": "Red Hat Integration Camel K 1",
+								"product": {
+									"name": "Red Hat Integration Camel K 1",
+									"product_id": "red_hat_integration_camel_k_1",
+									"product_identification_helper": {
+										"cpe": "cpe:/a:redhat:integration:1"
+									}
+								}
+							}
+						],
+						"category": "product_family",
+						"name": "Red Hat Integration Camel K 1"
+					},
+					{
+						"branches": [
+							{
+								"category": "product_name",
+								"name": "Red Hat Process Automation 7",
+								"product": {
+									"name": "Red Hat Process Automation 7",
+									"product_id": "red_hat_process_automation_7",
+									"product_identification_helper": {
+										"cpe": "cpe:/a:redhat:jboss_enterprise_bpms_platform:7"
+									}
+								}
+							}
+						],
+						"category": "product_family",
+						"name": "Red Hat Process Automation 7"
+					},
+					{
+						"branches": [
+							{
+								"category": "product_name",
+								"name": "Red Hat Single Sign-On 7",
+								"product": {
+									"name": "Red Hat Single Sign-On 7",
+									"product_id": "red_hat_single_sign-on_7",
+									"product_identification_helper": {
+										"cpe": "cpe:/a:redhat:red_hat_single_sign_on:7"
+									}
+								}
+							}
+						],
+						"category": "product_family",
+						"name": "Red Hat Single Sign-On 7"
+					},
+					{
+						"category": "product_version",
+						"name": "quarkus-camel-bom",
+						"product": {
+							"name": "quarkus-camel-bom",
+							"product_id": "quarkus-camel-bom",
+							"product_identification_helper": {
+								"purl": "pkg:generic/redhat/com.redhat.quarkus.platform/quarkus-camel-bom"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "quarkus-cxf-bom",
+						"product": {
+							"name": "quarkus-cxf-bom",
+							"product_id": "quarkus-cxf-bom",
+							"product_identification_helper": {
+								"purl": "pkg:generic/redhat/com.redhat.quarkus.platform/quarkus-cxf-bom"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "camel-http",
+						"product": {
+							"name": "camel-http",
+							"product_id": "camel-http",
+							"product_identification_helper": {
+								"purl": "pkg:maven/org.apache.camel/camel-http"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "camel-http-base",
+						"product": {
+							"name": "camel-http-base",
+							"product_id": "camel-http-base",
+							"product_identification_helper": {
+								"purl": "pkg:maven/org.apache.camel/camel-http-base"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "camel-http-common",
+						"product": {
+							"name": "camel-http-common",
+							"product_id": "camel-http-common",
+							"product_identification_helper": {
+								"purl": "pkg:maven/org.apache.camel/camel-http-common"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "camel-http-starter",
+						"product": {
+							"name": "camel-http-starter",
+							"product_id": "camel-http-starter",
+							"product_identification_helper": {
+								"purl": "pkg:maven/org.apache.camel.springboot/camel-http-starter"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "camel-http4",
+						"product": {
+							"name": "camel-http4",
+							"product_id": "camel-http4",
+							"product_identification_helper": {
+								"purl": "pkg:maven/org.apache.camel/camel-http4"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "camel-http4-starter",
+						"product": {
+							"name": "camel-http4-starter",
+							"product_id": "camel-http4-starter",
+							"product_identification_helper": {
+								"purl": "pkg:maven/org.apache.camel/camel-http4-starter"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "camel-http-kafka-connector",
+						"product": {
+							"name": "camel-http-kafka-connector",
+							"product_id": "camel-http-kafka-connector",
+							"product_identification_helper": {
+								"purl": "pkg:maven/org.apache.camel.kafkaconnector/camel-http-kafka-connector"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "camel-https-kafka-connector",
+						"product": {
+							"name": "camel-https-kafka-connector",
+							"product_id": "camel-https-kafka-connector",
+							"product_identification_helper": {
+								"purl": "pkg:maven/org.apache.camel.kafkaconnector/camel-https-kafka-connector"
+							}
+						}
+					}
+				],
+				"category": "vendor",
+				"name": "Red Hat"
+			}
+		],
+		"relationships": [
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "quarkus-camel-bom as a component of Red Hat build of Apache Camel 4 for Quarkus 3",
+					"product_id": "red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-camel-bom"
+				},
+				"product_reference": "quarkus-camel-bom",
+				"relates_to_product_reference": "red_hat_build_of_apache_camel_4_for_quarkus_3"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "quarkus-cxf-bom as a component of Red Hat build of Apache Camel 4 for Quarkus 3",
+					"product_id": "red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-cxf-bom"
+				},
+				"product_reference": "quarkus-cxf-bom",
+				"relates_to_product_reference": "red_hat_build_of_apache_camel_4_for_quarkus_3"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http as a component of Red Hat build of Apache Camel for Spring Boot 4",
+					"product_id": "red_hat_build_of_apache_camel_for_spring_boot_4:camel-http"
+				},
+				"product_reference": "camel-http",
+				"relates_to_product_reference": "red_hat_build_of_apache_camel_for_spring_boot_4"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-base as a component of Red Hat build of Apache Camel for Spring Boot 4",
+					"product_id": "red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-base"
+				},
+				"product_reference": "camel-http-base",
+				"relates_to_product_reference": "red_hat_build_of_apache_camel_for_spring_boot_4"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-common as a component of Red Hat build of Apache Camel for Spring Boot 4",
+					"product_id": "red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-common"
+				},
+				"product_reference": "camel-http-common",
+				"relates_to_product_reference": "red_hat_build_of_apache_camel_for_spring_boot_4"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-starter as a component of Red Hat build of Apache Camel for Spring Boot 4",
+					"product_id": "red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-starter"
+				},
+				"product_reference": "camel-http-starter",
+				"relates_to_product_reference": "red_hat_build_of_apache_camel_for_spring_boot_4"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http as a component of Red Hat Fuse 7",
+					"product_id": "red_hat_fuse_7:camel-http"
+				},
+				"product_reference": "camel-http",
+				"relates_to_product_reference": "red_hat_fuse_7"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-base as a component of Red Hat Fuse 7",
+					"product_id": "red_hat_fuse_7:camel-http-base"
+				},
+				"product_reference": "camel-http-base",
+				"relates_to_product_reference": "red_hat_fuse_7"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-common as a component of Red Hat Fuse 7",
+					"product_id": "red_hat_fuse_7:camel-http-common"
+				},
+				"product_reference": "camel-http-common",
+				"relates_to_product_reference": "red_hat_fuse_7"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-starter as a component of Red Hat Fuse 7",
+					"product_id": "red_hat_fuse_7:camel-http-starter"
+				},
+				"product_reference": "camel-http-starter",
+				"relates_to_product_reference": "red_hat_fuse_7"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http4 as a component of Red Hat Fuse 7",
+					"product_id": "red_hat_fuse_7:camel-http4"
+				},
+				"product_reference": "camel-http4",
+				"relates_to_product_reference": "red_hat_fuse_7"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http4-starter as a component of Red Hat Fuse 7",
+					"product_id": "red_hat_fuse_7:camel-http4-starter"
+				},
+				"product_reference": "camel-http4-starter",
+				"relates_to_product_reference": "red_hat_fuse_7"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http as a component of Red Hat Integration Camel K 1",
+					"product_id": "red_hat_integration_camel_k_1:camel-http"
+				},
+				"product_reference": "camel-http",
+				"relates_to_product_reference": "red_hat_integration_camel_k_1"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-base as a component of Red Hat Integration Camel K 1",
+					"product_id": "red_hat_integration_camel_k_1:camel-http-base"
+				},
+				"product_reference": "camel-http-base",
+				"relates_to_product_reference": "red_hat_integration_camel_k_1"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-common as a component of Red Hat Integration Camel K 1",
+					"product_id": "red_hat_integration_camel_k_1:camel-http-common"
+				},
+				"product_reference": "camel-http-common",
+				"relates_to_product_reference": "red_hat_integration_camel_k_1"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-kafka-connector as a component of Red Hat Integration Camel K 1",
+					"product_id": "red_hat_integration_camel_k_1:camel-http-kafka-connector"
+				},
+				"product_reference": "camel-http-kafka-connector",
+				"relates_to_product_reference": "red_hat_integration_camel_k_1"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-https-kafka-connector as a component of Red Hat Integration Camel K 1",
+					"product_id": "red_hat_integration_camel_k_1:camel-https-kafka-connector"
+				},
+				"product_reference": "camel-https-kafka-connector",
+				"relates_to_product_reference": "red_hat_integration_camel_k_1"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-common as a component of Red Hat Process Automation 7",
+					"product_id": "red_hat_process_automation_7:camel-http-common"
+				},
+				"product_reference": "camel-http-common",
+				"relates_to_product_reference": "red_hat_process_automation_7"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "camel-http-common as a component of Red Hat Single Sign-On 7",
+					"product_id": "red_hat_single_sign-on_7:camel-http-common"
+				},
+				"product_reference": "camel-http-common",
+				"relates_to_product_reference": "red_hat_single_sign-on_7"
+			}
+		]
+	},
+	"vulnerabilities": [
+		{
+			"cve": "CVE-2025-29891",
+			"cwe": {
+				"id": "CWE-164",
+				"name": "Improper Neutralization of Internal Special Elements"
+			},
+			"discovery_date": "2025-03-12T15:01:09.851375+00:00",
+			"ids": [
+				{
+					"system_name": "Red Hat Bugzilla ID",
+					"text": "2351685"
+				}
+			],
+			"notes": [
+				{
+					"category": "description",
+					"text": "Bypass/Injection vulnerability in Apache Camel.\n\nThis issue affects Apache Camel: from 4.10.0 before 4.10.2, from 4.8.0 before 4.8.5, from 3.10.0 before 3.22.4.\n\nUsers are recommended to upgrade to version 4.10.2 for 4.10.x LTS, 4.8.5 for 4.8.x LTS and 3.22.4 for 3.x releases.\n\nThis vulnerability is present in Camel's default incoming header filter, that allows an attacker to include Camel specific headers that for some Camel components can alter the behaviours such as the camel-bean component, or the camel-exec component.\n\nIf you have Camel applications that are directly connected to the internet via HTTP, then an attacker could include parameters in the HTTP requests that are sent to the Camel application that get translated into headers. \n\nThe headers could be both provided as request parameters for an HTTP methods invocation or as part of the payload of the HTTP methods invocation.\n\nAll the known Camel HTTP component such as camel-servlet, camel-jetty, camel-undertow, camel-platform-http, and camel-netty-http would be vulnerable out of the box.\n\nThis CVE is related to the CVE-2025-27636: while they have the same root cause and are fixed with the same fix, CVE-2025-27636 was assumed to only be exploitable if an attacker could add malicious HTTP headers, while we have now determined that it is also exploitable via HTTP parameters. Like in CVE-2025-27636, exploitation is only possible if the Camel route uses particular vulnerable components.",
+					"title": "Vulnerability description"
+				},
+				{
+					"category": "summary",
+					"text": "camel-http: org.apache.camel: Apache Camel: Camel Message Header Injection through request parameters",
+					"title": "Vulnerability summary"
+				},
+				{
+					"category": "other",
+					"text": "This CVE is related to the CVE-2025-27636: while they have the same root cause and are fixed with the same fix, CVE-2025-27636 was assumed to only be exploitable if an attacker could add malicious HTTP headers, while we have now determined that it is also exploitable via HTTP parameters. Like in CVE-2025-27636, exploitation is only possible if the Camel route uses particular vulnerable components.",
+					"title": "Statement"
+				},
+				{
+					"category": "general",
+					"text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+					"title": "CVSS score applicability"
+				}
+			],
+			"product_status": {
+				"known_affected": [
+					"red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-camel-bom",
+					"red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-cxf-bom",
+					"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http",
+					"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-base",
+					"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-common",
+					"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-starter",
+					"red_hat_fuse_7:camel-http",
+					"red_hat_fuse_7:camel-http-base",
+					"red_hat_fuse_7:camel-http-common",
+					"red_hat_fuse_7:camel-http-starter",
+					"red_hat_fuse_7:camel-http4",
+					"red_hat_fuse_7:camel-http4-starter",
+					"red_hat_integration_camel_k_1:camel-http",
+					"red_hat_integration_camel_k_1:camel-http-base",
+					"red_hat_integration_camel_k_1:camel-http-common",
+					"red_hat_integration_camel_k_1:camel-http-kafka-connector",
+					"red_hat_integration_camel_k_1:camel-https-kafka-connector",
+					"red_hat_process_automation_7:camel-http-common",
+					"red_hat_single_sign-on_7:camel-http-common"
+				]
+			},
+			"references": [
+				{
+					"category": "self",
+					"summary": "Canonical URL",
+					"url": "https://access.redhat.com/security/cve/CVE-2025-29891"
+				},
+				{
+					"category": "external",
+					"summary": "RHBZ#2351685",
+					"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2351685"
+				},
+				{
+					"category": "external",
+					"summary": "https://www.cve.org/CVERecord?id=CVE-2025-29891",
+					"url": "https://www.cve.org/CVERecord?id=CVE-2025-29891"
+				},
+				{
+					"category": "external",
+					"summary": "https://nvd.nist.gov/vuln/detail/CVE-2025-29891",
+					"url": "https://nvd.nist.gov/vuln/detail/CVE-2025-29891"
+				},
+				{
+					"category": "external",
+					"summary": "https://camel.apache.org/security/CVE-2025-27636.html",
+					"url": "https://camel.apache.org/security/CVE-2025-27636.html"
+				},
+				{
+					"category": "external",
+					"summary": "https://camel.apache.org/security/CVE-2025-29891.html",
+					"url": "https://camel.apache.org/security/CVE-2025-29891.html"
+				}
+			],
+			"release_date": "2025-03-12T14:42:59.644000+00:00",
+			"remediations": [
+				{
+					"category": "workaround",
+					"details": "As a workaround, users could use removeHeaders EIP, to filter out anything like ‘cAmel, cAMEL’ etc, or in general everything not starting with ‘Camel’, ‘camel’ or ‘org.apache.camel.’.",
+					"product_ids": [
+						"red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-camel-bom",
+						"red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-cxf-bom",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-base",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-common",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-starter",
+						"red_hat_fuse_7:camel-http",
+						"red_hat_fuse_7:camel-http-base",
+						"red_hat_fuse_7:camel-http-common",
+						"red_hat_fuse_7:camel-http-starter",
+						"red_hat_fuse_7:camel-http4",
+						"red_hat_fuse_7:camel-http4-starter",
+						"red_hat_integration_camel_k_1:camel-http",
+						"red_hat_integration_camel_k_1:camel-http-base",
+						"red_hat_integration_camel_k_1:camel-http-common",
+						"red_hat_integration_camel_k_1:camel-http-kafka-connector",
+						"red_hat_integration_camel_k_1:camel-https-kafka-connector",
+						"red_hat_process_automation_7:camel-http-common",
+						"red_hat_single_sign-on_7:camel-http-common"
+					]
+				},
+				{
+					"category": "none_available",
+					"details": "Fix deferred",
+					"product_ids": [
+						"red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-camel-bom",
+						"red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-cxf-bom",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-base",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-common",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-starter",
+						"red_hat_fuse_7:camel-http",
+						"red_hat_fuse_7:camel-http-base",
+						"red_hat_fuse_7:camel-http-common",
+						"red_hat_fuse_7:camel-http-starter",
+						"red_hat_fuse_7:camel-http4",
+						"red_hat_fuse_7:camel-http4-starter",
+						"red_hat_integration_camel_k_1:camel-http",
+						"red_hat_integration_camel_k_1:camel-http-base",
+						"red_hat_integration_camel_k_1:camel-http-common",
+						"red_hat_integration_camel_k_1:camel-http-kafka-connector",
+						"red_hat_integration_camel_k_1:camel-https-kafka-connector",
+						"red_hat_process_automation_7:camel-http-common",
+						"red_hat_single_sign-on_7:camel-http-common"
+					]
+				}
+			],
+			"scores": [
+				{
+					"cvss_v3": {
+						"attackComplexity": "LOW",
+						"attackVector": "NETWORK",
+						"availabilityImpact": "LOW",
+						"baseScore": 6.3,
+						"baseSeverity": "MEDIUM",
+						"confidentialityImpact": "LOW",
+						"integrityImpact": "LOW",
+						"privilegesRequired": "LOW",
+						"scope": "UNCHANGED",
+						"userInteraction": "NONE",
+						"vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+						"version": "3.1"
+					},
+					"products": [
+						"red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-camel-bom",
+						"red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-cxf-bom",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-base",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-common",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-starter",
+						"red_hat_fuse_7:camel-http",
+						"red_hat_fuse_7:camel-http-base",
+						"red_hat_fuse_7:camel-http-common",
+						"red_hat_fuse_7:camel-http-starter",
+						"red_hat_fuse_7:camel-http4",
+						"red_hat_fuse_7:camel-http4-starter",
+						"red_hat_integration_camel_k_1:camel-http",
+						"red_hat_integration_camel_k_1:camel-http-base",
+						"red_hat_integration_camel_k_1:camel-http-common",
+						"red_hat_integration_camel_k_1:camel-http-kafka-connector",
+						"red_hat_integration_camel_k_1:camel-https-kafka-connector",
+						"red_hat_process_automation_7:camel-http-common",
+						"red_hat_single_sign-on_7:camel-http-common"
+					]
+				}
+			],
+			"threats": [
+				{
+					"category": "impact",
+					"details": "Moderate",
+					"product_ids": [
+						"red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-camel-bom",
+						"red_hat_build_of_apache_camel_4_for_quarkus_3:quarkus-cxf-bom",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-base",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-common",
+						"red_hat_build_of_apache_camel_for_spring_boot_4:camel-http-starter",
+						"red_hat_fuse_7:camel-http",
+						"red_hat_fuse_7:camel-http-base",
+						"red_hat_fuse_7:camel-http-common",
+						"red_hat_fuse_7:camel-http-starter",
+						"red_hat_fuse_7:camel-http4",
+						"red_hat_fuse_7:camel-http4-starter",
+						"red_hat_integration_camel_k_1:camel-http",
+						"red_hat_integration_camel_k_1:camel-http-base",
+						"red_hat_integration_camel_k_1:camel-http-common",
+						"red_hat_integration_camel_k_1:camel-http-kafka-connector",
+						"red_hat_integration_camel_k_1:camel-https-kafka-connector",
+						"red_hat_process_automation_7:camel-http-common",
+						"red_hat_single_sign-on_7:camel-http-common"
+					]
+				}
+			],
+			"title": "camel-http: org.apache.camel: Apache Camel: Camel Message Header Injection through request parameters"
+		}
+	]
+}

--- a/pkg/extract/redhat/vex/testdata/golden/data/2025/CVE-2025-29891.json
+++ b/pkg/extract/redhat/vex/testdata/golden/data/2025/CVE-2025-29891.json
@@ -1,0 +1,10 @@
+{
+	"id": "CVE-2025-29891",
+	"data_source": {
+		"id": "redhat-vex",
+		"raws": [
+			"repository2cpe/repository-to-cpe.json",
+			"vex/2025/CVE-2025-29891.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/vex/vex.go
+++ b/pkg/extract/redhat/vex/vex.go
@@ -341,10 +341,10 @@ func walkProductTree(pt vex.ProductTree, c2r map[string][]string) (map[vex.Produ
 						default:
 							p.modularitylabel = fmt.Sprintf("%s:%s", instance.Name, strings.Split(instance.Version, ":")[0])
 						}
-					case strings.HasPrefix(fpn.ProductIdentificationHelper.PURL, "pkg:oci/"), strings.HasPrefix(fpn.ProductIdentificationHelper.PURL, "pkg:maven/"), strings.HasPrefix(fpn.ProductIdentificationHelper.PURL, "pkg:koji/"):
+					case strings.HasPrefix(fpn.ProductIdentificationHelper.PURL, "pkg:oci/"), strings.HasPrefix(fpn.ProductIdentificationHelper.PURL, "pkg:maven/"), strings.HasPrefix(fpn.ProductIdentificationHelper.PURL, "pkg:generic/"), strings.HasPrefix(fpn.ProductIdentificationHelper.PURL, "pkg:koji/"):
 						return nil, nil
 					default:
-						return nil, errors.Errorf("unexpected purl format. expected: %q, actual: %q", []string{"pkg:rpm/...", "pkg:rpmmod/...", "pkg:oci/...", "pkg:maven/...", "pkg:koji/..."}, fpn.ProductIdentificationHelper.PURL)
+						return nil, errors.Errorf("unexpected purl format. expected: %q, actual: %q", []string{"pkg:rpm/...", "pkg:rpmmod/...", "pkg:oci/...", "pkg:maven/...", "pkg:generic/...", "pkg:koji/..."}, fpn.ProductIdentificationHelper.PURL)
 					}
 				}
 			}


### PR DESCRIPTION
Fix this CI error: https://github.com/vulsio/vuls-data-db/actions/runs/13904094881/job/38902780756

```
unexpected purl format. expected: ["pkg:rpm/..." "pkg:rpmmod/..." "pkg:oci/..." "pkg:maven/..." "pkg:koji/..."], actual: "pkg:generic/redhat/com.redhat.quarkus.platform/quarkus-cxf-bom"
github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/vex.walkProductTree.func4
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/vex/vex.go:347
[snip]
extract vuls-data-raw-redhat-vex/2025/CVE-2025-29891.json
[snip]
```