### PR TITLE
chore(fetch/ubuntu/tracker): add output to git clone error

### DIFF
--- a/pkg/fetch/ubuntu/tracker/tracker.go
+++ b/pkg/fetch/ubuntu/tracker/tracker.go
@@ -81,8 +81,8 @@ func Fetch(opts ...Option) error {
 	}
 	defer os.RemoveAll(cloneDir)
 
-	if err := exec.Command("git", "clone", "--depth", "1", options.repoURL, cloneDir).Run(); err != nil {
-		return errors.Wrapf(err, "git clone --depth 1 %s %s", options.repoURL, cloneDir)
+	if output, err := exec.Command("git", "clone", "--depth", "1", options.repoURL, cloneDir).CombinedOutput(); err != nil {
+		return errors.Wrapf(err, "git clone --depth 1 %s %s. output:\n%s", options.repoURL, cloneDir, string(output))
 	}
 
 	for _, target := range []string{"active", "retired", "ignored"} {


### PR DESCRIPTION
At ubuntu-cve-tracker fetch, "git clone" fails sometimes but I don't know why:
https://github.com/vulsio/vuls-data-db/actions/runs/21562766759/job/62129307249
```
2026/02/01 12:59:40 [INFO] Fetch Ubuntu CVE Tracker
exit status 128
git clone --depth 1 git://git.launchpad.net/ubuntu-cve-tracker /tmp/vuls-data-update2206642388
github.com/MaineK00n/vuls-data-update/pkg/fetch/ubuntu/tracker.Fetch
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/fetch/ubuntu/tracker/tracker.go:85
github.com/MaineK00n/vuls-data-update/pkg/cmd/fetch.newCmdUbuntuCVETracker.func1
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/fetch/fetch.go:5261
[snip]
```

This PR adds "git clone"'s stdout/stderr to error logging.

-----------

By intentional error embedding,:
```
[0]% git diff
diff --git a/pkg/fetch/ubuntu/tracker/tracker.go b/pkg/fetch/ubuntu/tracker/tracker.go
index c20230c5..006c4e45 100644
--- a/pkg/fetch/ubuntu/tracker/tracker.go
+++ b/pkg/fetch/ubuntu/tracker/tracker.go
@@ -81,7 +81,7 @@ func Fetch(opts ...Option) error {
        }
        defer os.RemoveAll(cloneDir)

-       if output, err := exec.Command("git", "clone", "--depth", "1", options.repoURL, cloneDir).CombinedOutput(); err != nil {
+       if output, err := exec.Command("git", "clone", "--depth", "1", options.repoURL+"XXX", cloneDir).CombinedOutput(); err != nil {
                return errors.Wrapf(err, "git clone --depth 1 %s %s. output:\n%s", options.repoURL, cloneDir, string(output))
        }
```

the log output is:
```
[0]% go run ./cmd/vuls-data-update fetch ubuntu-cve-tracker
2026/02/02 12:02:11 [INFO] Fetch Ubuntu CVE Tracker
exit status 128
git clone --depth 1 git://git.launchpad.net/ubuntu-cve-tracker /tmp/vuls-data-update649293070. output:
Cloning into '/tmp/vuls-data-update649293070'...
fatal: remote error: Repository 'ubuntu-cve-trackerXXX' not found.

github.com/MaineK00n/vuls-data-update/pkg/fetch/ubuntu/tracker.Fetch
        /home/shino/g/vuls-data-update/pkg/fetch/ubuntu/tracker/tracker.go:85
github.com/MaineK00n/vuls-data-update/pkg/cmd/fetch.newCmdUbuntuCVETracker.func1
        /home/shino/g/vuls-data-update/pkg/cmd/fetch/fetch.go:5299
[snip]
```
