### PR TITLE
fix(extract/redhat/csaf,vex): adjust for redhat data bugs

### DIFF
--- a/pkg/extract/redhat/csaf/csaf.go
+++ b/pkg/extract/redhat/csaf/csaf.go
@@ -170,7 +170,7 @@ func Extract(csafDir, repository2cpeDir string, opts ...Option) error {
 }
 
 func (e extractor) extract(adv csaf.CSAF, c2r map[string][]string) (dataTypes.Data, error) {
-	pm, err := walkProductTree(adv.ProductTree, c2r)
+	pm, err := walkProductTree(adv.Document.Tracking.ID, adv.ProductTree, c2r)
 	if err != nil {
 		return dataTypes.Data{}, errors.Wrap(err, "walk product_tree")
 	}
@@ -256,7 +256,7 @@ type status struct {
 	AffectedStatus string
 }
 
-func walkProductTree(pt csaf.ProductTree, c2r map[string][]string) (map[csaf.ProductID][]product, error) {
+func walkProductTree(cveid string, pt csaf.ProductTree, c2r map[string][]string) (map[csaf.ProductID][]product, error) {
 	var f func(m map[csaf.ProductID]csaf.FullProductName, branch csaf.Branch) error
 	f = func(m map[csaf.ProductID]csaf.FullProductName, branch csaf.Branch) error {
 		for _, b := range branch.Branches {
@@ -362,12 +362,18 @@ func walkProductTree(pt csaf.ProductTree, c2r map[string][]string) (map[csaf.Pro
 								// binary rpm: 'arch=<arch>'
 								switch m["arch"] {
 								case "":
+									// Red Hat VEX data bug: https://issues.redhat.com/browse/SECDATA-1097?focusedId=28054960&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28054960
+									if slices.Contains([]string{"CVE-2025-26699", "CVE-2025-30472", "CVE-2025-47287", "CVE-2025-48432"}, cveid) {
+										return nil, nil
+									}
 									return nil, errors.Errorf("unexpected purl format. expected: %q, actual: %q", "pkg:rpm/redhat/<name>@<version>?arch=<arch>(&epoch=<epoch>)", fpn.ProductIdentificationHelper.PURL)
 								default:
 									p.arch = m["arch"]
 								}
 							}
 						default:
+							// Red Hat VEX data bug: https://issues.redhat.com/browse/SECDATA-1097?focusedId=28062364&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28062364
+
 							switch instance.Version {
 							case "":
 								return nil, errors.Errorf("unexpected purl format. expected: %q, actual: %q", "pkg:rpm/redhat/<name>@<version>?arch=<arch>(&epoch=<epoch>)&rpmmod=<<module>:<stream>:<version>:<context>(:<arch>)>", fpn.ProductIdentificationHelper.PURL)

--- a/pkg/extract/redhat/vex/testdata/golden/data/2023/CVE-2023-6212.json
+++ b/pkg/extract/redhat/vex/testdata/golden/data/2023/CVE-2023-6212.json
@@ -1852,6 +1852,38 @@
 										}
 									}
 								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed",
+										"vendor": "Out of support scope"
+									},
+									"package": {
+										"type": "source",
+										"source": {
+											"name": "firefox"
+										}
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed",
+										"vendor": "Out of support scope"
+									},
+									"package": {
+										"type": "source",
+										"source": {
+											"name": "thunderbird"
+										}
+									}
+								}
 							}
 						]
 					},

--- a/pkg/extract/redhat/vex/testdata/golden/data/2023/CVE-2023-6228.json
+++ b/pkg/extract/redhat/vex/testdata/golden/data/2023/CVE-2023-6228.json
@@ -400,6 +400,22 @@
 										}
 									}
 								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed",
+										"vendor": "Out of support scope"
+									},
+									"package": {
+										"type": "source",
+										"source": {
+											"name": "libtiff"
+										}
+									}
+								}
 							}
 						]
 					},
@@ -490,6 +506,38 @@
 										"type": "binary",
 										"binary": {
 											"name": "libtiff-tools"
+										}
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed",
+										"vendor": "Out of support scope"
+									},
+									"package": {
+										"type": "source",
+										"source": {
+											"name": "compat-libtiff3"
+										}
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed",
+										"vendor": "Out of support scope"
+									},
+									"package": {
+										"type": "source",
+										"source": {
+											"name": "libtiff"
 										}
 									}
 								}

--- a/pkg/extract/redhat/vex/testdata/golden/data/2024/CVE-2024-56171.json
+++ b/pkg/extract/redhat/vex/testdata/golden/data/2024/CVE-2024-56171.json
@@ -1035,6 +1035,22 @@
 										}
 									}
 								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed",
+										"vendor": "Affected"
+									},
+									"package": {
+										"type": "source",
+										"source": {
+											"name": "libxml2"
+										}
+									}
+								}
 							}
 						]
 					},
@@ -1109,6 +1125,22 @@
 										"type": "binary",
 										"binary": {
 											"name": "libxml2-static"
+										}
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed",
+										"vendor": "Out of support scope"
+									},
+									"package": {
+										"type": "source",
+										"source": {
+											"name": "libxml2"
 										}
 									}
 								}


### PR DESCRIPTION
```console
$ vuls-data-update dotgit pull --restore ghcr.io/vulsio/vuls-data-db:vuls-data-raw-redhat-repository-to-cpe

$ vuls-data-update dotgit pull --restore ghcr.io/vulsio/vuls-data-db:vuls-data-raw-redhat-vex
$ vuls-data-update extract redhat-vex ~/.cache/vuls-data-update/dotgit/ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-vex ~/.cache/vuls-data-update/dotgit/ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-repository-to-cpe

$ vuls-data-update dotgit pull --restore ghcr.io/vulsio/vuls-data-db:vuls-data-raw-redhat-csaf
$ vuls-data-update extract redhat-csaf ~/.cache/vuls-data-update/dotgit/ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-csaf ~/.cache/vuls-data-update/dotgit/ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-repository-to-cpe
```