### PR TITLE
feat(extract/fedora): collect CVE-ID from bugzilla desc

### DIFF
--- a/pkg/extract/fedora/testdata/fixtures/F42/2025/FEDORA-2025-f5bf0fb721.json
+++ b/pkg/extract/fedora/testdata/fixtures/F42/2025/FEDORA-2025-f5bf0fb721.json
@@ -1,0 +1,784 @@
+{
+	"alias": "FEDORA-2025-f5bf0fb721",
+	"autokarma": true,
+	"autotime": true,
+	"bugs": [
+		{
+			"bug_id": 2368931,
+			"security": true,
+			"title": "CVE-2025-5262 libvpx: Double-free in libvpx encoder [fedora-all]",
+			"bugzilla": {
+				"bug_id": "2368931",
+				"creation_ts": "2025-05-28 10:02:45 +0000",
+				"short_desc": "CVE-2025-5262 libvpx: Double-free in libvpx encoder [fedora-all]",
+				"delta_ts": "2025-06-08 02:31:45 +0000",
+				"classification": "Fedora",
+				"product": "Fedora",
+				"component": "libvpx",
+				"version": "42",
+				"rep_platform": "Unspecified",
+				"op_sys": "Unspecified",
+				"bug_status": "CLOSED",
+				"resolution": "ERRATA",
+				"keywords": "Security, SecurityTracking",
+				"priority": "urgent",
+				"bug_severity": "urgent",
+				"blocked": [
+					{
+						"bug_id": "2368749",
+						"alias": [
+							"CVE-2025-5283"
+						],
+						"creation_ts": "2025-05-27 13:01:16 +0000",
+						"short_desc": "CVE-2025-5283 libvpx: Double-free in libvpx encoder",
+						"delta_ts": "2025-09-01 08:28:30 +0000",
+						"classification": "Other",
+						"product": "Security Response",
+						"component": "vulnerability",
+						"version": "unspecified",
+						"rep_platform": "All",
+						"op_sys": "Linux",
+						"bug_status": "NEW",
+						"keywords": "Security",
+						"priority": "high",
+						"bug_severity": "high",
+						"depends_on": [
+							"2368932",
+							"2368931"
+						],
+						"external_bugs": {
+							"text": "RHSA-2025:9331",
+							"name": "Red Hat Product Errata"
+						},
+						"long_desc": [
+							{
+								"isprivate": "0",
+								"commentid": "18501001",
+								"comment_count": "0",
+								"who": {
+									"text": "bzimport",
+									"name": "OSIDB Bzimport"
+								},
+								"bug_when": "2025-05-27 13:01:16 +0000",
+								"thetext": "A double-free could have occurred in `vpx_codec_enc_init_multi` after a failed allocation when initializing the encoder for WebRTC. This could have caused memory corruption and a potentially exploitable crash. This vulnerability affects Firefox < 139, Firefox ESR < 115.24, and Firefox ESR < 128.11."
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523373",
+								"comment_count": "1",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-16 15:37:23 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 9\n\nVia RHSA-2025:9118 https://access.redhat.com/errata/RHSA-2025:9118"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523399",
+								"comment_count": "2",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-16 16:00:38 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 10\n\nVia RHSA-2025:9120 https://access.redhat.com/errata/RHSA-2025:9120"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523409",
+								"comment_count": "3",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-16 16:20:12 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 8\n\nVia RHSA-2025:9119 https://access.redhat.com/errata/RHSA-2025:9119"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523420",
+								"comment_count": "4",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-16 16:24:32 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 8.2 Advanced Update Support\n\nVia RHSA-2025:9128 https://access.redhat.com/errata/RHSA-2025:9128"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523423",
+								"comment_count": "5",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-16 16:26:26 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 8.4 Advanced Mission Critical Update Support\n\nVia RHSA-2025:9127 https://access.redhat.com/errata/RHSA-2025:9127"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523438",
+								"comment_count": "6",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-16 16:36:49 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 9.2 Update Services for SAP Solutions\n\nVia RHSA-2025:9123 https://access.redhat.com/errata/RHSA-2025:9123"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523441",
+								"comment_count": "7",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-16 16:40:55 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 8.8 Update Services for SAP Solutions\n  Red Hat Enterprise Linux 8.8 Telecommunications Update Service\n\nVia RHSA-2025:9125 https://access.redhat.com/errata/RHSA-2025:9125"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523444",
+								"comment_count": "8",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-16 16:44:03 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 8.6 Advanced Mission Critical Update Support\n  Red Hat Enterprise Linux 8.6 Update Services for SAP Solutions\n  Red Hat Enterprise Linux 8.6 Telecommunications Update Service\n\nVia RHSA-2025:9126 https://access.redhat.com/errata/RHSA-2025:9126"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523445",
+								"comment_count": "9",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-16 16:44:07 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 9.0 Update Services for SAP Solutions\n\nVia RHSA-2025:9124 https://access.redhat.com/errata/RHSA-2025:9124"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523446",
+								"comment_count": "10",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-16 16:45:53 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 9.4 Extended Update Support\n\nVia RHSA-2025:9122 https://access.redhat.com/errata/RHSA-2025:9122"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18523843",
+								"comment_count": "11",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-17 07:10:12 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 8.6 Advanced Mission Critical Update Support\n  Red Hat Enterprise Linux 8.6 Update Services for SAP Solutions\n  Red Hat Enterprise Linux 8.6 Telecommunications Update Service\n\nVia RHSA-2025:9155 https://access.redhat.com/errata/RHSA-2025:9155"
+							},
+							{
+								"isprivate": "0",
+								"commentid": "18530344",
+								"comment_count": "12",
+								"who": {
+									"text": "errata-xmlrpc",
+									"name": "errata-xmlrpc"
+								},
+								"bug_when": "2025-06-23 02:39:46 +0000",
+								"thetext": "This issue has been addressed in the following products:\n\n  Red Hat Enterprise Linux 7 Extended Lifecycle Support\n\nVia RHSA-2025:9331 https://access.redhat.com/errata/RHSA-2025:9331"
+							}
+						]
+					}
+				],
+				"long_desc": [
+					{
+						"isprivate": "0",
+						"commentid": "18502008",
+						"comment_count": "0",
+						"who": {
+							"text": "mcascell",
+							"name": "Mauro Matteo Cascella"
+						},
+						"bug_when": "2025-05-28 10:02:45 +0000",
+						"thetext": "More information about this security flaw is available in the following bug:\n\nhttps://bugzilla.redhat.com/show_bug.cgi?id=2368749\n\nDisclaimer: Community trackers are created by Red Hat Product Security team on a best effort basis. Package maintainers are required to ascertain if the flaw indeed affects their package, before starting the update process."
+					},
+					{
+						"isprivate": "0",
+						"commentid": "18507745",
+						"comment_count": "1",
+						"who": {
+							"text": "updates",
+							"name": "Fedora Update System"
+						},
+						"bug_when": "2025-06-03 14:48:46 +0000",
+						"thetext": "FEDORA-2025-8d38482143 (libvpx-1.15.0-3.fc43) has been submitted as an update to Fedora 43.\nhttps://bodhi.fedoraproject.org/updates/FEDORA-2025-8d38482143"
+					},
+					{
+						"isprivate": "0",
+						"commentid": "18507778",
+						"comment_count": "2",
+						"who": {
+							"text": "updates",
+							"name": "Fedora Update System"
+						},
+						"bug_when": "2025-06-03 15:07:08 +0000",
+						"thetext": "FEDORA-2025-15220f1411 (libvpx-1.15.0-3.fc41) has been submitted as an update to Fedora 41.\nhttps://bodhi.fedoraproject.org/updates/FEDORA-2025-15220f1411"
+					},
+					{
+						"isprivate": "0",
+						"commentid": "18507779",
+						"comment_count": "3",
+						"who": {
+							"text": "updates",
+							"name": "Fedora Update System"
+						},
+						"bug_when": "2025-06-03 15:07:36 +0000",
+						"thetext": "FEDORA-2025-f5bf0fb721 (libvpx-1.15.0-3.fc42) has been submitted as an update to Fedora 42.\nhttps://bodhi.fedoraproject.org/updates/FEDORA-2025-f5bf0fb721"
+					},
+					{
+						"isprivate": "0",
+						"commentid": "18507815",
+						"comment_count": "4",
+						"who": {
+							"text": "updates",
+							"name": "Fedora Update System"
+						},
+						"bug_when": "2025-06-03 16:11:00 +0000",
+						"thetext": "FEDORA-2025-8d38482143 (libvpx-1.15.0-3.fc43) has been pushed to the Fedora 43 stable repository.\nIf problem still persists, please make note of it in this bug report."
+					},
+					{
+						"isprivate": "0",
+						"commentid": "18508231",
+						"comment_count": "5",
+						"who": {
+							"text": "updates",
+							"name": "Fedora Update System"
+						},
+						"bug_when": "2025-06-04 04:30:13 +0000",
+						"thetext": "FEDORA-2025-f5bf0fb721 has been pushed to the Fedora 42 testing repository.\nSoon you'll be able to install the update with the following command:\n`sudo dnf upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2025-f5bf0fb721`\nYou can provide feedback for this update here: https://bodhi.fedoraproject.org/updates/FEDORA-2025-f5bf0fb721\n\nSee also https://fedoraproject.org/wiki/QA:Updates_Testing for more information on how to test updates."
+					},
+					{
+						"isprivate": "0",
+						"commentid": "18508274",
+						"comment_count": "6",
+						"who": {
+							"text": "updates",
+							"name": "Fedora Update System"
+						},
+						"bug_when": "2025-06-04 05:04:28 +0000",
+						"thetext": "FEDORA-2025-15220f1411 has been pushed to the Fedora 41 testing repository.\nSoon you'll be able to install the update with the following command:\n`sudo dnf upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2025-15220f1411`\nYou can provide feedback for this update here: https://bodhi.fedoraproject.org/updates/FEDORA-2025-15220f1411\n\nSee also https://fedoraproject.org/wiki/QA:Updates_Testing for more information on how to test updates."
+					},
+					{
+						"isprivate": "0",
+						"commentid": "18510491",
+						"comment_count": "7",
+						"who": {
+							"text": "updates",
+							"name": "Fedora Update System"
+						},
+						"bug_when": "2025-06-06 01:44:17 +0000",
+						"thetext": "FEDORA-2025-f5bf0fb721 (libvpx-1.15.0-3.fc42) has been pushed to the Fedora 42 stable repository.\nIf problem still persists, please make note of it in this bug report."
+					},
+					{
+						"isprivate": "0",
+						"commentid": "18512134",
+						"comment_count": "8",
+						"who": {
+							"text": "updates",
+							"name": "Fedora Update System"
+						},
+						"bug_when": "2025-06-08 02:31:45 +0000",
+						"thetext": "FEDORA-2025-15220f1411 (libvpx-1.15.0-3.fc41) has been pushed to the Fedora 41 stable repository.\nIf problem still persists, please make note of it in this bug report."
+					}
+				]
+			}
+		}
+	],
+	"builds": [
+		{
+			"epoch": 0,
+			"nvr": "libvpx-1.15.0-3.fc42",
+			"release_id": 84,
+			"signed": true,
+			"type": "rpm",
+			"package": {
+				"aarch64": [
+					{
+						"name": "libvpx-utils-debuginfo",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "aarch64"
+					},
+					{
+						"name": "libvpx",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "aarch64"
+					},
+					{
+						"name": "libvpx-debuginfo",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "aarch64"
+					},
+					{
+						"name": "libvpx-utils",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "aarch64"
+					},
+					{
+						"name": "libvpx-devel",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "aarch64"
+					},
+					{
+						"name": "libvpx-debugsource",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "aarch64"
+					}
+				],
+				"i686": [
+					{
+						"name": "libvpx-debuginfo",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "i686"
+					},
+					{
+						"name": "libvpx",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "i686"
+					},
+					{
+						"name": "libvpx-devel",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "i686"
+					},
+					{
+						"name": "libvpx-debugsource",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "i686"
+					},
+					{
+						"name": "libvpx-utils-debuginfo",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "i686"
+					},
+					{
+						"name": "libvpx-utils",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "i686"
+					}
+				],
+				"ppc64le": [
+					{
+						"name": "libvpx-debuginfo",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "ppc64le"
+					},
+					{
+						"name": "libvpx-utils-debuginfo",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "ppc64le"
+					},
+					{
+						"name": "libvpx-devel",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "ppc64le"
+					},
+					{
+						"name": "libvpx",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "ppc64le"
+					},
+					{
+						"name": "libvpx-utils",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "ppc64le"
+					},
+					{
+						"name": "libvpx-debugsource",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "ppc64le"
+					}
+				],
+				"s390x": [
+					{
+						"name": "libvpx-debuginfo",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "s390x"
+					},
+					{
+						"name": "libvpx",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "s390x"
+					},
+					{
+						"name": "libvpx-debugsource",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "s390x"
+					},
+					{
+						"name": "libvpx-devel",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "s390x"
+					},
+					{
+						"name": "libvpx-utils-debuginfo",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "s390x"
+					},
+					{
+						"name": "libvpx-utils",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "s390x"
+					}
+				],
+				"src": [
+					{
+						"name": "libvpx",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "src"
+					}
+				],
+				"x86_64": [
+					{
+						"name": "libvpx-debuginfo",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "x86_64"
+					},
+					{
+						"name": "libvpx-utils",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "x86_64"
+					},
+					{
+						"name": "libvpx",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "x86_64"
+					},
+					{
+						"name": "libvpx-utils-debuginfo",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "x86_64"
+					},
+					{
+						"name": "libvpx-debugsource",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "x86_64"
+					},
+					{
+						"name": "libvpx-devel",
+						"version": "1.15.0",
+						"release": "3.fc42",
+						"arch": "x86_64"
+					}
+				]
+			}
+		}
+	],
+	"close_bugs": true,
+	"comments": [
+		{
+			"id": 4106246,
+			"text": "This update has been submitted for testing by wtaymans. ",
+			"timestamp": "2025-06-03 15:07:33",
+			"update_id": 720757,
+			"user": {
+				"avatar": "https://apps.fedoraproject.org/img/icons/bodhi-24.png",
+				"id": 91,
+				"name": "bodhi",
+				"openid": "bodhi.id.fedoraproject.org"
+			},
+			"user_id": 91
+		},
+		{
+			"id": 4106247,
+			"text": "This update's test gating status has been changed to 'waiting'.",
+			"timestamp": "2025-06-03 15:07:34",
+			"update_id": 720757,
+			"user": {
+				"avatar": "https://apps.fedoraproject.org/img/icons/bodhi-24.png",
+				"id": 91,
+				"name": "bodhi",
+				"openid": "bodhi.id.fedoraproject.org"
+			},
+			"user_id": 91
+		},
+		{
+			"id": 4106388,
+			"text": "This update's test gating status has been changed to 'passed'.",
+			"timestamp": "2025-06-03 17:52:20",
+			"update_id": 720757,
+			"user": {
+				"avatar": "https://apps.fedoraproject.org/img/icons/bodhi-24.png",
+				"id": 91,
+				"name": "bodhi",
+				"openid": "bodhi.id.fedoraproject.org"
+			},
+			"user_id": 91
+		},
+		{
+			"id": 4106784,
+			"text": "This update has been pushed to testing.",
+			"timestamp": "2025-06-04 04:30:26",
+			"update_id": 720757,
+			"user": {
+				"avatar": "https://apps.fedoraproject.org/img/icons/bodhi-24.png",
+				"id": 91,
+				"name": "bodhi",
+				"openid": "bodhi.id.fedoraproject.org"
+			},
+			"user_id": 91
+		},
+		{
+			"id": 4106983,
+			"karma": 1,
+			"text": "Works.",
+			"timestamp": "2025-06-04 09:17:51",
+			"update_id": 720757,
+			"user": {
+				"avatar": "https://seccdn.libravatar.org/avatar/adb4c3f28bd6969871988f992b1bf71e404f03e3570fbfa0fc9bd7d0bf0003f8?s=24&d=retro",
+				"email": "bojan@rexursive.com",
+				"groups": [
+					{
+						"name": "packager"
+					},
+					{
+						"name": "ipausers"
+					},
+					{
+						"name": "fedora-contributor"
+					},
+					{
+						"name": "signed_fpca"
+					},
+					{
+						"name": "fedorabugs"
+					}
+				],
+				"id": 198,
+				"name": "bojan",
+				"openid": "bojan.id.fedoraproject.org"
+			},
+			"user_id": 198
+		},
+		{
+			"id": 4107006,
+			"karma": 1,
+			"text": "Works great!  LGTM!  =)",
+			"timestamp": "2025-06-04 10:14:14",
+			"update_id": 720757,
+			"user": {
+				"avatar": "https://seccdn.libravatar.org/avatar/28bacfa3be75032390ac2c7a34599aeb825c3b62b2c55ef64821d2fc023b56cb?s=24&d=retro",
+				"email": "besser82.fpo@gmail.com",
+				"groups": [
+					{
+						"name": "proventesters"
+					},
+					{
+						"name": "packager"
+					},
+					{
+						"name": "ipausers"
+					},
+					{
+						"name": "fedora-contributor"
+					},
+					{
+						"name": "signed_fpca"
+					},
+					{
+						"name": "fedorabugs"
+					},
+					{
+						"name": "ambassadors"
+					},
+					{
+						"name": "designteam"
+					},
+					{
+						"name": "shogun-ca"
+					},
+					{
+						"name": "alt-gtk-de-sig"
+					},
+					{
+						"name": "trust admins"
+					}
+				],
+				"id": 206,
+				"name": "besser82",
+				"openid": "besser82.id.fedoraproject.org"
+			},
+			"user_id": 206
+		},
+		{
+			"id": 4107008,
+			"text": "This update can be pushed to stable now if the maintainer wishes",
+			"timestamp": "2025-06-04 10:16:58",
+			"update_id": 720757,
+			"user": {
+				"avatar": "https://apps.fedoraproject.org/img/icons/bodhi-24.png",
+				"id": 91,
+				"name": "bodhi",
+				"openid": "bodhi.id.fedoraproject.org"
+			},
+			"user_id": 91
+		},
+		{
+			"id": 4107767,
+			"karma": 1,
+			"text": "Works",
+			"timestamp": "2025-06-05 03:05:42",
+			"update_id": 720757,
+			"user": {
+				"avatar": "https://seccdn.libravatar.org/avatar/2181042739e66860b61edeb85351c63ba595fd70a9fe274a54f69df91f135dba?s=24&d=retro",
+				"email": "derekenz@gmail.com",
+				"groups": [
+					{
+						"name": "ipausers"
+					},
+					{
+						"name": "signed_fpca"
+					}
+				],
+				"id": 8341,
+				"name": "derekenz",
+				"openid": "derekenz.id.fedoraproject.org"
+			},
+			"user_id": 8341
+		},
+		{
+			"id": 4107768,
+			"text": "This update has been submitted for stable by bodhi. ",
+			"timestamp": "2025-06-05 03:05:43",
+			"update_id": 720757,
+			"user": {
+				"avatar": "https://apps.fedoraproject.org/img/icons/bodhi-24.png",
+				"id": 91,
+				"name": "bodhi",
+				"openid": "bodhi.id.fedoraproject.org"
+			},
+			"user_id": 91
+		},
+		{
+			"id": 4108715,
+			"text": "This update has been pushed to stable.",
+			"timestamp": "2025-06-06 01:44:26",
+			"update_id": 720757,
+			"user": {
+				"avatar": "https://apps.fedoraproject.org/img/icons/bodhi-24.png",
+				"id": 91,
+				"name": "bodhi",
+				"openid": "bodhi.id.fedoraproject.org"
+			},
+			"user_id": 91
+		}
+	],
+	"content_type": "rpm",
+	"critpath": true,
+	"critpath_groups": "critical-path-anaconda critical-path-apps critical-path-compose critical-path-gnome critical-path-kde critical-path-lxde critical-path-lxqt critical-path-server critical-path-xfce",
+	"date_approved": "2025-06-04 10:16:58",
+	"date_pushed": "2025-06-06 01:43:35",
+	"date_stable": "2025-06-06 01:43:35",
+	"date_submitted": "2025-06-03 15:07:33",
+	"date_testing": "2025-06-04 04:29:45",
+	"karma": 3,
+	"meets_testing_requirements": true,
+	"notes": "Add patch for double free",
+	"pushed": true,
+	"release": {
+		"branch": "f42",
+		"candidate_tag": "f42-updates-candidate",
+		"composed_by_bodhi": true,
+		"create_automatic_updates": false,
+		"dist_tag": "f42",
+		"eol": "2026-05-13",
+		"id_prefix": "FEDORA",
+		"long_name": "Fedora 42",
+		"mail_template": "fedora_errata_template",
+		"name": "F42",
+		"override_tag": "f42-override",
+		"package_manager": "dnf",
+		"pending_signing_tag": "f42-signing-pending",
+		"pending_stable_tag": "f42-updates-pending",
+		"pending_testing_tag": "f42-updates-testing-pending",
+		"stable_tag": "f42-updates",
+		"state": "current",
+		"testing_repository": "updates-testing",
+		"testing_tag": "f42-updates-testing",
+		"version": "42"
+	},
+	"require_bugs": true,
+	"require_testcases": true,
+	"severity": "urgent",
+	"stable_days": 14,
+	"stable_karma": 3,
+	"status": "stable",
+	"suggest": "unspecified",
+	"test_gating_status": "passed",
+	"title": "libvpx-1.15.0-3.fc42",
+	"type": "security",
+	"url": "https://bodhi.fedoraproject.org/updates/FEDORA-2025-f5bf0fb721",
+	"unstable_karma": -3,
+	"updateid": "FEDORA-2025-f5bf0fb721",
+	"user": {
+		"avatar": "https://seccdn.libravatar.org/avatar/7d40df84052758e99b77ed0951e7fa8ef10cbe62a56509171d32480533b6fc30?s=24&d=retro",
+		"email": "wtaymans@redhat.com",
+		"groups": [
+			{
+				"name": "packager"
+			},
+			{
+				"name": "ipausers"
+			},
+			{
+				"name": "fedora-contributor"
+			},
+			{
+				"name": "signed_fpca"
+			},
+			{
+				"name": "fedorabugs"
+			}
+		],
+		"id": 691,
+		"name": "wtaymans",
+		"openid": "wtaymans.id.fedoraproject.org"
+	},
+	"version_hash": "6b7f42ce6db5d185d5446725ca38784d79fb622c"
+}

--- a/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-5911638116.json
+++ b/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-5911638116.json
@@ -58,32 +58,6 @@
 		{
 			"content": {
 				"id": "CVE-2023-2602",
-				"title": "CVE-2023-2602 libcap: Memory Leak on pthread_create() Error",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "low"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2209114"
-					}
-				],
-				"published": "2023-05-22T16:54:30Z",
-				"modified": "2023-11-21T11:41:39Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2023-2602",
 				"title": "CVE-2023-2602 libcap: Memory Leak on pthread_create() Error [fedora-38]",
 				"severity": [
 					{
@@ -106,32 +80,6 @@
 					"ecosystem": "fedora:38"
 				}
 			]
-		},
-		{
-			"content": {
-				"id": "CVE-2023-2603",
-				"title": "CVE-2023-2603 libcap: Integer Overflow in _libcap_strdup()",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2209113"
-					}
-				],
-				"published": "2023-05-22T16:54:28Z",
-				"modified": "2023-11-21T11:41:35Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
 		}
 	],
 	"detections": [
@@ -142,6 +90,105 @@
 					"criteria": {
 						"operator": "OR",
 						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libcap-debuginfo",
+											"architectures": [
+												"x86_64",
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:2.48-7.fc38"
+											}
+										],
+										"fixed": [
+											"0:2.48-7.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libcap-static",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:2.48-7.fc38"
+											}
+										],
+										"fixed": [
+											"0:2.48-7.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libcap-debugsource",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:2.48-7.fc38"
+											}
+										],
+										"fixed": [
+											"0:2.48-7.fc38"
+										]
+									}
+								}
+							},
 							{
 								"type": "version",
 								"version": {
@@ -186,112 +233,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "libcap-debuginfo",
-											"architectures": [
-												"ppc64le",
-												"s390x",
-												"x86_64",
-												"aarch64",
-												"i686"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:2.48-7.fc38"
-											}
-										],
-										"fixed": [
-											"0:2.48-7.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
 											"name": "libcap-devel",
 											"architectures": [
-												"i686",
-												"ppc64le",
-												"s390x",
 												"x86_64",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:2.48-7.fc38"
-											}
-										],
-										"fixed": [
-											"0:2.48-7.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "libcap-debugsource",
-											"architectures": [
 												"aarch64",
 												"i686",
 												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:2.48-7.fc38"
-											}
-										],
-										"fixed": [
-											"0:2.48-7.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "libcap-static",
-											"architectures": [
-												"ppc64le",
-												"s390x",
-												"x86_64",
-												"aarch64",
-												"i686"
+												"s390x"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-5911638116.json
+++ b/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-5911638116.json
@@ -32,7 +32,7 @@
 		{
 			"content": {
 				"id": "CVE-2023-2603",
-				"title": "CVE-2023-2603 libcap: Integer Overflow in _libcap_strdup()",
+				"title": "CVE-2023-2603 libcap: Integer Overflow in _libcap_strdup() [fedora-38]",
 				"severity": [
 					{
 						"type": "vendor",
@@ -43,11 +43,11 @@
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2209113"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2210635"
 					}
 				],
-				"published": "2023-05-22T16:54:28Z",
-				"modified": "2023-11-21T11:41:35Z"
+				"published": "2023-05-29T04:14:59Z",
+				"modified": "2023-11-24T02:19:05Z"
 			},
 			"segments": [
 				{
@@ -80,6 +80,58 @@
 					"ecosystem": "fedora:38"
 				}
 			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-2602",
+				"title": "CVE-2023-2602 libcap: Memory Leak on pthread_create() Error [fedora-38]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "low"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2210643"
+					}
+				],
+				"published": "2023-05-29T04:15:44Z",
+				"modified": "2023-11-24T02:19:08Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-2603",
+				"title": "CVE-2023-2603 libcap: Integer Overflow in _libcap_strdup()",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2209113"
+					}
+				],
+				"published": "2023-05-22T16:54:28Z",
+				"modified": "2023-11-21T11:41:35Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
 		}
 	],
 	"detections": [
@@ -102,12 +154,12 @@
 										"binary": {
 											"name": "libcap",
 											"architectures": [
+												"x86_64",
+												"aarch64",
 												"i686",
 												"ppc64le",
 												"s390x",
-												"src",
-												"x86_64",
-												"aarch64"
+												"src"
 											]
 										}
 									},
@@ -136,77 +188,11 @@
 										"binary": {
 											"name": "libcap-debuginfo",
 											"architectures": [
+												"ppc64le",
+												"s390x",
 												"x86_64",
 												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:2.48-7.fc38"
-											}
-										],
-										"fixed": [
-											"0:2.48-7.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "libcap-static",
-											"architectures": [
-												"x86_64",
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:2.48-7.fc38"
-											}
-										],
-										"fixed": [
-											"0:2.48-7.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "libcap-debugsource",
-											"architectures": [
-												"x86_64",
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x"
+												"i686"
 											]
 										}
 									},
@@ -235,11 +221,77 @@
 										"binary": {
 											"name": "libcap-devel",
 											"architectures": [
+												"i686",
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:2.48-7.fc38"
+											}
+										],
+										"fixed": [
+											"0:2.48-7.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libcap-debugsource",
+											"architectures": [
 												"aarch64",
 												"i686",
 												"ppc64le",
 												"s390x",
 												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:2.48-7.fc38"
+											}
+										],
+										"fixed": [
+											"0:2.48-7.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libcap-static",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"i686"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-bb021a4854.json
+++ b/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-bb021a4854.json
@@ -47,71 +47,39 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "thunderbird-debugsource",
-											"architectures": [
-												"i686",
-												"ppc64le",
-												"x86_64",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:115.5.0-1.fc38"
-											}
-										],
-										"fixed": [
-											"0:115.5.0-1.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "thunderbird-debuginfo",
-											"architectures": [
-												"i686",
-												"ppc64le",
-												"x86_64",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:115.5.0-1.fc38"
-											}
-										],
-										"fixed": [
-											"0:115.5.0-1.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
 											"name": "thunderbird-librnp-rnp",
+											"architectures": [
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:115.5.0-1.fc38"
+											}
+										],
+										"fixed": [
+											"0:115.5.0-1.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "thunderbird-wayland",
 											"architectures": [
 												"x86_64",
 												"aarch64",
@@ -145,11 +113,43 @@
 										"binary": {
 											"name": "thunderbird",
 											"architectures": [
+												"aarch64",
+												"i686",
 												"ppc64le",
 												"src",
-												"x86_64",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:115.5.0-1.fc38"
+											}
+										],
+										"fixed": [
+											"0:115.5.0-1.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "thunderbird-debugsource",
+											"architectures": [
 												"aarch64",
-												"i686"
+												"i686",
+												"ppc64le",
+												"x86_64"
 											]
 										}
 									},
@@ -178,10 +178,10 @@
 										"binary": {
 											"name": "thunderbird-librnp-rnp-debuginfo",
 											"architectures": [
-												"x86_64",
 												"aarch64",
 												"i686",
-												"ppc64le"
+												"ppc64le",
+												"x86_64"
 											]
 										}
 									},
@@ -208,12 +208,12 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "thunderbird-wayland",
+											"name": "thunderbird-debuginfo",
 											"architectures": [
-												"aarch64",
-												"i686",
 												"ppc64le",
-												"x86_64"
+												"x86_64",
+												"aarch64",
+												"i686"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-bb021a4854.json
+++ b/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-bb021a4854.json
@@ -47,103 +47,6 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "thunderbird",
-											"architectures": [
-												"i686",
-												"ppc64le",
-												"src",
-												"x86_64",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:115.5.0-1.fc38"
-											}
-										],
-										"fixed": [
-											"0:115.5.0-1.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "thunderbird-librnp-rnp-debuginfo",
-											"architectures": [
-												"ppc64le",
-												"x86_64",
-												"aarch64",
-												"i686"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:115.5.0-1.fc38"
-											}
-										],
-										"fixed": [
-											"0:115.5.0-1.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "thunderbird-wayland",
-											"architectures": [
-												"i686",
-												"ppc64le",
-												"x86_64",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:115.5.0-1.fc38"
-											}
-										],
-										"fixed": [
-											"0:115.5.0-1.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
 											"name": "thunderbird-debugsource",
 											"architectures": [
 												"i686",
@@ -210,10 +113,107 @@
 										"binary": {
 											"name": "thunderbird-librnp-rnp",
 											"architectures": [
+												"x86_64",
+												"aarch64",
+												"i686",
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:115.5.0-1.fc38"
+											}
+										],
+										"fixed": [
+											"0:115.5.0-1.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "thunderbird",
+											"architectures": [
 												"ppc64le",
+												"src",
 												"x86_64",
 												"aarch64",
 												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:115.5.0-1.fc38"
+											}
+										],
+										"fixed": [
+											"0:115.5.0-1.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "thunderbird-librnp-rnp-debuginfo",
+											"architectures": [
+												"x86_64",
+												"aarch64",
+												"i686",
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:115.5.0-1.fc38"
+											}
+										],
+										"fixed": [
+											"0:115.5.0-1.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "thunderbird-wayland",
+											"architectures": [
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"x86_64"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-bd14c83780.json
+++ b/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-bd14c83780.json
@@ -54,32 +54,6 @@
 					"ecosystem": "fedora:38"
 				}
 			]
-		},
-		{
-			"content": {
-				"id": "CVE-2023-31083",
-				"title": "CVE-2023-31083 kernel: race condition between HCIUARTSETPROTO and HCIUARTGETPROTO in hci_uart_tty_ioctl",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2213132"
-					}
-				],
-				"published": "2023-06-07T08:13:27Z",
-				"modified": "2023-10-29T11:27:18Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
 		}
 	],
 	"detections": [
@@ -100,7 +74,68 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-debuginfo",
+											"name": "kernel-modules-extra",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debuginfo-common-ppc64le",
+											"architectures": [
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-devel-matched",
 											"architectures": [
 												"aarch64",
 												"ppc64le",
@@ -132,11 +167,280 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-core",
+											"name": "kernel-debuginfo-common-s390x",
 											"architectures": [
-												"aarch64",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug-modules-extra",
+											"architectures": [
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug-devel",
+											"architectures": [
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debuginfo-common-x86_64",
+											"architectures": [
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug-core",
+											"architectures": [
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debuginfo",
+											"architectures": [
 												"ppc64le",
 												"s390x",
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-modules",
+											"architectures": [
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug-modules-core",
+											"architectures": [
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug-debuginfo",
+											"architectures": [
+												"aarch64",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug-uki-virt",
+											"architectures": [
 												"x86_64"
 											]
 										}
@@ -166,8 +470,8 @@
 										"binary": {
 											"name": "kernel-debug-modules",
 											"architectures": [
-												"aarch64",
-												"x86_64"
+												"x86_64",
+												"aarch64"
 											]
 										}
 									},
@@ -194,12 +498,76 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-modules",
+											"name": "kernel-modules-internal",
 											"architectures": [
+												"x86_64",
 												"aarch64",
 												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-devel",
+											"architectures": [
+												"ppc64le",
 												"s390x",
-												"x86_64"
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-core",
+											"architectures": [
+												"x86_64",
+												"aarch64",
+												"ppc64le",
+												"s390x"
 											]
 										}
 									},
@@ -259,310 +627,8 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-debug-devel-matched",
+											"name": "kernel-debug",
 											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debuginfo-common-ppc64le",
-											"architectures": [
-												"ppc64le"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug-uki-virt",
-											"architectures": [
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debuginfo-common-aarch64",
-											"architectures": [
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug-modules-core",
-											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug-modules-extra",
-											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-modules-extra",
-											"architectures": [
-												"aarch64",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug-modules-internal",
-											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-modules-internal",
-											"architectures": [
-												"aarch64",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debuginfo-common-x86_64",
-											"architectures": [
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-devel",
-											"architectures": [
-												"ppc64le",
-												"s390x",
 												"x86_64",
 												"aarch64"
 											]
@@ -591,69 +657,10 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-debug-devel",
+											"name": "kernel-debug-modules-internal",
 											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug-debuginfo",
-											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debuginfo-common-s390x",
-											"architectures": [
-												"s390x"
+												"x86_64",
+												"aarch64"
 											]
 										}
 									},
@@ -709,130 +716,6 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-debug-core",
-											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-modules-core",
-											"architectures": [
-												"x86_64",
-												"aarch64",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug",
-											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-devel-matched",
-											"architectures": [
-												"x86_64",
-												"aarch64",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
 											"name": "kernel-doc",
 											"architectures": [
 												"noarch"
@@ -862,13 +745,71 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-cross-headers",
+											"name": "kernel-modules-core",
 											"architectures": [
 												"aarch64",
-												"i686",
 												"ppc64le",
 												"s390x",
 												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug-devel-matched",
+											"architectures": [
+												"aarch64",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debuginfo-common-aarch64",
+											"architectures": [
+												"aarch64"
 											]
 										}
 									},
@@ -929,7 +870,40 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "perf-debuginfo",
+											"name": "kernel-cross-headers",
+											"architectures": [
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-tools-libs",
 											"architectures": [
 												"s390x",
 												"x86_64",
@@ -961,140 +935,44 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "perf",
+											"name": "rv",
 											"architectures": [
-												"ppc64le",
 												"s390x",
-												"x86_64",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-tools-debugsource",
-											"architectures": [
-												"ppc64le",
-												"s390x",
-												"x86_64",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "libperf-debuginfo",
-											"architectures": [
-												"aarch64",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-tools-libs-devel",
-											"architectures": [
-												"ppc64le",
-												"s390x",
-												"x86_64",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-tools-libs",
-											"architectures": [
 												"x86_64",
 												"aarch64",
-												"ppc64le",
-												"s390x"
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "python3-perf-debuginfo",
+											"architectures": [
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"ppc64le"
 											]
 										}
 									},
@@ -1153,7 +1031,7 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-tools-debuginfo",
+											"name": "python3-perf",
 											"architectures": [
 												"s390x",
 												"x86_64",
@@ -1185,12 +1063,77 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "rtla",
+											"name": "bpftool-debuginfo",
 											"architectures": [
-												"ppc64le",
 												"s390x",
 												"x86_64",
-												"aarch64"
+												"aarch64",
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-tools",
+											"architectures": [
+												"s390x",
+												"src",
+												"x86_64",
+												"aarch64",
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libperf-debuginfo",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
 											]
 										}
 									},
@@ -1219,10 +1162,10 @@
 										"binary": {
 											"name": "libperf",
 											"architectures": [
-												"s390x",
 												"x86_64",
 												"aarch64",
-												"ppc64le"
+												"ppc64le",
+												"s390x"
 											]
 										}
 									},
@@ -1249,12 +1192,12 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "rv",
+											"name": "kernel-tools-libs-devel",
 											"architectures": [
+												"aarch64",
 												"ppc64le",
 												"s390x",
-												"x86_64",
-												"aarch64"
+												"x86_64"
 											]
 										}
 									},
@@ -1281,7 +1224,39 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "python3-perf-debuginfo",
+											"name": "perf-debuginfo",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "perf",
 											"architectures": [
 												"x86_64",
 												"aarch64",
@@ -1345,7 +1320,7 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "bpftool-debuginfo",
+											"name": "kernel-tools-debugsource",
 											"architectures": [
 												"aarch64",
 												"ppc64le",
@@ -1377,13 +1352,12 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-tools",
+											"name": "kernel-tools-debuginfo",
 											"architectures": [
-												"ppc64le",
 												"s390x",
-												"src",
 												"x86_64",
-												"aarch64"
+												"aarch64",
+												"ppc64le"
 											]
 										}
 									},
@@ -1410,12 +1384,12 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "python3-perf",
+											"name": "rtla",
 											"architectures": [
+												"s390x",
 												"x86_64",
 												"aarch64",
-												"ppc64le",
-												"s390x"
+												"ppc64le"
 											]
 										}
 									},
@@ -1444,10 +1418,10 @@
 										"binary": {
 											"name": "kernel-tools-libs-debuginfo",
 											"architectures": [
-												"aarch64",
-												"ppc64le",
 												"s390x",
-												"x86_64"
+												"x86_64",
+												"aarch64",
+												"ppc64le"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-bd14c83780.json
+++ b/pkg/extract/fedora/testdata/golden/data/F38/2023/FEDORA-2023-bd14c83780.json
@@ -32,6 +32,32 @@
 		{
 			"content": {
 				"id": "CVE-2023-31083",
+				"title": "CVE-2023-31083 kernel: race condition between HCIUARTSETPROTO and HCIUARTGETPROTO in hci_uart_tty_ioctl [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2213133"
+					}
+				],
+				"published": "2023-06-07T08:13:39Z",
+				"modified": "2023-11-27T01:34:35Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-31083",
 				"title": "CVE-2023-31083 kernel: race condition between HCIUARTSETPROTO and HCIUARTGETPROTO in hci_uart_tty_ioctl",
 				"severity": [
 					{
@@ -74,370 +100,11 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-debug-devel",
-											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-doc",
-											"architectures": [
-												"noarch"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debuginfo-common-ppc64le",
-											"architectures": [
-												"ppc64le"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug-uki-virt",
-											"architectures": [
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-devel",
+											"name": "kernel-debuginfo",
 											"architectures": [
 												"aarch64",
 												"ppc64le",
 												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-modules",
-											"architectures": [
-												"aarch64",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-modules-extra",
-											"architectures": [
-												"aarch64",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug",
-											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug-devel-matched",
-											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debuginfo-common-x86_64",
-											"architectures": [
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug-debuginfo",
-											"architectures": [
-												"aarch64",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debuginfo-common-aarch64",
-											"architectures": [
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-101.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-101.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-debug-core",
-											"architectures": [
-												"aarch64",
 												"x86_64"
 											]
 										}
@@ -527,7 +194,7 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-modules-internal",
+											"name": "kernel-modules",
 											"architectures": [
 												"aarch64",
 												"ppc64le",
@@ -559,11 +226,71 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-devel-matched",
+											"name": "kernel",
 											"architectures": [
-												"s390x",
-												"x86_64",
 												"aarch64",
+												"ppc64le",
+												"s390x",
+												"src",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug-devel-matched",
+											"architectures": [
+												"aarch64",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debuginfo-common-ppc64le",
+											"architectures": [
 												"ppc64le"
 											]
 										}
@@ -591,12 +318,38 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-debuginfo",
+											"name": "kernel-debug-uki-virt",
 											"architectures": [
-												"s390x",
-												"x86_64",
-												"aarch64",
-												"ppc64le"
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debuginfo-common-aarch64",
+											"architectures": [
+												"aarch64"
 											]
 										}
 									},
@@ -653,12 +406,10 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-modules-core",
+											"name": "kernel-debug-modules-extra",
 											"architectures": [
-												"s390x",
-												"x86_64",
 												"aarch64",
-												"ppc64le"
+												"x86_64"
 											]
 										}
 									},
@@ -685,9 +436,11 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-debug-modules-extra",
+											"name": "kernel-modules-extra",
 											"architectures": [
 												"aarch64",
+												"ppc64le",
+												"s390x",
 												"x86_64"
 											]
 										}
@@ -745,12 +498,132 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel",
+											"name": "kernel-modules-internal",
 											"architectures": [
 												"aarch64",
 												"ppc64le",
 												"s390x",
-												"src",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debuginfo-common-x86_64",
+											"architectures": [
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-devel",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug-devel",
+											"architectures": [
+												"aarch64",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug-debuginfo",
+											"architectures": [
+												"aarch64",
 												"x86_64"
 											]
 										}
@@ -836,14 +709,133 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-headers",
+											"name": "kernel-debug-core",
 											"architectures": [
-												"ppc64le",
-												"s390x",
-												"src",
+												"aarch64",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-modules-core",
+											"architectures": [
 												"x86_64",
 												"aarch64",
-												"i686"
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug",
+											"architectures": [
+												"aarch64",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-devel-matched",
+											"architectures": [
+												"x86_64",
+												"aarch64",
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-doc",
+											"architectures": [
+												"noarch"
 											]
 										}
 									},
@@ -872,11 +864,11 @@
 										"binary": {
 											"name": "kernel-cross-headers",
 											"architectures": [
-												"s390x",
-												"x86_64",
 												"aarch64",
 												"i686",
-												"ppc64le"
+												"ppc64le",
+												"s390x",
+												"x86_64"
 											]
 										}
 									},
@@ -903,77 +895,46 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-tools",
+											"name": "kernel-headers",
 											"architectures": [
+												"aarch64",
+												"i686",
+												"ppc64le",
 												"s390x",
 												"src",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-101.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-101.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "perf-debuginfo",
+											"architectures": [
+												"s390x",
 												"x86_64",
 												"aarch64",
 												"ppc64le"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-tools-libs",
-											"architectures": [
-												"aarch64",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "python3-perf-debuginfo",
-											"architectures": [
-												"aarch64",
-												"ppc64le",
-												"s390x",
-												"x86_64"
 											]
 										}
 									},
@@ -1002,10 +963,10 @@
 										"binary": {
 											"name": "perf",
 											"architectures": [
+												"ppc64le",
 												"s390x",
 												"x86_64",
-												"aarch64",
-												"ppc64le"
+												"aarch64"
 											]
 										}
 									},
@@ -1032,7 +993,103 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "libperf-devel",
+											"name": "kernel-tools-debugsource",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libperf-debuginfo",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-tools-libs-devel",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-tools-libs",
 											"architectures": [
 												"x86_64",
 												"aarch64",
@@ -1064,12 +1121,12 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "rv",
+											"name": "bpftool",
 											"architectures": [
-												"aarch64",
 												"ppc64le",
 												"s390x",
-												"x86_64"
+												"x86_64",
+												"aarch64"
 											]
 										}
 									},
@@ -1096,7 +1153,7 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "libperf-debuginfo",
+											"name": "kernel-tools-debuginfo",
 											"architectures": [
 												"s390x",
 												"x86_64",
@@ -1128,12 +1185,140 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "kernel-tools-debuginfo",
+											"name": "rtla",
 											"architectures": [
-												"aarch64",
 												"ppc64le",
 												"s390x",
-												"x86_64"
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libperf",
+											"architectures": [
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "rv",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "python3-perf-debuginfo",
+											"architectures": [
+												"x86_64",
+												"aarch64",
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libperf-devel",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64"
 											]
 										}
 									},
@@ -1192,135 +1377,40 @@
 									"package": {
 										"type": "binary",
 										"binary": {
+											"name": "kernel-tools",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"src",
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:6.6.2-100.fc38"
+											}
+										],
+										"fixed": [
+											"0:6.6.2-100.fc38"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
 											"name": "python3-perf",
-											"architectures": [
-												"s390x",
-												"x86_64",
-												"aarch64",
-												"ppc64le"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "rtla",
-											"architectures": [
-												"s390x",
-												"x86_64",
-												"aarch64",
-												"ppc64le"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-tools-libs-devel",
-											"architectures": [
-												"aarch64",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "perf-debuginfo",
-											"architectures": [
-												"aarch64",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "bpftool",
 											"architectures": [
 												"x86_64",
 												"aarch64",
@@ -1352,71 +1442,7 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "libperf",
-											"architectures": [
-												"aarch64",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
 											"name": "kernel-tools-libs-debuginfo",
-											"architectures": [
-												"ppc64le",
-												"s390x",
-												"x86_64",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:6.6.2-100.fc38"
-											}
-										],
-										"fixed": [
-											"0:6.6.2-100.fc38"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "kernel-tools-debugsource",
 											"architectures": [
 												"aarch64",
 												"ppc64le",

--- a/pkg/extract/fedora/testdata/golden/data/F38M/2023/FEDORA-MODULAR-2023-5b8a7bde59.json
+++ b/pkg/extract/fedora/testdata/golden/data/F38M/2023/FEDORA-MODULAR-2023-5b8a7bde59.json
@@ -31,138 +31,8 @@
 	"vulnerabilities": [
 		{
 			"content": {
-				"id": "CVE-2022-21594",
-				"title": "CVE-2022-21594 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142861"
-					}
-				],
-				"published": "2022-11-15T11:28:08Z",
-				"modified": "2023-09-22T09:14:13Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21599",
-				"title": "CVE-2022-21599 mysql: Server: Stored Procedure unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142863"
-					}
-				],
-				"published": "2022-11-15T11:28:20Z",
-				"modified": "2023-09-22T09:14:37Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-39400",
-				"title": "CVE-2022-39400 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142879"
-					}
-				],
-				"published": "2022-11-15T11:29:51Z",
-				"modified": "2023-09-22T09:16:50Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21604",
-				"title": "CVE-2022-21604 mysql: InnoDB unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142865"
-					}
-				],
-				"published": "2022-11-15T11:28:31Z",
-				"modified": "2023-09-22T09:14:52Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21611",
-				"title": "CVE-2022-21611 mysql: InnoDB unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142869"
-					}
-				],
-				"published": "2022-11-15T11:28:54Z",
-				"modified": "2023-09-22T09:15:32Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
 				"id": "CVE-2022-21617",
-				"title": "CVE-2022-21617 mysql: Server: Connection Handling unspecified vulnerability (CPU Oct 2022)",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
 				"severity": [
 					{
 						"type": "vendor",
@@ -173,63 +43,11 @@
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142870"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
 					}
 				],
-				"published": "2022-11-15T11:29:00Z",
-				"modified": "2023-09-22T09:15:40Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21637",
-				"title": "CVE-2022-21637 mysql: InnoDB unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142875"
-					}
-				],
-				"published": "2022-11-15T11:29:27Z",
-				"modified": "2023-09-22T09:16:17Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-39410",
-				"title": "CVE-2022-39410 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142881"
-					}
-				],
-				"published": "2022-11-15T11:30:02Z",
-				"modified": "2023-09-22T09:17:06Z"
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
 			},
 			"segments": [
 				{
@@ -291,110 +109,6 @@
 		},
 		{
 			"content": {
-				"id": "CVE-2023-21912",
-				"title": "CVE-2023-21912 mysql: Server: Security: Privileges unspecified vulnerability (CPU Apr 2023)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "high"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2188110"
-					}
-				],
-				"published": "2023-04-19T20:02:39Z",
-				"modified": "2023-05-17T03:44:59Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21625",
-				"title": "CVE-2022-21625 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142871"
-					}
-				],
-				"published": "2022-11-15T11:29:06Z",
-				"modified": "2023-09-22T09:15:47Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21632",
-				"title": "CVE-2022-21632 mysql: Server: Security: Privileges unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142872"
-					}
-				],
-				"published": "2022-11-15T11:29:11Z",
-				"modified": "2023-09-22T09:15:56Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21640",
-				"title": "CVE-2022-21640 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142877"
-					}
-				],
-				"published": "2022-11-15T11:29:39Z",
-				"modified": "2023-09-22T09:16:30Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
 				"id": "CVE-2023-21917",
 				"title": "CVE-2023-21917 mysql: Server: Optimizer unspecified vulnerability (CPU Apr 2023)",
 				"severity": [
@@ -447,59 +161,7 @@
 		},
 		{
 			"content": {
-				"id": "CVE-2022-21599",
-				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
-					}
-				],
-				"published": "2022-11-15T16:38:40Z",
-				"modified": "2023-09-16T00:28:34Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
 				"id": "CVE-2022-21604",
-				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
-					}
-				],
-				"published": "2022-11-15T16:38:40Z",
-				"modified": "2023-09-16T00:28:34Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21608",
 				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
 				"severity": [
 					{
@@ -551,7 +213,7 @@
 		},
 		{
 			"content": {
-				"id": "CVE-2022-21617",
+				"id": "CVE-2022-21625",
 				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
 				"severity": [
 					{
@@ -577,7 +239,189 @@
 		},
 		{
 			"content": {
-				"id": "CVE-2022-21625",
+				"id": "CVE-2022-21633",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-39408",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-39410",
+				"title": "CVE-2022-39410 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142881"
+					}
+				],
+				"published": "2022-11-15T11:30:02Z",
+				"modified": "2023-09-22T09:17:06Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21640",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-21865",
+				"title": "CVE-2023-21865 mysql: Server: Optimizer unspecified vulnerability (CPU Jan 2023)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2162272"
+					}
+				],
+				"published": "2023-01-19T09:23:01Z",
+				"modified": "2023-09-22T09:19:09Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-21912",
+				"title": "CVE-2023-21912 mysql: Server: Security: Privileges unspecified vulnerability (CPU Apr 2023)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "high"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2188110"
+					}
+				],
+				"published": "2023-04-19T20:02:39Z",
+				"modified": "2023-05-17T03:44:59Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21599",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21608",
 				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
 				"severity": [
 					{
@@ -629,59 +473,7 @@
 		},
 		{
 			"content": {
-				"id": "CVE-2022-21633",
-				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
-					}
-				],
-				"published": "2022-11-15T16:38:40Z",
-				"modified": "2023-09-16T00:28:34Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
 				"id": "CVE-2022-21637",
-				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
-					}
-				],
-				"published": "2022-11-15T16:38:40Z",
-				"modified": "2023-09-16T00:28:34Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21640",
 				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
 				"severity": [
 					{
@@ -730,136 +522,6 @@
 					"ecosystem": "fedora:38"
 				}
 			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-39408",
-				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
-					}
-				],
-				"published": "2022-11-15T16:38:40Z",
-				"modified": "2023-09-16T00:28:34Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21608",
-				"title": "CVE-2022-21608 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142868"
-					}
-				],
-				"published": "2022-11-15T11:28:48Z",
-				"modified": "2023-09-22T09:15:24Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21633",
-				"title": "CVE-2022-21633 mysql: Server: Replication unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142873"
-					}
-				],
-				"published": "2022-11-15T11:29:16Z",
-				"modified": "2023-09-22T09:16:03Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-39408",
-				"title": "CVE-2022-39408 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142880"
-					}
-				],
-				"published": "2022-11-15T11:29:56Z",
-				"modified": "2023-09-22T09:16:57Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2023-21865",
-				"title": "CVE-2023-21865 mysql: Server: Optimizer unspecified vulnerability (CPU Jan 2023)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2162272"
-					}
-				],
-				"published": "2023-01-19T09:23:01Z",
-				"modified": "2023-09-22T09:19:09Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
 		}
 	],
 	"detections": [
@@ -880,78 +542,12 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "mysql:8.0::community-mysql-debugsource",
-											"architectures": [
-												"ppc64le",
-												"s390x",
-												"aarch64",
-												"i686",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-devel",
-											"architectures": [
-												"ppc64le",
-												"s390x",
-												"aarch64",
-												"i686",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
 											"name": "mysql:8.0::community-mysql-errmsg",
 											"architectures": [
-												"ppc64le",
 												"s390x",
 												"aarch64",
 												"i686",
+												"ppc64le",
 												"x86_64"
 											]
 										}
@@ -981,11 +577,143 @@
 										"binary": {
 											"name": "mysql:8.0::community-mysql-libs-debuginfo",
 											"architectures": [
-												"i686",
 												"x86_64",
-												"ppc64le",
 												"s390x",
-												"aarch64"
+												"aarch64",
+												"i686",
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-devel",
+											"architectures": [
+												"x86_64",
+												"s390x",
+												"aarch64",
+												"i686",
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-devel-debuginfo",
+											"architectures": [
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"x86_64",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-libs",
+											"architectures": [
+												"s390x",
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-server",
+											"architectures": [
+												"s390x",
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"x86_64"
 											]
 										}
 									},
@@ -1014,10 +742,10 @@
 										"binary": {
 											"name": "mysql:8.0::community-mysql-server-debuginfo",
 											"architectures": [
-												"ppc64le",
 												"s390x",
 												"aarch64",
 												"i686",
+												"ppc64le",
 												"x86_64"
 											]
 										}
@@ -1050,8 +778,41 @@
 												"s390x",
 												"aarch64",
 												"i686",
-												"x86_64",
-												"ppc64le"
+												"ppc64le",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-test-debuginfo",
+											"architectures": [
+												"s390x",
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"x86_64"
 											]
 										}
 									},
@@ -1081,11 +842,11 @@
 											"name": "mysql:8.0::community-mysql",
 											"architectures": [
 												"ppc64le",
-												"src",
+												"x86_64",
 												"s390x",
+												"src",
 												"aarch64",
-												"i686",
-												"x86_64"
+												"i686"
 											]
 										}
 									},
@@ -1114,143 +875,11 @@
 										"binary": {
 											"name": "mysql:8.0::community-mysql-common",
 											"architectures": [
-												"ppc64le",
+												"x86_64",
 												"s390x",
 												"aarch64",
 												"i686",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-devel-debuginfo",
-											"architectures": [
-												"aarch64",
-												"i686",
-												"x86_64",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-libs",
-											"architectures": [
-												"aarch64",
-												"i686",
-												"x86_64",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-server",
-											"architectures": [
-												"i686",
-												"x86_64",
-												"ppc64le",
-												"s390x",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-test-debuginfo",
-											"architectures": [
-												"ppc64le",
-												"s390x",
-												"aarch64",
-												"i686",
-												"x86_64"
+												"ppc64le"
 											]
 										}
 									},
@@ -1279,11 +908,44 @@
 										"binary": {
 											"name": "mysql:8.0::community-mysql-debuginfo",
 											"architectures": [
-												"x86_64",
-												"ppc64le",
 												"s390x",
 												"aarch64",
-												"i686"
+												"i686",
+												"ppc64le",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-debugsource",
+											"architectures": [
+												"i686",
+												"ppc64le",
+												"x86_64",
+												"s390x",
+												"aarch64"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F38M/2023/FEDORA-MODULAR-2023-5b8a7bde59.json
+++ b/pkg/extract/fedora/testdata/golden/data/F38M/2023/FEDORA-MODULAR-2023-5b8a7bde59.json
@@ -31,8 +31,8 @@
 	"vulnerabilities": [
 		{
 			"content": {
-				"id": "CVE-2022-21608",
-				"title": "CVE-2022-21608 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
+				"id": "CVE-2022-21594",
+				"title": "CVE-2022-21594 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
 				"severity": [
 					{
 						"type": "vendor",
@@ -43,115 +43,11 @@
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142868"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142861"
 					}
 				],
-				"published": "2022-11-15T11:28:48Z",
-				"modified": "2023-09-22T09:15:24Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21617",
-				"title": "CVE-2022-21617 mysql: Server: Connection Handling unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142870"
-					}
-				],
-				"published": "2022-11-15T11:29:00Z",
-				"modified": "2023-09-22T09:15:40Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21637",
-				"title": "CVE-2022-21637 mysql: InnoDB unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142875"
-					}
-				],
-				"published": "2022-11-15T11:29:27Z",
-				"modified": "2023-09-22T09:16:17Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21640",
-				"title": "CVE-2022-21640 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142877"
-					}
-				],
-				"published": "2022-11-15T11:29:39Z",
-				"modified": "2023-09-22T09:16:30Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2023-21912",
-				"title": "CVE-2023-21912 mysql: Server: Security: Privileges unspecified vulnerability (CPU Apr 2023)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "high"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2188110"
-					}
-				],
-				"published": "2023-04-19T20:02:39Z",
-				"modified": "2023-05-17T03:44:59Z"
+				"published": "2022-11-15T11:28:08Z",
+				"modified": "2023-09-22T09:14:13Z"
 			},
 			"segments": [
 				{
@@ -213,8 +109,8 @@
 		},
 		{
 			"content": {
-				"id": "CVE-2022-39408",
-				"title": "CVE-2022-39408 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
+				"id": "CVE-2022-21604",
+				"title": "CVE-2022-21604 mysql: InnoDB unspecified vulnerability (CPU Oct 2022)",
 				"severity": [
 					{
 						"type": "vendor",
@@ -225,63 +121,11 @@
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142880"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142865"
 					}
 				],
-				"published": "2022-11-15T11:29:56Z",
-				"modified": "2023-09-22T09:16:57Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-39410",
-				"title": "CVE-2022-39410 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142881"
-					}
-				],
-				"published": "2022-11-15T11:30:02Z",
-				"modified": "2023-09-22T09:17:06Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2023-21917",
-				"title": "CVE-2023-21917 mysql: Server: Optimizer unspecified vulnerability (CPU Apr 2023)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2188112"
-					}
-				],
-				"published": "2023-04-19T20:02:49Z",
-				"modified": "2023-09-22T09:24:10Z"
+				"published": "2022-11-15T11:28:31Z",
+				"modified": "2023-09-22T09:14:52Z"
 			},
 			"segments": [
 				{
@@ -317,8 +161,8 @@
 		},
 		{
 			"content": {
-				"id": "CVE-2022-21632",
-				"title": "CVE-2022-21632 mysql: Server: Security: Privileges unspecified vulnerability (CPU Oct 2022)",
+				"id": "CVE-2022-21617",
+				"title": "CVE-2022-21617 mysql: Server: Connection Handling unspecified vulnerability (CPU Oct 2022)",
 				"severity": [
 					{
 						"type": "vendor",
@@ -329,11 +173,11 @@
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142872"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142870"
 					}
 				],
-				"published": "2022-11-15T11:29:11Z",
-				"modified": "2023-09-22T09:15:56Z"
+				"published": "2022-11-15T11:29:00Z",
+				"modified": "2023-09-22T09:15:40Z"
 			},
 			"segments": [
 				{
@@ -343,8 +187,8 @@
 		},
 		{
 			"content": {
-				"id": "CVE-2022-21633",
-				"title": "CVE-2022-21633 mysql: Server: Replication unspecified vulnerability (CPU Oct 2022)",
+				"id": "CVE-2022-21637",
+				"title": "CVE-2022-21637 mysql: InnoDB unspecified vulnerability (CPU Oct 2022)",
 				"severity": [
 					{
 						"type": "vendor",
@@ -355,11 +199,11 @@
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142873"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142875"
 					}
 				],
-				"published": "2022-11-15T11:29:16Z",
-				"modified": "2023-09-22T09:16:03Z"
+				"published": "2022-11-15T11:29:27Z",
+				"modified": "2023-09-22T09:16:17Z"
 			},
 			"segments": [
 				{
@@ -369,8 +213,8 @@
 		},
 		{
 			"content": {
-				"id": "CVE-2023-21865",
-				"title": "CVE-2023-21865 mysql: Server: Optimizer unspecified vulnerability (CPU Jan 2023)",
+				"id": "CVE-2022-39410",
+				"title": "CVE-2022-39410 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
 				"severity": [
 					{
 						"type": "vendor",
@@ -381,89 +225,11 @@
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2162272"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142881"
 					}
 				],
-				"published": "2023-01-19T09:23:01Z",
-				"modified": "2023-09-22T09:19:09Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2023-21874",
-				"title": "CVE-2023-21874 mysql: Server: Thread Pooling unspecified vulnerability (CPU Jan 2023)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "low"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2162281"
-					}
-				],
-				"published": "2023-01-19T09:23:49Z",
-				"modified": "2023-09-22T09:20:48Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21604",
-				"title": "CVE-2022-21604 mysql: InnoDB unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142865"
-					}
-				],
-				"published": "2022-11-15T11:28:31Z",
-				"modified": "2023-09-22T09:14:52Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:38"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2022-21625",
-				"title": "CVE-2022-21625 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142871"
-					}
-				],
-				"published": "2022-11-15T11:29:06Z",
-				"modified": "2023-09-22T09:15:47Z"
+				"published": "2022-11-15T11:30:02Z",
+				"modified": "2023-09-22T09:17:06Z"
 			},
 			"segments": [
 				{
@@ -499,8 +265,60 @@
 		},
 		{
 			"content": {
-				"id": "CVE-2022-21594",
-				"title": "CVE-2022-21594 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
+				"id": "CVE-2023-21874",
+				"title": "CVE-2023-21874 mysql: Server: Thread Pooling unspecified vulnerability (CPU Jan 2023)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "low"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2162281"
+					}
+				],
+				"published": "2023-01-19T09:23:49Z",
+				"modified": "2023-09-22T09:20:48Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-21912",
+				"title": "CVE-2023-21912 mysql: Server: Security: Privileges unspecified vulnerability (CPU Apr 2023)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "high"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2188110"
+					}
+				],
+				"published": "2023-04-19T20:02:39Z",
+				"modified": "2023-05-17T03:44:59Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21625",
+				"title": "CVE-2022-21625 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
 				"severity": [
 					{
 						"type": "vendor",
@@ -511,11 +329,531 @@
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142861"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142871"
 					}
 				],
-				"published": "2022-11-15T11:28:08Z",
-				"modified": "2023-09-22T09:14:13Z"
+				"published": "2022-11-15T11:29:06Z",
+				"modified": "2023-09-22T09:15:47Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21632",
+				"title": "CVE-2022-21632 mysql: Server: Security: Privileges unspecified vulnerability (CPU Oct 2022)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142872"
+					}
+				],
+				"published": "2022-11-15T11:29:11Z",
+				"modified": "2023-09-22T09:15:56Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21640",
+				"title": "CVE-2022-21640 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142877"
+					}
+				],
+				"published": "2022-11-15T11:29:39Z",
+				"modified": "2023-09-22T09:16:30Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-21917",
+				"title": "CVE-2023-21917 mysql: Server: Optimizer unspecified vulnerability (CPU Apr 2023)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2188112"
+					}
+				],
+				"published": "2023-04-19T20:02:49Z",
+				"modified": "2023-09-22T09:24:10Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21594",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21599",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21604",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21608",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21611",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21617",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21625",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21632",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21633",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21637",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21640",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-39400",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-39408",
+				"title": "CVE-2022-21594 CVE-2022-21599 CVE-2022-21604 CVE-2022-21608 CVE-2022-21611 CVE-2022-21617 CVE-2022-21625 CVE-2022-21632 CVE-2022-21633 CVE-2022-21637 CVE-2022-21640 CVE-2022-39400 CVE-2022-39408 ... mysql:8.0/community-mysql: various flaws [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142973"
+					}
+				],
+				"published": "2022-11-15T16:38:40Z",
+				"modified": "2023-09-16T00:28:34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21608",
+				"title": "CVE-2022-21608 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142868"
+					}
+				],
+				"published": "2022-11-15T11:28:48Z",
+				"modified": "2023-09-22T09:15:24Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-21633",
+				"title": "CVE-2022-21633 mysql: Server: Replication unspecified vulnerability (CPU Oct 2022)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142873"
+					}
+				],
+				"published": "2022-11-15T11:29:16Z",
+				"modified": "2023-09-22T09:16:03Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-39408",
+				"title": "CVE-2022-39408 mysql: Server: Optimizer unspecified vulnerability (CPU Oct 2022)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142880"
+					}
+				],
+				"published": "2022-11-15T11:29:56Z",
+				"modified": "2023-09-22T09:16:57Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:38"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-21865",
+				"title": "CVE-2023-21865 mysql: Server: Optimizer unspecified vulnerability (CPU Jan 2023)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2162272"
+					}
+				],
+				"published": "2023-01-19T09:23:01Z",
+				"modified": "2023-09-22T09:19:09Z"
 			},
 			"segments": [
 				{
@@ -542,11 +880,110 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "mysql:8.0::community-mysql-libs",
+											"name": "mysql:8.0::community-mysql-debugsource",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"aarch64",
+												"i686",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-devel",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"aarch64",
+												"i686",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-errmsg",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"aarch64",
+												"i686",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-libs-debuginfo",
 											"architectures": [
 												"i686",
-												"ppc64le",
 												"x86_64",
+												"ppc64le",
 												"s390x",
 												"aarch64"
 											]
@@ -575,12 +1012,12 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "mysql:8.0::community-mysql-server",
+											"name": "mysql:8.0::community-mysql-server-debuginfo",
 											"architectures": [
+												"ppc64le",
 												"s390x",
 												"aarch64",
 												"i686",
-												"ppc64le",
 												"x86_64"
 											]
 										}
@@ -613,7 +1050,41 @@
 												"s390x",
 												"aarch64",
 												"i686",
+												"x86_64",
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql",
+											"architectures": [
 												"ppc64le",
+												"src",
+												"s390x",
+												"aarch64",
+												"i686",
 												"x86_64"
 											]
 										}
@@ -644,241 +1115,9 @@
 											"name": "mysql:8.0::community-mysql-common",
 											"architectures": [
 												"ppc64le",
-												"x86_64",
-												"s390x",
-												"aarch64",
-												"i686"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-debuginfo",
-											"architectures": [
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"x86_64",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-debugsource",
-											"architectures": [
-												"i686",
-												"ppc64le",
-												"x86_64",
-												"s390x",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-devel",
-											"architectures": [
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"x86_64",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-libs-debuginfo",
-											"architectures": [
 												"s390x",
 												"aarch64",
 												"i686",
-												"ppc64le",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-server-debuginfo",
-											"architectures": [
-												"s390x",
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql-test-debuginfo",
-											"architectures": [
-												"s390x",
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
-											}
-										],
-										"fixed": [
-											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "mysql:8.0::community-mysql",
-											"architectures": [
-												"s390x",
-												"src",
-												"aarch64",
-												"i686",
-												"ppc64le",
 												"x86_64"
 											]
 										}
@@ -908,10 +1147,109 @@
 										"binary": {
 											"name": "mysql:8.0::community-mysql-devel-debuginfo",
 											"architectures": [
+												"aarch64",
+												"i686",
+												"x86_64",
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-libs",
+											"architectures": [
+												"aarch64",
+												"i686",
+												"x86_64",
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-server",
+											"architectures": [
+												"i686",
+												"x86_64",
+												"ppc64le",
+												"s390x",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:8.0.34-2.module_f38+17431+1f3fdb0a"
+											}
+										],
+										"fixed": [
+											"0:8.0.34-2.module_f38+17431+1f3fdb0a"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mysql:8.0::community-mysql-test-debuginfo",
+											"architectures": [
+												"ppc64le",
 												"s390x",
 												"aarch64",
 												"i686",
-												"ppc64le",
 												"x86_64"
 											]
 										}
@@ -939,13 +1277,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "mysql:8.0::community-mysql-errmsg",
+											"name": "mysql:8.0::community-mysql-debuginfo",
 											"architectures": [
+												"x86_64",
+												"ppc64le",
 												"s390x",
 												"aarch64",
-												"i686",
-												"ppc64le",
-												"x86_64"
+												"i686"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F40/2024/FEDORA-2024-900475e0f7.json
+++ b/pkg/extract/fedora/testdata/golden/data/F40/2024/FEDORA-2024-900475e0f7.json
@@ -106,6 +106,84 @@
 					"ecosystem": "fedora:40"
 				}
 			]
+		},
+		{
+			"content": {
+				"id": "CVE-2024-38439",
+				"title": "CVE-2024-38439 CVE-2024-38440 CVE-2024-38441 netatalk: multiple vulnerabilities [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2292818"
+					}
+				],
+				"published": "2024-06-18T03:21:22Z",
+				"modified": "2024-07-09T01:54:40Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:40"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2024-38440",
+				"title": "CVE-2024-38439 CVE-2024-38440 CVE-2024-38441 netatalk: multiple vulnerabilities [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2292818"
+					}
+				],
+				"published": "2024-06-18T03:21:22Z",
+				"modified": "2024-07-09T01:54:40Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:40"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2024-38441",
+				"title": "CVE-2024-38439 CVE-2024-38440 CVE-2024-38441 netatalk: multiple vulnerabilities [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2292818"
+					}
+				],
+				"published": "2024-06-18T03:21:22Z",
+				"modified": "2024-07-09T01:54:40Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:40"
+				}
+			]
 		}
 	],
 	"detections": [
@@ -126,14 +204,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "netatalk",
+											"name": "netatalk-devel",
 											"architectures": [
+												"s390x",
 												"x86_64",
 												"aarch64",
 												"i686",
-												"ppc64le",
-												"s390x",
-												"src"
+												"ppc64le"
 											]
 										}
 									},
@@ -162,11 +239,11 @@
 										"binary": {
 											"name": "netatalk-debugsource",
 											"architectures": [
+												"aarch64",
 												"i686",
 												"ppc64le",
 												"s390x",
-												"x86_64",
-												"aarch64"
+												"x86_64"
 											]
 										}
 									},
@@ -195,11 +272,11 @@
 										"binary": {
 											"name": "netatalk-debuginfo",
 											"architectures": [
+												"x86_64",
+												"aarch64",
 												"i686",
 												"ppc64le",
-												"s390x",
-												"x86_64",
-												"aarch64"
+												"s390x"
 											]
 										}
 									},
@@ -226,13 +303,14 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "netatalk-devel",
+											"name": "netatalk",
 											"architectures": [
+												"aarch64",
 												"i686",
 												"ppc64le",
 												"s390x",
-												"x86_64",
-												"aarch64"
+												"src",
+												"x86_64"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F40/2024/FEDORA-2024-900475e0f7.json
+++ b/pkg/extract/fedora/testdata/golden/data/F40/2024/FEDORA-2024-900475e0f7.json
@@ -32,110 +32,6 @@
 		{
 			"content": {
 				"id": "CVE-2024-38439",
-				"title": "CVE-2024-38439 CVE-2024-38441 CVE-2024-38440 netatalk: multiple vulnerabilities",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2292817"
-					}
-				],
-				"published": "2024-06-18T03:21:00Z",
-				"modified": "2024-06-29T16:25:44Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:40"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2024-38440",
-				"title": "CVE-2024-38439 CVE-2024-38441 CVE-2024-38440 netatalk: multiple vulnerabilities",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2292817"
-					}
-				],
-				"published": "2024-06-18T03:21:00Z",
-				"modified": "2024-06-29T16:25:44Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:40"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2024-38441",
-				"title": "CVE-2024-38439 CVE-2024-38441 CVE-2024-38440 netatalk: multiple vulnerabilities",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2292817"
-					}
-				],
-				"published": "2024-06-18T03:21:00Z",
-				"modified": "2024-06-29T16:25:44Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:40"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2024-38439",
-				"title": "CVE-2024-38439 CVE-2024-38440 CVE-2024-38441 netatalk: multiple vulnerabilities [fedora-all]",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "medium"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2292818"
-					}
-				],
-				"published": "2024-06-18T03:21:22Z",
-				"modified": "2024-07-09T01:54:40Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:40"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2024-38440",
 				"title": "CVE-2024-38439 CVE-2024-38440 CVE-2024-38441 netatalk: multiple vulnerabilities [fedora-all]",
 				"severity": [
 					{
@@ -162,6 +58,32 @@
 		{
 			"content": {
 				"id": "CVE-2024-38441",
+				"title": "CVE-2024-38439 CVE-2024-38440 CVE-2024-38441 netatalk: multiple vulnerabilities [fedora-all]",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2292818"
+					}
+				],
+				"published": "2024-06-18T03:21:22Z",
+				"modified": "2024-07-09T01:54:40Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:40"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2024-38440",
 				"title": "CVE-2024-38439 CVE-2024-38440 CVE-2024-38441 netatalk: multiple vulnerabilities [fedora-all]",
 				"severity": [
 					{
@@ -204,13 +126,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "netatalk-devel",
+											"name": "netatalk-debuginfo",
 											"architectures": [
+												"i686",
+												"ppc64le",
 												"s390x",
 												"x86_64",
-												"aarch64",
-												"i686",
-												"ppc64le"
+												"aarch64"
 											]
 										}
 									},
@@ -239,11 +161,11 @@
 										"binary": {
 											"name": "netatalk-debugsource",
 											"architectures": [
-												"aarch64",
 												"i686",
 												"ppc64le",
 												"s390x",
-												"x86_64"
+												"x86_64",
+												"aarch64"
 											]
 										}
 									},
@@ -270,8 +192,9 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "netatalk-debuginfo",
+											"name": "netatalk",
 											"architectures": [
+												"src",
 												"x86_64",
 												"aarch64",
 												"i686",
@@ -303,14 +226,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "netatalk",
+											"name": "netatalk-devel",
 											"architectures": [
-												"aarch64",
-												"i686",
 												"ppc64le",
 												"s390x",
-												"src",
-												"x86_64"
+												"x86_64",
+												"aarch64",
+												"i686"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F40/2025/FEDORA-2025-bca38111fc.json
+++ b/pkg/extract/fedora/testdata/golden/data/F40/2025/FEDORA-2025-bca38111fc.json
@@ -32,58 +32,6 @@
 		{
 			"content": {
 				"id": "CVE-2025-3416",
-				"title": "CVE-2025-3416 rust-openssl: rust-openssl Use-After-Free in `Md::fetch` and `Cipher::fetch`",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "low"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2357560"
-					}
-				],
-				"published": "2025-04-04T21:02:38Z",
-				"modified": "2025-09-01T08:28:32Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:40"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2025-3416",
-				"title": "CVE-2025-3416 icecat: rust-openssl Use-After-Free in `Md::fetch` and `Cipher::fetch` [fedora-40]",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "low"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2357926"
-					}
-				],
-				"published": "2025-04-07T14:56:16Z",
-				"modified": "2025-04-30T02:00:21Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:40"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2025-3416",
 				"title": "CVE-2025-3416 icecat: rust-openssl Use-After-Free in `Md::fetch` and `Cipher::fetch` [fedora-41]",
 				"severity": [
 					{
@@ -128,10 +76,10 @@
 										"binary": {
 											"name": "icecat-debuginfo",
 											"architectures": [
-												"s390x",
 												"x86_64",
 												"aarch64",
-												"ppc64le"
+												"ppc64le",
+												"s390x"
 											]
 										}
 									},
@@ -160,10 +108,10 @@
 										"binary": {
 											"name": "icecat-langpacks",
 											"architectures": [
-												"x86_64",
-												"aarch64",
 												"ppc64le",
-												"s390x"
+												"s390x",
+												"x86_64",
+												"aarch64"
 											]
 										}
 									},
@@ -192,11 +140,11 @@
 										"binary": {
 											"name": "icecat",
 											"architectures": [
-												"src",
 												"x86_64",
 												"aarch64",
 												"ppc64le",
-												"s390x"
+												"s390x",
+												"src"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F40/2025/FEDORA-2025-fd490bcdcd.json
+++ b/pkg/extract/fedora/testdata/golden/data/F40/2025/FEDORA-2025-fd490bcdcd.json
@@ -31,16 +31,6 @@
 	"vulnerabilities": [
 		{
 			"content": {
-				"id": "CVE-2025-26594"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:40"
-				}
-			]
-		},
-		{
-			"content": {
 				"id": "CVE-2025-26595"
 			},
 			"segments": [
@@ -108,6 +98,16 @@
 					"ecosystem": "fedora:40"
 				}
 			]
+		},
+		{
+			"content": {
+				"id": "CVE-2025-26594"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:40"
+				}
+			]
 		}
 	],
 	"detections": [
@@ -128,112 +128,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "xorg-x11-server-devel",
-											"architectures": [
-												"x86_64",
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-Xdmx-debuginfo",
-											"architectures": [
-												"x86_64",
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-Xephyr-debuginfo",
-											"architectures": [
-												"s390x",
-												"x86_64",
-												"aarch64",
-												"i686",
-												"ppc64le"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
 											"name": "xorg-x11-server-Xorg-debuginfo",
 											"architectures": [
-												"i686",
 												"ppc64le",
 												"s390x",
 												"x86_64",
-												"aarch64"
+												"aarch64",
+												"i686"
 											]
 										}
 									},
@@ -262,6 +163,171 @@
 										"binary": {
 											"name": "xorg-x11-server-Xnest-debuginfo",
 											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-Xvfb-debuginfo",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-debugsource",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-Xephyr",
+											"architectures": [
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-Xvfb",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-Xephyr-debuginfo",
+											"architectures": [
 												"i686",
 												"ppc64le",
 												"s390x",
@@ -293,13 +359,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "xorg-x11-server-Xdmx",
+											"name": "xorg-x11-server-Xdmx-debuginfo",
 											"architectures": [
+												"ppc64le",
+												"s390x",
 												"x86_64",
 												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x"
+												"i686"
 											]
 										}
 									},
@@ -326,13 +392,79 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "xorg-x11-server-Xorg",
+											"name": "xorg-x11-server-common",
 											"architectures": [
+												"ppc64le",
+												"s390x",
 												"x86_64",
+												"aarch64",
+												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-debuginfo",
+											"architectures": [
 												"aarch64",
 												"i686",
 												"ppc64le",
-												"s390x"
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-Xnest",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"i686"
 											]
 										}
 									},
@@ -388,105 +520,6 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "xorg-x11-server-debugsource",
-											"architectures": [
-												"x86_64",
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-debuginfo",
-											"architectures": [
-												"s390x",
-												"x86_64",
-												"aarch64",
-												"i686",
-												"ppc64le"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-Xvfb",
-											"architectures": [
-												"x86_64",
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
 											"name": "xorg-x11-server-source",
 											"architectures": [
 												"noarch"
@@ -516,46 +549,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "xorg-x11-server-Xvfb-debuginfo",
+											"name": "xorg-x11-server-Xorg",
 											"architectures": [
-												"aarch64",
-												"i686",
 												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-Xephyr",
-											"architectures": [
 												"s390x",
 												"x86_64",
 												"aarch64",
-												"i686",
-												"ppc64le"
+												"i686"
 											]
 										}
 									},
@@ -582,13 +582,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "xorg-x11-server-common",
+											"name": "xorg-x11-server-Xdmx",
 											"architectures": [
+												"ppc64le",
+												"s390x",
 												"x86_64",
 												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x"
+												"i686"
 											]
 										}
 									},
@@ -615,13 +615,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "xorg-x11-server-Xnest",
+											"name": "xorg-x11-server-devel",
 											"architectures": [
-												"aarch64",
 												"i686",
 												"ppc64le",
 												"s390x",
-												"x86_64"
+												"x86_64",
+												"aarch64"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F40/2025/FEDORA-2025-fd490bcdcd.json
+++ b/pkg/extract/fedora/testdata/golden/data/F40/2025/FEDORA-2025-fd490bcdcd.json
@@ -128,203 +128,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "xorg-x11-server-source",
+											"name": "xorg-x11-server-devel",
 											"architectures": [
-												"noarch"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-Xdmx",
-											"architectures": [
-												"i686",
-												"ppc64le",
-												"s390x",
 												"x86_64",
-												"aarch64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-Xephyr",
-											"architectures": [
 												"aarch64",
 												"i686",
 												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-Xephyr-debuginfo",
-											"architectures": [
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-debuginfo",
-											"architectures": [
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server",
-											"architectures": [
-												"src"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-debugsource",
-											"architectures": [
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x",
-												"x86_64"
+												"s390x"
 											]
 										}
 									},
@@ -384,79 +194,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "xorg-x11-server-Xorg",
+											"name": "xorg-x11-server-Xephyr-debuginfo",
 											"architectures": [
-												"ppc64le",
 												"s390x",
 												"x86_64",
 												"aarch64",
-												"i686"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-Xnest",
-											"architectures": [
-												"aarch64",
 												"i686",
-												"ppc64le",
-												"s390x",
-												"x86_64"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.20.14-37.fc40"
-											}
-										],
-										"fixed": [
-											"0:1.20.14-37.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "xorg-x11-server-devel",
-											"architectures": [
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x",
-												"x86_64"
+												"ppc64le"
 											]
 										}
 									},
@@ -485,11 +229,11 @@
 										"binary": {
 											"name": "xorg-x11-server-Xorg-debuginfo",
 											"architectures": [
-												"aarch64",
 												"i686",
 												"ppc64le",
 												"s390x",
-												"x86_64"
+												"x86_64",
+												"aarch64"
 											]
 										}
 									},
@@ -518,11 +262,11 @@
 										"binary": {
 											"name": "xorg-x11-server-Xnest-debuginfo",
 											"architectures": [
-												"aarch64",
 												"i686",
 												"ppc64le",
 												"s390x",
-												"x86_64"
+												"x86_64",
+												"aarch64"
 											]
 										}
 									},
@@ -549,7 +293,7 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "xorg-x11-server-Xvfb-debuginfo",
+											"name": "xorg-x11-server-Xdmx",
 											"architectures": [
 												"x86_64",
 												"aarch64",
@@ -582,7 +326,230 @@
 									"package": {
 										"type": "binary",
 										"binary": {
+											"name": "xorg-x11-server-Xorg",
+											"architectures": [
+												"x86_64",
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server",
+											"architectures": [
+												"src"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-debugsource",
+											"architectures": [
+												"x86_64",
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-debuginfo",
+											"architectures": [
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"i686",
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
 											"name": "xorg-x11-server-Xvfb",
+											"architectures": [
+												"x86_64",
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-source",
+											"architectures": [
+												"noarch"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-Xvfb-debuginfo",
+											"architectures": [
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-Xephyr",
 											"architectures": [
 												"s390x",
 												"x86_64",
@@ -617,11 +584,44 @@
 										"binary": {
 											"name": "xorg-x11-server-common",
 											"architectures": [
+												"x86_64",
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.20.14-37.fc40"
+											}
+										],
+										"fixed": [
+											"0:1.20.14-37.fc40"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "xorg-x11-server-Xnest",
+											"architectures": [
+												"aarch64",
 												"i686",
 												"ppc64le",
 												"s390x",
-												"x86_64",
-												"aarch64"
+												"x86_64"
 											]
 										}
 									},

--- a/pkg/extract/fedora/testdata/golden/data/F42/2025/FEDORA-2025-f5bf0fb721.json
+++ b/pkg/extract/fedora/testdata/golden/data/F42/2025/FEDORA-2025-f5bf0fb721.json
@@ -1,29 +1,29 @@
 {
-	"id": "FEDORA-2025-bca38111fc",
+	"id": "FEDORA-2025-f5bf0fb721",
 	"advisories": [
 		{
 			"content": {
-				"id": "FEDORA-2025-bca38111fc",
-				"title": "icecat-115.22.0-2.rh1.fc40",
-				"description": "- Rebuild with pregenerated cbindgen",
+				"id": "FEDORA-2025-f5bf0fb721",
+				"title": "libvpx-1.15.0-3.fc42",
+				"description": "Add patch for double free",
 				"severity": [
 					{
 						"type": "vendor",
 						"source": "fedoraproject.org",
-						"vendor": "unspecified"
+						"vendor": "urgent"
 					}
 				],
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bodhi.fedoraproject.org/updates/FEDORA-2025-bca38111fc"
+						"url": "https://bodhi.fedoraproject.org/updates/FEDORA-2025-f5bf0fb721"
 					}
 				],
-				"published": "2025-04-21T16:20:39Z"
+				"published": "2025-06-03T15:07:33Z"
 			},
 			"segments": [
 				{
-					"ecosystem": "fedora:40"
+					"ecosystem": "fedora:42"
 				}
 			]
 		}
@@ -31,86 +31,60 @@
 	"vulnerabilities": [
 		{
 			"content": {
-				"id": "CVE-2025-3416",
-				"title": "CVE-2025-3416 rust-openssl: rust-openssl Use-After-Free in `Md::fetch` and `Cipher::fetch`",
+				"id": "CVE-2025-5283",
+				"title": "CVE-2025-5283 libvpx: Double-free in libvpx encoder",
 				"severity": [
 					{
 						"type": "vendor",
 						"source": "fedoraproject.org",
-						"vendor": "low"
+						"vendor": "high"
 					}
 				],
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2357560"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2368749"
 					}
 				],
-				"published": "2025-04-04T21:02:38Z",
-				"modified": "2025-09-01T08:28:32Z"
+				"published": "2025-05-27T13:01:16Z",
+				"modified": "2025-09-01T08:28:30Z"
 			},
 			"segments": [
 				{
-					"ecosystem": "fedora:40"
+					"ecosystem": "fedora:42"
 				}
 			]
 		},
 		{
 			"content": {
-				"id": "CVE-2025-3416",
-				"title": "CVE-2025-3416 icecat: rust-openssl Use-After-Free in `Md::fetch` and `Cipher::fetch` [fedora-40]",
+				"id": "CVE-2025-5262",
+				"title": "CVE-2025-5262 libvpx: Double-free in libvpx encoder [fedora-all]",
 				"severity": [
 					{
 						"type": "vendor",
 						"source": "fedoraproject.org",
-						"vendor": "low"
+						"vendor": "urgent"
 					}
 				],
 				"references": [
 					{
 						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2357926"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2368931"
 					}
 				],
-				"published": "2025-04-07T14:56:16Z",
-				"modified": "2025-04-30T02:00:21Z"
+				"published": "2025-05-28T10:02:45Z",
+				"modified": "2025-06-08T02:31:45Z"
 			},
 			"segments": [
 				{
-					"ecosystem": "fedora:40"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2025-3416",
-				"title": "CVE-2025-3416 icecat: rust-openssl Use-After-Free in `Md::fetch` and `Cipher::fetch` [fedora-41]",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "low"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2357938"
-					}
-				],
-				"published": "2025-04-07T14:57:18Z",
-				"modified": "2025-04-30T02:00:23Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:40"
+					"ecosystem": "fedora:42"
 				}
 			]
 		}
 	],
 	"detections": [
 		{
-			"ecosystem": "fedora:40",
+			"ecosystem": "fedora:42",
 			"conditions": [
 				{
 					"criteria": {
@@ -126,42 +100,11 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "icecat-debuginfo",
-											"architectures": [
-												"s390x",
-												"x86_64",
-												"aarch64",
-												"ppc64le"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "2:115.22.0-2.rh1.fc40"
-											}
-										],
-										"fixed": [
-											"2:115.22.0-2.rh1.fc40"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "icecat-langpacks",
+											"name": "libvpx-utils-debuginfo",
 											"architectures": [
 												"x86_64",
 												"aarch64",
+												"i686",
 												"ppc64le",
 												"s390x"
 											]
@@ -171,11 +114,11 @@
 										"type": "rpm",
 										"range": [
 											{
-												"lt": "2:115.22.0-2.rh1.fc40"
+												"lt": "0:1.15.0-3.fc42"
 											}
 										],
 										"fixed": [
-											"2:115.22.0-2.rh1.fc40"
+											"0:1.15.0-3.fc42"
 										]
 									}
 								}
@@ -190,11 +133,78 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "icecat",
+											"name": "libvpx-utils",
+											"architectures": [
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.15.0-3.fc42"
+											}
+										],
+										"fixed": [
+											"0:1.15.0-3.fc42"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libvpx-debuginfo",
+											"architectures": [
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64",
+												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.15.0-3.fc42"
+											}
+										],
+										"fixed": [
+											"0:1.15.0-3.fc42"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libvpx",
 											"architectures": [
 												"src",
 												"x86_64",
 												"aarch64",
+												"i686",
 												"ppc64le",
 												"s390x"
 											]
@@ -204,11 +214,11 @@
 										"type": "rpm",
 										"range": [
 											{
-												"lt": "2:115.22.0-2.rh1.fc40"
+												"lt": "0:1.15.0-3.fc42"
 											}
 										],
 										"fixed": [
-											"2:115.22.0-2.rh1.fc40"
+											"0:1.15.0-3.fc42"
 										]
 									}
 								}
@@ -223,12 +233,13 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "icecat-debugsource",
+											"name": "libvpx-devel",
 											"architectures": [
+												"ppc64le",
+												"s390x",
 												"x86_64",
 												"aarch64",
-												"ppc64le",
-												"s390x"
+												"i686"
 											]
 										}
 									},
@@ -236,11 +247,44 @@
 										"type": "rpm",
 										"range": [
 											{
-												"lt": "2:115.22.0-2.rh1.fc40"
+												"lt": "0:1.15.0-3.fc42"
 											}
 										],
 										"fixed": [
-											"2:115.22.0-2.rh1.fc40"
+											"0:1.15.0-3.fc42"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libvpx-debugsource",
+											"architectures": [
+												"i686",
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.15.0-3.fc42"
+											}
+										],
+										"fixed": [
+											"0:1.15.0-3.fc42"
 										]
 									}
 								}
@@ -254,7 +298,7 @@
 	"data_source": {
 		"id": "fedora",
 		"raws": [
-			"fixtures/F40/2025/FEDORA-2025-bca38111fc.json"
+			"fixtures/F42/2025/FEDORA-2025-f5bf0fb721.json"
 		]
 	}
 }

--- a/pkg/extract/fedora/testdata/golden/data/F42/2025/FEDORA-2025-f5bf0fb721.json
+++ b/pkg/extract/fedora/testdata/golden/data/F42/2025/FEDORA-2025-f5bf0fb721.json
@@ -31,32 +31,6 @@
 	"vulnerabilities": [
 		{
 			"content": {
-				"id": "CVE-2025-5283",
-				"title": "CVE-2025-5283 libvpx: Double-free in libvpx encoder",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "fedoraproject.org",
-						"vendor": "high"
-					}
-				],
-				"references": [
-					{
-						"source": "fedoraproject.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2368749"
-					}
-				],
-				"published": "2025-05-27T13:01:16Z",
-				"modified": "2025-09-01T08:28:30Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "fedora:42"
-				}
-			]
-		},
-		{
-			"content": {
 				"id": "CVE-2025-5262",
 				"title": "CVE-2025-5262 libvpx: Double-free in libvpx encoder [fedora-all]",
 				"severity": [
@@ -74,6 +48,32 @@
 				],
 				"published": "2025-05-28T10:02:45Z",
 				"modified": "2025-06-08T02:31:45Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "fedora:42"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2025-5283",
+				"title": "CVE-2025-5283 libvpx: Double-free in libvpx encoder",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fedoraproject.org",
+						"vendor": "high"
+					}
+				],
+				"references": [
+					{
+						"source": "fedoraproject.org",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2368749"
+					}
+				],
+				"published": "2025-05-27T13:01:16Z",
+				"modified": "2025-09-01T08:28:30Z"
 			},
 			"segments": [
 				{
@@ -100,46 +100,14 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "libvpx-utils-debuginfo",
+											"name": "libvpx",
 											"architectures": [
+												"s390x",
+												"src",
 												"x86_64",
 												"aarch64",
 												"i686",
-												"ppc64le",
-												"s390x"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.15.0-3.fc42"
-											}
-										],
-										"fixed": [
-											"0:1.15.0-3.fc42"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "libvpx-utils",
-											"architectures": [
-												"aarch64",
-												"i686",
-												"ppc64le",
-												"s390x",
-												"x86_64"
+												"ppc64le"
 											]
 										}
 									},
@@ -199,9 +167,74 @@
 									"package": {
 										"type": "binary",
 										"binary": {
-											"name": "libvpx",
+											"name": "libvpx-utils",
 											"architectures": [
-												"src",
+												"i686",
+												"ppc64le",
+												"s390x",
+												"x86_64",
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.15.0-3.fc42"
+											}
+										],
+										"fixed": [
+											"0:1.15.0-3.fc42"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libvpx-utils-debuginfo",
+											"architectures": [
+												"x86_64",
+												"aarch64",
+												"i686",
+												"ppc64le",
+												"s390x"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.15.0-3.fc42"
+											}
+										],
+										"fixed": [
+											"0:1.15.0-3.fc42"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "libvpx-debugsource",
+											"architectures": [
 												"x86_64",
 												"aarch64",
 												"i686",
@@ -234,39 +267,6 @@
 										"type": "binary",
 										"binary": {
 											"name": "libvpx-devel",
-											"architectures": [
-												"ppc64le",
-												"s390x",
-												"x86_64",
-												"aarch64",
-												"i686"
-											]
-										}
-									},
-									"affected": {
-										"type": "rpm",
-										"range": [
-											{
-												"lt": "0:1.15.0-3.fc42"
-											}
-										],
-										"fixed": [
-											"0:1.15.0-3.fc42"
-										]
-									}
-								}
-							},
-							{
-								"type": "version",
-								"version": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "fixed"
-									},
-									"package": {
-										"type": "binary",
-										"binary": {
-											"name": "libvpx-debugsource",
 											"architectures": [
 												"i686",
 												"ppc64le",


### PR DESCRIPTION
As in F42/2025/FEDORA-2025-f5bf0fb721, there were cases where the CVE-ID obtained from the alias by tracing blocked was different from the CVE-ID written in bugzilla's short_desc.
With this PR, we will also collect CVE-IDs from bugzilla's short_desc.