### PR TITLE
fix(dotgit/pull): properly delete pulled directory

### DIFF
--- a/pkg/dotgit/pull/pull.go
+++ b/pkg/dotgit/pull/pull.go
@@ -80,8 +80,8 @@ func Pull(repository string, opts ...Option) error {
 		return errors.Errorf("unexpected repository format. expected: %q, actual: %q", []string{"<repository>@<digest>", "<repository>:<tag>", "<repository>:<tag>@<digest>"}, repository)
 	}
 
-	if err := os.RemoveAll(filepath.Join(options.dir, repo.Reference.Reference)); err != nil {
-		return errors.Wrapf(err, "remove %s", filepath.Join(options.dir, repo.Reference.Reference))
+	if err := os.RemoveAll(filepath.Join(options.dir, repo.Reference.Registry, repo.Reference.Repository, repo.Reference.Reference)); err != nil {
+		return errors.Wrapf(err, "remove %s", filepath.Join(options.dir, repo.Reference.Registry, repo.Reference.Repository, repo.Reference.Reference))
 	}
 
 	_, r, err := oras.Fetch(ctx, repo, repo.Reference.Reference, oras.DefaultFetchOptions)


### PR DESCRIPTION
## before
```console
$ mkdir vuls-data-raw-redhat-repository-to-cpe
$ mkdir -p ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-repository-to-cpe
$ touch ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-repository-to-cpe/test
$ vuls-data-update dotgit pull --dir . ghcr.io/vulsio/vuls-data-db:vuls-data-raw-redhat-repository-to-cpe

$ ls
ghcr.io/

$ git -C ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-repository-to-cpe status
On branch main
Your branch is ahead of 'origin/main' by 209 commits.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    repository-to-cpe.json

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	test

no changes added to commit (use "git add" and/or "git commit -a")
```

## after
```console
$ mkdir vuls-data-raw-redhat-repository-to-cpe
$ mkdir -p ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-repository-to-cpe
$ touch ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-repository-to-cpe/test
$ vuls-data-update dotgit pull --dir . ghcr.io/vulsio/vuls-data-db:vuls-data-raw-redhat-repository-to-cpe

$ ls
ghcr.io/  vuls-data-raw-redhat-repository-to-cpe/

$ git -C ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-repository-to-cpe status
On branch main
Your branch is ahead of 'origin/main' by 209 commits.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    repository-to-cpe.json

no changes added to commit (use "git add" and/or "git commit -a")
```