### PR TITLE
feat(fetch): allow invalid UTF-8

### DIFF
--- a/pkg/fetch/debian/tracker/salsa/salsa.go
+++ b/pkg/fetch/debian/tracker/salsa/salsa.go
@@ -209,7 +209,7 @@ func Fetch(opts ...Option) error {
 						log.Printf("[INFO] Fetched Debian %s %s %s", codename, repo, section)
 						bar := progressbar.Default(int64(len(mmm)))
 						for name, source := range mmm {
-							if err := util.Write(filepath.Join(options.dir, "packages", codename, repo, section, name[:1], fmt.Sprintf("%s.json", name)), source); err != nil {
+							if err := util.Write(filepath.Join(options.dir, "packages", codename, repo, section, name[:1], fmt.Sprintf("%s.json", name)), source, util.WithAllowInvalidUTF8(true)); err != nil {
 								return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "packages", codename, repo, section, name[:1], fmt.Sprintf("%s.json", name)))
 							}
 							_ = bar.Add(1)

--- a/pkg/fetch/suse/csaf/csaf.go
+++ b/pkg/fetch/suse/csaf/csaf.go
@@ -3,6 +3,7 @@ package csaf
 import (
 	"archive/tar"
 	"compress/bzip2"
+	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"fmt"
 	"io"
@@ -106,7 +107,7 @@ func Fetch(opts ...Option) error {
 		}
 
 		var adv CSAF
-		if err := json.UnmarshalRead(tr, &adv); err != nil {
+		if err := json.UnmarshalRead(tr, &adv, jsontext.AllowInvalidUTF8(true)); err != nil {
 			return errors.Wrap(err, "decode json")
 		}
 

--- a/pkg/fetch/suse/osv/osv.go
+++ b/pkg/fetch/suse/osv/osv.go
@@ -3,6 +3,7 @@ package osv
 import (
 	"archive/tar"
 	"compress/bzip2"
+	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"fmt"
 	"io"
@@ -106,7 +107,7 @@ func Fetch(opts ...Option) error {
 		}
 
 		var adv OSV
-		if err := json.UnmarshalRead(tr, &adv); err != nil {
+		if err := json.UnmarshalRead(tr, &adv, jsontext.AllowInvalidUTF8(true)); err != nil {
 			return errors.Wrap(err, "decode json")
 		}
 

--- a/pkg/fetch/wrlinux/wrlinux.go
+++ b/pkg/fetch/wrlinux/wrlinux.go
@@ -117,7 +117,7 @@ func Fetch(opts ...Option) error {
 				return errors.Wrapf(err, "unexpected ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", v.Candidate)
 			}
 
-			if err := util.Write(filepath.Join(options.dir, splitted[1], fmt.Sprintf("%s.json", v.Candidate)), v); err != nil {
+			if err := util.Write(filepath.Join(options.dir, splitted[1], fmt.Sprintf("%s.json", v.Candidate)), v, util.WithAllowInvalidUTF8(true)); err != nil {
 				return errors.Wrapf(err, "write %s", filepath.Join(options.dir, splitted[1], fmt.Sprintf("%s.json", v.Candidate)))
 			}
 


### PR DESCRIPTION
https://github.com/vulsio/vuls-data-db/actions/runs/19928689683/job/57134860955#step:8:892
https://github.com/vulsio/vuls-data-db/actions/runs/19928689683/job/57134860638#step:8:94
https://github.com/vulsio/vuls-data-db/actions/runs/19928689683/job/57134860807#step:8:42
https://github.com/vulsio/vuls-data-db/actions/runs/19928689683/job/57134859932#step:8:42

```console
$ vuls-data-updateo fetch suse-osv
2025/12/10 16:31:33 [INFO] Fetch SUSE OSV

$ vuls-data-updateo fetch suse-csaf
2025/12/10 16:32:14 [INFO] Fetch SUSE CSAF

$ vuls-data-updateo fetch wrlinux
2025/12/10 16:34:23 [INFO] Fetch Wind River Linux CVE Tracker

$ vuls-data-updateo fetch debian-security-tracker-salsa
2025/12/10 16:35:32 [INFO] Fetch Debian Security Tracker Salsa repository
2025/12/10 16:35:33 [INFO] Read CPE/list
 100% |█████████████████████████████████████████████████████████████████████████████| (2354/2354, 45175 it/s)        
2025/12/10 16:35:33 [INFO] Read CVE/list
2025/12/10 16:35:49 [WARN] REJECTED bug has package annotations: "CVE-2018-10886"
 100% |████████████████████████████████████████████████████████████████████████| (370760/370760, 35653 it/s)         
2025/12/10 16:36:03 [INFO] Read DLA/list
 100% |█████████████████████████████████████████████████████████████████████████████| (4582/4582, 26053 it/s)        
2025/12/10 16:36:03 [INFO] Read DSA/list
 100% |█████████████████████████████████████████████████████████████████████████████| (6136/6136, 23614 it/s)        
2025/12/10 16:36:03 [INFO] Read DTSA/list
 100% |███████████████████████████████████████████████████████████████████████████████| (208/208, 31726 it/s)        
2025/12/10 16:36:03 [INFO] Fetch Package Source
2025/12/10 16:36:03 Fetch Debian potato main
2025/12/10 16:36:05 Fetch Debian potato security
2025/12/10 16:36:05 [WARN] fetch http://archive.debian.org/debian-security/dists/potato/updates/Release error: error response with status code 404
2025/12/10 16:36:05 Fetch Debian potato backport
2025/12/10 16:36:06 [WARN] fetch http://archive.debian.org/debian-backports/dists/potato-backports/Release error: error response with status code 404
2025/12/10 16:36:06 [INFO] Fetched Debian potato main main
 100% |█████████████████████████████████████████████████████████████████████████████| (2647/2647, 32848 it/s)        
2025/12/10 16:36:06 [INFO] Fetched Debian potato main contrib
 100% |█████████████████████████████████████████████████████████████████████████████████| (97/97, 34412 it/s)        
2025/12/10 16:36:06 [INFO] Fetched Debian potato main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (220/220, 45578 it/s)        
2025/12/10 16:36:06 Fetch Debian woody main
2025/12/10 16:36:07 Fetch Debian woody security
2025/12/10 16:36:09 Fetch Debian woody backport
2025/12/10 16:36:09 [WARN] fetch http://archive.debian.org/debian-backports/dists/woody-backports/Release error: error response with status code 404
2025/12/10 16:36:09 [INFO] Fetched Debian woody main main
 100% |█████████████████████████████████████████████████████████████████████████████| (5218/5218, 46806 it/s)        
2025/12/10 16:36:09 [INFO] Fetched Debian woody main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (159/159, 49514 it/s)        
2025/12/10 16:36:09 [INFO] Fetched Debian woody main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (208/208, 50607 it/s)        
2025/12/10 16:36:09 [INFO] Fetched Debian woody security main
 100% |███████████████████████████████████████████████████████████████████████████████| (445/445, 49848 it/s)        
2025/12/10 16:36:09 [INFO] Fetched Debian woody security contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (5/5, 14135 it/s)        
2025/12/10 16:36:09 [INFO] Fetched Debian woody security non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (4/4, 19865 it/s)        
2025/12/10 16:36:09 Fetch Debian sarge main
2025/12/10 16:36:11 Fetch Debian sarge security
2025/12/10 16:36:13 Fetch Debian sarge backport
2025/12/10 16:36:15 [INFO] Fetched Debian sarge security main
 100% |███████████████████████████████████████████████████████████████████████████████| (390/390, 19230 it/s)        
2025/12/10 16:36:15 [INFO] Fetched Debian sarge security contrib
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:36:15 [INFO] Fetched Debian sarge security non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (1/1, 10630 it/s)        
2025/12/10 16:36:15 [INFO] Fetched Debian sarge backport contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (5/5, 18441 it/s)        
2025/12/10 16:36:15 [INFO] Fetched Debian sarge backport non-free
 100% |█████████████████████████████████████████████████████████████████████████████████| (14/14, 28315 it/s)        
2025/12/10 16:36:15 [INFO] Fetched Debian sarge backport main
 100% |███████████████████████████████████████████████████████████████████████████████| (880/880, 50526 it/s)        
2025/12/10 16:36:15 [INFO] Fetched Debian sarge main main
 100% |█████████████████████████████████████████████████████████████████████████████| (8727/8727, 47023 it/s)        
2025/12/10 16:36:16 [INFO] Fetched Debian sarge main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (164/164, 52769 it/s)        
2025/12/10 16:36:16 [INFO] Fetched Debian sarge main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (159/159, 54967 it/s)        
2025/12/10 16:36:16 Fetch Debian etch main
2025/12/10 16:36:16 Fetch Debian etch security
2025/12/10 16:36:17 Fetch Debian etch backport
2025/12/10 16:36:19 [INFO] Fetched Debian etch backport main
 100% |███████████████████████████████████████████████████████████████████████████████| (503/503, 33489 it/s)        
2025/12/10 16:36:19 [INFO] Fetched Debian etch backport contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (3/3, 25171 it/s)        
2025/12/10 16:36:19 [INFO] Fetched Debian etch backport non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (3/3, 29848 it/s)        
2025/12/10 16:36:19 [INFO] Fetched Debian etch main main
 100% |███████████████████████████████████████████████████████████████████████████| (10213/10213, 47928 it/s)        
2025/12/10 16:36:20 [INFO] Fetched Debian etch main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (126/126, 53209 it/s)        
2025/12/10 16:36:20 [INFO] Fetched Debian etch main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (211/211, 72963 it/s)        
2025/12/10 16:36:20 [INFO] Fetched Debian etch security main
 100% |███████████████████████████████████████████████████████████████████████████████| (339/339, 71293 it/s)        
2025/12/10 16:36:20 [INFO] Fetched Debian etch security contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (1/1, 22278 it/s)        
2025/12/10 16:36:20 [INFO] Fetched Debian etch security non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (5/5, 53057 it/s)        
2025/12/10 16:36:20 Fetch Debian lenny main
2025/12/10 16:36:22 Fetch Debian lenny security
2025/12/10 16:36:23 Fetch Debian lenny backport
2025/12/10 16:36:26 [INFO] Fetched Debian lenny main main
 100% |███████████████████████████████████████████████████████████████████████████| (12099/12099, 43567 it/s)        
2025/12/10 16:36:26 [INFO] Fetched Debian lenny main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (177/177, 57454 it/s)        
2025/12/10 16:36:26 [INFO] Fetched Debian lenny main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (240/240, 57551 it/s)        
2025/12/10 16:36:26 [INFO] Fetched Debian lenny security main
 100% |███████████████████████████████████████████████████████████████████████████████| (298/298, 53352 it/s)        
2025/12/10 16:36:26 [INFO] Fetched Debian lenny security contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (1/1, 17203 it/s)        
2025/12/10 16:36:26 [INFO] Fetched Debian lenny security non-free
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:36:26 [INFO] Fetched Debian lenny backport main
 100% |███████████████████████████████████████████████████████████████████████████████| (653/653, 51886 it/s)        
2025/12/10 16:36:26 [INFO] Fetched Debian lenny backport contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (2/2, 30462 it/s)        
2025/12/10 16:36:26 [INFO] Fetched Debian lenny backport non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (4/4, 38186 it/s)        
2025/12/10 16:36:26 Fetch Debian squeeze main
2025/12/10 16:36:26 Fetch Debian squeeze security
2025/12/10 16:36:28 Fetch Debian squeeze backport
2025/12/10 16:36:29 [INFO] Fetched Debian squeeze main main
 100% |███████████████████████████████████████████████████████████████████████████| (14585/14585, 35906 it/s)        
2025/12/10 16:36:30 [INFO] Fetched Debian squeeze main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (124/124, 49471 it/s)        
2025/12/10 16:36:30 [INFO] Fetched Debian squeeze main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (239/239, 52827 it/s)        
2025/12/10 16:36:30 [INFO] Fetched Debian squeeze security contrib
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:36:30 [INFO] Fetched Debian squeeze security non-free
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:36:30 [INFO] Fetched Debian squeeze security main
 100% |███████████████████████████████████████████████████████████████████████████████| (305/305, 48784 it/s)        
2025/12/10 16:36:30 [INFO] Fetched Debian squeeze backport non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (9/9, 36729 it/s)        
2025/12/10 16:36:30 [INFO] Fetched Debian squeeze backport main
 100% |███████████████████████████████████████████████████████████████████████████████| (607/607, 40751 it/s)        
2025/12/10 16:36:30 [INFO] Fetched Debian squeeze backport contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (5/5, 26505 it/s)        
2025/12/10 16:36:30 Fetch Debian wheezy main
2025/12/10 16:36:30 Fetch Debian wheezy security
2025/12/10 16:36:30 Fetch Debian wheezy backport
2025/12/10 16:36:30 [INFO] Fetched Debian wheezy main main
 100% |███████████████████████████████████████████████████████████████████████████| (17145/17145, 41931 it/s)        
2025/12/10 16:36:30 [INFO] Fetched Debian wheezy main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (132/132, 56765 it/s)        
2025/12/10 16:36:30 [INFO] Fetched Debian wheezy main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (268/268, 55354 it/s)        
2025/12/10 16:36:30 [INFO] Fetched Debian wheezy security main
 100% |███████████████████████████████████████████████████████████████████████████████| (628/628, 50623 it/s)        
2025/12/10 16:36:31 [INFO] Fetched Debian wheezy security contrib
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:36:31 [INFO] Fetched Debian wheezy security non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (2/2, 27988 it/s)        
2025/12/10 16:36:31 [INFO] Fetched Debian wheezy backport main
 100% |█████████████████████████████████████████████████████████████████████████████| (1067/1067, 40734 it/s)        
2025/12/10 16:36:31 [INFO] Fetched Debian wheezy backport contrib
 100% |█████████████████████████████████████████████████████████████████████████████████| (17/17, 30747 it/s)        
2025/12/10 16:36:31 [INFO] Fetched Debian wheezy backport non-free
 100% |█████████████████████████████████████████████████████████████████████████████████| (18/18, 41867 it/s)        
2025/12/10 16:36:31 Fetch Debian jessie main
2025/12/10 16:36:31 Fetch Debian jessie security
2025/12/10 16:36:31 Fetch Debian jessie backport
2025/12/10 16:36:32 [INFO] Fetched Debian jessie backport main
 100% |█████████████████████████████████████████████████████████████████████████████| (2010/2010, 36516 it/s)        
2025/12/10 16:36:32 [INFO] Fetched Debian jessie backport contrib
 100% |█████████████████████████████████████████████████████████████████████████████████| (13/13, 31867 it/s)        
2025/12/10 16:36:32 [INFO] Fetched Debian jessie backport non-free
 100% |█████████████████████████████████████████████████████████████████████████████████| (15/15, 32655 it/s)        
2025/12/10 16:36:32 [INFO] Fetched Debian jessie main main
 100% |███████████████████████████████████████████████████████████████████████████| (20536/20536, 41385 it/s)        
2025/12/10 16:36:32 [INFO] Fetched Debian jessie main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (133/133, 39308 it/s)        
2025/12/10 16:36:32 [INFO] Fetched Debian jessie main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (278/278, 37109 it/s)        
2025/12/10 16:36:32 [INFO] Fetched Debian jessie security main
 100% |███████████████████████████████████████████████████████████████████████████████| (685/685, 47783 it/s)        
2025/12/10 16:36:32 [INFO] Fetched Debian jessie security contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (1/1, 15248 it/s)        
2025/12/10 16:36:32 [INFO] Fetched Debian jessie security non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (3/3, 27986 it/s)        
2025/12/10 16:36:32 Fetch Debian stretch main
2025/12/10 16:36:33 Fetch Debian stretch security
2025/12/10 16:36:33 Fetch Debian stretch backport
2025/12/10 16:36:35 [INFO] Fetched Debian stretch backport main
 100% |█████████████████████████████████████████████████████████████████████████████| (1727/1727, 23777 it/s)        
2025/12/10 16:36:35 [INFO] Fetched Debian stretch backport contrib
 100% |█████████████████████████████████████████████████████████████████████████████████| (15/15, 33076 it/s)        
2025/12/10 16:36:35 [INFO] Fetched Debian stretch backport non-free
 100% |█████████████████████████████████████████████████████████████████████████████████| (15/15, 33195 it/s)        
2025/12/10 16:36:35 [INFO] Fetched Debian stretch main main
 100% |███████████████████████████████████████████████████████████████████████████| (24723/24723, 40191 it/s)        
2025/12/10 16:36:35 [INFO] Fetched Debian stretch main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (142/142, 34548 it/s)        
2025/12/10 16:36:36 [INFO] Fetched Debian stretch main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (276/276, 55845 it/s)        
2025/12/10 16:36:36 [INFO] Fetched Debian stretch security main
 100% |███████████████████████████████████████████████████████████████████████████████| (801/801, 38489 it/s)        
2025/12/10 16:36:36 [INFO] Fetched Debian stretch security contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (2/2, 20544 it/s)        
2025/12/10 16:36:36 [INFO] Fetched Debian stretch security non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (5/5, 26153 it/s)        
2025/12/10 16:36:36 Fetch Debian buster main
2025/12/10 16:36:37 Fetch Debian buster security
2025/12/10 16:36:38 Fetch Debian buster backport
2025/12/10 16:36:40 [INFO] Fetched Debian buster main main
 100% |███████████████████████████████████████████████████████████████████████████| (28398/28398, 41188 it/s)        
2025/12/10 16:36:41 [INFO] Fetched Debian buster main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (135/135, 37863 it/s)        
2025/12/10 16:36:41 [INFO] Fetched Debian buster main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (303/303, 35930 it/s)        
2025/12/10 16:36:41 [INFO] Fetched Debian buster security main
 100% |█████████████████████████████████████████████████████████████████████████████| (1000/1000, 35285 it/s)        
2025/12/10 16:36:41 [INFO] Fetched Debian buster security contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (1/1, 16282 it/s)        
2025/12/10 16:36:41 [INFO] Fetched Debian buster security non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (8/8, 26211 it/s)        
2025/12/10 16:36:41 [INFO] Fetched Debian buster backport main
 100% |█████████████████████████████████████████████████████████████████████████████| (1694/1694, 34388 it/s)        
2025/12/10 16:36:41 [INFO] Fetched Debian buster backport contrib
 100% |█████████████████████████████████████████████████████████████████████████████████| (16/16, 38143 it/s)        
2025/12/10 16:36:41 [INFO] Fetched Debian buster backport non-free
 100% |█████████████████████████████████████████████████████████████████████████████████| (18/18, 32502 it/s)        
2025/12/10 16:36:41 Fetch Debian bullseye main
2025/12/10 16:36:42 Fetch Debian bullseye security
2025/12/10 16:36:44 Fetch Debian bullseye backport
2025/12/10 16:36:44 [WARN] fetch http://deb.debian.org/debian/dists/bullseye-backports/Release error: error response with status code 404
2025/12/10 16:36:44 [INFO] Fetched Debian bullseye main main
 100% |███████████████████████████████████████████████████████████████████████████| (30856/30856, 38367 it/s)        
2025/12/10 16:36:45 [INFO] Fetched Debian bullseye main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (136/136, 39150 it/s)        
2025/12/10 16:36:45 [INFO] Fetched Debian bullseye main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (276/276, 43695 it/s)        
2025/12/10 16:36:45 [INFO] Fetched Debian bullseye security contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (1/1, 11661 it/s)        
2025/12/10 16:36:45 [INFO] Fetched Debian bullseye security non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (3/3, 25318 it/s)        
2025/12/10 16:36:45 [INFO] Fetched Debian bullseye security main
 100% |███████████████████████████████████████████████████████████████████████████████| (793/793, 37900 it/s)        
2025/12/10 16:36:45 Fetch Debian bookworm main
2025/12/10 16:36:47 Fetch Debian bookworm security
2025/12/10 16:36:51 Fetch Debian bookworm backport
2025/12/10 16:36:53 [INFO] Fetched Debian bookworm main main
 100% |███████████████████████████████████████████████████████████████████████████| (34293/34293, 40601 it/s)        
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (159/159, 52339 it/s)        
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm main non-free-firmware
 100% |██████████████████████████████████████████████████████████████████████████████████| (15/15, 1481 it/s)        
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (268/268, 36287 it/s)        
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm security contrib
 100% |███████████████████████████████████████████████████████████████████████████████████| (1/1, 12013 it/s)        
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm security non-free-firmware
 100% |████████████████████████████████████████████████████████████████████████████████████| (2/2, 5092 it/s)        
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm security non-free
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm security main
 100% |███████████████████████████████████████████████████████████████████████████████| (452/452, 19653 it/s)        
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm backport contrib
 100% |█████████████████████████████████████████████████████████████████████████████████| (11/11, 29384 it/s)        
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm backport non-free-firmware
 100% |███████████████████████████████████████████████████████████████████████████████████| (2/2, 19426 it/s)        
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm backport non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (5/5, 27286 it/s)        
2025/12/10 16:36:54 [INFO] Fetched Debian bookworm backport main
 100% |███████████████████████████████████████████████████████████████████████████████| (948/948, 37884 it/s)        
2025/12/10 16:36:54 Fetch Debian trixie main
2025/12/10 16:36:56 Fetch Debian trixie security
2025/12/10 16:36:59 Fetch Debian trixie backport
2025/12/10 16:37:01 [INFO] Fetched Debian trixie main main
 100% |███████████████████████████████████████████████████████████████████████████| (37588/37588, 39294 it/s)        
2025/12/10 16:37:02 [INFO] Fetched Debian trixie main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (159/159, 10131 it/s)        
2025/12/10 16:37:02 [INFO] Fetched Debian trixie main non-free-firmware
 100% |█████████████████████████████████████████████████████████████████████████████████| (14/14, 12048 it/s)        
2025/12/10 16:37:02 [INFO] Fetched Debian trixie main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (262/262, 51898 it/s)        
2025/12/10 16:37:02 [INFO] Fetched Debian trixie security main
 100% |███████████████████████████████████████████████████████████████████████████████| (300/300, 45628 it/s)        
2025/12/10 16:37:02 [INFO] Fetched Debian trixie security contrib
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:37:02 [INFO] Fetched Debian trixie security non-free-firmware
 100% |███████████████████████████████████████████████████████████████████████████████████| (1/1, 16893 it/s)        
2025/12/10 16:37:02 [INFO] Fetched Debian trixie security non-free
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:37:02 [INFO] Fetched Debian trixie backport contrib
 100% |█████████████████████████████████████████████████████████████████████████████████| (11/11, 32001 it/s)        
2025/12/10 16:37:02 [INFO] Fetched Debian trixie backport non-free-firmware
 100% |███████████████████████████████████████████████████████████████████████████████████| (3/3, 23184 it/s)        
2025/12/10 16:37:02 [INFO] Fetched Debian trixie backport non-free
 100% |███████████████████████████████████████████████████████████████████████████████████| (1/1, 19910 it/s)        
2025/12/10 16:37:02 [INFO] Fetched Debian trixie backport main
 100% |███████████████████████████████████████████████████████████████████████████████| (256/256, 34611 it/s)        
2025/12/10 16:37:02 Fetch Debian forky main
2025/12/10 16:37:04 Fetch Debian forky security
2025/12/10 16:37:08 Fetch Debian forky backport
2025/12/10 16:37:10 [INFO] Fetched Debian forky main main
 100% |███████████████████████████████████████████████████████████████████████████| (37616/37616, 38705 it/s)        
2025/12/10 16:37:11 [INFO] Fetched Debian forky main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (159/159, 39395 it/s)        
2025/12/10 16:37:11 [INFO] Fetched Debian forky main non-free-firmware
 100% |█████████████████████████████████████████████████████████████████████████████████| (18/18, 14647 it/s)        
2025/12/10 16:37:11 [INFO] Fetched Debian forky main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (247/247, 44351 it/s)        
2025/12/10 16:37:11 [INFO] Fetched Debian forky security main
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:37:11 [INFO] Fetched Debian forky security contrib
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:37:11 [INFO] Fetched Debian forky security non-free-firmware
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:37:11 [INFO] Fetched Debian forky security non-free
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:37:11 [INFO] Fetched Debian forky backport main
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:37:11 [INFO] Fetched Debian forky backport contrib
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:37:11 [INFO] Fetched Debian forky backport non-free-firmware
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:37:11 [INFO] Fetched Debian forky backport non-free
   0% |                                                                                      | (0/0, 0 it/hr) [0s:0s]
2025/12/10 16:37:11 Fetch Debian sid main
2025/12/10 16:37:14 [INFO] Fetched Debian sid main main
 100% |███████████████████████████████████████████████████████████████████████████| (39191/39191, 39287 it/s)        
2025/12/10 16:37:15 [INFO] Fetched Debian sid main contrib
 100% |███████████████████████████████████████████████████████████████████████████████| (197/197, 56233 it/s)        
2025/12/10 16:37:15 [INFO] Fetched Debian sid main non-free-firmware
 100% |█████████████████████████████████████████████████████████████████████████████████| (20/20, 44259 it/s)        
2025/12/10 16:37:15 [INFO] Fetched Debian sid main non-free
 100% |███████████████████████████████████████████████████████████████████████████████| (276/276, 42763 it/s)
```