### PR TITLE
fix(extract/redhat/oval/v2): add new comment pattern

### DIFF
--- a/pkg/extract/redhat/oval/v2/v2.go
+++ b/pkg/extract/redhat/oval/v2/v2.go
@@ -923,7 +923,7 @@ func (e extractor) walkCriterions(ca criteriaTypes.Criteria, name, stream string
 			default:
 				return criteriaTypes.Criteria{}, errors.Errorf("unexpected evr operation. expected: %q, actual: %q", []string{"equals"}, s.Evr.Operation)
 			}
-		case strings.Contains(t1.Comment, " is installed"):
+		case strings.HasSuffix(t1.Comment, " is installed"):
 			var o v2.RpminfoObject
 			if err := e.read(name, stream, "objects", "rpminfo_object", t1.Object.ObjectRef, &o); err != nil {
 				return criteriaTypes.Criteria{}, errors.Wrapf(err, "read %s", filepath.Join("objects", "rpminfo_object", t1.Object.ObjectRef))
@@ -943,7 +943,7 @@ func (e extractor) walkCriterions(ca criteriaTypes.Criteria, name, stream string
 					},
 				},
 			})
-		case strings.Contains(t1.Comment, " is not installed"): // unaffected only
+		case strings.HasSuffix(t1.Comment, " is not installed"): // unaffected only
 		case strings.Contains(t1.Comment, " not installed for "):
 			var o v2.RpminfoObject
 			if err := e.read(name, stream, "objects", "rpminfo_object", t1.Object.ObjectRef, &o); err != nil {
@@ -960,8 +960,9 @@ func (e extractor) walkCriterions(ca criteriaTypes.Criteria, name, stream string
 					},
 				},
 			})
-		case strings.Contains(t1.Comment, " is signed with Red Hat redhatrelease key"):
-		case strings.Contains(t1.Comment, " is signed with Red Hat redhatrelease2 key"):
+		case strings.HasSuffix(t1.Comment, " is signed with Red Hat redhatrelease key"),
+			strings.HasSuffix(t1.Comment, " is signed with Red Hat redhatrelease2 key"),
+			strings.HasSuffix(t1.Comment, " is signed with Red Hat release4,release2,ima key"):
 		default:
 			return criteriaTypes.Criteria{}, errors.Errorf("unexpected comment format. expected: %q, actual: %q", []string{
 				"<package> is earlier than <version>",
@@ -971,6 +972,7 @@ func (e extractor) walkCriterions(ca criteriaTypes.Criteria, name, stream string
 				"<package> not installed for <version>",
 				"<package> is signed with Red Hat redhatrelease key",
 				"<package> is signed with Red Hat redhatrelease2 key",
+				"<package> is signed with Red Hat release4,release2,ima key",
 			}, t1.Comment)
 		}
 	}


### PR DESCRIPTION
fix
```
2026-01-16T04:03:16.8861242Z ##[group]Run vuls-data-update extract redhat-ovalv2 --dir ghcr.io/vulsio/vuls-data-db/vuls-data-extracted-redhat-ovalv2 ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-ovalv2 ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-repository-to-cpe
2026-01-16T04:03:16.8862996Z [36;1mvuls-data-update extract redhat-ovalv2 --dir ghcr.io/vulsio/vuls-data-db/vuls-data-extracted-redhat-ovalv2 ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-ovalv2 ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-repository-to-cpe[0m
2026-01-16T04:03:16.8895193Z shell: /usr/bin/bash -e {0}
2026-01-16T04:03:16.8895471Z env:
2026-01-16T04:03:16.8895746Z   GOEXPERIMENT: jsonv2
2026-01-16T04:03:16.8896052Z   GOTOOLCHAIN: local
2026-01-16T04:03:16.8896406Z ##[endgroup]
2026-01-16T04:03:16.9024592Z 2026/01/16 04:03:16 [INFO] Extract RedHat OVAL v2
2026-01-16T04:16:33.8034844Z unexpected comment format. expected: ["<package> is earlier than <version>" "<package> version equals <version>" "<package> is installed" "<package> is not installed" "<package> not installed for <version>" "<package> is signed with Red Hat redhatrelease key" "<package> is signed with Red Hat redhatrelease2 key"], actual: "kernel is signed with Red Hat release4,release2,ima key"
2026-01-16T04:16:33.8037864Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.walkCriterions
2026-01-16T04:16:33.8039052Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:966
2026-01-16T04:16:33.8040007Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.walkCriteria
2026-01-16T04:16:33.8041035Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:822
2026-01-16T04:16:33.8042352Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.walkCriteria
2026-01-16T04:16:33.8043322Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:811
2026-01-16T04:16:33.8044252Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.walkCriteria
2026-01-16T04:16:33.8045423Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:811
2026-01-16T04:16:33.8046423Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.collectPackages
2026-01-16T04:16:33.8047577Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:514
2026-01-16T04:16:33.8048587Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract.func2
2026-01-16T04:16:33.8049656Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:297
2026-01-16T04:16:33.8050622Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract
2026-01-16T04:16:33.8051642Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:302
2026-01-16T04:16:33.8052557Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract.func1
2026-01-16T04:16:33.8053405Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:140
2026-01-16T04:16:33.8053805Z path/filepath.walkDir
2026-01-16T04:16:33.8054140Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:310
2026-01-16T04:16:33.8054485Z path/filepath.walkDir
2026-01-16T04:16:33.8054803Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
2026-01-16T04:16:33.8055364Z path/filepath.WalkDir
2026-01-16T04:16:33.8055683Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:400
2026-01-16T04:16:33.8056137Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract
2026-01-16T04:16:33.8056898Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:119
2026-01-16T04:16:33.8057655Z github.com/MaineK00n/vuls-data-update/pkg/cmd/extract.newCmdRedHatOVALv2.func1
2026-01-16T04:16:33.8058558Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/extract/extract.go:2346
2026-01-16T04:16:33.8059262Z github.com/spf13/cobra.(*Command).execute
2026-01-16T04:16:33.8060263Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-16T04:16:33.8060940Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-16T04:16:33.8061654Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-16T04:16:33.8062347Z github.com/spf13/cobra.(*Command).Execute
2026-01-16T04:16:33.8063100Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-16T04:16:33.8063774Z main.main
2026-01-16T04:16:33.8064418Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-16T04:16:33.8065615Z runtime.main
2026-01-16T04:16:33.8066172Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-16T04:16:33.8066752Z runtime.goexit
2026-01-16T04:16:33.8067312Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-16T04:16:33.8067968Z walk criterions
2026-01-16T04:16:33.8068689Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.walkCriteria
2026-01-16T04:16:33.8069846Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:824
2026-01-16T04:16:33.8070927Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.walkCriteria
2026-01-16T04:16:33.8072052Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:811
2026-01-16T04:16:33.8073128Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.walkCriteria
2026-01-16T04:16:33.8074179Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:811
2026-01-16T04:16:33.8074862Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.collectPackages
2026-01-16T04:16:33.8075733Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:514
2026-01-16T04:16:33.8076491Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract.func2
2026-01-16T04:16:33.8077069Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:297
2026-01-16T04:16:33.8077607Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract
2026-01-16T04:16:33.8078158Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:302
2026-01-16T04:16:33.8078673Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract.func1
2026-01-16T04:16:33.8079211Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:140
2026-01-16T04:16:33.8079603Z path/filepath.walkDir
2026-01-16T04:16:33.8079939Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:310
2026-01-16T04:16:33.8080267Z path/filepath.walkDir
2026-01-16T04:16:33.8080582Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
2026-01-16T04:16:33.8080910Z path/filepath.WalkDir
2026-01-16T04:16:33.8081218Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:400
2026-01-16T04:16:33.8081660Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract
2026-01-16T04:16:33.8082181Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:119
2026-01-16T04:16:33.8082708Z github.com/MaineK00n/vuls-data-update/pkg/cmd/extract.newCmdRedHatOVALv2.func1
2026-01-16T04:16:33.8083237Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/extract/extract.go:2346
2026-01-16T04:16:33.8083627Z github.com/spf13/cobra.(*Command).execute
2026-01-16T04:16:33.8084014Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-16T04:16:33.8084378Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-16T04:16:33.8084762Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-16T04:16:33.8085297Z github.com/spf13/cobra.(*Command).Execute
2026-01-16T04:16:33.8085673Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-16T04:16:33.8086005Z main.main
2026-01-16T04:16:33.8086324Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-16T04:16:33.8086681Z runtime.main
2026-01-16T04:16:33.8086952Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-16T04:16:33.8087383Z runtime.goexit
2026-01-16T04:16:33.8087675Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-16T04:16:33.8087980Z walk criteria
2026-01-16T04:16:33.8088340Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.walkCriteria
2026-01-16T04:16:33.8088925Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:813
2026-01-16T04:16:33.8089475Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.walkCriteria
2026-01-16T04:16:33.8090042Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:811
2026-01-16T04:16:33.8090609Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.collectPackages
2026-01-16T04:16:33.8091198Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:514
2026-01-16T04:16:33.8091745Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract.func2
2026-01-16T04:16:33.8092316Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:297
2026-01-16T04:16:33.8092848Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract
2026-01-16T04:16:33.8093393Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:302
2026-01-16T04:16:33.8093901Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract.func1
2026-01-16T04:16:33.8094440Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:140
2026-01-16T04:16:33.8094821Z path/filepath.walkDir
2026-01-16T04:16:33.8095497Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:310
2026-01-16T04:16:33.8095908Z path/filepath.walkDir
2026-01-16T04:16:33.8096226Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
2026-01-16T04:16:33.8096682Z path/filepath.WalkDir
2026-01-16T04:16:33.8096986Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:400
2026-01-16T04:16:33.8097438Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract
2026-01-16T04:16:33.8097956Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:119
2026-01-16T04:16:33.8098483Z github.com/MaineK00n/vuls-data-update/pkg/cmd/extract.newCmdRedHatOVALv2.func1
2026-01-16T04:16:33.8099009Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/extract/extract.go:2346
2026-01-16T04:16:33.8099395Z github.com/spf13/cobra.(*Command).execute
2026-01-16T04:16:33.8099775Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-16T04:16:33.8100136Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-16T04:16:33.8100515Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-16T04:16:33.8100875Z github.com/spf13/cobra.(*Command).Execute
2026-01-16T04:16:33.8101251Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-16T04:16:33.8101572Z main.main
2026-01-16T04:16:33.8101888Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-16T04:16:33.8102251Z runtime.main
2026-01-16T04:16:33.8102521Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-16T04:16:33.8102822Z runtime.goexit
2026-01-16T04:16:33.8103107Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-16T04:16:33.8103417Z walk criteria
2026-01-16T04:16:33.8103800Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.walkCriteria
2026-01-16T04:16:33.8104378Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:813
2026-01-16T04:16:33.8105177Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.collectPackages
2026-01-16T04:16:33.8105786Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:514
2026-01-16T04:16:33.8106346Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract.func2
2026-01-16T04:16:33.8106911Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:297
2026-01-16T04:16:33.8107572Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract
2026-01-16T04:16:33.8108138Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:302
2026-01-16T04:16:33.8108651Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract.func1
2026-01-16T04:16:33.8109183Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:140
2026-01-16T04:16:33.8109568Z path/filepath.walkDir
2026-01-16T04:16:33.8109886Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:310
2026-01-16T04:16:33.8110208Z path/filepath.walkDir
2026-01-16T04:16:33.8110519Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
2026-01-16T04:16:33.8110840Z path/filepath.WalkDir
2026-01-16T04:16:33.8111145Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:400
2026-01-16T04:16:33.8111585Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract
2026-01-16T04:16:33.8112162Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:119
2026-01-16T04:16:33.8112719Z github.com/MaineK00n/vuls-data-update/pkg/cmd/extract.newCmdRedHatOVALv2.func1
2026-01-16T04:16:33.8113251Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/extract/extract.go:2346
2026-01-16T04:16:33.8113630Z github.com/spf13/cobra.(*Command).execute
2026-01-16T04:16:33.8114008Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-16T04:16:33.8114371Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-16T04:16:33.8114746Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-16T04:16:33.8166083Z github.com/spf13/cobra.(*Command).Execute
2026-01-16T04:16:33.8166618Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-16T04:16:33.8167230Z main.main
2026-01-16T04:16:33.8167619Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-16T04:16:33.8168034Z runtime.main
2026-01-16T04:16:33.8168312Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-16T04:16:33.8168622Z runtime.goexit
2026-01-16T04:16:33.8168908Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-16T04:16:33.8169230Z walk criteria
2026-01-16T04:16:33.8169609Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.collectPackages
2026-01-16T04:16:33.8170241Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:516
2026-01-16T04:16:33.8170810Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract.func2
2026-01-16T04:16:33.8171389Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:297
2026-01-16T04:16:33.8171916Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract
2026-01-16T04:16:33.8172463Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:302
2026-01-16T04:16:33.8172970Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract.func1
2026-01-16T04:16:33.8173495Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:140
2026-01-16T04:16:33.8173872Z path/filepath.walkDir
2026-01-16T04:16:33.8174200Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:310
2026-01-16T04:16:33.8174528Z path/filepath.walkDir
2026-01-16T04:16:33.8174834Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
2026-01-16T04:16:33.8175321Z path/filepath.WalkDir
2026-01-16T04:16:33.8175624Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:400
2026-01-16T04:16:33.8176064Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract
2026-01-16T04:16:33.8176579Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:119
2026-01-16T04:16:33.8177110Z github.com/MaineK00n/vuls-data-update/pkg/cmd/extract.newCmdRedHatOVALv2.func1
2026-01-16T04:16:33.8177634Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/extract/extract.go:2346
2026-01-16T04:16:33.8178019Z github.com/spf13/cobra.(*Command).execute
2026-01-16T04:16:33.8178532Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-16T04:16:33.8178903Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-16T04:16:33.8179275Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-16T04:16:33.8179631Z github.com/spf13/cobra.(*Command).Execute
2026-01-16T04:16:33.8179999Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-16T04:16:33.8180318Z main.main
2026-01-16T04:16:33.8180634Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-16T04:16:33.8180986Z runtime.main
2026-01-16T04:16:33.8181254Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-16T04:16:33.8181559Z runtime.goexit
2026-01-16T04:16:33.8181847Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-16T04:16:33.8182172Z collect packages
2026-01-16T04:16:33.8182544Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract.func2
2026-01-16T04:16:33.8183138Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:299
2026-01-16T04:16:33.8183673Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract
2026-01-16T04:16:33.8184211Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:302
2026-01-16T04:16:33.8184723Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract.func1
2026-01-16T04:16:33.8185541Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:140
2026-01-16T04:16:33.8185942Z path/filepath.walkDir
2026-01-16T04:16:33.8186269Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:310
2026-01-16T04:16:33.8186610Z path/filepath.walkDir
2026-01-16T04:16:33.8187054Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
2026-01-16T04:16:33.8187382Z path/filepath.WalkDir
2026-01-16T04:16:33.8187687Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:400
2026-01-16T04:16:33.8188138Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract
2026-01-16T04:16:33.8188662Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:119
2026-01-16T04:16:33.8189189Z github.com/MaineK00n/vuls-data-update/pkg/cmd/extract.newCmdRedHatOVALv2.func1
2026-01-16T04:16:33.8189721Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/extract/extract.go:2346
2026-01-16T04:16:33.8190107Z github.com/spf13/cobra.(*Command).execute
2026-01-16T04:16:33.8190485Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-16T04:16:33.8190851Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-16T04:16:33.8191229Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-16T04:16:33.8191593Z github.com/spf13/cobra.(*Command).Execute
2026-01-16T04:16:33.8191955Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-16T04:16:33.8192279Z main.main
2026-01-16T04:16:33.8192598Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-16T04:16:33.8192946Z runtime.main
2026-01-16T04:16:33.8193218Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-16T04:16:33.8193520Z runtime.goexit
2026-01-16T04:16:33.8193799Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-16T04:16:33.8194111Z walk detections
2026-01-16T04:16:33.8194454Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.extractor.extract
2026-01-16T04:16:33.8195138Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:304
2026-01-16T04:16:33.8195654Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract.func1
2026-01-16T04:16:33.8196188Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:140
2026-01-16T04:16:33.8196570Z path/filepath.walkDir
2026-01-16T04:16:33.8196876Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:310
2026-01-16T04:16:33.8197201Z path/filepath.walkDir
2026-01-16T04:16:33.8197618Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
2026-01-16T04:16:33.8197942Z path/filepath.WalkDir
2026-01-16T04:16:33.8198237Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:400
2026-01-16T04:16:33.8198672Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract
2026-01-16T04:16:33.8199184Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:119
2026-01-16T04:16:33.8199698Z github.com/MaineK00n/vuls-data-update/pkg/cmd/extract.newCmdRedHatOVALv2.func1
2026-01-16T04:16:33.8200223Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/extract/extract.go:2346
2026-01-16T04:16:33.8200605Z github.com/spf13/cobra.(*Command).execute
2026-01-16T04:16:33.8200979Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-16T04:16:33.8201344Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-16T04:16:33.8201716Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-16T04:16:33.8202074Z github.com/spf13/cobra.(*Command).Execute
2026-01-16T04:16:33.8202440Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-16T04:16:33.8202762Z main.main
2026-01-16T04:16:33.8203077Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-16T04:16:33.8203429Z runtime.main
2026-01-16T04:16:33.8203699Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-16T04:16:33.8203998Z runtime.goexit
2026-01-16T04:16:33.8204282Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-16T04:16:33.8205035Z extract ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-ovalv2/9/rhel-9/definitions/oval:com.redhat.rhsa:def:202520518.json
2026-01-16T04:16:33.8205754Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract.func1
2026-01-16T04:16:33.8206423Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:142
2026-01-16T04:16:33.8206803Z path/filepath.walkDir
2026-01-16T04:16:33.8207120Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:310
2026-01-16T04:16:33.8207454Z path/filepath.walkDir
2026-01-16T04:16:33.8207765Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
2026-01-16T04:16:33.8208087Z path/filepath.WalkDir
2026-01-16T04:16:33.8208387Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:400
2026-01-16T04:16:33.8208828Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract
2026-01-16T04:16:33.8209352Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:119
2026-01-16T04:16:33.8209879Z github.com/MaineK00n/vuls-data-update/pkg/cmd/extract.newCmdRedHatOVALv2.func1
2026-01-16T04:16:33.8210409Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/extract/extract.go:2346
2026-01-16T04:16:33.8210797Z github.com/spf13/cobra.(*Command).execute
2026-01-16T04:16:33.8211179Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-16T04:16:33.8211545Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-16T04:16:33.8211926Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-16T04:16:33.8212281Z github.com/spf13/cobra.(*Command).Execute
2026-01-16T04:16:33.8212649Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-16T04:16:33.8212974Z main.main
2026-01-16T04:16:33.8213286Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-16T04:16:33.8213641Z runtime.main
2026-01-16T04:16:33.8213914Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-16T04:16:33.8214212Z runtime.goexit
2026-01-16T04:16:33.8214490Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-16T04:16:33.8215084Z walk ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-ovalv2/9/rhel-9/definitions
2026-01-16T04:16:33.8215599Z github.com/MaineK00n/vuls-data-update/pkg/extract/redhat/oval/v2.Extract
2026-01-16T04:16:33.8216108Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/extract/redhat/oval/v2/v2.go:193
2026-01-16T04:16:33.8216743Z github.com/MaineK00n/vuls-data-update/pkg/cmd/extract.newCmdRedHatOVALv2.func1
2026-01-16T04:16:33.8217274Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/extract/extract.go:2346
2026-01-16T04:16:33.8217654Z github.com/spf13/cobra.(*Command).execute
2026-01-16T04:16:33.8218022Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-16T04:16:33.8218380Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-16T04:16:33.8218897Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-16T04:16:33.8219516Z github.com/spf13/cobra.(*Command).Execute
2026-01-16T04:16:33.8220163Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-16T04:16:33.8220713Z main.main
2026-01-16T04:16:33.8221242Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-16T04:16:33.8221891Z runtime.main
2026-01-16T04:16:33.8222410Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-16T04:16:33.8222973Z runtime.goexit
2026-01-16T04:16:33.8223564Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
2026-01-16T04:16:33.8224180Z failed to extract redhat ovalv2
2026-01-16T04:16:33.8225079Z github.com/MaineK00n/vuls-data-update/pkg/cmd/extract.newCmdRedHatOVALv2.func1
2026-01-16T04:16:33.8226058Z 	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/extract/extract.go:2347
2026-01-16T04:16:33.8226663Z github.com/spf13/cobra.(*Command).execute
2026-01-16T04:16:33.8227055Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
2026-01-16T04:16:33.8227425Z github.com/spf13/cobra.(*Command).ExecuteC
2026-01-16T04:16:33.8227807Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
2026-01-16T04:16:33.8228160Z github.com/spf13/cobra.(*Command).Execute
2026-01-16T04:16:33.8228700Z 	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
2026-01-16T04:16:33.8229028Z main.main
2026-01-16T04:16:33.8229359Z 	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
2026-01-16T04:16:33.8229718Z runtime.main
2026-01-16T04:16:33.8229998Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
2026-01-16T04:16:33.8230302Z runtime.goexit
2026-01-16T04:16:33.8230585Z 	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
```
https://github.com/vulsio/vuls-data-db/actions/runs/21054862959/job/60549782808#step:9:297