### PR TITLE
fix(fetch/suse/csaf_vex): allow invalid UTF-8

### DIFF
--- a/pkg/fetch/suse/csaf_vex/csaf_vex.go
+++ b/pkg/fetch/suse/csaf_vex/csaf_vex.go
@@ -3,6 +3,7 @@ package csaf_vex
 import (
 	"archive/tar"
 	"compress/bzip2"
+	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"fmt"
 	"io"
@@ -105,7 +106,7 @@ func Fetch(opts ...Option) error {
 		}
 
 		var adv CSAF
-		if err := json.UnmarshalRead(tr, &adv); err != nil {
+		if err := json.UnmarshalRead(tr, &adv, jsontext.AllowInvalidUTF8(true)); err != nil {
 			return errors.Wrap(err, "decode json")
 		}
 


### PR DESCRIPTION
CI Error:

https://github.com/vulsio/vuls-data-db/actions/runs/20447971828/job/58755167691#step:8:42

```
Run vuls-data-update fetch suse-csaf-vex --dir ghcr.io/vulsio/vuls-data-db/vuls-data-raw-suse-csaf-vex
2025/12/23 01:17:55 [INFO] Fetch SUSE CSAF VEX
jsontext: invalid UTF-8 within "/document/notes/1/text" after offset 880
decode json
github.com/MaineK00n/vuls-data-update/pkg/fetch/suse/csaf_vex.Fetch
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/fetch/suse/csaf_vex/csaf_vex.go:109
github.com/MaineK00n/vuls-data-update/pkg/cmd/fetch.newCmdSUSECSAFVEX.func1
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/fetch/fetch.go:5088
github.com/spf13/cobra.(*Command).execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
runtime.main
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
runtime.goexit
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
failed to fetch suse csaf vex
github.com/MaineK00n/vuls-data-update/pkg/cmd/fetch.newCmdSUSECSAFVEX.func1
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/fetch/fetch.go:5089
github.com/spf13/cobra.(*Command).execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
runtime.main
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
runtime.goexit
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
Error: Process completed with exit code 1.
```

cf. https://github.com/MaineK00n/vuls-data-update/pull/651
