### PR TITLE
feat(dotgit/tag,untag): add commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/go-git/go-git/v5 v5.16.2
 	github.com/google/go-cmp v0.7.0
+	github.com/google/go-containerregistry v0.20.6
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/go-version v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/cheggaaa/pb/v3 v3.1.7 h1:2FsIW307kt7A/rz/ZI2lvPO+v3wKazzE4K/0LtTWsOI=
 github.com/cheggaaa/pb/v3 v3.1.7/go.mod h1:/Ji89zfVPeC/u5j8ukD0MBPHt2bzTYp74lQ7KlgFWTQ=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/containerd/stargz-snapshotter/estargz v0.16.3 h1:7evrXtoh1mSbGj/pfRccTampEyKpjpOnS3CyiV1Ebr8=
+github.com/containerd/stargz-snapshotter/estargz v0.16.3/go.mod h1:uyr4BfYfOj3G9WBVE8cOlQmXAbPN9VEQpBBeJIuOipU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
@@ -38,6 +40,12 @@ github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/cli v28.2.2+incompatible h1:qzx5BNUDFqlvyq4AHzdNB7gSyVTmU4cgsyN9SdInc1A=
+github.com/docker/cli v28.2.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
+github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
+github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
@@ -61,6 +69,8 @@ github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUv
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-containerregistry v0.20.6 h1:cvWX87UxxLgaH76b4hIvya6Dzz9qHB31qAwjAohdSTU=
+github.com/google/go-containerregistry v0.20.6/go.mod h1:T0x8MuoAoKX/873bkeSfLD2FAkwCDf9/HZgsFJ02E2Y=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -108,6 +118,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
@@ -140,6 +152,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
@@ -159,6 +173,8 @@ github.com/tealeg/xlsx v1.0.5/go.mod h1:btRS8dz54TDnvKNosuAqxrM1QgN1udgk9O34bDCn
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
+github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=
+github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/pkg/cmd/dotgit/dotgit.go
+++ b/pkg/cmd/dotgit/dotgit.go
@@ -22,11 +22,14 @@ func NewCmdDotGit() *cobra.Command {
 			$ vuls-data-update dotgit diff tree --pathspec bookworm/2025/CVE-2025-0001.json vuls-data-raw-debian-security-tracker-api 729c12ba5ff2dafacaf26b9311d8dcbea1d98bd3 main
 
 			$ vuls-data-update dotgit log vuls-data-raw-debian-security-tracker-api
-			
+
 			$ vuls-data-update dotgit ls local
 			$ vuls-data-update dotgit ls remote
 			$ vuls-data-update dotgit status local vuls-data-raw-debian-security-tracker-api
 			$ vuls-data-update dotgit status remote ghcr.io/vulsio/vuls-data-db:vuls-data-raw-debian-security-tracker-api
+
+			$ vuls-data-update dotgit remote tag ghcr.io/vulsio/vuls-data-db:vuls-data-raw-debian-security-tracker-api vuls-data-raw-test
+			$ vuls-data-update dotgit remote untag ghcr.io/vulsio/vuls-data-db:vuls-data-raw-test
 		`),
 	}
 
@@ -37,6 +40,7 @@ func NewCmdDotGit() *cobra.Command {
 		newCmdLog(),
 		newCmdLs(),
 		newCmdStatus(),
+		newCmdRemote(),
 	)
 
 	return cmd

--- a/pkg/cmd/dotgit/remote.go
+++ b/pkg/cmd/dotgit/remote.go
@@ -1,0 +1,82 @@
+package dotgit
+
+import (
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/dotgit/remote/tag"
+	"github.com/MaineK00n/vuls-data-update/pkg/dotgit/remote/untag"
+)
+
+func newCmdRemote() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remote",
+		Short: "Operations for remote dotgits",
+		Example: heredoc.Doc(`
+			$ vuls-data-update dotgit remote tag ghcr.io/vulsio/vuls-data-db:vuls-data-raw-debian-security-tracker-api:vuls-data-raw-debian-security-tracker-api vuls-data-raw-test
+			$ vuls-data-update dotgit remote untag ghcr.io/vulsio/vuls-data-db:vuls-data-raw-debian-security-tracker-api:vuls-data-raw-test
+		`),
+	}
+
+	cmd.AddCommand(newCmdRemoteTag(), newCmdRemoteUntag())
+
+	return cmd
+}
+
+func newCmdRemoteTag() *cobra.Command {
+	options := &struct {
+		token string
+	}{
+		token: os.Getenv("GITHUB_TOKEN"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "tag <image> <new-tag>",
+		Short: "Add new tag to remote dotgit images",
+		Example: heredoc.Doc(`
+			$ vuls-data-update dotgit remote tag ghcr.io/vulsio/vuls-data-db:vuls-data-raw-debian-security-tracker-api vuls-data-raw-test
+			$ vuls-data-update dotgit remote tag ghcr.io/vulsio/vuls-data-db@sha256:5b71484ba9f1565f7ed5cd3aa34b027c44e1773a6e418328ea38a05f9b459f23 vuls-raw-test
+		`),
+		Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := tag.Tag(args[0], args[1], options.token); err != nil {
+				return errors.Wrap(err, "failed to add tag")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.token, "token", "", options.token, "specify GitHub token")
+
+	return cmd
+}
+
+func newCmdRemoteUntag() *cobra.Command {
+	options := &struct {
+		token string
+	}{
+		token: os.Getenv("GITHUB_TOKEN"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "untag <image>",
+		Short: "Remove tag from remote dotgit images",
+		Example: heredoc.Doc(`
+			$ vuls-data-update dotgit remote untag ghcr.io/vulsio/vuls-data-db:vuls-data-raw-test
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := untag.Untag(args[0], options.token); err != nil {
+				return errors.Wrap(err, "failed to remove tag")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.token, "token", "", options.token, "specify GitHub token")
+
+	return cmd
+}

--- a/pkg/dotgit/remote/tag/tag.go
+++ b/pkg/dotgit/remote/tag/tag.go
@@ -1,0 +1,39 @@
+package tag
+
+import (
+	"context"
+	"log"
+
+	"github.com/pkg/errors"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+)
+
+func Tag(imageRef, newTag, token string) error {
+	log.Printf("[INFO] Tag dotgit %s as %s", imageRef, newTag)
+
+	repo, err := remote.NewRepository(imageRef)
+	if err != nil {
+		return errors.Wrapf(err, "create client for %s", imageRef)
+	}
+	if repo.Reference.Reference == "" {
+		return errors.Errorf("unexpected image format. expected: %q, actual: %q", []string{"<repository>@<digest>", "<repository>:<tag>", "<repository>:<tag>@<digest>"}, imageRef)
+	}
+
+	repo.Client = &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.NewCache(),
+		Credential: auth.StaticCredential(repo.Reference.Host(), auth.Credential{
+			Username: "user", // Any string but empty
+			Password: token,
+		}),
+	}
+
+	if _, err := oras.Tag(context.TODO(), repo, repo.Reference.Reference, newTag); err != nil {
+		return errors.Wrapf(err, "tag %s as %s", repo.Reference.Reference, newTag)
+	}
+
+	return nil
+}

--- a/pkg/dotgit/remote/tag/tag_test.go
+++ b/pkg/dotgit/remote/tag/tag_test.go
@@ -1,0 +1,97 @@
+package tag_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/dotgit/remote/tag"
+)
+
+func TestTag(t *testing.T) {
+	type args struct {
+		imageRef string
+		newTag   string
+		token    string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "happy",
+			args: args{
+				imageRef: "ghcr.io/test-owner/test-pack:existing-tag",
+				newTag:   "new-tag",
+				token:    "token",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, _, _ := strings.Cut(strings.TrimPrefix(tt.args.imageRef, "ghcr.io/"), ":")
+			reg := registry.New()
+			s := httptest.NewTLSServer(reg)
+			defer s.Close()
+
+			originalTransport := http.DefaultTransport
+			http.DefaultTransport = s.Client().Transport
+			defer func() {
+				http.DefaultTransport = originalTransport
+			}()
+
+			for tag, content := range map[string]string{
+				"existing-tag": "bar",
+				"another-tag":  "foo",
+			} {
+				u, err := url.Parse(fmt.Sprintf("%s/v2/%s/manifests/%s", s.URL, repo, tag))
+				if err != nil {
+					t.Fatalf("parse url: %v", err)
+				}
+				req, err := http.NewRequest(http.MethodPut, u.String(), io.NopCloser(strings.NewReader(content)))
+				if err != nil {
+					t.Fatalf("create request: %v", err)
+				}
+				req.Header.Set("Content-Type", "text/plain")
+				resp, err := s.Client().Do(req)
+				if err != nil {
+					t.Fatalf("put manifest: %v", err)
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusCreated {
+					t.Fatalf("unexpected status: %d", resp.StatusCode)
+				}
+			}
+
+			err := tag.Tag(strings.Replace(tt.args.imageRef, "ghcr.io", strings.TrimPrefix(s.URL, "https://"), 1), tt.args.newTag, tt.args.token)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Tag() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			u, err := url.Parse(fmt.Sprintf("%s/v2/%s/manifests/%s", s.URL, repo, tt.args.newTag))
+			if err != nil {
+				t.Fatalf("parse url: %v", err)
+			}
+			req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+			if err != nil {
+				t.Errorf("create request: %v", err)
+			}
+			resp, err := s.Client().Do(req)
+			if err != nil {
+				t.Fatalf("put manifest: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("unexpected status: %d", resp.StatusCode)
+			}
+		})
+	}
+}

--- a/pkg/dotgit/remote/untag/untag.go
+++ b/pkg/dotgit/remote/untag/untag.go
@@ -1,0 +1,208 @@
+package untag
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+
+	ls "github.com/MaineK00n/vuls-data-update/pkg/dotgit/ls/remote"
+)
+
+type options struct {
+	registryHost string
+	githubAPIURL string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type githubAPIURLOption string
+
+func (u githubAPIURLOption) apply(opts *options) {
+	opts.githubAPIURL = string(u)
+}
+
+func WithGitHubAPIURL(url string) Option {
+	return githubAPIURLOption(url)
+}
+
+type registryHostOption string
+
+func (u registryHostOption) apply(opts *options) {
+	opts.registryHost = string(u)
+}
+
+func WithRegistryHost(host string) Option {
+	return registryHostOption(host)
+}
+
+func Untag(imageRef, token string, opts ...Option) error {
+	options := &options{
+		githubAPIURL: "https://api.github.com",
+		registryHost: "ghcr.io",
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	log.Printf("[INFO] Untag dotgit %s", imageRef)
+
+	ctx := context.TODO()
+
+	index := strings.LastIndex(imageRef, ":")
+	if index == -1 {
+		return errors.Errorf("unexpected image format. expected: %q, actual: %q", "ghcr.io/<owner>/<package>:tag", imageRef)
+	}
+
+	repoRef := imageRef[:index]
+	tag, _, _ := strings.Cut(imageRef[index+1:], "@")
+
+	ss := strings.SplitN(repoRef, "/", 3)
+	if len(ss) != 3 {
+		return errors.Errorf("unexpected repository format. expected: %q, actual: %q", "ghcr.io/<owner>/<package>", repoRef)
+	}
+	if ss[0] != "ghcr.io" {
+		return errors.Errorf("only ghcr.io is supported. repository: %s", repoRef)
+	}
+
+	user, err := options.callGitHubAPI(http.MethodGet, token, []string{"users", ss[1]})
+	if err != nil {
+		return errors.Wrap(err, "call GitHub API")
+	}
+
+	repoType, err := func() (string, error) {
+		t, ok := user["type"].(string)
+		if !ok {
+			return "", errors.Errorf("invalid user info. user: %+v", user)
+		}
+		switch t {
+		case "User":
+			return "users", nil
+		case "Organization":
+			return "orgs", nil
+		default:
+			return "", errors.Errorf("unexpected repository type. expected: %q, actual: %s", []string{"User", "Organization"}, t)
+		}
+	}()
+	if err != nil {
+		return errors.Wrap(err, "get repository type")
+	}
+
+	dummyDesc, err := options.moveTagToDummy(ctx, ss[1], ss[2], tag, token)
+	if err != nil {
+		return errors.Wrapf(err, "move tag to dummy")
+	}
+
+	if err := options.deleteDummy(repoType, ss[1], ss[2], dummyDesc, token); err != nil {
+		return errors.Wrapf(err, "delete dummy")
+	}
+
+	return nil
+}
+
+func (o options) moveTagToDummy(ctx context.Context, owner, pack, tag, token string) (ocispec.Descriptor, error) {
+	dst, err := remote.NewRepository(fmt.Sprintf("%s/%s/%s", o.registryHost, owner, pack))
+	if err != nil {
+		return ocispec.Descriptor{}, errors.Wrapf(err, "new repository. URL: %s", fmt.Sprintf("%s/%s/%s", o.registryHost, owner, pack))
+	}
+
+	dst.Client = &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.NewCache(),
+		Credential: auth.StaticCredential(dst.Reference.Host(), auth.Credential{
+			Username: "user", // Any string but empty
+			Password: token,
+		}),
+	}
+
+	original, r, err := oras.Fetch(ctx, dst, tag, oras.DefaultFetchOptions)
+	if err != nil {
+		return ocispec.Descriptor{}, errors.Wrapf(err, "fetch original manifest. tag: %s", tag)
+	}
+	defer r.Close()
+	log.Printf("[INFO] Original digest: %s", original.Digest.String())
+	log.Printf("[INFO] If you made a mistake, run the following command: vuls-data-update dotgit remote tag ghcr.io/%s/%s@%s %s --token $(gh auth token)", owner, pack, original.Digest.String(), tag)
+
+	dummyDesc, err := oras.PackManifest(ctx, dst, oras.PackManifestVersion1_1, "application/vnd.vulsio.vuls-data-db.dotgit.dummy.artifact.v1", oras.PackManifestOptions{})
+	if err != nil {
+		return ocispec.Descriptor{}, errors.Wrapf(err, "pack manifest")
+	}
+
+	if err := dst.Tag(ctx, dummyDesc, tag); err != nil {
+		return ocispec.Descriptor{}, errors.Wrapf(err, "tag. manifest: %s", dummyDesc.Digest.String())
+	}
+
+	return dummyDesc, nil
+}
+
+func (o options) deleteDummy(repoType, owner, pack string, dummyDesc ocispec.Descriptor, token string) error {
+	rs, err := ls.List([]string{fmt.Sprintf("%s:%s/%s", strings.TrimSuffix(repoType, "s"), owner, pack)}, token, ls.WithbaseURL(o.githubAPIURL))
+	if err != nil {
+		return errors.Wrapf(err, "list versions")
+	}
+
+	i := slices.IndexFunc(rs, func(r ls.Response) bool {
+		return r.Digest == dummyDesc.Digest.String()
+	})
+	if i == -1 {
+		return errors.Errorf("dummy version not found. digest: %s", dummyDesc.Digest.String())
+	}
+
+	if _, err := o.callGitHubAPI(http.MethodDelete, token, []string{repoType, owner, "packages", "container", pack, "versions", fmt.Sprintf("%d", rs[i].ID)}); err != nil {
+		return errors.Wrap(err, "call GitHub API")
+	}
+
+	return nil
+}
+
+func (o options) callGitHubAPI(method string, token string, path []string) (map[string]any, error) {
+	u, err := url.Parse(o.githubAPIURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parse url. URL: %s", o.githubAPIURL)
+	}
+	u = u.JoinPath(path...)
+
+	header := make(http.Header)
+	header.Set("Accept", "application/vnd.github+json")
+	header.Set("X-GitHub-Api-Version", "2022-11-28")
+	header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	req, err := http.NewRequest(method, u.String(), nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "create request")
+	}
+	req.Header = header
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "do request. method: %s, url: %s", method, u.String())
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil, nil
+	case http.StatusOK:
+		var m map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+			return nil, errors.Wrap(err, "decode response")
+		}
+		return m, nil
+	default:
+		return nil, errors.Errorf("unexpected response status. expected: %d, actual: %d", http.StatusOK, resp.StatusCode)
+	}
+}

--- a/pkg/dotgit/remote/untag/untag_test.go
+++ b/pkg/dotgit/remote/untag/untag_test.go
@@ -1,0 +1,204 @@
+package untag_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/opencontainers/go-digest"
+
+	ls "github.com/MaineK00n/vuls-data-update/pkg/dotgit/ls/remote"
+	"github.com/MaineK00n/vuls-data-update/pkg/dotgit/remote/untag"
+)
+
+type manifest struct {
+	id     uint32
+	digest string
+}
+
+type user struct {
+	Login string `json:"login"`
+	Type  string `json:"type"`
+}
+
+func TestUntag(t *testing.T) {
+	type args struct {
+		imageRef string
+		token    string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "happy",
+			args: args{
+				imageRef: "ghcr.io/test-owner/test-pack:existing-tag",
+				token:    "token",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, _, _ := strings.Cut(strings.TrimPrefix(tt.args.imageRef, "ghcr.io/"), ":")
+			owner, pack, _ := strings.Cut(repo, "/")
+			ms := make(map[string]manifest)
+			tag2digest := make(map[string]string)
+
+			reg := registry.New()
+
+			h := func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == fmt.Sprintf("/users/%s", owner):
+					switch r.Method {
+					case http.MethodGet:
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(user{Login: owner, Type: "Organization"}); err != nil {
+							t.Errorf("write response: %v", err)
+						}
+					default:
+						t.Errorf("unexpected request received. method: %s, URL: %s", r.Method, r.URL.String())
+						http.Error(w, "Bad Request", http.StatusBadRequest)
+					}
+				case strings.HasPrefix(r.URL.Path, fmt.Sprintf("/orgs/%s/packages/container/%s/versions", owner, pack)):
+					switch r.Method {
+					case http.MethodGet:
+						vs := make([]ls.Version, 0, len(ms))
+						tags := make(map[string][]string)
+						for t, d := range tag2digest {
+							tags[d] = append(tags[d], t)
+						}
+						for d, m := range ms {
+							vs = append(vs, ls.Version{
+								ID:   int(m.id),
+								Name: d,
+								URL:  fmt.Sprintf("https://api.github.com/orgs/%s/packages/container/%s/versions/%d", owner, pack, m.id),
+								Metadata: &ls.Metadata{
+									PackageType: "container",
+									Container: &ls.Container{
+										Tags: tags[d],
+									},
+								},
+							})
+						}
+
+						w.WriteHeader(http.StatusOK)
+						if err := json.NewEncoder(w).Encode(vs); err != nil {
+							t.Errorf("write response: %v", err)
+						}
+					case http.MethodDelete:
+						id := strings.TrimPrefix(r.URL.Path, fmt.Sprintf("/orgs/%s/packages/container/%s/versions/", owner, pack))
+						maps.DeleteFunc(ms, func(d string, m manifest) bool {
+							return fmt.Sprintf("%d", m.id) == id
+						})
+
+						w.WriteHeader(http.StatusNoContent)
+					default:
+						http.Error(w, "Bad Request", http.StatusBadRequest)
+					}
+
+				case strings.HasPrefix(r.URL.Path, fmt.Sprintf("/v2/%s/%s/manifests/sha256:", owner, pack)):
+					d := strings.TrimPrefix(r.URL.Path, fmt.Sprintf("/v2/%s/%s/manifests/", owner, pack))
+					switch r.Method {
+					case http.MethodPut:
+						if _, ok := ms[d]; !ok {
+							ms[d] = manifest{
+								id:     uint32(len(ms) + 1),
+								digest: d,
+							}
+						}
+					default:
+					}
+					reg.ServeHTTP(w, r)
+
+				case strings.HasPrefix(r.URL.Path, fmt.Sprintf("/v2/%s/%s/manifests/", owner, pack)):
+					switch r.Method {
+					case http.MethodPut:
+						bs, err := io.ReadAll(r.Body)
+						if err != nil {
+							http.Error(w, "Bad Request", http.StatusBadRequest)
+							return
+						}
+						d := digest.FromBytes(bs).String()
+						r.Body = io.NopCloser(bytes.NewReader(bs))
+
+						if _, ok := ms[d]; !ok {
+							ms[d] = manifest{
+								id:     uint32(len(ms) + 1), // assume manifest is deleted only once and at last
+								digest: d,
+							}
+						}
+
+						tag2digest[strings.TrimPrefix(r.URL.Path, fmt.Sprintf("/v2/%s/%s/manifests/", owner, pack))] = d
+					default:
+					}
+					reg.ServeHTTP(w, r)
+				default:
+					reg.ServeHTTP(w, r)
+				}
+			}
+
+			s := httptest.NewTLSServer(http.HandlerFunc(h))
+			defer s.Close()
+
+			originalTransport := http.DefaultTransport
+			http.DefaultTransport = s.Client().Transport
+			defer func() {
+				http.DefaultTransport = originalTransport
+			}()
+
+			for tag, content := range map[string]string{
+				"not-to-be-deleted": "foo",
+				"existing-tag":      "bar",
+			} {
+				u, err := url.Parse(fmt.Sprintf("%s/v2/%s/%s/manifests/%s", s.URL, owner, pack, tag))
+				if err != nil {
+					t.Fatalf("parse url: %v", err)
+				}
+				req, err := http.NewRequest(http.MethodPut, u.String(), io.NopCloser(strings.NewReader(content)))
+				if err != nil {
+					t.Fatalf("create request: %v", err)
+				}
+				req.Header.Set("Content-Type", "text/plain")
+				resp, err := s.Client().Do(req)
+				if err != nil {
+					t.Fatalf("put manifest: %v", err)
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusCreated {
+					t.Fatalf("unexpected status: %d", resp.StatusCode)
+				}
+			}
+
+			err := untag.Untag(tt.args.imageRef, tt.args.token, untag.WithGitHubAPIURL(s.URL), untag.WithRegistryHost(strings.TrimPrefix(s.URL, "https://")))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Untag() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			rs, err := ls.List([]string{fmt.Sprintf("org:%s/%s", owner, pack)}, tt.args.token, ls.WithbaseURL(s.URL))
+			if err != nil {
+				t.Errorf("List() error = %v", err)
+				return
+			}
+
+			if slices.IndexFunc(rs, func(r ls.Response) bool { return r.Name == tt.args.imageRef }) != -1 {
+				t.Errorf("tag still exists. tag: %s", tt.args.imageRef)
+			}
+
+			if slices.IndexFunc(rs, func(r ls.Response) bool { return r.Name == fmt.Sprintf("ghcr.io/%s/%s:not-to-be-deleted", owner, pack) }) == -1 {
+				t.Errorf("wrong tag deleted. tag: %s", fmt.Sprintf("ghcr.io/%s/%s:not-to-be-deleted", owner, pack))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/MaineK00n/vuls-data-update/issues/502

```
## Add a tag
% go run ./cmd/vuls-data-update dotgit remote tag --token $(gh auth token) ghcr.io/vulsio/vuls-data-db-backup:vuls-data-raw-ubuntu-oval-backup-daily test-tag
2025/08/27 19:02:15 [INFO] Tag dotgit ghcr.io/vulsio/vuls-data-db-backup:vuls-data-raw-ubuntu-oval-backup-daily as test-tag

## It's actually added
% gh api --paginate /orgs/vulsio/packages/container/vuls-data-db-backup/versions | jq -r '. | .[] |  .metadata.container.tags | join(",")' | grep -E '(raw-ubuntu-oval-backup-daily|test-tag)'
test-tag,vuls-data-raw-ubuntu-oval-backup-daily

## Remove the tag
% go run ./cmd/vuls-data-update dotgit remote untag --token $(gh auth token) ghcr.io/vulsio/vuls-data-db-backup:test-tag                                    2025/08/27 19:03:33 [INFO] Untag dotgit ghcr.io/vulsio/vuls-data-db-backup:test-tag

## Yay, removed!
% gh api --paginate /orgs/vulsio/packages/container/vuls-data-db-backup/versions | jq -r '. | .[] |  .metadata.container.tags | join(",")' | grep -E '(raw-ubuntu-oval-backup-daily|test-tag)'
vuls-data-raw-ubuntu-oval-backup-daily
```
