### PR TITLE
feat(fetch/siemens/csaf): wait 3 second, retry 403

### DIFF
--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -4900,7 +4900,7 @@ func newCmdSiemensCSAF() *cobra.Command {
 			retry: 3,
 		},
 		concurrency: 1,
-		wait:        3,
+		wait:        3 * time.Second,
 	}
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
```console
$ curl -i https://cert-portal.siemens.com/productcert/csaf/ssa-539476.json
HTTP/2 403 
server: CloudFront
date: Fri, 05 Dec 2025 06:38:09 GMT
content-length: 188
content-type: text/plain
x-cache: Error from cloudfront
via: 1.1 1ff8037ac9f48617b00cd24bb229942a.cloudfront.net (CloudFront)
x-amz-cf-pop: NRT12-P8
x-amz-cf-id: FP_SQfv1WohteU1XgOibD2qwJYUFGmLcCVQZ65W_Pp7ZPE3Ixtlmjw==

You made too many requests in a short time for our system. As we want to improve the stability, can you please contact productcert@siemens.com and we will work out what caused this effect?
```