### PR TITLE
fix(extract/suse/oval): handle empty SUSE-SU ID

### DIFF
--- a/pkg/extract/suse/oval/oval.go
+++ b/pkg/extract/suse/oval/oval.go
@@ -481,6 +481,13 @@ func buildAdvisoryAndVulnerability(def oval.Definition) ([]advisoryContentTypes.
 				URL:    strings.TrimSuffix(strings.TrimSpace(r.RefURL), "/"),
 			}] = struct{}{}
 		case "SUSE-SU":
+			if r.RefID == "" {
+				if r.RefURL == "" {
+					continue
+				}
+				return nil, vulnerabilityContentTypes.Content{}, errors.New("unexpected empty SUSE-SU ID.")
+			}
+
 			advs = append(advs, advisoryContentTypes.Content{
 				ID:    advisoryContentTypes.AdvisoryID(strings.TrimSpace(r.RefID)),
 				Title: r.RefID,

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/11/vulnerability/definitions/oval%3Aorg.opensuse.security%3Adef%3A20093547.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/11/vulnerability/definitions/oval%3Aorg.opensuse.security%3Adef%3A20093547.json
@@ -1,0 +1,90 @@
+{
+	"id": "oval:org.opensuse.security:def:20093547",
+	"version": "1",
+	"class": "vulnerability",
+	"metadata": {
+		"title": "CVE-2009-3547",
+		"affected": {
+			"family": "unix",
+			"platform": [
+				"SUSE Linux Enterprise Server 11",
+				"SUSE Linux Enterprise Server for SAP Applications 11"
+			]
+		},
+		"reference": [
+			{
+				"ref_id": "Mitre CVE-2009-3547",
+				"ref_url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3547",
+				"source": "CVE"
+			},
+			{
+				"ref_id": "SUSE CVE-2009-3547",
+				"ref_url": "https://www.suse.com/security/cve/CVE-2009-3547",
+				"source": "SUSE CVE"
+			},
+			{
+				"source": "SUSE-SU"
+			},
+			{
+				"ref_id": "SUSE-SA:2009:054",
+				"ref_url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00005.html",
+				"source": "SUSE-SU"
+			},
+			{
+				"ref_id": "SUSE-SA:2009:055",
+				"ref_url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00006.html",
+				"source": "SUSE-SU"
+			},
+			{
+				"ref_id": "SUSE-SA:2009:056",
+				"ref_url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00007.html",
+				"source": "SUSE-SU"
+			},
+			{
+				"ref_id": "SUSE-SA:2009:060",
+				"ref_url": "https://lists.opensuse.org/opensuse-security-announce/2009-12/msg00001.html",
+				"source": "SUSE-SU"
+			},
+			{
+				"ref_id": "SUSE-SA:2010:001",
+				"ref_url": "https://lists.opensuse.org/opensuse-security-announce/2010-01/msg00000.html",
+				"source": "SUSE-SU"
+			},
+			{
+				"ref_id": "SUSE-SA:2010:012",
+				"ref_url": "https://lists.opensuse.org/opensuse-security-announce/2010-02/msg00005.html",
+				"source": "SUSE-SU"
+			}
+		],
+		"description": "\n    Multiple race conditions in fs/pipe.c in the Linux kernel before 2.6.32-rc6 allow local users to cause a denial of service (NULL pointer dereference and system crash) or gain privileges by attempting to open an anonymous pipe via a /proc/*/fd/ pathname.\n    ",
+		"advisory": {
+			"from": "security@suse.de",
+			"severity": "Important",
+			"cve": [
+				{
+					"text": "CVE-2009-3547",
+					"href": "https://www.suse.com/security/cve/CVE-2009-3547/",
+					"impact": "important"
+				}
+			],
+			"bugzilla": [
+				{
+					"text": "SUSE bug 550001",
+					"href": "https://bugzilla.suse.com/550001"
+				}
+			],
+			"issued": {
+				"date": "2022-05-20"
+			},
+			"updated": {
+				"date": "2022-05-20"
+			},
+			"affected_cpe_list": {
+				"cpe": [
+					"cpe:/o:suse:sles_sap:11",
+					"cpe:/o:suse:suse_sles:11"
+				]
+			}
+		}
+	}
+}

--- a/pkg/extract/suse/oval/testdata/golden/data/2009/CVE-2009-3547.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2009/CVE-2009-3547.json
@@ -1,0 +1,155 @@
+{
+	"id": "CVE-2009-3547",
+	"advisories": [
+		{
+			"content": {
+				"id": "SUSE-SA:2009:054",
+				"title": "SUSE-SA:2009:054",
+				"references": [
+					{
+						"source": "SUSE",
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00005.html"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "suse.linux.enterprise:11"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "SUSE-SA:2009:055",
+				"title": "SUSE-SA:2009:055",
+				"references": [
+					{
+						"source": "SUSE",
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00006.html"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "suse.linux.enterprise:11"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "SUSE-SA:2009:056",
+				"title": "SUSE-SA:2009:056",
+				"references": [
+					{
+						"source": "SUSE",
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00007.html"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "suse.linux.enterprise:11"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "SUSE-SA:2009:060",
+				"title": "SUSE-SA:2009:060",
+				"references": [
+					{
+						"source": "SUSE",
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-12/msg00001.html"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "suse.linux.enterprise:11"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "SUSE-SA:2010:001",
+				"title": "SUSE-SA:2010:001",
+				"references": [
+					{
+						"source": "SUSE",
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2010-01/msg00000.html"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "suse.linux.enterprise:11"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "SUSE-SA:2010:012",
+				"title": "SUSE-SA:2010:012",
+				"references": [
+					{
+						"source": "SUSE",
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2010-02/msg00005.html"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "suse.linux.enterprise:11"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2009-3547",
+				"title": "CVE-2009-3547",
+				"description": "Multiple race conditions in fs/pipe.c in the Linux kernel before 2.6.32-rc6 allow local users to cause a denial of service (NULL pointer dereference and system crash) or gain privileges by attempting to open an anonymous pipe via a /proc/*/fd/ pathname.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "SUSE Severity",
+						"vendor": "Important"
+					},
+					{
+						"type": "vendor",
+						"source": "SUSE impact",
+						"vendor": "important"
+					}
+				],
+				"references": [
+					{
+						"source": "CVE",
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3547"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://bugzilla.suse.com/550001"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-2009-3547"
+					}
+				],
+				"published": "2022-05-20T00:00:00Z",
+				"modified": "2022-05-20T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "suse.linux.enterprise:11"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "suse-oval",
+		"raws": [
+			"fixtures/suse.linux.enterprise/11/vulnerability/definitions/oval:org.opensuse.security:def:20093547.json"
+		]
+	}
+}


### PR DESCRIPTION
Got an error at "vuls db add" step.

```
failed to exec vuls: key required
put "vulnerability -> advisory -> "
github.com/MaineK00n/vuls2/pkg/db/session/internal/boltdb.putAdvisory
        /home/shino/g/suse-extract/vuls2/pkg/db/session/internal/boltdb/boltdb.go:314
github.com/MaineK00n/vuls2/pkg/db/session/internal/boltdb.(*Connection).Put.func1.(*Connection).Put.func1.1.3
        /home/shino/g/suse-extract/vuls2/pkg/db/session/internal/boltdb/boltdb.go:158
path/filepath.walkDir
        /home/shino/sdk/go1.25.4/src/path/filepath/path.go:310
path/filepath.walkDir
        /home/shino/sdk/go1.25.4/src/path/filepath/path.go:332
path/filepath.walkDir
        /home/shino/sdk/go1.25.4/src/path/filepath/path.go:332
path/filepath.WalkDir
        /home/shino/sdk/go1.25.4/src/path/filepath/path.go:400
github.com/MaineK00n/vuls2/pkg/db/session/internal/boltdb.(*Connection).Put.func1.1
        /home/shino/g/suse-extract/vuls2/pkg/db/session/internal/boltdb/boltdb.go:134
[snip]
```

Such a data!! 🤷 
```
<definition id="oval:org.opensuse.security:def:20093547" version="1" class="vulnerability">
 <metadata>
 <title>CVE-2009-3547</title>
    <affected family="unix">
            <platform>SUSE Linux Enterprise Server 11</platform>
            <platform>SUSE Linux Enterprise Server for SAP Applications 11</platform>
    </affected>
    <reference ref_id="Mitre CVE-2009-3547" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3547" source="CVE"/>
    <reference ref_id="SUSE CVE-2009-3547" ref_url="https://www.suse.com/security/cve/CVE-2009-3547" source="SUSE CVE"/>
                <reference ref_id="" ref_url="" source="SUSE-SU"/>
```