### PR TITLE
feat(affected/range): RPM version only type

### DIFF
--- a/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range/range.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range/range.go
@@ -28,6 +28,7 @@ const (
 	RangeTypeSEMVER
 	RangeTypeAPK
 	RangeTypeRPM
+	RangeTypeRPMVersionOnly
 	RangeTypeDPKG
 	RangeTypePacman
 	RangeTypeFreeBSDPkg
@@ -49,6 +50,8 @@ func (t RangeType) String() string {
 		return "apk"
 	case RangeTypeRPM:
 		return "rpm"
+	case RangeTypeRPMVersionOnly:
+		return "rpm-version-only"
 	case RangeTypeDPKG:
 		return "dpkg"
 	case RangeTypePacman:
@@ -92,6 +95,8 @@ func (t *RangeType) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 		*t = RangeTypeAPK
 	case "rpm":
 		*t = RangeTypeRPM
+	case "rpm-version-only":
+		*t = RangeTypeRPMVersionOnly
 	case "dpkg":
 		*t = RangeTypeDPKG
 	case "pacman":
@@ -134,6 +139,8 @@ func (t *RangeType) UnmarshalJSON(data []byte) error {
 		rt = RangeTypeAPK
 	case "rpm":
 		rt = RangeTypeRPM
+	case "rpm-version-only":
+		rt = RangeTypeRPMVersionOnly
 	case "dpkg":
 		rt = RangeTypeDPKG
 	case "pacman":
@@ -290,6 +297,10 @@ func (t RangeType) Compare(family ecosystemTypes.Ecosystem, v1, v2 string) (int,
 			}
 			return rpm.NewVersion(v1).Compare(rpm.NewVersion(v2)), nil
 		}
+	case RangeTypeRPMVersionOnly:
+		va := rpm.NewVersion(v1)
+		vb := rpm.NewVersion(v2)
+		return rpm.NewVersion(va.Version()).Compare(rpm.NewVersion(vb.Version())), nil
 	case RangeTypeDPKG:
 		va, err := deb.NewVersion(v1)
 		if err != nil {

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range/range_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range/range_test.go
@@ -372,6 +372,41 @@ func TestRangeType_Compare(t *testing.T) {
 			want: -1,
 		},
 		{
+			name: "rpm version only v1: 0.0.1, v2: 0.0.1",
+			rt:   affectedrangeTypes.RangeTypeRPMVersionOnly,
+			args: args{
+				v1: "0.0.1",
+				v2: "0.0.1",
+			},
+			want: 0,
+		},
+		{
+			name: "rpm version only v1: 1:0.0.1-1, v2: 0.0.2",
+			rt:   affectedrangeTypes.RangeTypeRPMVersionOnly,
+			args: args{
+				v1: "1:0.0.1-1",
+				v2: "0.0.2",
+			},
+			want: -1,
+		},
+		{
+			name: "rpm version only v1: 1:0.0.2, v2: 0.0.1",
+			rt:   affectedrangeTypes.RangeTypeRPMVersionOnly,
+			args: args{
+				v1: "1:0.0.2",
+				v2: "0.0.1",
+			},
+			want: +1,
+		},
+		{
+			name: "rpm version only v1: 1:0.0.1-1, v2: 0.0.1",
+			rt:   affectedrangeTypes.RangeTypeRPMVersionOnly,
+			args: args{
+				v1: "1:0.0.1-1",
+				v2: "0.0.1",
+			},
+			want: 0,
+		}, {
 			name: "unknown type",
 			rt:   affectedrangeTypes.RangeTypeUnknown,
 			args: args{


### PR DESCRIPTION
Will be used in SUSE extract.
If this type is introduced, old JSON custom handlers will emit errors in (un)marshalling. So this PR is separated from SUSE extract one to apply as early as possible.  
