### PR TITLE
fix(fetch/fortinet/csaf): support no csaf url

### DIFF
--- a/pkg/fetch/fortinet/csaf/csaf.go
+++ b/pkg/fetch/fortinet/csaf/csaf.go
@@ -127,6 +127,10 @@ func (opts options) fetch(ids []string) error {
 			if err != nil {
 				return errors.Wrap(err, "fetch csaf url")
 			}
+			if u == "" {
+				return nil
+			}
+
 			time.Sleep(opts.wait)
 
 			if err := opts.fetchCSAF(client, u); err != nil {
@@ -191,9 +195,6 @@ func (opts options) fetchCSAFURL(client *utilhttp.Client, id string) (string, er
 		default:
 			continue
 		}
-	}
-	if u == "" {
-		return "", errors.New("CSAF download URL not found")
 	}
 	return u, nil
 }

--- a/pkg/fetch/fortinet/csaf/csaf_test.go
+++ b/pkg/fetch/fortinet/csaf/csaf_test.go
@@ -38,7 +38,6 @@ func TestFetch(t *testing.T) {
 			args: args{
 				args: []string{"FG-IR-24-437"},
 			},
-			hasError: true,
 		},
 		{
 			name: "invalid-csaf",


### PR DESCRIPTION
fix
```
2026-01-15T12:32:25.7685961Z ##[group]Run vuls-data-update fetch fortinet-csaf --dir ghcr.io/vulsio/vuls-data-db/vuls-data-raw-fortinet-csaf --concurrency 1 $(curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename | tr '\n' ' ')
2026-01-15T12:32:25.7687639Z [36;1mvuls-data-update fetch fortinet-csaf --dir ghcr.io/vulsio/vuls-data-db/vuls-data-raw-fortinet-csaf --concurrency 1 $(curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename | tr '\n' ' ')[0m
2026-01-15T12:32:25.7720232Z shell: /usr/bin/bash -e {0}
2026-01-15T12:32:25.7720464Z env:
2026-01-15T12:32:25.7720649Z   GOEXPERIMENT: jsonv2
2026-01-15T12:32:25.7720879Z   GOTOOLCHAIN: local
2026-01-15T12:32:25.7721071Z ##[endgroup]
2026-01-15T12:32:25.7830219Z   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
2026-01-15T12:32:25.7831924Z                                  Dload  Upload   Total   Spent    Left  Speed
2026-01-15T12:32:25.7832657Z 
2026-01-15T12:32:26.0135401Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
2026-01-15T12:32:26.0136316Z 100 35405  100 35405    0     0   149k      0 --:--:-- --:--:-- --:--:--  150k
2026-01-15T12:32:26.0720889Z 2026/01/15 12:32:26 [INFO] Fetch Fortinet CSAF
2026-01-15T12:32:26.0721300Z 
2026-01-15T12:32:29.6735956Z    0% |                                               | (0/50, 0 it/hr) [0s:0s]
2026-01-15T12:32:29.6738325Z                                                                                
2026-01-15T12:32:29.6738666Z 
2026-01-15T12:32:31.7496857Z    2% |                                          | (1/50, 17 it/min) [3s:2m56s]
2026-01-15T12:32:31.7499075Z                                                                                
2026-01-15T12:32:31.7499489Z 
2026-01-15T12:32:33.8288901Z    4% |█                                           | (2/50, 58 it/min) [5s:49s]
2026-01-15T12:32:33.8291439Z                                                                                
2026-01-15T12:32:33.8291681Z 
2026-01-15T12:32:35.9064417Z    6% |██                                         | (3/50, 43 it/min) [7s:1m5s]
2026-01-15T12:32:35.9067014Z                                                                                
2026-01-15T12:32:35.9067495Z 
2026-01-15T12:32:37.9834151Z    8% |███                                       | (4/50, 39 it/min) [9s:1m11s]
2026-01-15T12:32:37.9835883Z                                                                                
2026-01-15T12:32:37.9836174Z 
2026-01-15T12:32:40.0641005Z   10% |████                                     | (5/50, 36 it/min) [11s:1m14s]
2026-01-15T12:32:40.0642801Z                                                                                
2026-01-15T12:32:40.0643165Z 
2026-01-15T12:32:41.1234486Z   12% |████                                     | (6/50, 35 it/min) [13s:1m16s]
2026-01-15T12:32:41.1236160Z                                                                                
2026-01-15T12:32:41.1236522Z 
2026-01-15T12:32:43.2014177Z   14% |█████                                     | (7/50, 38 it/min) [15s:1m7s]
2026-01-15T12:32:43.2015718Z                                                                                
2026-01-15T12:32:43.2016019Z 
2026-01-15T12:32:45.2781165Z   16% |██████                                    | (8/50, 37 it/min) [17s:1m8s]
2026-01-15T12:32:45.2782954Z                                                                                
2026-01-15T12:32:45.2783275Z 
2026-01-15T12:32:47.4420422Z   18% |███████                                   | (9/50, 36 it/min) [19s:1m8s]
2026-01-15T12:32:47.4421911Z                                                                                
2026-01-15T12:32:47.4422655Z 
2026-01-15T12:32:49.5373847Z   20% |████████                                 | (10/50, 35 it/min) [21s:1m8s]
2026-01-15T12:32:49.5375113Z                                                                                
2026-01-15T12:32:49.5375363Z 
2026-01-15T12:32:51.6210775Z   22% |█████████                                | (11/50, 34 it/min) [23s:1m8s]
2026-01-15T12:32:51.6212335Z                                                                                
2026-01-15T12:32:51.6212647Z 
2026-01-15T12:32:53.7169573Z   24% |█████████                               | (12/50, 32 it/min) [25s:1m12s]
2026-01-15T12:32:53.7171626Z                                                                                
2026-01-15T12:32:53.7171947Z 
2026-01-15T12:32:55.7919520Z   26% |██████████                              | (13/50, 31 it/min) [27s:1m10s]
2026-01-15T12:32:55.7921034Z                                                                                
2026-01-15T12:32:55.7921386Z 
2026-01-15T12:32:57.8666462Z   28% |███████████                              | (14/50, 31 it/min) [29s:1m8s]
2026-01-15T12:32:57.8668552Z                                                                                
2026-01-15T12:32:57.8668866Z 
2026-01-15T12:32:59.9482085Z   30% |████████████                             | (15/50, 31 it/min) [31s:1m6s]
2026-01-15T12:32:59.9483987Z                                                                                
2026-01-15T12:32:59.9484282Z 
2026-01-15T12:33:02.0251704Z   32% |█████████████                            | (16/50, 31 it/min) [33s:1m4s]
2026-01-15T12:33:02.0253906Z                                                                                
2026-01-15T12:33:02.0254242Z 
2026-01-15T12:33:04.1029921Z   34% |█████████████                            | (17/50, 29 it/min) [35s:1m8s]
2026-01-15T12:33:04.1032418Z                                                                                
2026-01-15T12:33:04.1032883Z 
2026-01-15T12:33:06.1877012Z   36% |██████████████                           | (18/50, 29 it/min) [38s:1m6s]
2026-01-15T12:33:06.1878650Z                                                                                
2026-01-15T12:33:06.1878944Z 
2026-01-15T12:33:08.2701479Z   38% |███████████████                          | (19/50, 29 it/min) [40s:1m4s]
2026-01-15T12:33:08.2703155Z                                                                                
2026-01-15T12:33:08.2703480Z 
2026-01-15T12:33:10.3467753Z   40% |████████████████                         | (20/50, 29 it/min) [42s:1m2s]
2026-01-15T12:33:10.3469635Z                                                                                
2026-01-15T12:33:10.3469975Z 
2026-01-15T12:33:12.4235522Z   42% |█████████████████                        | (21/50, 29 it/min) [44s:1m0s]
2026-01-15T12:33:12.4237256Z                                                                                
2026-01-15T12:33:12.4237673Z 
2026-01-15T12:33:14.4975519Z   44% |██████████████████                        | (22/50, 29 it/min) [46s:58s]
2026-01-15T12:33:14.4977091Z                                                                                
2026-01-15T12:33:14.4977370Z 
2026-01-15T12:33:16.5728459Z   46% |███████████████████                       | (23/50, 29 it/min) [48s:56s]
2026-01-15T12:33:16.5730278Z                                                                                
2026-01-15T12:33:16.5730585Z 
2026-01-15T12:33:22.4486699Z   48% |████████████████████                      | (24/50, 29 it/min) [50s:54s]
2026-01-15T12:33:22.4488843Z                                                                                
2026-01-15T12:33:22.4489160Z 
2026-01-15T12:33:25.2869326Z   50% |█████████████████████                     | (25/50, 27 it/min) [56s:55s]
2026-01-15T12:33:25.2870826Z                                                                                
2026-01-15T12:33:25.2871116Z 
2026-01-15T12:33:31.6432519Z   52% |█████████████████████                     | (26/50, 26 it/min) [59s:54s]
2026-01-15T12:33:31.6434583Z                                                                                
2026-01-15T12:33:31.6434831Z 
2026-01-15T12:33:41.7590399Z   54% |██████████████████████                   | (27/50, 24 it/min) [1m5s:56s]
2026-01-15T12:33:41.7592693Z                                                                                
2026-01-15T12:33:41.7593033Z 
2026-01-15T12:33:48.3625858Z   56% |█████████████████████                  | (28/50, 22 it/min) [1m15s:1m0s]
2026-01-15T12:33:48.3627338Z                                                                                
2026-01-15T12:33:48.3627582Z 
2026-01-15T12:33:51.7822348Z   57% |██████████████████████                 | (29/50, 20 it/min) [1m22s:1m2s]
2026-01-15T12:33:51.7823848Z                                                                                
2026-01-15T12:33:51.7824136Z 
2026-01-15T12:33:55.0622019Z   60% |███████████████████████                | (30/50, 19 it/min) [1m25s:1m3s]
2026-01-15T12:33:55.0624564Z                                                                                
2026-01-15T12:33:55.0625059Z 
2026-01-15T12:33:57.1615147Z   62% |████████████████████████               | (31/50, 18 it/min) [1m28s:1m3s]
2026-01-15T12:33:57.1616812Z                                                                                
2026-01-15T12:33:57.1617117Z 
2026-01-15T12:34:01.0339424Z   64% |████████████████████████               | (32/50, 18 it/min) [1m31s:1m0s]
2026-01-15T12:34:01.0341901Z                                                                                
2026-01-15T12:34:01.0342377Z 
2026-01-15T12:34:03.3820336Z   66% |█████████████████████████              | (33/50, 16 it/min) [1m34s:1m1s]
2026-01-15T12:34:03.3822956Z                                                                                
2026-01-15T12:34:06.3852467Z 
2026-01-15T12:34:06.3853504Z   68% |███████████████████████████             | (34/50, 16 it/min) [1m37s:59s]
2026-01-15T12:34:06.3855020Z                                                                                
2026-01-15T12:34:06.3855352Z 
2026-01-15T12:34:08.7090316Z   70% |████████████████████████████            | (35/50, 17 it/min) [1m40s:52s]
2026-01-15T12:34:08.7091890Z                                                                                
2026-01-15T12:34:08.7092177Z 
2026-01-15T12:34:10.7854372Z   72% |████████████████████████████            | (36/50, 18 it/min) [1m42s:47s]
2026-01-15T12:34:10.7856085Z                                                                                
2026-01-15T12:34:10.7856397Z 
2026-01-15T12:34:13.6894870Z   74% |█████████████████████████████           | (37/50, 20 it/min) [1m44s:39s]
2026-01-15T12:34:13.6896551Z                                                                                
2026-01-15T12:34:13.6896852Z 
2026-01-15T12:34:15.7660814Z   76% |██████████████████████████████          | (38/50, 21 it/min) [1m47s:34s]
2026-01-15T12:34:15.7662466Z                                                                                
2026-01-15T12:34:17.8423784Z 
2026-01-15T12:34:17.8424974Z   78% |███████████████████████████████         | (39/50, 23 it/min) [1m49s:28s]
2026-01-15T12:34:17.8426710Z                                                                                
2026-01-15T12:34:17.8427440Z 
2026-01-15T12:34:20.8535938Z   80% |████████████████████████████████        | (40/50, 24 it/min) [1m51s:24s]
2026-01-15T12:34:20.8537564Z                                                                                
2026-01-15T12:34:20.8537863Z 
2026-01-15T12:34:23.5431278Z   82% |████████████████████████████████        | (41/50, 24 it/min) [1m54s:22s]
2026-01-15T12:34:23.5433107Z                                                                                
2026-01-15T12:34:23.5433420Z 
2026-01-15T12:34:25.6207725Z   84% |█████████████████████████████████       | (42/50, 24 it/min) [1m57s:20s]
2026-01-15T12:34:25.6210581Z                                                                                
2026-01-15T12:34:25.6210989Z 
2026-01-15T12:34:27.6970980Z   86% |██████████████████████████████████      | (43/50, 25 it/min) [1m59s:16s]
2026-01-15T12:34:27.6972767Z                                                                                
2026-01-15T12:34:29.7737916Z 
2026-01-15T12:34:29.7739306Z   88% |████████████████████████████████████     | (44/50, 25 it/min) [2m1s:14s]
2026-01-15T12:34:29.7741115Z                                                                                
2026-01-15T12:34:29.7741421Z 
2026-01-15T12:34:31.8508385Z   90% |████████████████████████████████████     | (45/50, 26 it/min) [2m3s:11s]
2026-01-15T12:34:31.8510859Z                                                                                
2026-01-15T12:34:31.8511165Z 
2026-01-15T12:34:33.9273168Z   92% |██████████████████████████████████████    | (46/50, 27 it/min) [2m5s:9s]
2026-01-15T12:34:33.9274872Z                                                                                
2026-01-15T12:34:33.9275208Z 
2026-01-15T12:34:36.0066867Z   94% |███████████████████████████████████████   | (47/50, 27 it/min) [2m7s:6s]
2026-01-15T12:34:36.0069685Z                                                                                
2026-01-15T12:34:36.0070061Z 
2026-01-15T12:34:38.0860380Z   96% |████████████████████████████████████████  | (48/50, 27 it/min) [2m9s:4s]
2026-01-15T12:34:38.0862005Z                                                                                
2026-01-15T12:34:38.0862313Z 
2026-01-15T12:34:40.1631603Z   98% |████████████████████████████████████████ | (49/50, 27 it/min) [2m12s:2s]
2026-01-15T12:34:40.1634035Z                                                                                
2026-01-15T12:34:40.1634454Z 
2026-01-15T12:34:40.1634809Z  100% |█████████████████████████████████████████| (50/50, 22 it/min)
2026-01-15T12:34:40.1635262Z CSAF download URL not found
2026-01-15T12:34:40.1635799Z github.com/MaineK00n/vuls-data-update/pkg/fetch/fortinet/csaf.options.fetchCSAFURL
2026-01-15T12:34:40.1639118Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/fetch/fortinet/csaf/csaf.go:196
2026-01-15T12:34:40.1639757Z github.com/MaineK00n/vuls-data-update/pkg/fetch/fortinet/csaf.options.fetch.func1
2026-01-15T12:34:40.1640412Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/fetch/fortinet/csaf/csaf.go:126
2026-01-15T12:34:40.1640869Z golang.org/x/sync/errgroup.(*Group).Go.func1
2026-01-15T12:34:40.1641318Z 	/home/runner/go/pkg/mod/golang.org/x/sync@v0.19.0/errgroup/errgroup.go:93
2026-01-15T12:34:40.1641717Z runtime.goexit
2026-01-15T12:34:40.1642029Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-15T12:34:40.1642374Z fetch csaf url
2026-01-15T12:34:40.1642737Z github.com/MaineK00n/vuls-data-update/pkg/fetch/fortinet/csaf.options.fetch.func1
2026-01-15T12:34:40.1643353Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/fetch/fortinet/csaf/csaf.go:128
2026-01-15T12:34:40.1643804Z golang.org/x/sync/errgroup.(*Group).Go.func1
2026-01-15T12:34:40.1644249Z 	/home/runner/go/pkg/mod/golang.org/x/sync@v0.19.0/errgroup/errgroup.go:93
2026-01-15T12:34:40.1644983Z runtime.goexit
2026-01-15T12:34:40.1645286Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-15T12:34:40.1645626Z err in goroutine
2026-01-15T12:34:40.1646146Z github.com/MaineK00n/vuls-data-update/pkg/fetch/fortinet/csaf.options.fetch
2026-01-15T12:34:40.1646795Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/fetch/fortinet/csaf/csaf.go:140
2026-01-15T12:34:40.1647330Z github.com/MaineK00n/vuls-data-update/pkg/fetch/fortinet/csaf.Fetch
2026-01-15T12:34:40.1648058Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/fetch/fortinet/csaf/csaf.go:104
2026-01-15T12:34:40.1648788Z github.com/MaineK00n/vuls-data-update/pkg/cmd/fetch.newCmdFortinetCSAF.func1
2026-01-15T12:34:40.1649678Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/fetch/fetch.go:1768
2026-01-15T12:34:40.1650364Z github.com/spf13/cobra.(*Command).execute
2026-01-15T12:34:40.1651019Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-15T12:34:40.1651711Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-15T12:34:40.1652376Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-15T12:34:40.1653040Z github.com/spf13/cobra.(*Command).Execute
2026-01-15T12:34:40.1653753Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-15T12:34:40.1654354Z main.main
2026-01-15T12:34:40.1654690Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-15T12:34:40.1655060Z runtime.main
2026-01-15T12:34:40.1655342Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-15T12:34:40.1655651Z runtime.goexit
2026-01-15T12:34:40.1655939Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-15T12:34:40.1656249Z fetch
2026-01-15T12:34:40.1656529Z github.com/MaineK00n/vuls-data-update/pkg/fetch/fortinet/csaf.Fetch
2026-01-15T12:34:40.1657039Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/fetch/fortinet/csaf/csaf.go:105
2026-01-15T12:34:40.1657584Z github.com/MaineK00n/vuls-data-update/pkg/cmd/fetch.newCmdFortinetCSAF.func1
2026-01-15T12:34:40.1658380Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/fetch/fetch.go:1768
2026-01-15T12:34:40.1658847Z github.com/spf13/cobra.(*Command).execute
2026-01-15T12:34:40.1659255Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-15T12:34:40.1659631Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-15T12:34:40.1660018Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-15T12:34:40.1660387Z github.com/spf13/cobra.(*Command).Execute
2026-01-15T12:34:40.1660774Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-15T12:34:40.1661110Z main.main
2026-01-15T12:34:40.1661434Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-15T12:34:40.1661802Z runtime.main
2026-01-15T12:34:40.1662084Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-15T12:34:40.1662403Z runtime.goexit
2026-01-15T12:34:40.1662694Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-15T12:34:40.1663035Z failed to fetch fortinet csaf
2026-01-15T12:34:40.1663419Z github.com/MaineK00n/vuls-data-update/pkg/cmd/fetch.newCmdFortinetCSAF.func1
2026-01-15T12:34:40.1663951Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/fetch/fetch.go:1769
2026-01-15T12:34:40.1664335Z github.com/spf13/cobra.(*Command).execute
2026-01-15T12:34:40.1664725Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-15T12:34:40.1665095Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-15T12:34:40.1665479Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-15T12:34:40.1665843Z github.com/spf13/cobra.(*Command).Execute
2026-01-15T12:34:40.1666221Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-15T12:34:40.1666546Z main.main
2026-01-15T12:34:40.1666871Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-15T12:34:40.1667433Z runtime.main
2026-01-15T12:34:40.1667715Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-15T12:34:40.1668025Z runtime.goexit
2026-01-15T12:34:40.1668540Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
```
https://github.com/vulsio/vuls-data-db/actions/runs/21031033125/job/60467054930