### PR TITLE
fix(fetch/redhat/cve): fix sleep duration

### DIFF
--- a/pkg/fetch/redhat/cve/cve.go
+++ b/pkg/fetch/redhat/cve/cve.go
@@ -199,7 +199,7 @@ func (opts options) list(client *utilhttp.Client) ([]string, error) {
 					us = append(us, e.ResourceURL)
 				}
 
-				time.Sleep(time.Duration(opts.wait) * time.Second)
+				time.Sleep(opts.wait)
 			}
 
 			select {


### PR DESCRIPTION
I thought it was abnormal to need more than six hours.
https://github.com/vulsio/vuls-data-db/actions/runs/19893545454/job/57018091305

The reason is that opts.wait is already time.Duration, but it is multiplied by time.Second, so it ends up sleeping for a much longer time than expected.