### PR TITLE
fix(extract/suse/oval): set Vulnerable flag of kernel livepatch to true

### DIFF
--- a/pkg/extract/suse/oval/oval.go
+++ b/pkg/extract/suse/oval/oval.go
@@ -875,7 +875,7 @@ func (e extractor) translateEVRCriterion(oc oval.Criterion, t oval.RpminfoTest, 
 				Version: &vcTypes.Criterion{
 					Vulnerable: true,
 					FixStatus: &fixstatusTypes.FixStatus{
-						Class: fixstatusTypes.ClassUnknown,
+						Class: fixstatusTypes.ClassFixed,
 					},
 					Package: pkg,
 					Affected: &affectedTypes.Affected{

--- a/pkg/extract/suse/oval/testdata/golden/data/2022/CVE-2022-0330.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2022/CVE-2022-0330.json
@@ -2895,7 +2895,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -2962,7 +2962,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3029,7 +3029,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3096,7 +3096,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3163,7 +3163,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3230,7 +3230,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3297,7 +3297,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3364,7 +3364,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3431,7 +3431,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3498,7 +3498,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3565,7 +3565,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3632,7 +3632,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -3699,7 +3699,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -8834,7 +8834,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -8901,7 +8901,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -8968,7 +8968,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -9365,7 +9365,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -9432,7 +9432,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -9499,7 +9499,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -9566,7 +9566,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -9936,7 +9936,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -10003,7 +10003,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -10070,7 +10070,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -10137,7 +10137,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -10204,7 +10204,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -10271,7 +10271,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -10338,7 +10338,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -10405,7 +10405,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -10472,7 +10472,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -10539,7 +10539,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",
@@ -10606,7 +10606,7 @@
 																"version": {
 																	"vulnerable": true,
 																	"fix_status": {
-																		"class": "unknown"
+																		"class": "fixed"
 																	},
 																	"package": {
 																		"type": "binary",


### PR DESCRIPTION
Vulnerable flag for kernel livepatch criterions were false.
This PR set them to true.

The reason of change is:
- In the environment where kernel itself and its livepatch are both installed,
- Updating livepatch package without restarting OS totally, so it should be listed in vulnerable packages, I think. 

Also, change fix statuses of kernel with "equal" criterias (siblings livepatch) of  from "unknown" to "fixed".