### PR TITLE
fix(fetch/suse/oval): Exclude slem 5-affected

### DIFF
--- a/pkg/fetch/suse/oval/oval.go
+++ b/pkg/fetch/suse/oval/oval.go
@@ -248,6 +248,12 @@ func (opts options) walkIndexOf() ([]string, error) {
 			!strings.HasPrefix(txt, "suse.linux.enterprise.micro") {
 			return
 		}
+		switch txt {
+		case "suse.linux.enterprise.micro.5-affected.xml.gz", "suse.linux.enterprise.micro.5-patch.xml.gz", "suse.linux.enterprise.micro.5.xml.gz":
+			// SLEM 5 series has "5" and "5.y". SLEM 6 series has "6.y" only. Exclude "5" here.
+			return
+		default:
+		}
 
 		switch {
 		case strings.Contains(txt, "-affected"):

--- a/pkg/fetch/suse/oval/oval.go
+++ b/pkg/fetch/suse/oval/oval.go
@@ -239,20 +239,20 @@ func (opts options) walkIndexOf() ([]string, error) {
 		if !strings.HasSuffix(txt, ".xml.gz") {
 			return
 		}
-		if !strings.HasPrefix(txt, "opensuse") &&
-			!strings.HasPrefix(txt, "opensuse.leap") &&
-			!strings.HasPrefix(txt, "opensuse.leap.micro") &&
-			!strings.HasPrefix(txt, "opensuse.tumbleweed") &&
-			!strings.HasPrefix(txt, "suse.linux.enterprise.desktop") &&
-			!strings.HasPrefix(txt, "suse.linux.enterprise.server") &&
-			!strings.HasPrefix(txt, "suse.linux.enterprise.micro") {
+
+		switch {
+		case strings.HasPrefix(txt, "opensuse"), strings.HasPrefix(txt, "opensuse.leap"), strings.HasPrefix(txt, "opensuse.leap.micro"), strings.HasPrefix(txt, "opensuse.tumbleweed"),
+			strings.HasPrefix(txt, "suse.linux.enterprise.desktop"), strings.HasPrefix(txt, "suse.linux.enterprise.server"):
 			return
-		}
-		switch txt {
-		case "suse.linux.enterprise.micro.5-affected.xml.gz", "suse.linux.enterprise.micro.5-patch.xml.gz", "suse.linux.enterprise.micro.5.xml.gz":
-			// SLEM 5 series has "5" and "5.y". SLEM 6 series has "6.y" only. Exclude "5" here.
-			return
+		case strings.HasPrefix(txt, "suse.linux.enterprise.micro"):
+			switch txt {
+			case "suse.linux.enterprise.micro.5-affected.xml.gz", "suse.linux.enterprise.micro.5-patch.xml.gz", "suse.linux.enterprise.micro.5.xml.gz":
+				// SLEM 5 series has "5" and "5.y". SLEM 6 series has "6.y" only. Exclude "5" here.
+				return
+			default:
+			}
 		default:
+			return
 		}
 
 		switch {


### PR DESCRIPTION
SLEM 5 series has duplicated xml files at https://ftp.suse.com/pub/projects/security/oval/
- one is version "5"
- others are version "5.y"

SLEM 6 series has only "6.y" ones. This PR picks "5.y" and exclude "5".

----------

Before:

```
% ll ~/.cache/vdu/fetch/suse/oval-before/suse.linux.enterprise.micro
total 36K
drwxr-xr-x 4 shino shino 4.0K Oct  7 17:40 5/
drwxr-xr-x 4 shino shino 4.0K Oct  7 17:41 5.0/
drwxr-xr-x 4 shino shino 4.0K Oct  7 17:41 5.1/
drwxr-xr-x 4 shino shino 4.0K Oct  7 17:42 5.2/
drwxr-xr-x 4 shino shino 4.0K Oct  7 17:41 5.3/
drwxr-xr-x 4 shino shino 4.0K Oct  7 17:41 5.4/
drwxr-xr-x 4 shino shino 4.0K Oct  7 17:40 5.5/
drwxr-xr-x 4 shino shino 4.0K Oct  7 17:42 6.0/
drwxr-xr-x 4 shino shino 4.0K Oct  7 17:42 6.1/
```

After:

```
% ll ~/.cache/vdu/fetch/suse/oval/suse.linux.enterprise.micro/
total 32K
drwxr-xr-x 4 shino shino 4.0K Oct  7 18:06 5.0/
drwxr-xr-x 4 shino shino 4.0K Oct  7 18:10 5.1/
drwxr-xr-x 4 shino shino 4.0K Oct  7 18:07 5.2/
drwxr-xr-x 4 shino shino 4.0K Oct  7 18:06 5.3/
drwxr-xr-x 4 shino shino 4.0K Oct  7 18:07 5.4/
drwxr-xr-x 4 shino shino 4.0K Oct  7 18:09 5.5/
drwxr-xr-x 4 shino shino 4.0K Oct  7 18:06 6.0/
drwxr-xr-x 4 shino shino 4.0K Oct  7 18:05 6.1/
```