### PR TITLE
refactor: migrate from log to log/slog with structured logging

### DIFF
--- a/pkg/dotgit/compress/compress.go
+++ b/pkg/dotgit/compress/compress.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -61,7 +61,7 @@ func Compress(src, dst string, opts ...Option) error {
 		opt.apply(options)
 	}
 
-	log.Printf("[INFO] Compress %s dotgit to %s", src, dst)
+	slog.Info("Compress dotgit", slog.String("src", src), slog.String("dst", dst))
 
 	if err := options.compress(src, dst); err != nil {
 		if err2 := os.Remove(dst); err2 != nil {

--- a/pkg/dotgit/pull/pull.go
+++ b/pkg/dotgit/pull/pull.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json/v2"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -82,7 +82,7 @@ func Pull(repository string, opts ...Option) error {
 		opt.apply(options)
 	}
 
-	log.Printf("[INFO] Pull dotgit from %s", repository)
+	slog.Info("Pull dotgit", slog.String("repository", repository))
 
 	ctx := context.TODO()
 

--- a/pkg/dotgit/registry/delete/delete.go
+++ b/pkg/dotgit/registry/delete/delete.go
@@ -3,7 +3,7 @@ package delete
 import (
 	"encoding/json/v2"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -144,7 +144,7 @@ func Delete(image, token string, opts ...Option) error {
 				if err := utilGitHub.Do(http.MethodDelete, uu.String(), token, func(resp *http.Response) error {
 					switch resp.StatusCode {
 					case http.StatusNoContent:
-						log.Printf("[INFO] Deleted: %s@%s (ID: %d)\n", repo.Reference.Repository, repo.Reference.Reference, id)
+						slog.Info("Deleted", slog.String("repository", repo.Reference.Repository), slog.String("reference", repo.Reference.Reference), slog.Int("id", id))
 						return nil
 					default:
 						return errors.Errorf("unexpected response status. expected: %d, actual: %d", []int{http.StatusNoContent}, resp.StatusCode)

--- a/pkg/dotgit/registry/tag/tag.go
+++ b/pkg/dotgit/registry/tag/tag.go
@@ -2,7 +2,7 @@ package tag
 
 import (
 	"context"
-	"log"
+	"log/slog"
 
 	"github.com/pkg/errors"
 	"oras.land/oras-go/v2"
@@ -12,7 +12,7 @@ import (
 )
 
 func Tag(imageRef, newTag, token string) error {
-	log.Printf("[INFO] Tag dotgit %s as %s", imageRef, newTag)
+	slog.Info("Tag dotgit", slog.String("image", imageRef), slog.String("tag", newTag))
 
 	repo, err := remote.NewRepository(imageRef)
 	if err != nil {

--- a/pkg/dotgit/registry/untag/untag.go
+++ b/pkg/dotgit/registry/untag/untag.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json/v2"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
@@ -59,7 +59,7 @@ func Untag(imageRef, token string, opts ...Option) error {
 		o.apply(options)
 	}
 
-	log.Printf("[INFO] Untag dotgit %s", imageRef)
+	slog.Info("Untag dotgit", slog.String("image", imageRef))
 
 	ctx := context.TODO()
 
@@ -138,8 +138,8 @@ func (o options) moveTagToDummy(ctx context.Context, owner, pack, tag, token str
 		return ocispec.Descriptor{}, errors.Wrapf(err, "fetch original manifest. tag: %s", tag)
 	}
 	defer r.Close()
-	log.Printf("[INFO] Original digest: %s", original.Digest.String())
-	log.Printf("[INFO] If you made a mistake, run the following command: vuls-data-update dotgit remote tag ghcr.io/%s/%s@%s %s --token $(gh auth token)", owner, pack, original.Digest.String(), tag)
+	slog.Info("Original digest", slog.String("digest", original.Digest.String()))
+	slog.Info("If you made a mistake, run the following command", slog.String("cmd", fmt.Sprintf("vuls-data-update dotgit remote tag ghcr.io/%s/%s@%s %s --token $(gh auth token)", owner, pack, original.Digest.String(), tag)))
 
 	dummyDesc, err := oras.PackManifest(ctx, dst, oras.PackManifestVersion1_1, "application/vnd.vulsio.vuls-data-db.dotgit.dummy.artifact.v1", oras.PackManifestOptions{})
 	if err != nil {

--- a/pkg/extract/alma/errata/errata.go
+++ b/pkg/extract/alma/errata/errata.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -73,7 +73,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract AlmaLinux Errata")
+	slog.Info("Extract AlmaLinux Errata")
 	ventries, err := os.ReadDir(args)
 	if err != nil {
 		return errors.Wrapf(err, "read dir %s", args)

--- a/pkg/extract/alma/osv/osv.go
+++ b/pkg/extract/alma/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract AlmaLinux OSV")
+	slog.Info("Extract AlmaLinux OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/alma/oval/oval.go
+++ b/pkg/extract/alma/oval/oval.go
@@ -2,7 +2,7 @@ package oval
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract AlmaLinux OVAL")
+	slog.Info("Extract AlmaLinux OVAL")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/alpine/osv/osv.go
+++ b/pkg/extract/alpine/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Alpine Linux OSV")
+	slog.Info("Extract Alpine Linux OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/alpine/secdb/secdb.go
+++ b/pkg/extract/alpine/secdb/secdb.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +67,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Alpine Linux SecDB")
+	slog.Info("Extract Alpine Linux SecDB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/amazon/amazon.go
+++ b/pkg/extract/amazon/amazon.go
@@ -3,7 +3,7 @@ package amazon
 import (
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -69,7 +69,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Amazon Linux")
+	slog.Info("Extract Amazon Linux")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/android/osv/osv.go
+++ b/pkg/extract/android/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Android OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/arch/arch.go
+++ b/pkg/extract/arch/arch.go
@@ -3,7 +3,7 @@ package arch
 import (
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -68,7 +68,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Arch Linux")
+	slog.Info("Extract Arch Linux")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/attack/attack.go
+++ b/pkg/extract/attack/attack.go
@@ -2,7 +2,7 @@ package attack
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract MITRE ATT&CK")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/bitnami/osv/osv.go
+++ b/pkg/extract/bitnami/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Bitnami OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/capec/capec.go
+++ b/pkg/extract/capec/capec.go
@@ -2,7 +2,7 @@ package capec
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract MITRE CAPEC")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/cargo/db/db.go
+++ b/pkg/extract/cargo/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Cargo DB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/cargo/ghsa/ghsa.go
+++ b/pkg/extract/cargo/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract GitHub Security Advisory: Cargo")
+	slog.Info("Extract Cargo GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/cargo/osv/osv.go
+++ b/pkg/extract/cargo/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Cargo OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/chainguard/osv/osv.go
+++ b/pkg/extract/chainguard/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Chainguard OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/cisa/kev/kev.go
+++ b/pkg/extract/cisa/kev/kev.go
@@ -3,7 +3,7 @@ package kev
 import (
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"time"
 
@@ -55,7 +55,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract CISA Known Exploited Vulnerabilities Catalog")
+	slog.Info("Extract CISA Known Exploited Vulnerabilities Catalog")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/composer/db/db.go
+++ b/pkg/extract/composer/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Composer DB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/composer/ghsa/ghsa.go
+++ b/pkg/extract/composer/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Composer GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/composer/glsa/glsa.go
+++ b/pkg/extract/composer/glsa/glsa.go
@@ -2,7 +2,7 @@ package glsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Composer GLSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/composer/osv/osv.go
+++ b/pkg/extract/composer/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Composer OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/conan/glsa/glsa.go
+++ b/pkg/extract/conan/glsa/glsa.go
@@ -2,7 +2,7 @@ package glsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Conan GLSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/cwe/cwe.go
+++ b/pkg/extract/cwe/cwe.go
@@ -2,7 +2,7 @@ package cwe
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract MITRE CWE")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/debian/osv/osv.go
+++ b/pkg/extract/debian/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Debian OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/debian/oval/oval.go
+++ b/pkg/extract/debian/oval/oval.go
@@ -2,7 +2,7 @@ package oval
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Debian OVAL")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/debian/tracker/api/api.go
+++ b/pkg/extract/debian/tracker/api/api.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Debian Security Tracker API")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/debian/tracker/salsa/salsa.go
+++ b/pkg/extract/debian/tracker/salsa/salsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -90,7 +90,7 @@ func Extract(root string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Debian Security Tracker Salsa repository")
+	slog.Info("Extract Debian Security Tracker Salsa")
 
 	pkgs, err := options.walkPackages(root)
 	if err != nil {

--- a/pkg/extract/eol/eol.go
+++ b/pkg/extract/eol/eol.go
@@ -2,7 +2,7 @@ package eol
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"maps"
 	"path/filepath"
 	"slices"
@@ -63,7 +63,7 @@ func Extract(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract End of Life")
+	slog.Info("Extract End of Life")
 	now := time.Now().UTC()
 	for c, eols := range options.eols {
 		for e, m := range eols {

--- a/pkg/extract/epss/epss.go
+++ b/pkg/extract/epss/epss.go
@@ -3,7 +3,7 @@ package epss
 import (
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"time"
@@ -55,7 +55,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Exploit Prediction Scoring System: EPSS")
+	slog.Info("Extract Exploit Prediction Scoring System: EPSS")
 
 	var latest time.Time
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {

--- a/pkg/extract/erlang/ghsa/ghsa.go
+++ b/pkg/extract/erlang/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Erlang GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/erlang/osv/osv.go
+++ b/pkg/extract/erlang/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Erlang OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/exploit/exploitdb/exploitdb.go
+++ b/pkg/extract/exploit/exploitdb/exploitdb.go
@@ -2,7 +2,7 @@ package exploitdb
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Exploit-DB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/exploit/github/github.go
+++ b/pkg/extract/exploit/github/github.go
@@ -2,7 +2,7 @@ package github
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Exploit GitHub")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/exploit/inthewild/inthewild.go
+++ b/pkg/extract/exploit/inthewild/inthewild.go
@@ -2,7 +2,7 @@ package inthewild
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Exploit InTheWild")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/exploit/trickest/trickest.go
+++ b/pkg/extract/exploit/trickest/trickest.go
@@ -2,7 +2,7 @@ package trickest
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Exploit Trickest")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/fedora/api/api.go
+++ b/pkg/extract/fedora/api/api.go
@@ -3,7 +3,7 @@ package api
 import (
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -72,7 +72,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Fedora & EPEL")
+	slog.Info("Extract Fedora API")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/fortinet/cvrf/cvrf.go
+++ b/pkg/extract/fortinet/cvrf/cvrf.go
@@ -2,7 +2,7 @@ package cvrf
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Fortinet CVRF")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/fortinet/handmade/handmade.go
+++ b/pkg/extract/fortinet/handmade/handmade.go
@@ -2,7 +2,7 @@ package handmade
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
@@ -40,7 +40,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Fortinet Handmade")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/freebsd/freebsd.go
+++ b/pkg/extract/freebsd/freebsd.go
@@ -3,7 +3,7 @@ package freebsd
 import (
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strings"
 
@@ -68,7 +68,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract FreeBSD")
+	slog.Info("Extract FreeBSD")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/gentoo/gentoo.go
+++ b/pkg/extract/gentoo/gentoo.go
@@ -2,7 +2,7 @@ package gentoo
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Gentoo")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/ghactions/osv/osv.go
+++ b/pkg/extract/ghactions/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract GitHub Actions OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/git/osv/osv.go
+++ b/pkg/extract/git/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Git OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/golang/db/db.go
+++ b/pkg/extract/golang/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Golang DB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/golang/ghsa/ghsa.go
+++ b/pkg/extract/golang/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Golang GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/golang/glsa/glsa.go
+++ b/pkg/extract/golang/glsa/glsa.go
@@ -2,7 +2,7 @@ package glsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Golang GLSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/golang/osv/osv.go
+++ b/pkg/extract/golang/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Golang OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/golang/vulndb/vulndb.go
+++ b/pkg/extract/golang/vulndb/vulndb.go
@@ -2,7 +2,7 @@ package vulndb
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Golang VulnDB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/haskell/db/db.go
+++ b/pkg/extract/haskell/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Haskell DB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/haskell/osv/osv.go
+++ b/pkg/extract/haskell/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Haskell OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/jvn/feed/detail/detail.go
+++ b/pkg/extract/jvn/feed/detail/detail.go
@@ -2,7 +2,7 @@ package detail
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract JVN Feed Detail")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/jvn/feed/product/product.go
+++ b/pkg/extract/jvn/feed/product/product.go
@@ -2,7 +2,7 @@ package product
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract JVN Feed Product")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/jvn/feed/rss/rss.go
+++ b/pkg/extract/jvn/feed/rss/rss.go
@@ -2,7 +2,7 @@ package rss
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract JVN Feed RSS")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/linux/osv/osv.go
+++ b/pkg/extract/linux/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Linux OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/maven/ghsa/ghsa.go
+++ b/pkg/extract/maven/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Maven GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/maven/glsa/glsa.go
+++ b/pkg/extract/maven/glsa/glsa.go
@@ -2,7 +2,7 @@ package glsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Maven GLSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/maven/osv/osv.go
+++ b/pkg/extract/maven/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Maven OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/microsoft/bulletin/bulletin.go
+++ b/pkg/extract/microsoft/bulletin/bulletin.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -76,7 +76,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Microsoft Bulletin")
+	slog.Info("Extract Microsoft Bulletin")
 
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -2,7 +2,7 @@ package cvrf
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Microsoft CVRF")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -67,7 +67,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Microsoft MSUC")
+	slog.Info("Extract Microsoft MSUC")
 
 	uidm, err := buildUpdateIDMap(args)
 	if err != nil {

--- a/pkg/extract/microsoft/wsusscn2/wsusscn2.go
+++ b/pkg/extract/microsoft/wsusscn2/wsusscn2.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +52,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Microsoft WSUSSCN2")
+	slog.Info("Extract Microsoft WSUSSCN2")
 	if err := options.extract(args); err != nil {
 		return errors.Wrapf(err, "extract")
 	}

--- a/pkg/extract/mitre/cvrf/cvrf.go
+++ b/pkg/extract/mitre/cvrf/cvrf.go
@@ -2,7 +2,7 @@ package cvrf
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract MITRE CVE CVRF")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/mitre/v4/v4.go
+++ b/pkg/extract/mitre/v4/v4.go
@@ -2,7 +2,7 @@ package v4
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract MITRE CVE v4")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/mitre/v5/v5.go
+++ b/pkg/extract/mitre/v5/v5.go
@@ -3,7 +3,7 @@ package v5
 import (
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"time"
 
@@ -60,7 +60,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract MITRE v5")
+	slog.Info("Extract MITRE CVE v5")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -150,7 +150,7 @@ func extract(fetched v5.CVE, raws []string) (dataTypes.Data, error) {
 								if metric.CVSSv2 != nil {
 									v2, err := v2Types.Parse(metric.CVSSv2.VectorString)
 									if err != nil {
-										log.Printf("[WARN] unexpected CVSS v2 vector: %s", metric.CVSSv2.VectorString)
+										slog.Warn("unexpected CVSS v2 vector", slog.String("vector", metric.CVSSv2.VectorString))
 										continue
 									}
 									ss = append(ss, severityTypes.Severity{
@@ -162,7 +162,7 @@ func extract(fetched v5.CVE, raws []string) (dataTypes.Data, error) {
 								if metric.CVSSv30 != nil {
 									v30, err := v30Types.Parse(metric.CVSSv30.VectorString)
 									if err != nil {
-										log.Printf("[WARN] unexpected CVSS v3.0 vector: %s", metric.CVSSv30.VectorString)
+										slog.Warn("unexpected CVSS v3.0 vector", slog.String("vector", metric.CVSSv30.VectorString))
 										continue
 									}
 									ss = append(ss, severityTypes.Severity{
@@ -174,7 +174,7 @@ func extract(fetched v5.CVE, raws []string) (dataTypes.Data, error) {
 								if metric.CVSSv31 != nil {
 									v31, err := v31Types.Parse(metric.CVSSv31.VectorString)
 									if err != nil {
-										log.Printf("[WARN] unexpected CVSS v3.1 vector: %s", metric.CVSSv31.VectorString)
+										slog.Warn("unexpected CVSS v3.1 vector", slog.String("vector", metric.CVSSv31.VectorString))
 										continue
 									}
 									ss = append(ss, severityTypes.Severity{
@@ -186,7 +186,7 @@ func extract(fetched v5.CVE, raws []string) (dataTypes.Data, error) {
 								if metric.CVSSv40 != nil {
 									v40, err := v40Types.Parse(metric.CVSSv40.VectorString)
 									if err != nil {
-										log.Printf("[WARN] unexpected CVSS v4.0 vector: %s", metric.CVSSv40.VectorString)
+										slog.Warn("unexpected CVSS v4.0 vector", slog.String("vector", metric.CVSSv40.VectorString))
 										continue
 									}
 									ss = append(ss, severityTypes.Severity{

--- a/pkg/extract/msf/msf.go
+++ b/pkg/extract/msf/msf.go
@@ -2,7 +2,7 @@ package msf
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Metasploit Framework")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/netbsd/netbsd.go
+++ b/pkg/extract/netbsd/netbsd.go
@@ -2,7 +2,7 @@ package netbsd
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NetBSD")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/npm/db/db.go
+++ b/pkg/extract/npm/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract npm DB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/npm/ghsa/ghsa.go
+++ b/pkg/extract/npm/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract npm GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/npm/glsa/glsa.go
+++ b/pkg/extract/npm/glsa/glsa.go
@@ -2,7 +2,7 @@ package glsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract npm GLSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/npm/osv/osv.go
+++ b/pkg/extract/npm/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract npm OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/nuget/ghsa/ghsa.go
+++ b/pkg/extract/nuget/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NuGet GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/nuget/glsa/glsa.go
+++ b/pkg/extract/nuget/glsa/glsa.go
@@ -2,7 +2,7 @@ package glsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NuGet GLSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/nuget/osv/osv.go
+++ b/pkg/extract/nuget/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NuGet OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/nvd/api/cpe/cpe.go
+++ b/pkg/extract/nvd/api/cpe/cpe.go
@@ -2,7 +2,7 @@ package cpe
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NVD API CPE")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/nvd/api/cve/cve.go
+++ b/pkg/extract/nvd/api/cve/cve.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -98,7 +98,7 @@ func Extract(cveDir, cpematchDir string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract NVD API CVE")
+	slog.Info("Extract NVD API CVE")
 
 	g, ctx := errgroup.WithContext(context.Background())
 	g.SetLimit(options.concurrency)

--- a/pkg/extract/nvd/feed/cpe/v1/v1.go
+++ b/pkg/extract/nvd/feed/cpe/v1/v1.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NVD Feed CPE v1")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/nvd/feed/cpe/v2/v2.go
+++ b/pkg/extract/nvd/feed/cpe/v2/v2.go
@@ -2,7 +2,7 @@ package v2
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NVD Feed CPE v2")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/nvd/feed/cpematch/v1/v1.go
+++ b/pkg/extract/nvd/feed/cpematch/v1/v1.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NVD Feed CPE Match v1")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/nvd/feed/cpematch/v2/v2.go
+++ b/pkg/extract/nvd/feed/cpematch/v2/v2.go
@@ -2,7 +2,7 @@ package v2
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NVD Feed CPE Match v2")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/nvd/feed/cve/v1/v1.go
+++ b/pkg/extract/nvd/feed/cve/v1/v1.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NVD Feed CVE v1")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/nvd/feed/cve/v2/v2.go
+++ b/pkg/extract/nvd/feed/cve/v2/v2.go
@@ -2,7 +2,7 @@ package v2
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract NVD Feed CVE v2")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/oracle/linux/linux.go
+++ b/pkg/extract/oracle/linux/linux.go
@@ -3,7 +3,7 @@ package linux
 import (
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,7 +82,7 @@ func Extract(inputDir string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Oracle Linux")
+	slog.Info("Extract Oracle Linux")
 
 	if err := filepath.WalkDir(filepath.Join(inputDir, "definitions"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -182,7 +182,7 @@ func (e extractor) extract(def linux.Definition) (dataTypes.Data, error) {
 				_, rhs, _ := strings.Cut(cve.CVSS2, "/")
 				v2, err := cvssV2Types.Parse(strings.TrimPrefix(rhs, "CVSS:2/")) // e.g. AV:L/AC:L/Au:N/C:C/I:C/A:C ; oval:com.oracle.elsa-201729301 CVE-2017-1000111, CVSS:2/AV:N/AC:M/Au:N/C:N/I:N/A:C ; oval:com.oracle.elsa-20184110 CVE-2018-1093
 				if err != nil {
-					log.Printf("[WARN] failed to parse CVSSv2. cve: %s, error: %s", cve.Text, err)
+					slog.Warn("failed to parse CVSSv2", slog.String("cve", cve.Text), slog.Any("err", err))
 					if !errors.Is(err, gocvss20.ErrTooShortVector) && !errors.Is(err, gocvss20.ErrInvalidMetricOrder) && !errors.Is(err, gocvss20.ErrInvalidMetricValue) { // e.g. AV:N/AC:N/Au:N/C:N/I:N/A:N ; oval:com.oracle.elsa:def:20100046 CVE-2009-2910
 						return nil, errors.Wrap(err, "parse cvss2")
 					}
@@ -200,7 +200,7 @@ func (e extractor) extract(def linux.Definition) (dataTypes.Data, error) {
 				case strings.HasPrefix(rhs, "CVSS:3.0"):
 					v30, err := cvssV30Types.Parse(rhs)
 					if err != nil {
-						log.Printf("[WARN] failed to parse CVSSv3.0. cve: %s, error: %s", cve.Text, err)
+						slog.Warn("failed to parse CVSSv3.0", slog.String("cve", cve.Text), slog.Any("err", err))
 						if !errors.Is(err, gocvss30.ErrTooShortVector) && !errors.Is(err, gocvss30.ErrInvalidMetricValue) { // e.g. CVSS:3.0/AV:N/AC:N/PR:N/UI:N/S:U/C:N/I:N/A:N ; oval:com.oracle.elsa:def:20130727 CVE-2013-1798
 							return nil, errors.Wrap(err, "parse cvss3")
 						}
@@ -214,7 +214,7 @@ func (e extractor) extract(def linux.Definition) (dataTypes.Data, error) {
 				case strings.HasPrefix(rhs, "CVSS:3.1"):
 					v31, err := cvssV31Types.Parse(rhs)
 					if err != nil {
-						log.Printf("[WARN] failed to parse CVSSv3.1. cve: %s, error: %s", cve.Text, err)
+						slog.Warn("failed to parse CVSSv3.1", slog.String("cve", cve.Text), slog.Any("err", err))
 						if !errors.Is(err, gocvss31.ErrTooShortVector) && !errors.Is(err, gocvss31.ErrInvalidMetricValue) {
 							return nil, errors.Wrap(err, "parse cvss3")
 						}

--- a/pkg/extract/oss-fuzz/osv/osv.go
+++ b/pkg/extract/oss-fuzz/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract OSS-Fuzz OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/perl/db/db.go
+++ b/pkg/extract/perl/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Perl DB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/pip/db/db.go
+++ b/pkg/extract/pip/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract pip DB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/pip/ghsa/ghsa.go
+++ b/pkg/extract/pip/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract pip GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/pip/glsa/glsa.go
+++ b/pkg/extract/pip/glsa/glsa.go
@@ -2,7 +2,7 @@ package glsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract pip GLSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/pip/osv/osv.go
+++ b/pkg/extract/pip/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract pip OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/pub/ghsa/ghsa.go
+++ b/pkg/extract/pub/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Pub GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/pub/osv/osv.go
+++ b/pkg/extract/pub/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Pub OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/r/db/db.go
+++ b/pkg/extract/r/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract R DB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/r/osv/osv.go
+++ b/pkg/extract/r/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract R OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/redhat/csaf/csaf.go
+++ b/pkg/extract/redhat/csaf/csaf.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io/fs"
-	"log"
+	"log/slog"
 	"maps"
 	"path/filepath"
 	"slices"
@@ -86,7 +86,7 @@ func Extract(csafDir, repository2cpeDir string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract RedHat CSAF")
+	slog.Info("Extract RedHat CSAF")
 
 	br := utiljson.NewJSONReader()
 	var r2c repository2cpe.RepositoryToCPE

--- a/pkg/extract/redhat/cve/cve.go
+++ b/pkg/extract/redhat/cve/cve.go
@@ -2,7 +2,7 @@ package cve
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract RedHat CVE")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/redhat/cvrf/cvrf.go
+++ b/pkg/extract/redhat/cvrf/cvrf.go
@@ -2,7 +2,7 @@ package cvrf
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract RedHat CVRF")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/redhat/osv/osv.go
+++ b/pkg/extract/redhat/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract RedHat OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/redhat/oval/v1/v1.go
+++ b/pkg/extract/redhat/oval/v1/v1.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -84,7 +84,7 @@ func Extract(ovalDir, repository2cpeDir string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract RedHat OVAL v1")
+	slog.Info("Extract RedHat OVAL v1")
 
 	br := utiljson.NewJSONReader()
 	var r2c repository2cpe.RepositoryToCPE

--- a/pkg/extract/redhat/oval/v2/v2.go
+++ b/pkg/extract/redhat/oval/v2/v2.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -88,7 +88,7 @@ func Extract(ovalDir, repository2cpeDir string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract RedHat OVAL v2")
+	slog.Info("Extract RedHat OVAL v2")
 
 	br := utiljson.NewJSONReader()
 	var r2c repository2cpe.RepositoryToCPE

--- a/pkg/extract/redhat/vex/vex.go
+++ b/pkg/extract/redhat/vex/vex.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io/fs"
-	"log"
+	"log/slog"
 	"maps"
 	"path/filepath"
 	"slices"
@@ -86,7 +86,7 @@ func Extract(vexDir, repository2cpeDir string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract RedHat VEX")
+	slog.Info("Extract RedHat VEX")
 
 	br := utiljson.NewJSONReader()
 	var r2c repository2cpe.RepositoryToCPE
@@ -351,7 +351,7 @@ func walkProductTree(trackingID string, pt vex.ProductTree, c2r map[string][]str
 									// https://issues.redhat.com/projects/SECDATA/issues/SECDATA-1206
 									switch trackingID {
 									case "CVE-2024-6923":
-										log.Printf("[WARN] %s: skip product with unexpected rpmmod format. expected: %q, actual: %q", trackingID, "pkg:rpm/redhat/<name>?arch=<arch>(&epoch=<epoch>)&rpmmod=<<module>:<stream>>", fpn.ProductIdentificationHelper.PURL)
+										slog.Warn("skip product with unexpected rpmmod format", slog.String("tracking_id", trackingID), slog.String("expected", "pkg:rpm/redhat/<name>?arch=<arch>(&epoch=<epoch>)&rpmmod=<<module>:<stream>>"), slog.String("purl", fpn.ProductIdentificationHelper.PURL))
 										return nil, nil
 									default:
 										return nil, errors.Errorf("unexpected purl format. expected: %q, actual: %q", "pkg:rpm/redhat/<name>?arch=<arch>(&epoch=<epoch>)&rpmmod=<<module>:<stream>>", fpn.ProductIdentificationHelper.PURL)
@@ -779,7 +779,7 @@ func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityConten
 	for pid, ps := range pm {
 		for _, p := range ps {
 			if p.name == "" {
-				log.Printf("[WARN] package name of %q in %q cannot be found", pid, string(baseVulnerability.ID))
+				slog.Warn("package name cannot be found", slog.String("product_id", string(pid)), slog.String("vulnerability_id", string(baseVulnerability.ID)))
 				continue
 			}
 
@@ -790,7 +790,7 @@ func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityConten
 			ass, found := assm[pid]
 			if !found {
 				// FIXME: what to do?
-				log.Printf("[WARN] advisory/severity/status not found for pid: %s", pid)
+				slog.Warn("advisory/severity/status not found for pid", slog.String("product_id", string(pid)))
 				continue
 			}
 

--- a/pkg/extract/rocky/errata/errata.go
+++ b/pkg/extract/rocky/errata/errata.go
@@ -3,7 +3,7 @@ package errata
 import (
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -75,7 +75,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Rocky Linux Errata")
+	slog.Info("Extract Rocky Linux Errata")
 
 	entries, err := os.ReadDir(args)
 	if err != nil {
@@ -191,7 +191,7 @@ func extract(fetched errata.Advisory, raws []string) (dataTypes.Data, error) {
 			// This should be an error, but until it is corrected, it will be processed in the log and no criterion will be generated for that package.
 			// https://github.com/resf/distro-tools/issues/72
 			if strings.Contains(evr, ".module+el") && (p.ModuleName == nil || p.ModuleStream == nil) {
-				log.Printf("[WARN] skip generating criterion for %q in %q: module package must have module info. module_name: %v, module_stream: %v", p.NEVRA, fetched.Name, p.ModuleName, p.ModuleStream)
+				slog.Warn("skip generating criterion: module package must have module info", slog.String("name", fetched.Name), slog.String("nevra", p.NEVRA), slog.Any("module_name", p.ModuleName), slog.Any("module_stream", p.ModuleStream))
 				continue
 			}
 

--- a/pkg/extract/rocky/osv/osv.go
+++ b/pkg/extract/rocky/osv/osv.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -75,7 +75,7 @@ func Extract(inputDir string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Rocky Linux OSV")
+	slog.Info("Extract Rocky Linux OSV")
 	entries, err := os.ReadDir(inputDir)
 	if err != nil {
 		return errors.Wrapf(err, "read dir %s", inputDir)

--- a/pkg/extract/rubygems/db/db.go
+++ b/pkg/extract/rubygems/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract RubyGems DB")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/rubygems/ghsa/ghsa.go
+++ b/pkg/extract/rubygems/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract RubyGems GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/rubygems/glsa/glsa.go
+++ b/pkg/extract/rubygems/glsa/glsa.go
@@ -2,7 +2,7 @@ package glsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract RubyGems GLSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/rubygems/osv/osv.go
+++ b/pkg/extract/rubygems/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract RubyGems OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/snort/snort.go
+++ b/pkg/extract/snort/snort.go
@@ -2,7 +2,7 @@ package snort
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Snort")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/suse/csaf/csaf.go
+++ b/pkg/extract/suse/csaf/csaf.go
@@ -2,7 +2,7 @@ package csaf
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract SUSE CSAF")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/suse/csaf_vex/csaf_vex.go
+++ b/pkg/extract/suse/csaf_vex/csaf_vex.go
@@ -2,7 +2,7 @@ package csaf_vex
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract SUSE CSAF VEX")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/suse/cvrf/cvrf.go
+++ b/pkg/extract/suse/cvrf/cvrf.go
@@ -2,7 +2,7 @@ package cvrf
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract SUSE CVRF")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/suse/cvrf_cve/cvrf_cve.go
+++ b/pkg/extract/suse/cvrf_cve/cvrf_cve.go
@@ -2,7 +2,7 @@ package cvrf_cve
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract SUSE CVRF CVE")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/suse/osv/osv.go
+++ b/pkg/extract/suse/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract SUSE OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/suse/oval/oval.go
+++ b/pkg/extract/suse/oval/oval.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -102,7 +102,7 @@ func Extract(inputDir string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract SUSE OVAL")
+	slog.Info("Extract SUSE OVAL")
 
 	type osver struct {
 		osname  string
@@ -151,7 +151,7 @@ func Extract(inputDir string, opts ...Option) error {
 
 	for _, ov := range ovs {
 		baseDir := filepath.Join(inputDir, ov.osname, ov.version, "vulnerability")
-		log.Printf("[INFO] extract OVAL files. dir: %s", baseDir)
+		slog.Info("extract OVAL files", slog.String("dir", baseDir))
 
 		g, ctx := errgroup.WithContext(context.Background())
 		g.SetLimit(options.concurrency)

--- a/pkg/extract/swift/ghsa/ghsa.go
+++ b/pkg/extract/swift/ghsa/ghsa.go
@@ -2,7 +2,7 @@ package ghsa
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Swift GHSA")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/swift/osv/osv.go
+++ b/pkg/extract/swift/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Swift OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/ubuntu/osv/osv.go
+++ b/pkg/extract/ubuntu/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Ubuntu OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/ubuntu/oval/oval.go
+++ b/pkg/extract/ubuntu/oval/oval.go
@@ -2,7 +2,7 @@ package oval
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Ubuntu OVAL")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/ubuntu/tracker/tracker.go
+++ b/pkg/extract/ubuntu/tracker/tracker.go
@@ -3,7 +3,7 @@ package tracker
 import (
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"maps"
 	"path/filepath"
 	"slices"
@@ -69,7 +69,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract Ubuntu CVE Tracker")
+	slog.Info("Extract Ubuntu CVE Tracker")
 	for _, target := range []string{"active", "retired"} {
 		if err := filepath.WalkDir(filepath.Join(args, target), func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
@@ -375,7 +375,7 @@ func extract(fetched tracker.Advisory, paths []string) (dataTypes.Data, error) {
 			return "", errors.Errorf("unexpected release name. expected: %q, actual: %q", slices.Collect(maps.Keys(rtov)), release)
 		}(rn)
 		if err != nil {
-			log.Printf("[WARN] failed to find version from release. err: %s", err)
+			slog.Warn("failed to find version from release", slog.Any("err", err))
 			continue
 		}
 		if v == "" {

--- a/pkg/extract/vulncheck/kev/kev.go
+++ b/pkg/extract/vulncheck/kev/kev.go
@@ -2,7 +2,7 @@ package kev
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract VulnCheck KEV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/wolfi/osv/osv.go
+++ b/pkg/extract/wolfi/osv/osv.go
@@ -2,7 +2,7 @@ package osv
 
 import (
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Extract ")
+	slog.Info("Extract Wolfi OSV")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/fetch/alma/errata/errata.go
+++ b/pkg/fetch/alma/errata/errata.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -81,7 +81,7 @@ func Fetch(opts ...Option) error {
 	}
 
 	for v, url := range options.urls {
-		log.Printf("[INFO] Fetch AlmaLinux %s", v)
+		slog.Info("Fetch AlmaLinux", slog.String("version", v))
 		advs, err := func() ([]Erratum, error) {
 			resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(url)
 			if err != nil {

--- a/pkg/fetch/alma/osv/osv.go
+++ b/pkg/fetch/alma/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch AlmaLinux OSV")
+	slog.Info("Fetch AlmaLinux OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/alma/oval/oval.go
+++ b/pkg/fetch/alma/oval/oval.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -77,7 +77,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch AlmaLinux OVAL")
+	slog.Info("Fetch AlmaLinux OVAL")
 	ovals, err := options.walkIndexOf()
 	if err != nil {
 		return errors.Wrap(err, "walk index of")
@@ -86,13 +86,13 @@ func Fetch(opts ...Option) error {
 	for _, ovalname := range ovals {
 		ver := strings.TrimPrefix(strings.TrimSuffix(ovalname, ".xml.bz2"), "org.almalinux.alsa-")
 
-		log.Printf("[INFO] Fetch AlmaLinux %s OVAL", ver)
+		slog.Info("Fetch AlmaLinux OVAL", slog.String("version", ver))
 		root, err := options.fetch(ovalname)
 		if err != nil {
 			return errors.Wrapf(err, "fetch alma %s oval", ver)
 		}
 
-		log.Printf("[INFO] Fetch AlmaLinux %s Definitions", ver)
+		slog.Info("Fetch AlmaLinux Definitions", slog.String("version", ver))
 		bar := progressbar.Default(int64(len(root.Definitions.Definition)))
 		for _, def := range root.Definitions.Definition {
 			if err := util.Write(filepath.Join(options.dir, ver, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -102,7 +102,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch AlmaLinux %s Tests", ver)
+		slog.Info("Fetch AlmaLinux Tests", slog.String("version", ver))
 		bar = progressbar.Default(int64(len(root.Tests.RpminfoTest) + len(root.Tests.RpmverifyfileTest) + len(root.Tests.Textfilecontent54Test) + len(root.Tests.UnameTest)))
 		for _, test := range root.Tests.RpminfoTest {
 			if err := util.Write(filepath.Join(options.dir, ver, "tests", "rpminfo_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -130,7 +130,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch AlmaLinux %s Objects", ver)
+		slog.Info("Fetch AlmaLinux Objects", slog.String("version", ver))
 		bar = progressbar.Default(int64(len(root.Objects.RpminfoObject) + len(root.Objects.RpmverifyfileObject) + len(root.Objects.Textfilecontent54Object) + 1))
 		for _, object := range root.Objects.RpminfoObject {
 			if err := util.Write(filepath.Join(options.dir, ver, "objects", "rpminfo_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -158,7 +158,7 @@ func Fetch(opts ...Option) error {
 		_ = bar.Add(1)
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch AlmaLinux %s States", ver)
+		slog.Info("Fetch AlmaLinux States", slog.String("version", ver))
 		bar = progressbar.Default(int64(len(root.States.RpminfoState) + len(root.States.RpmverifyfileState) + len(root.States.Textfilecontent54State) + len(root.States.UnameState)))
 		for _, state := range root.States.RpminfoState {
 			if err := util.Write(filepath.Join(options.dir, ver, "states", "rpminfo_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {
@@ -186,7 +186,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch AlmaLinux %s Variables", ver)
+		slog.Info("Fetch AlmaLinux Variables", slog.String("version", ver))
 		bar = progressbar.Default(1)
 		if root.Variables.LocalVariable.ID != "" {
 			if err := util.Write(filepath.Join(options.dir, ver, "variables", "local_variable", fmt.Sprintf("%s.json", root.Variables.LocalVariable.ID)), root.Variables.LocalVariable); err != nil {

--- a/pkg/fetch/alpine/osv/osv.go
+++ b/pkg/fetch/alpine/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Alpine Linux OSV")
+	slog.Info("Fetch Alpine Linux OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/alpine/secdb/secdb.go
+++ b/pkg/fetch/alpine/secdb/secdb.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -80,7 +80,7 @@ func Fetch(opts ...Option) error {
 	}
 
 	for _, r := range releases {
-		log.Printf("[INFO] Fetch Alpine Linux %s", r)
+		slog.Info("Fetch Alpine Linux", slog.String("release", r))
 		files, err := options.walkDistroVersion(r)
 		if err != nil {
 			return errors.Wrapf(err, "walk alpine linux %s", r)

--- a/pkg/fetch/alt/oval/oval.go
+++ b/pkg/fetch/alt/oval/oval.go
@@ -7,7 +7,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -76,14 +76,14 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch ALT Linux OVAL")
+	slog.Info("Fetch ALT Linux OVAL")
 	bs, err := options.fetchBranches()
 	if err != nil {
 		return errors.Wrap(err, "fetch branches")
 	}
 
 	for _, b := range bs {
-		log.Printf("[INFO] Fetch ALT Linux %s OVAL", b)
+		slog.Info("Fetch ALT Linux OVAL", slog.String("branch", b))
 		if err := options.fetch(b); err != nil {
 			return errors.Wrapf(err, "fetch alt linux %s oval", b)
 		}

--- a/pkg/fetch/amazon/amazon.go
+++ b/pkg/fetch/amazon/amazon.go
@@ -7,7 +7,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -99,7 +99,7 @@ func Fetch(opts ...Option) error {
 	}
 
 	for v := range options.mirrorURLs {
-		log.Printf("[INFO] Fetch Amazon Linux %s", v)
+		slog.Info("Fetch Amazon Linux", slog.String("version", v))
 		advs := make(map[string][]Update)
 		switch v {
 		case "1", "2022":
@@ -169,7 +169,7 @@ func Fetch(opts ...Option) error {
 		}
 
 		for r, us := range advs {
-			log.Printf("[INFO] Fetched Amazon Linux %s %s", v, r)
+			slog.Info("Fetched Amazon Linux", slog.String("version", v), slog.String("release", r))
 			bar := progressbar.Default(int64(len(us)))
 			for _, u := range us {
 				y, err := func() (string, error) {
@@ -331,7 +331,7 @@ func getPackageRepository(mirror string) string {
 		_, rhs, _ := strings.Cut(mirror, "/extras/")
 		lhs, _, found := strings.Cut(rhs, "/")
 		if !found {
-			log.Printf("WARN: failed to find repository. mirror: %s", mirror)
+			slog.Warn("failed to find repository", slog.String("mirror", mirror))
 			return "unknown"
 		}
 		return filepath.Join("extras", lhs)
@@ -340,7 +340,7 @@ func getPackageRepository(mirror string) string {
 	case strings.Contains(mirror, "/nvidia/"):
 		return "nvidia"
 	default:
-		log.Printf("WARN: failed to find repository. mirror: %s", mirror)
+		slog.Warn("failed to find repository", slog.String("mirror", mirror))
 		return "unknown"
 	}
 }

--- a/pkg/fetch/anchore/enrichment/enrichment.go
+++ b/pkg/fetch/anchore/enrichment/enrichment.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/json/v2"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Anchore Enrichment")
+	slog.Info("Fetch Anchore Enrichment")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch")

--- a/pkg/fetch/android/osv/osv.go
+++ b/pkg/fetch/android/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Android OSV")
+	slog.Info("Fetch Android OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/anolis/oval/oval.go
+++ b/pkg/fetch/anolis/oval/oval.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Anolis OS OVAL")
+	slog.Info("Fetch Anolis OS OVAL")
 	ovals, err := options.fetchList()
 	if err != nil {
 		return errors.Wrap(err, "fetch list")
@@ -84,13 +84,13 @@ func Fetch(opts ...Option) error {
 	for _, ovalname := range ovals {
 		ver := strings.TrimPrefix(strings.TrimSuffix(ovalname, ".oval.xml"), "anolis-")
 
-		log.Printf("[INFO] Fetch Anolis OS %s OVAL", ver)
+		slog.Info("Fetch Anolis OS OVAL", slog.String("version", ver))
 		root, err := options.fetch(ovalname)
 		if err != nil {
 			return errors.Wrapf(err, "fetch anolis %s oval", ver)
 		}
 
-		log.Printf("[INFO] Fetch Anolis OS %s Definitions", ver)
+		slog.Info("Fetch Anolis OS Definitions", slog.String("version", ver))
 		bar := progressbar.Default(int64(len(root.Definitions.Definition)))
 		for _, def := range root.Definitions.Definition {
 			if err := util.Write(filepath.Join(options.dir, ver, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -100,7 +100,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Anolis OS %s Tests", ver)
+		slog.Info("Fetch Anolis OS Tests", slog.String("version", ver))
 		bar = progressbar.Default(int64(len(root.Tests.RpminfoTest) + len(root.Tests.Textfilecontent54Test)))
 		for _, test := range root.Tests.RpminfoTest {
 			if err := util.Write(filepath.Join(options.dir, ver, "tests", "rpminfo_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -116,7 +116,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Anolis OS %s Objects", ver)
+		slog.Info("Fetch Anolis OS Objects", slog.String("version", ver))
 		bar = progressbar.Default(int64(len(root.Objects.RpminfoObject) + len(root.Objects.Textfilecontent54Object)))
 		for _, object := range root.Objects.RpminfoObject {
 			if err := util.Write(filepath.Join(options.dir, ver, "objects", "rpminfo_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -132,7 +132,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Anolis OS %s States", ver)
+		slog.Info("Fetch Anolis OS States", slog.String("version", ver))
 		bar = progressbar.Default(int64(len(root.States.RpminfoState) + len(root.States.Textfilecontent54State)))
 		for _, state := range root.States.RpminfoState {
 			if err := util.Write(filepath.Join(options.dir, ver, "states", "rpminfo_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {

--- a/pkg/fetch/arch/arch.go
+++ b/pkg/fetch/arch/arch.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -72,7 +72,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Arch Linux")
+	slog.Info("Fetch Arch Linux")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.advisoryURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch advisory")

--- a/pkg/fetch/bellsoft/alpaquita/osv/osv.go
+++ b/pkg/fetch/bellsoft/alpaquita/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch BellSoft Alpaquita OSV")
+	slog.Info("Fetch BellSoft Alpaquita OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/bellsoft/hardened-containers/osv/osv.go
+++ b/pkg/fetch/bellsoft/hardened-containers/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch BellSoft Hardened Containers OSV")
+	slog.Info("Fetch BellSoft Hardened Containers OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/bitnami/osv/osv.go
+++ b/pkg/fetch/bitnami/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Bitnami OSV")
+	slog.Info("Fetch Bitnami OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/bottlerocket/bottlerocket.go
+++ b/pkg/fetch/bottlerocket/bottlerocket.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -73,7 +73,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Bottlerocket")
+	slog.Info("Fetch Bottlerocket")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch bottlerocket updateinfo")

--- a/pkg/fetch/cargo/db/db.go
+++ b/pkg/fetch/cargo/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -69,7 +69,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Cargo DB")
+	slog.Info("Fetch Cargo DB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/cargo/ghsa/ghsa.go
+++ b/pkg/fetch/cargo/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Cargo GHSA")
+	slog.Info("Fetch Cargo GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/cargo/osv/osv.go
+++ b/pkg/fetch/cargo/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Cargo OSV")
+	slog.Info("Fetch Cargo OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/cert-bund/csaf/csaf.go
+++ b/pkg/fetch/cert-bund/csaf/csaf.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -98,7 +98,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Cert-Bund CSAF")
+	slog.Info("Fetch Cert-Bund CSAF")
 	if err := options.fetch(); err != nil {
 		return errors.Wrap(err, "fetch")
 	}

--- a/pkg/fetch/chainguard/osv/osv.go
+++ b/pkg/fetch/chainguard/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Chainguard OSV")
+	slog.Info("Fetch Chainguard OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/chainguard/secdb/secdb.go
+++ b/pkg/fetch/chainguard/secdb/secdb.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -71,7 +71,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Chainguard SecDB")
+	slog.Info("Fetch Chainguard SecDB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch")

--- a/pkg/fetch/cisa/coun7er/coun7er.go
+++ b/pkg/fetch/cisa/coun7er/coun7er.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -71,7 +71,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch CISA COUN7ER")
+	slog.Info("Fetch CISA COUN7ER")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch cisa coun7er data")

--- a/pkg/fetch/cisa/csaf/csaf.go
+++ b/pkg/fetch/cisa/csaf/csaf.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -77,7 +77,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch CISA CSAF")
+	slog.Info("Fetch CISA CSAF")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch cisa csaf")

--- a/pkg/fetch/cisa/kev/kev.go
+++ b/pkg/fetch/cisa/kev/kev.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -73,7 +73,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch CISA Known Exploited Vulnerabilities Catalog")
+	slog.Info("Fetch CISA Known Exploited Vulnerabilities Catalog")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch cisa kev data")

--- a/pkg/fetch/cisco/csaf/csaf.go
+++ b/pkg/fetch/cisco/csaf/csaf.go
@@ -8,7 +8,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -100,7 +100,7 @@ func Fetch(ids []string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Cisco Security Advisories (CSAF). dir: %s", options.dir)
+	slog.Info("Fetch Cisco Security Advisories (CSAF)", slog.String("dir", options.dir))
 
 	us := make([]string, 0, len(ids))
 	for _, id := range ids {

--- a/pkg/fetch/cisco/cvrf/cvrf.go
+++ b/pkg/fetch/cisco/cvrf/cvrf.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -98,7 +98,7 @@ func Fetch(ids []string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Cisco Security Advisories (CVRF). dir: %s", options.dir)
+	slog.Info("Fetch Cisco Security Advisories (CVRF)", slog.String("dir", options.dir))
 
 	us := make([]string, 0, len(ids))
 	for _, id := range ids {

--- a/pkg/fetch/cisco/json/json.go
+++ b/pkg/fetch/cisco/json/json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -90,7 +90,7 @@ func Fetch(id, secret string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Cisco Security Advisories (JSON). dir: %s", options.dir)
+	slog.Info("Fetch Cisco Security Advisories (JSON)", slog.String("dir", options.dir))
 
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 

--- a/pkg/fetch/composer/db/db.go
+++ b/pkg/fetch/composer/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -69,7 +69,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Composer DB")
+	slog.Info("Fetch Composer DB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/composer/ghsa/ghsa.go
+++ b/pkg/fetch/composer/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Composer GHSA")
+	slog.Info("Fetch Composer GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/composer/glsa/glsa.go
+++ b/pkg/fetch/composer/glsa/glsa.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Composer GLSA")
+	slog.Info("Fetch Composer GLSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/composer/osv/osv.go
+++ b/pkg/fetch/composer/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Composer OSV")
+	slog.Info("Fetch Composer OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/conan/glsa/glsa.go
+++ b/pkg/fetch/conan/glsa/glsa.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Conan GLSA")
+	slog.Info("Fetch Conan GLSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/debian/osv/osv.go
+++ b/pkg/fetch/debian/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Debian OSV")
+	slog.Info("Fetch Debian OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/debian/oval/oval.go
+++ b/pkg/fetch/debian/oval/oval.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -77,7 +77,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Debian OVAL")
+	slog.Info("Fetch Debian OVAL")
 	ovals, err := options.walkIndexOf()
 	if err != nil {
 		return errors.Wrap(err, "walk index of")
@@ -86,13 +86,13 @@ func Fetch(opts ...Option) error {
 	for _, ovalname := range ovals {
 		code := strings.TrimPrefix(strings.TrimSuffix(ovalname, ".xml.bz2"), "oval-definitions-")
 
-		log.Printf("[INFO] Fetch Debian %s OVAL", code)
+		slog.Info("Fetch Debian OVAL", slog.String("codename", code))
 		root, err := options.fetch(ovalname)
 		if err != nil {
 			return errors.Wrapf(err, "fetch debian %s oval", code)
 		}
 
-		log.Printf("[INFO] Fetch Debian %s Definitions", code)
+		slog.Info("Fetch Debian Definitions", slog.String("codename", code))
 		bar := progressbar.Default(int64(len(root.Definitions.Definition)))
 		for _, def := range root.Definitions.Definition {
 			if err := util.Write(filepath.Join(options.dir, code, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -102,7 +102,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Debian %s Tests", code)
+		slog.Info("Fetch Debian Tests", slog.String("codename", code))
 		bar = progressbar.Default(2 + int64(len(root.Tests.DpkginfoTest)))
 		if err := util.Write(filepath.Join(options.dir, code, "tests", "textfilecontent54_test", fmt.Sprintf("%s.json", root.Tests.Textfilecontent54Test.ID)), root.Tests.Textfilecontent54Test); err != nil {
 			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, code, "tests", "textfilecontent54_test", fmt.Sprintf("%s.json", root.Tests.Textfilecontent54Test.ID)))
@@ -120,7 +120,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Debian %s Objects", code)
+		slog.Info("Fetch Debian Objects", slog.String("codename", code))
 		bar = progressbar.Default(2 + int64(len(root.Objects.DpkginfoObject)))
 		if err := util.Write(filepath.Join(options.dir, code, "objects", "textfilecontent54_object", fmt.Sprintf("%s.json", root.Objects.Textfilecontent54Object.ID)), root.Objects.Textfilecontent54Object); err != nil {
 			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, code, "objects", "textfilecontent54_object", fmt.Sprintf("%s.json", root.Objects.Textfilecontent54Object.ID)))
@@ -138,7 +138,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Debian %s States", code)
+		slog.Info("Fetch Debian States", slog.String("codename", code))
 		bar = progressbar.Default(1 + int64(len(root.States.DpkginfoState)))
 		if root.States.Textfilecontent54State.ID != "" {
 			if err := util.Write(filepath.Join(options.dir, code, "states", "textfilecontent54_state", fmt.Sprintf("%s.json", root.States.Textfilecontent54State.ID)), root.States.Textfilecontent54State); err != nil {

--- a/pkg/fetch/debian/tracker/api/api.go
+++ b/pkg/fetch/debian/tracker/api/api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Debian Security Tracker API")
+	slog.Info("Fetch Debian Security Tracker API")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.advisoryURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch advisory")
@@ -130,7 +130,7 @@ func Fetch(opts ...Option) error {
 	}
 
 	for code, advs := range m {
-		log.Printf("[INFO] Fetched Debian %s Advisory", code)
+		slog.Info("Fetched Debian Advisory", slog.String("codename", code))
 
 		bar := progressbar.Default(int64(len(advs)))
 		for _, a := range advs {

--- a/pkg/fetch/debian/tracker/salsa/salsa.go
+++ b/pkg/fetch/debian/tracker/salsa/salsa.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"maps"
 	"net/http"
 	"net/textproto"
@@ -157,7 +157,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Debian Security Tracker Salsa repository")
+	slog.Info("Fetch Debian Security Tracker Salsa repository")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch salsa repository")
@@ -192,7 +192,7 @@ func Fetch(opts ...Option) error {
 		d, f := filepath.Split(hdr.Name)
 		switch f {
 		case "config.json":
-			log.Printf("[INFO] Fetch Package Source")
+			slog.Info("Fetch Package Source")
 			archives, releases, err := parseConfig(tr)
 			if err != nil {
 				return errors.Wrap(err, "parse config")
@@ -206,7 +206,7 @@ func Fetch(opts ...Option) error {
 
 				for repo, mm := range m {
 					for section, mmm := range mm {
-						log.Printf("[INFO] Fetched Debian %s %s %s", codename, repo, section)
+						slog.Info("Fetched Debian", slog.String("codename", codename), slog.String("repo", repo), slog.String("section", section))
 						bar := progressbar.Default(int64(len(mmm)))
 						for name, source := range mmm {
 							if err := util.Write(filepath.Join(options.dir, "packages", codename, repo, section, name[:1], fmt.Sprintf("%s.json", name)), source, util.WithAllowInvalidUTF8(true)); err != nil {
@@ -221,7 +221,7 @@ func Fetch(opts ...Option) error {
 		case "list":
 			switch filepath.Base(d) {
 			case "CPE":
-				log.Printf("[INFO] Read CPE/list")
+				slog.Info("Read CPE/list")
 				cpes, err := cpelist(tr)
 				if err != nil {
 					return errors.Wrap(err, "parse CPE/list")
@@ -236,7 +236,7 @@ func Fetch(opts ...Option) error {
 				}
 				_ = bar.Close()
 			case "CVE":
-				log.Printf("[INFO] Read CVE/list")
+				slog.Info("Read CVE/list")
 				bugs, err := cvelist(tr)
 				if err != nil {
 					return errors.Wrap(err, "parse CVE/list")
@@ -262,7 +262,7 @@ func Fetch(opts ...Option) error {
 				}
 				_ = bar.Close()
 			case "DLA":
-				log.Printf("[INFO] Read DLA/list")
+				slog.Info("Read DLA/list")
 				bugs, err := dlalist(tr)
 				if err != nil {
 					return errors.Wrap(err, "parse DLA/list")
@@ -277,7 +277,7 @@ func Fetch(opts ...Option) error {
 				}
 				_ = bar.Close()
 			case "DSA":
-				log.Printf("[INFO] Read DSA/list")
+				slog.Info("Read DSA/list")
 				bugs, err := dsalist(tr)
 				if err != nil {
 					return errors.Wrap(err, "parse DSA/list")
@@ -292,7 +292,7 @@ func Fetch(opts ...Option) error {
 				}
 				_ = bar.Close()
 			case "DTSA":
-				log.Printf("[INFO] Read DTSA/list")
+				slog.Info("Read DTSA/list")
 				bugs, err := dtsalist(tr)
 				if err != nil {
 					return errors.Wrap(err, "parse DTSA/list")
@@ -324,7 +324,7 @@ func cpelist(r io.Reader) ([]CPE, error) {
 		line := s.Text()
 		lhs, rhs, ok := strings.Cut(line, ";")
 		if !ok {
-			log.Printf("[WARN] unexpected format. expected: \"<Package>;<CPE>\", actual: %q", line)
+			slog.Warn("unexpected CPE format", slog.String("expected", "<Package>;<CPE>"), slog.String("actual", line))
 			continue
 		}
 		cpes = append(cpes, CPE{
@@ -351,10 +351,10 @@ func cvelist(r io.Reader) ([]Bug, error) {
 
 		if desc := match[reHeader.SubexpIndex("description")]; desc != "" {
 			if desc[:1] == "(" && desc[len(desc)-1:] != ")" {
-				log.Printf("[WARN] missing ')': %q", line)
+				slog.Warn("missing ')'", slog.String("line", line))
 			}
 			if desc[:1] == "[" && desc[len(desc)-1:] != "]" {
-				log.Printf("[WARN] missing ']': %q", line)
+				slog.Warn("missing ']'", slog.String("line", line))
 			}
 		}
 		return match
@@ -500,7 +500,7 @@ func dlalist(r io.Reader) ([]Bug, error) {
 func checkrelease(anns []any, kind string) {
 	for _, ann := range anns {
 		if a, ok := ann.(PackageAnnotation); ok && a.Type == "package" && a.Release == "" {
-			log.Printf("[WARN] release annotation required in %q file", kind)
+			slog.Warn("release annotation required", slog.String("kind", kind))
 		}
 	}
 }
@@ -523,7 +523,7 @@ func parselist(r io.Reader, parseheader func(line string) []string, finish func(
 		case line == "":
 		case line[0] == ' ' || line[0] == '\t':
 			if len(header) == 0 {
-				log.Printf("[WARN] header expected: %q", line)
+				slog.Warn("header expected", slog.String("line", line))
 				break
 			}
 
@@ -541,7 +541,7 @@ func parselist(r io.Reader, parseheader func(line string) []string, finish func(
 					if a.Type == "package" {
 						if _, ok := relpkg[a.Release]; ok {
 							if _, ok := relpkg[a.Release][a.Package]; ok {
-								log.Printf("[WARN] duplicate package annotation: %q", line)
+								slog.Warn("duplicate package annotation", slog.String("line", line))
 								ann = nil
 							}
 						}
@@ -563,10 +563,10 @@ func parselist(r io.Reader, parseheader func(line string) []string, finish func(
 		default:
 			if len(header) != 0 {
 				if keys := slices.Collect(maps.Keys(anns_types)); slices.Contains(keys, "NOT-FOR-US") && slices.Contains(keys, "package") {
-					log.Printf("[WARN] NOT-FOR-US conflicts with package annotations: %q", headerline)
+					slog.Warn("NOT-FOR-US conflicts with package annotations", slog.String("header", headerline))
 				}
 				if keys := slices.Collect(maps.Keys(anns_types)); slices.Contains(keys, "REJECTED") && slices.Contains(keys, "package") {
-					log.Printf("[WARN] REJECTED bug has package annotations: %q", headerline)
+					slog.Warn("REJECTED bug has package annotations", slog.String("header", headerline))
 				}
 				bugs = append(bugs, finish(header, headerline, anns))
 
@@ -578,7 +578,7 @@ func parselist(r io.Reader, parseheader func(line string) []string, finish func(
 
 			header = parseheader(line)
 			if len(header) == 0 {
-				log.Printf("[WARN] malformed header: %q", line)
+				slog.Warn("malformed header", slog.String("line", line))
 			}
 		}
 	}
@@ -635,7 +635,7 @@ func annotationdispatcher(line string) any {
 		case slices.Contains(pseudoStruct, kind):
 			flags := parseinner(inner)
 			if kind == "itp" && !slices.ContainsFunc(flags, func(i any) bool { _, ok := i.(PackageBugAnnotation); return ok }) {
-				log.Printf("[WARN] <itp> needs Debian bug reference: %q", line)
+				slog.Warn("<itp> needs Debian bug reference", slog.String("line", line))
 			}
 			return PackageAnnotation{
 				Line:        line,
@@ -648,7 +648,7 @@ func annotationdispatcher(line string) any {
 				Flags:       flags,
 			}
 		default:
-			log.Printf("[WARN] invalid pseudo-version(%q): %q", kind, line)
+			slog.Warn("invalid pseudo-version", slog.String("kind", kind), slog.String("line", line))
 			return nil
 		}
 	case xrefRegexp.MatchString(line):
@@ -660,7 +660,7 @@ func annotationdispatcher(line string) any {
 				Bugs: x,
 			}
 		}
-		log.Printf("[WARN] empty cross-reference: %q", line)
+		slog.Warn("empty cross-reference", slog.String("line", line))
 		return nil
 	case flagRegexp.MatchString(line):
 		groups := flagRegexp.FindStringSubmatch(line)
@@ -676,7 +676,7 @@ func annotationdispatcher(line string) any {
 			Description: groups[stringRegexp.SubexpIndex("description")],
 		}
 	default:
-		log.Printf("[WARN] invalid annotation: %q", line)
+		slog.Warn("invalid annotation", slog.String("line", line))
 		return nil
 	}
 }
@@ -697,7 +697,7 @@ func parseinner(inner string) []any {
 				a, ok := i.(PackageUrgencyAnnotation)
 				return ok && a.Severity == f
 			}) {
-				log.Printf("[WARN] duplicate urgency(%q): %q", f, inner)
+				slog.Warn("duplicate urgency", slog.String("field", f), slog.String("inner", inner))
 			} else {
 				flags = append(flags, PackageUrgencyAnnotation{Severity: f})
 			}
@@ -705,18 +705,18 @@ func parseinner(inner string) []any {
 			groups := pkgBugRegexp.FindStringSubmatch(innerann)
 			no, err := strconv.Atoi(groups[pkgBugRegexp.SubexpIndex("no")])
 			if err != nil {
-				log.Printf("[WARN] atoi err: %s", err)
+				slog.Warn("atoi err", slog.Any("err", err))
 			}
 			if slices.ContainsFunc(flags, func(i any) bool {
 				a, ok := i.(PackageBugAnnotation)
 				return ok && a.Bug == no
 			}) {
-				log.Printf("[WARN] duplicate bug number(%q): %q", fmt.Sprintf("%d", no), inner)
+				slog.Warn("duplicate bug number", slog.String("number", fmt.Sprintf("%d", no)), slog.String("inner", inner))
 			} else {
 				flags = append(flags, PackageBugAnnotation{Bug: no})
 			}
 		default:
-			log.Printf("[WARN] invalid inner annotation(%q): %q", innerann, inner)
+			slog.Warn("invalid inner annotation", slog.String("annotation", innerann), slog.String("inner", inner))
 		}
 	}
 
@@ -727,7 +727,7 @@ func parseinner(inner string) []any {
 		}
 	}
 	if len(urgencies) > 1 {
-		log.Printf("[WARN] multiple urgencies(%q): %q", strings.Join(urgencies, ", "), inner)
+		slog.Warn("multiple urgencies", slog.String("urgencies", strings.Join(urgencies, ", ")), slog.String("inner", inner))
 	}
 
 	return flags
@@ -789,7 +789,7 @@ func (opts *options) fetchSource(codename string, archived bool) (map[string]map
 
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
 
-	log.Printf("Fetch Debian %s stable", codename)
+	slog.Info("Fetch Debian stable", slog.String("codename", codename))
 	sections, err := fetchRelease(client, fmt.Sprintf("%s/dists/%s/Release", stableURL, codename))
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch release")
@@ -807,7 +807,7 @@ func (opts *options) fetchSource(codename string, archived bool) (map[string]map
 		return m, nil
 	}
 
-	log.Printf("Fetch Debian %s security", codename)
+	slog.Info("Fetch Debian security", slog.String("codename", codename))
 	securityDistURL := fmt.Sprintf("%s/dists/%s/updates", securityURL, codename)
 	if slices.Index(codenames, codename) == -1 || slices.Index(codenames, codename) > slices.Index(codenames, "buster") {
 		securityDistURL = fmt.Sprintf("%s/dists/%s-security", securityURL, codename)
@@ -826,7 +826,7 @@ func (opts *options) fetchSource(codename string, archived bool) (map[string]map
 		m["security"][filepath.Base(section)] = sources
 	}
 
-	log.Printf("Fetch Debian %s backport", codename)
+	slog.Info("Fetch Debian backport", slog.String("codename", codename))
 	if slices.Index(codenames, codename) == -1 || slices.Index(codenames, codename) >= slices.Index(codenames, "wheezy") {
 		backportURL = stableURL
 	}
@@ -855,7 +855,7 @@ func fetchRelease(c *utilhttp.Client, releaseURL string) ([]string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Printf("[WARN] fetch %s error: %s", releaseURL, errors.Errorf("error response with status code %d", resp.StatusCode))
+		slog.Warn("fetch error", slog.String("url", releaseURL), slog.Any("err", errors.Errorf("error response with status code %d", resp.StatusCode)))
 		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil, nil
 	}
@@ -958,7 +958,7 @@ func parseSource(r io.Reader) (map[string]textproto.MIMEHeader, error) {
 
 		name := header.Get("Package")
 		if name == "" {
-			log.Printf("[WARN] Package header not found")
+			slog.Warn("Package header not found")
 			continue
 		}
 		m[name] = header

--- a/pkg/fetch/echo/data/data.go
+++ b/pkg/fetch/echo/data/data.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -71,7 +71,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Echo Data")
+	slog.Info("Fetch Echo Data")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch advisory")

--- a/pkg/fetch/echo/osv/osv.go
+++ b/pkg/fetch/echo/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Echo OSV")
+	slog.Info("Fetch Echo OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/endoflife-date/api/api.go
+++ b/pkg/fetch/endoflife-date/api/api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -96,7 +96,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch endoflife.date API")
+	slog.Info("Fetch endoflife.date API")
 	header := make(http.Header)
 	header.Set("Accept", "application/json")
 

--- a/pkg/fetch/endoflife-date/products/products.go
+++ b/pkg/fetch/endoflife-date/products/products.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"regexp"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch endoflife.date products")
+	slog.Info("Fetch endoflife.date products")
 
 	re, err := regexp.Compile(`(?s)^---\n(.*?)\n---`)
 	if err != nil {

--- a/pkg/fetch/enisa/euvd/detail/detail.go
+++ b/pkg/fetch/enisa/euvd/detail/detail.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -100,7 +100,7 @@ func Fetch(r io.Reader, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch European Union Vulnerability Database(EUVD) Detail")
+	slog.Info("Fetch European Union Vulnerability Database(EUVD) Detail")
 	if err := options.fetch(r); err != nil {
 		return errors.Wrap(err, "fetch")
 	}
@@ -150,7 +150,7 @@ func (opts options) fetch(r io.Reader) error {
 
 			return nil
 		case http.StatusNoContent:
-			log.Printf("[WARN] %s may have been deleted", resp.Request.URL.Query().Get("id"))
+			slog.Warn("may have been deleted", slog.String("id", resp.Request.URL.Query().Get("id")))
 			return nil
 		default:
 			_, _ = io.Copy(io.Discard, resp.Body)

--- a/pkg/fetch/enisa/euvd/list/list.go
+++ b/pkg/fetch/enisa/euvd/list/list.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -101,7 +101,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch European Union Vulnerability Database(EUVD) List")
+	slog.Info("Fetch European Union Vulnerability Database(EUVD) List")
 	if err := options.fetch(); err != nil {
 		return errors.Wrap(err, "fetch")
 	}

--- a/pkg/fetch/enisa/kev/kev.go
+++ b/pkg/fetch/enisa/kev/kev.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -72,7 +72,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch ENISA Known Exploited Vulnerabilities")
+	slog.Info("Fetch ENISA Known Exploited Vulnerabilities")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch")

--- a/pkg/fetch/epss/epss.go
+++ b/pkg/fetch/epss/epss.go
@@ -5,7 +5,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -101,7 +101,7 @@ func Fetch(args []string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Exploit Prediction Scoring System: EPSS")
+	slog.Info("Fetch Exploit Prediction Scoring System: EPSS")
 
 	urls := make([]string, 0, len(args))
 	for _, arg := range args {
@@ -121,7 +121,7 @@ func Fetch(args []string, opts ...Option) error {
 		if resp.StatusCode != http.StatusOK {
 			_, _ = io.Copy(io.Discard, resp.Body)
 			if resp.StatusCode == http.StatusNotFound && slices.Contains([]string{"2021-04-22", "2021-04-23", "2021-04-24", "2021-04-25", "2021-04-26", "2021-06-07", "2021-06-18", "2022-07-14", time.Now().UTC().Format("2006-01-02")}, strings.TrimSuffix(strings.TrimPrefix(path.Base(resp.Request.URL.Path), "epss_scores-"), ".csv.gz")) {
-				log.Printf("[WARN] %s is not found", resp.Request.URL)
+				slog.Warn("not found", slog.String("url", resp.Request.URL.String()))
 				return nil
 			}
 			return errors.Errorf("error response with status code %d", resp.StatusCode)
@@ -162,7 +162,7 @@ func Fetch(args []string, opts ...Option) error {
 				}
 				epss, err := strconv.ParseFloat(r[1], 64)
 				if err != nil {
-					log.Printf(`[WARN] error parse EPSS Score. strconv.ParseFloat(%s, 64)`, r[1])
+					slog.Warn("error parse EPSS Score", slog.String("value", r[1]))
 					break
 				}
 
@@ -178,12 +178,12 @@ func Fetch(args []string, opts ...Option) error {
 				}
 				epss, err := strconv.ParseFloat(r[1], 64)
 				if err != nil {
-					log.Printf(`[WARN] error parse EPSS Score. strconv.ParseFloat(%s, 64)`, r[1])
+					slog.Warn("error parse EPSS Score", slog.String("value", r[1]))
 					break
 				}
 				percentile, err := strconv.ParseFloat(r[2], 64)
 				if err != nil {
-					log.Printf(`[WARN] error parse EPSS Percentile. strconv.ParseFloat(%s, 64)`, r[2])
+					slog.Warn("error parse EPSS Percentile", slog.String("value", r[2]))
 					break
 				}
 				root.Data = append(root.Data, CVE{
@@ -195,13 +195,13 @@ func Fetch(args []string, opts ...Option) error {
 				switch len(r) {
 				case 2:
 					if !strings.HasPrefix(r[0], "#model_version:") {
-						log.Printf(`[WARN] unexpected model version. expected: "#model_version:<version>", actual: "%s"`, r[0])
+						slog.Warn("unexpected model version", slog.String("expected", "#model_version:<version>"), slog.String("actual", r[0]))
 						break
 					}
 					root.Model = strings.TrimPrefix(r[0], "#model_version:")
 
 					if !strings.HasPrefix(r[1], "score_date:") {
-						log.Printf(`[WARN] unexpected score date. expected: "#score_date:<2006-01-02T15:04:05-0700>", actual: "%s"`, r[1])
+						slog.Warn("unexpected score date", slog.String("expected", "score_date:<2006-01-02T15:04:05-0700>"), slog.String("actual", r[1]))
 						break
 					}
 					root.ScoreDate = strings.TrimPrefix(r[1], "score_date:")
@@ -211,12 +211,12 @@ func Fetch(args []string, opts ...Option) error {
 					}
 					epss, err := strconv.ParseFloat(r[1], 64)
 					if err != nil {
-						log.Printf(`[WARN] error parse EPSS Score. strconv.ParseFloat(%s, 64)`, r[1])
+						slog.Warn("error parse EPSS Score", slog.String("value", r[1]))
 						break
 					}
 					percentile, err := strconv.ParseFloat(r[2], 64)
 					if err != nil {
-						log.Printf(`[WARN] error parse EPSS Percentile. strconv.ParseFloat(%s, 64)`, r[2])
+						slog.Warn("error parse EPSS Percentile", slog.String("value", r[2]))
 						break
 					}
 					root.Data = append(root.Data, CVE{
@@ -225,19 +225,19 @@ func Fetch(args []string, opts ...Option) error {
 						Percentile: &percentile,
 					})
 				default:
-					log.Printf(`[WARN] unexpected epss line. expected: ["#model_version:<version>", "#score_date:<2006-01-02T15:04:05-0700>"] or ["<CVE ID>", "<EPSS Score>", "<EPSS Percentile>"], actual: %q`, r)
+					slog.Warn("unexpected epss line", slog.String("expected", `"#model_version:<version>", "score_date:<2006-01-02T15:04:05-0700>", "<CVE ID>", "<EPSS Score>", "<EPSS Percentile>"`), slog.Any("actual", r))
 				}
 			default:
 				switch len(r) {
 				case 2:
 					if !strings.HasPrefix(r[0], "#model_version:") {
-						log.Printf(`[WARN] unexpected model version. expected: "#model_version:<version>", actual: "%s"`, r[0])
+						slog.Warn("unexpected model version", slog.String("expected", "#model_version:<version>"), slog.String("actual", r[0]))
 						break
 					}
 					root.Model = strings.TrimPrefix(r[0], "#model_version:")
 
 					if !strings.HasPrefix(r[1], "score_date:") {
-						log.Printf(`[WARN] unexpected score date. expected: "#score_date:<2006-01-02T15:04:05-0700>", actual: "%s"`, r[1])
+						slog.Warn("unexpected score date", slog.String("expected", "score_date:<2006-01-02T15:04:05-0700>"), slog.String("actual", r[1]))
 						break
 					}
 					root.ScoreDate = strings.TrimPrefix(r[1], "score_date:")
@@ -247,12 +247,12 @@ func Fetch(args []string, opts ...Option) error {
 					}
 					epss, err := strconv.ParseFloat(r[1], 64)
 					if err != nil {
-						log.Printf(`[WARN] error parse EPSS Score. strconv.ParseFloat(%s, 64)`, r[1])
+						slog.Warn("error parse EPSS Score", slog.String("value", r[1]))
 						break
 					}
 					percentile, err := strconv.ParseFloat(r[2], 64)
 					if err != nil {
-						log.Printf(`[WARN] error parse EPSS Percentile. strconv.ParseFloat(%s, 64)`, r[2])
+						slog.Warn("error parse EPSS Percentile", slog.String("value", r[2]))
 						break
 					}
 					root.Data = append(root.Data, CVE{
@@ -261,7 +261,7 @@ func Fetch(args []string, opts ...Option) error {
 						Percentile: &percentile,
 					})
 				default:
-					log.Printf(`[WARN] unexpected epss line. expected: ["#model_version:<version>", "#score_date:<2006-01-02T15:04:05-0700>"] or ["<CVE ID>", "<EPSS Score>", "<EPSS Percentile>"], actual: %q`, r)
+					slog.Warn("unexpected epss line", slog.String("expected", `"#model_version:<version>", "score_date:<2006-01-02T15:04:05-0700>", "<CVE ID>", "<EPSS Score>", "<EPSS Percentile>"`), slog.Any("actual", r))
 				}
 			}
 

--- a/pkg/fetch/erlang/ghsa/ghsa.go
+++ b/pkg/fetch/erlang/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Erlang GHSA")
+	slog.Info("Fetch Erlang GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/erlang/osv/osv.go
+++ b/pkg/fetch/erlang/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Erlang OSV")
+	slog.Info("Fetch Erlang OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/exploit/exploitdb/exploitdb.go
+++ b/pkg/fetch/exploit/exploitdb/exploitdb.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"slices"
@@ -81,9 +81,9 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch ExploitDB")
+	slog.Info("Fetch ExploitDB")
 
-	log.Println(`[INFO] Exploits`)
+	slog.Info("Exploits")
 	es, err := options.fetchExploits()
 	if err != nil {
 		return errors.Wrap(err, "fetch exploits")
@@ -98,7 +98,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Println(`[INFO] Shellcodes`)
+	slog.Info("Shellcodes")
 	ss, err := options.fetchShellcodes()
 	if err != nil {
 		return errors.Wrap(err, "fetch shellcodes")
@@ -113,7 +113,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Println(`[INFO] Papers`)
+	slog.Info("Papers")
 	ps, err := options.fetchPapers()
 	if err != nil {
 		return errors.Wrap(err, "fetch papers")
@@ -128,7 +128,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Println(`[INFO] GHDB`)
+	slog.Info("GHDB")
 	ghdbs, err := options.fetchGHDB()
 	if err != nil {
 		return errors.Wrap(err, "fetch ghdb")

--- a/pkg/fetch/exploit/github/github.go
+++ b/pkg/fetch/exploit/github/github.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -76,7 +76,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Poc-in-GitHub")
+	slog.Info("Fetch Poc-in-GitHub")
 	var es []Exploit
 
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)

--- a/pkg/fetch/exploit/inthewild/inthewild.go
+++ b/pkg/fetch/exploit/inthewild/inthewild.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -80,7 +80,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch inthewild")
+	slog.Info("Fetch inthewild")
 	tempDir, err := os.MkdirTemp("", "vuls-data-update")
 	if err != nil {
 		return errors.Wrapf(err, "mkdir %s", tempDir)

--- a/pkg/fetch/exploit/trickest/trickest.go
+++ b/pkg/fetch/exploit/trickest/trickest.go
@@ -6,7 +6,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -77,7 +77,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch trickest")
+	slog.Info("Fetch trickest")
 	var es []Exploit
 
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)

--- a/pkg/fetch/fedora/api/api.go
+++ b/pkg/fetch/fedora/api/api.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"slices"
@@ -140,14 +140,14 @@ func Fetch(releases []string, opts ...Option) error {
 	}
 
 	for _, release := range extracted {
-		log.Printf("[INFO] Fetch Fedora %s", release)
-		log.Printf("[INFO] Fetch Fedora %s Advisory List", release)
+		slog.Info("Fetch Fedora", slog.String("release", release))
+		slog.Info("Fetch Fedora Advisory List", slog.String("release", release))
 		advs, err := options.advisories(client, release)
 		if err != nil {
 			return errors.Wrapf(err, "fetch %s security advisories", release)
 		}
 
-		log.Printf("[INFO] Finish Fedora %s Advisory", release)
+		slog.Info("Finish Fedora Advisory", slog.String("release", release))
 		advChan := make(chan Advisory, len(advs))
 		go func() {
 			defer close(advChan)

--- a/pkg/fetch/fedora/updateinfo/updateinfo.go
+++ b/pkg/fetch/fedora/updateinfo/updateinfo.go
@@ -9,7 +9,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path"
@@ -110,7 +110,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Fedora Updateinfo")
+	slog.Info("Fetch Fedora Updateinfo")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 
 	us, err := options.fetchFullFileTimeList(client)
@@ -126,7 +126,7 @@ func Fetch(opts ...Option) error {
 }
 
 func (o options) fetchFullFileTimeList(client *utilhttp.Client) ([]string, error) {
-	log.Printf("[INFO] Fetch Fedora fullfiletimelist")
+	slog.Info("Fetch Fedora fullfiletimelist")
 
 	var us []string
 

--- a/pkg/fetch/fortinet/csaf/csaf.go
+++ b/pkg/fetch/fortinet/csaf/csaf.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -109,7 +109,7 @@ func Fetch(args []string, opts ...Option) error {
 }
 
 func (opts options) fetch(ids []string) error {
-	log.Printf("[INFO] Fetch Fortinet CSAF")
+	slog.Info("Fetch Fortinet CSAF")
 
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
 

--- a/pkg/fetch/fortinet/cvrf/cvrf.go
+++ b/pkg/fetch/fortinet/cvrf/cvrf.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"mime"
 	"net/http"
 	"path/filepath"
@@ -99,7 +99,7 @@ func Fetch(args []string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Fortinet CVRF")
+	slog.Info("Fetch Fortinet CVRF")
 
 	urls := make([]string, 0, len(args))
 	for _, arg := range args {

--- a/pkg/fetch/freebsd/freebsd.go
+++ b/pkg/fetch/freebsd/freebsd.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -73,7 +73,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch FreeBSD")
+	slog.Info("Fetch FreeBSD")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch advisory")

--- a/pkg/fetch/gentoo/gentoo.go
+++ b/pkg/fetch/gentoo/gentoo.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Gentoo Linux")
+	slog.Info("Fetch Gentoo Linux")
 
 	cloneDir, err := os.MkdirTemp("", "vuls-data-update")
 	if err != nil {

--- a/pkg/fetch/ghactions/osv/osv.go
+++ b/pkg/fetch/ghactions/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch GitHub Actions OSV")
+	slog.Info("Fetch GitHub Actions OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/git/osv/osv.go
+++ b/pkg/fetch/git/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Git OSV")
+	slog.Info("Fetch Git OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/golang/db/db.go
+++ b/pkg/fetch/golang/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -69,7 +69,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Golang DB")
+	slog.Info("Fetch Golang DB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/golang/ghsa/ghsa.go
+++ b/pkg/fetch/golang/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Golang GHSA")
+	slog.Info("Fetch Golang GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/golang/glsa/glsa.go
+++ b/pkg/fetch/golang/glsa/glsa.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Golang GLSA")
+	slog.Info("Fetch Golang GLSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/golang/osv/osv.go
+++ b/pkg/fetch/golang/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Golang OSV")
+	slog.Info("Fetch Golang OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/golang/vulndb/vulndb.go
+++ b/pkg/fetch/golang/vulndb/vulndb.go
@@ -2,7 +2,7 @@ package vulndb
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -70,7 +70,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Golang go-vulndb")
+	slog.Info("Fetch Golang go-vulndb")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch go-vulndb data")

--- a/pkg/fetch/haskell/db/db.go
+++ b/pkg/fetch/haskell/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -69,7 +69,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Haskell DB")
+	slog.Info("Fetch Haskell DB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/haskell/ghc/osv/osv.go
+++ b/pkg/fetch/haskell/ghc/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Haskell GHC OSV")
+	slog.Info("Fetch Haskell GHC OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/haskell/hackage/osv/osv.go
+++ b/pkg/fetch/haskell/hackage/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Haskell Hackage OSV")
+	slog.Info("Fetch Haskell Hackage OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/julia/osv/osv.go
+++ b/pkg/fetch/julia/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Julia OSV")
+	slog.Info("Fetch Julia OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/jvn/feed/detail/detail.go
+++ b/pkg/fetch/jvn/feed/detail/detail.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -76,7 +76,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch JVNDB Detail")
+	slog.Info("Fetch JVNDB Detail")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientCheckRetry(jvnutil.CheckRetry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "get checksum")
@@ -101,7 +101,7 @@ func Fetch(opts ...Option) error {
 	}
 
 	for _, c := range filtered {
-		log.Printf("[INFO] Fetch JVNDB Detail Feed %s", c.Filename)
+		slog.Info("Fetch JVNDB Detail Feed", slog.String("feed", c.Filename))
 		vs, err := func() ([]Vulinfo, error) {
 			resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(c.URL)
 			if err != nil {

--- a/pkg/fetch/jvn/feed/product/product.go
+++ b/pkg/fetch/jvn/feed/product/product.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"slices"
@@ -77,7 +77,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch JVNDB Product")
+	slog.Info("Fetch JVNDB Product")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientCheckRetry(jvnutil.CheckRetry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "get checksum")
@@ -116,7 +116,7 @@ func Fetch(opts ...Option) error {
 		return 0
 	})
 
-	log.Printf("[INFO] Fetch JVNDB Product Feed %s", filtered[len(filtered)-1].Filename)
+	slog.Info("Fetch JVNDB Product Feed", slog.String("feed", filtered[len(filtered)-1].Filename))
 	resp, err = utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(filtered[len(filtered)-1].URL)
 	if err != nil {
 		return errors.Wrap(err, "fetch jvndb product")

--- a/pkg/fetch/jvn/feed/rss/rss.go
+++ b/pkg/fetch/jvn/feed/rss/rss.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"slices"
@@ -77,7 +77,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch JVNDB RSS")
+	slog.Info("Fetch JVNDB RSS")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientCheckRetry(jvnutil.CheckRetry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "get checksum")
@@ -118,7 +118,7 @@ func Fetch(opts ...Option) error {
 
 	advisories := make(map[string]Item)
 	for _, c := range filtered {
-		log.Printf("[INFO] Fetch JVNDB RSS Feed %s", c.Filename)
+		slog.Info("Fetch JVNDB RSS Feed", slog.String("feed", c.Filename))
 
 		items, err := func() ([]Item, error) {
 			resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(c.URL)

--- a/pkg/fetch/k8s/json/json.go
+++ b/pkg/fetch/k8s/json/json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -72,7 +72,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Kubernetes JSON")
+	slog.Info("Fetch Kubernetes JSON")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch k8s json")

--- a/pkg/fetch/k8s/osv/osv.go
+++ b/pkg/fetch/k8s/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Kubernetes OSV")
+	slog.Info("Fetch Kubernetes OSV")
 
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {

--- a/pkg/fetch/linux/osv/osv.go
+++ b/pkg/fetch/linux/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Linux OSV")
+	slog.Info("Fetch Linux OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/mageia/osv/osv.go
+++ b/pkg/fetch/mageia/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Mageia OSV")
+	slog.Info("Fetch Mageia OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/maven/ghsa/ghsa.go
+++ b/pkg/fetch/maven/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Maven GHSA")
+	slog.Info("Fetch Maven GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/maven/glsa/glsa.go
+++ b/pkg/fetch/maven/glsa/glsa.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Maven GLSA")
+	slog.Info("Fetch Maven GLSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/maven/osv/osv.go
+++ b/pkg/fetch/maven/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Maven OSV")
+	slog.Info("Fetch Maven OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/microsoft/advisory/advisory.go
+++ b/pkg/fetch/microsoft/advisory/advisory.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -72,7 +72,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Microsoft Advisory")
+	slog.Info("Fetch Microsoft Advisory")
 
 	bar := progressbar.Default(-1)
 	u := options.dataURL

--- a/pkg/fetch/microsoft/azure/oval/oval.go
+++ b/pkg/fetch/microsoft/azure/oval/oval.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Azure Linux OVAL")
+	slog.Info("Fetch Azure Linux OVAL")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch")
@@ -124,9 +124,9 @@ func Fetch(opts ...Option) error {
 			return errors.Errorf("unexpected oval file name. expected: %q, actual: %q", []string{"azurelinux-<version>-oval.xml", "cbl-mariner-<version>-oval.xml"}, filepath.Base(hdr.Name))
 		}
 
-		log.Printf("[INFO] Fetch %s %s OVAL", t, v)
+		slog.Info("Fetch OVAL", slog.String("type", t), slog.String("version", v))
 
-		log.Printf("[INFO] Fetch %s %s Definitions", t, v)
+		slog.Info("Fetch Definitions", slog.String("type", t), slog.String("version", v))
 		bar := progressbar.Default(int64(len(root.Definitions.Definition)))
 		for _, def := range root.Definitions.Definition {
 			if err := util.Write(filepath.Join(options.dir, t, v, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -136,7 +136,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch %s %s Tests", t, v)
+		slog.Info("Fetch Tests", slog.String("type", t), slog.String("version", v))
 		bar = progressbar.Default(int64(len(root.Tests.RpminfoTest)))
 		for _, test := range root.Tests.RpminfoTest {
 			if err := util.Write(filepath.Join(options.dir, t, v, "tests", "rpminfo_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -146,7 +146,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch %s %s Objects", t, v)
+		slog.Info("Fetch Objects", slog.String("type", t), slog.String("version", v))
 		bar = progressbar.Default(int64(len(root.Objects.RpminfoObject)))
 		for _, object := range root.Objects.RpminfoObject {
 			if err := util.Write(filepath.Join(options.dir, t, v, "objects", "rpminfo_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -156,7 +156,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch %s %s States", t, v)
+		slog.Info("Fetch States", slog.String("type", t), slog.String("version", v))
 		bar = progressbar.Default(int64(len(root.States.RpminfoState)))
 		for _, state := range root.States.RpminfoState {
 			if err := util.Write(filepath.Join(options.dir, t, v, "states", "rpminfo_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {

--- a/pkg/fetch/microsoft/bulletin/bulletin.go
+++ b/pkg/fetch/microsoft/bulletin/bulletin.go
@@ -3,7 +3,7 @@ package bulletin
 import (
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -77,7 +77,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Windows Bulletin")
+	slog.Info("Fetch Windows Bulletin")
 
 	bulletins := make(map[string][]Bulletin)
 	for _, u := range options.dataURLs {

--- a/pkg/fetch/microsoft/csaf/csaf.go
+++ b/pkg/fetch/microsoft/csaf/csaf.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -98,7 +98,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Microsoft CSAF")
+	slog.Info("Fetch Microsoft CSAF")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 
 	ls, err := options.fetchIndex(client)

--- a/pkg/fetch/microsoft/cvrf/cvrf.go
+++ b/pkg/fetch/microsoft/cvrf/cvrf.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -77,7 +77,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Windows CVRF")
+	slog.Info("Fetch Windows CVRF")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch updates")
@@ -95,7 +95,7 @@ func Fetch(opts ...Option) error {
 	}
 
 	for _, u := range us.Value {
-		log.Printf("[INFO] Fetch Windows CVRF %s", path.Base(u.CvrfURL))
+		slog.Info("Fetch Windows CVRF", slog.String("file", path.Base(u.CvrfURL)))
 		c, err := func() (*CVRF, error) {
 			resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(u.CvrfURL)
 			if err != nil {

--- a/pkg/fetch/microsoft/deployment/deployment.go
+++ b/pkg/fetch/microsoft/deployment/deployment.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -72,7 +72,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Microsoft Deployment")
+	slog.Info("Fetch Microsoft Deployment")
 
 	bar := progressbar.Default(-1)
 	u := options.dataURL

--- a/pkg/fetch/microsoft/msuc/msuc.go
+++ b/pkg/fetch/microsoft/msuc/msuc.go
@@ -3,7 +3,7 @@ package msuc
 import (
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path"
@@ -100,7 +100,7 @@ func Fetch(queries []string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Windows Microsoft Software Update Catalog")
+	slog.Info("Fetch Windows Microsoft Software Update Catalog")
 
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 	uids, err := options.search(client, util.Unique(queries))
@@ -110,7 +110,7 @@ func Fetch(queries []string, opts ...Option) error {
 
 	uidmap := make(map[string]struct{})
 	for len(uids) > 0 {
-		log.Printf("[INFO] Search %d Update IDs", len(uids))
+		slog.Info("Search Update IDs", slog.Int("count", len(uids)))
 
 		var us []string
 		for _, uid := range uids {
@@ -176,7 +176,7 @@ func Fetch(queries []string, opts ...Option) error {
 }
 
 func (opts options) search(client *utilhttp.Client, queries []string) ([]string, error) {
-	log.Printf("[INFO] Search %d queries", len(queries))
+	slog.Info("Search queries", slog.Int("count", len(queries)))
 
 	header := make(http.Header)
 	header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -216,7 +216,7 @@ func (opts options) search(client *utilhttp.Client, queries []string) ([]string,
 			}
 			id, _, ok := strings.Cut(val, "_")
 			if !ok {
-				log.Printf(`[WARN] unexpected id. id="%s"`, val)
+				slog.Warn("unexpected id", slog.String("id", val))
 				return
 			}
 			us = append(us, id)
@@ -258,36 +258,36 @@ func parseView(rd io.Reader, updateID string) (*Update, error) {
 	u.Description = doc.Find("span#ScopedViewHandler_desc").Text()
 	_, u.Architecture, found = strings.Cut(r.Replace(doc.Find("div#archDiv").Text()), ":")
 	if !found {
-		log.Printf(`[WARN] unexpected div#archDiv format. expected: "...:<arch>", actual: "%s"`, r.Replace(doc.Find("div#archDiv").Text()))
+		slog.Warn("unexpected div#archDiv format", slog.String("expected", "...:<arch>"), slog.String("actual", r.Replace(doc.Find("div#archDiv").Text())))
 	}
 	_, u.Classification, found = strings.Cut(r.Replace(doc.Find("div#classificationDiv").Text()), ":")
 	if !found {
-		log.Printf(`[WARN] unexpected div#classificationDiv format. expected: "...:<classification>", actual: "%s"`, r.Replace(doc.Find("div#classificationDiv").Text()))
+		slog.Warn("unexpected div#classificationDiv format", slog.String("expected", "...:<classification>"), slog.String("actual", r.Replace(doc.Find("div#classificationDiv").Text())))
 	}
 	_, u.SupportedProducts, found = strings.Cut(r.Replace(doc.Find("div#productsDiv").Text()), ":")
 	if !found {
-		log.Printf(`[WARN] unexpected div#productsDiv format. expected: "...:<products>", actual: "%s"`, r.Replace(doc.Find("div#products").Text()))
+		slog.Warn("unexpected div#productsDiv format", slog.String("expected", "...:<products>"), slog.String("actual", r.Replace(doc.Find("div#productsDiv").Text())))
 	}
 	_, u.SupportedLanguages, found = strings.Cut(r.Replace(doc.Find("div#languagesDiv").Text()), ":")
 	if !found {
-		log.Printf(`[WARN] unexpected div#languagesDiv format. expected: "...:<languages>", actual: "%s"`, r.Replace(doc.Find("div#languagesDiv").Text()))
+		slog.Warn("unexpected div#languagesDiv format", slog.String("expected", "...:<languages>"), slog.String("actual", r.Replace(doc.Find("div#languagesDiv").Text())))
 	}
 	_, u.SecurityBulliten, found = strings.Cut(r.Replace(doc.Find("div#securityBullitenDiv").Text()), ":")
 	if !found {
-		log.Printf(`[WARN] unexpected div#securityBullitenDiv format. expected: "...:<securityBulliten>", actual: "%s"`, r.Replace(doc.Find("div#securityBullitenDiv").Text()))
+		slog.Warn("unexpected div#securityBullitenDiv format", slog.String("expected", "...:<securityBulliten>"), slog.String("actual", r.Replace(doc.Find("div#securityBullitenDiv").Text())))
 	}
 	u.MSRCSeverity = doc.Find("span#ScopedViewHandler_msrcSeverity").Text()
 	_, u.KBArticle, found = strings.Cut(r.Replace(doc.Find("div#kbDiv").Text()), ":")
 	if !found {
-		log.Printf(`[WARN] unexpected div#kbDiv format. expected: "...:<kb>", actual: "%s"`, r.Replace(doc.Find("div#kbDiv").Text()))
+		slog.Warn("unexpected div#kbDiv format", slog.String("expected", "...:<kb>"), slog.String("actual", r.Replace(doc.Find("div#kbDiv").Text())))
 	}
 	_, u.MoreInfo, found = strings.Cut(r.Replace(doc.Find("div#moreInfoDiv").Text()), ":")
 	if !found {
-		log.Printf(`[WARN] unexpected div#moreInfoDiv format. expected: "...:<moreInfo>", actual: "%s"`, r.Replace(doc.Find("div#moreInfoDiv").Text()))
+		slog.Warn("unexpected div#moreInfoDiv format", slog.String("expected", "...:<moreInfo>"), slog.String("actual", r.Replace(doc.Find("div#moreInfoDiv").Text())))
 	}
 	_, u.SupportURL, found = strings.Cut(r.Replace(doc.Find("div#suportUrlDiv").Text()), ":")
 	if !found {
-		log.Printf(`[WARN] unexpected div#suportUrlDiv format. expected: "...:<suportUrl>", actual: "%s"`, r.Replace(doc.Find("div#suportUrlDiv").Text()))
+		slog.Warn("unexpected div#suportUrlDiv format", slog.String("expected", "...:<supportURL>"), slog.String("actual", r.Replace(doc.Find("div#suportUrlDiv").Text())))
 	}
 
 	doc.Find("div#supersededbyInfo > div > a").Each(func(_ int, s *goquery.Selection) {
@@ -296,7 +296,7 @@ func parseView(rd io.Reader, updateID string) (*Update, error) {
 			return
 		}
 		if !strings.HasPrefix(val, "ScopedViewInline.aspx?updateid=") {
-			log.Printf(`[WARN] unexpected href. href="%s"`, val)
+			slog.Warn("unexpected href", slog.String("href", val))
 			return
 		}
 		u.Supersededby = append(u.Supersededby, Supersededby{
@@ -314,11 +314,11 @@ func parseView(rd io.Reader, updateID string) (*Update, error) {
 	u.Connectivity = doc.Find("span#ScopedViewHandler_connectivity").Text()
 	_, u.UninstallNotes, found = strings.Cut(r.Replace(doc.Find("div#uninstallNotesDiv").Text()), ":")
 	if !found {
-		log.Printf(`[WARN] unexpected div#uninstallNotesDiv format. expected: "...:<uninstallNotes>", actual: "%s"`, r.Replace(doc.Find("div#uninstallNotesDiv").Text()))
+		slog.Warn("unexpected div#uninstallNotesDiv format", slog.String("expected", "...:<uninstallNotes>"), slog.String("actual", r.Replace(doc.Find("div#uninstallNotesDiv").Text())))
 	}
 	_, u.UninstallSteps, found = strings.Cut(r.Replace(doc.Find("div#uninstallStepsDiv").Text()), ":")
 	if !found {
-		log.Printf(`[WARN] unexpected div#uninstallStepsDiv format. expected: "...:<uninstallSteps>", actual: "%s"`, r.Replace(doc.Find("div#uninstallStepsDiv").Text()))
+		slog.Warn("unexpected div#uninstallStepsDiv format", slog.String("expected", "...:<uninstallSteps>"), slog.String("actual", r.Replace(doc.Find("div#uninstallStepsDiv").Text())))
 	}
 
 	return &u, nil

--- a/pkg/fetch/microsoft/product/product.go
+++ b/pkg/fetch/microsoft/product/product.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -72,7 +72,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Microsoft Product")
+	slog.Info("Fetch Microsoft Product")
 
 	bar := progressbar.Default(-1)
 	u := options.dataURL

--- a/pkg/fetch/microsoft/vex/vex.go
+++ b/pkg/fetch/microsoft/vex/vex.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -98,7 +98,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Microsoft VEX")
+	slog.Info("Fetch Microsoft VEX")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 
 	ls, err := options.fetchIndex(client)

--- a/pkg/fetch/microsoft/vulnerability/vulnerability.go
+++ b/pkg/fetch/microsoft/vulnerability/vulnerability.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -72,7 +72,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Microsoft Vulnerability")
+	slog.Info("Fetch Microsoft Vulnerability")
 
 	bar := progressbar.Default(-1)
 	u := options.dataURL

--- a/pkg/fetch/microsoft/wsusscn2/wsusscn2.go
+++ b/pkg/fetch/microsoft/wsusscn2/wsusscn2.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -90,7 +90,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Windows WSUSSCN2")
+	slog.Info("Fetch Windows WSUSSCN2")
 	rootDir, err := options.fetch()
 	if err != nil {
 		return errors.Wrap(err, "fetch wsusscn2.cab")
@@ -140,7 +140,7 @@ func (opts options) extract(tmpDir string) error {
 		return errors.Wrap(err, "look cabextract path")
 	}
 
-	log.Printf("[INFO] extract %s", filepath.Join(tmpDir, "wsusscn2.cab"))
+	slog.Info("extract", slog.String("path", filepath.Join(tmpDir, "wsusscn2.cab")))
 	if err := exec.Command(binPath, "-d", filepath.Join(tmpDir, "wsusscn2"), filepath.Join(tmpDir, "wsusscn2.cab")).Run(); err != nil {
 		return errors.Wrap(err, "run cabextract wsusscn2.cab")
 	}
@@ -159,7 +159,7 @@ func (opts options) extract(tmpDir string) error {
 		return errors.Wrap(err, "decode xml")
 	}
 
-	log.Printf("[INFO] extract %s", filepath.Join(tmpDir, "wsusscn2", "package.cab"))
+	slog.Info("extract", slog.String("path", filepath.Join(tmpDir, "wsusscn2", "package.cab")))
 	if err := exec.Command(binPath, "-d", filepath.Join(tmpDir, "wsusscn2", "package"), filepath.Join(tmpDir, "wsusscn2", "package.cab")).Run(); err != nil {
 		return errors.Wrap(err, "run cabextract wsusscn2/package.cab")
 	}
@@ -167,7 +167,7 @@ func (opts options) extract(tmpDir string) error {
 		return errors.Wrap(err, "remove wsusscn2/package.cab")
 	}
 
-	log.Printf("[INFO] extract %s - %s", filepath.Join(tmpDir, "wsusscn2", "package2.cab"), filepath.Join(tmpDir, "wsusscn2", fmt.Sprintf("package%d.cab", len(cabIndex.CABLIST.CAB))))
+	slog.Info("extract", slog.String("from", filepath.Join(tmpDir, "wsusscn2", "package2.cab")), slog.String("to", filepath.Join(tmpDir, "wsusscn2", fmt.Sprintf("package%d.cab", len(cabIndex.CABLIST.CAB)))))
 	eg, _ := errgroup.WithContext(context.TODO())
 	eg.SetLimit(opts.concurrency)
 	for _, c := range cabIndex.CABLIST.CAB {
@@ -207,7 +207,7 @@ func (opts options) extract(tmpDir string) error {
 }
 
 func (opts options) save(root string) error {
-	log.Printf("[INFO] save wsusscn2 update, core, extended, localized data")
+	slog.Info("save wsusscn2 update, core, extended, localized data")
 
 	f, err := os.Open(filepath.Join(root, "package", "package.xml"))
 	if err != nil {

--- a/pkg/fetch/minimos/osv/osv.go
+++ b/pkg/fetch/minimos/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch MinimOS OSV")
+	slog.Info("Fetch MinimOS OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/minimos/secdb/secdb.go
+++ b/pkg/fetch/minimos/secdb/secdb.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -71,7 +71,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch MinimOS SecDB")
+	slog.Info("Fetch MinimOS SecDB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch")

--- a/pkg/fetch/mitre/attack/attack.go
+++ b/pkg/fetch/mitre/attack/attack.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -73,7 +73,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch MITRE ATT&CK Enterprise")
+	slog.Info("Fetch MITRE ATT&CK Enterprise")
 	if err := func() error {
 		u, err := url.JoinPath(options.baseURL, "enterprise-attack/enterprise-attack.json")
 		if err != nil {
@@ -110,7 +110,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrap(err, "fetch enterprise")
 	}
 
-	log.Printf("[INFO] Fetch MITRE ATT&CK ICS")
+	slog.Info("Fetch MITRE ATT&CK ICS")
 	if err := func() error {
 		u, err := url.JoinPath(options.baseURL, "ics-attack/ics-attack.json")
 		if err != nil {
@@ -147,7 +147,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrap(err, "fetch ics")
 	}
 
-	log.Printf("[INFO] Fetch MITRE ATT&CK Mobile")
+	slog.Info("Fetch MITRE ATT&CK Mobile")
 	if err := func() error {
 		u, err := url.JoinPath(options.baseURL, "mobile-attack/mobile-attack.json")
 		if err != nil {

--- a/pkg/fetch/mitre/capec/capec.go
+++ b/pkg/fetch/mitre/capec/capec.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -72,7 +72,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch MITRE Common Attack Pattern Enumerations and Classifications: CAPEC")
+	slog.Info("Fetch MITRE Common Attack Pattern Enumerations and Classifications: CAPEC")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch capec data")

--- a/pkg/fetch/mitre/cvrf/cvrf.go
+++ b/pkg/fetch/mitre/cvrf/cvrf.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch MITRE CVE CVRF List")
+	slog.Info("Fetch MITRE CVE CVRF List")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch mitre data")

--- a/pkg/fetch/mitre/cwe/cwe.go
+++ b/pkg/fetch/mitre/cwe/cwe.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch MITRE Common Weakness Enumeration: CWE")
+	slog.Info("Fetch MITRE Common Weakness Enumeration: CWE")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch cwe data")
@@ -116,7 +116,7 @@ func Fetch(opts ...Option) error {
 		exRefs[ref.ReferenceID] = ref
 	}
 
-	log.Printf(`[INFO] Weakness`)
+	slog.Info("Fetch CWE Weakness")
 	weaknesses := convertWeaknesses(catalog.Weaknesses, exRefs)
 
 	bar := progressbar.Default(int64(len(weaknesses)))
@@ -129,7 +129,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Printf(`[INFO] Category`)
+	slog.Info("Fetch CWE Category")
 	categories := convertCategories(catalog.Categories, exRefs)
 
 	bar = progressbar.Default(int64(len(categories)))
@@ -142,7 +142,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Printf(`[INFO] View`)
+	slog.Info("Fetch CWE View")
 	views := convertViews(catalog.Views, exRefs)
 
 	bar = progressbar.Default(int64(len(views)))
@@ -196,7 +196,7 @@ func convertWeaknesses(weaknesses []weakness, exRefs map[string]ExternalReferenc
 		for _, ref := range w.References {
 			exRef, ok := exRefs[ref.ExternalReferenceID]
 			if !ok {
-				log.Printf(`[WARN] External_Reference not found. External_Reference_ID: %s`, ref.ExternalReferenceID)
+				slog.Warn("External_Reference not found", slog.String("external_reference_id", ref.ExternalReferenceID))
 				continue
 			}
 			references = append(references, Reference{
@@ -334,7 +334,7 @@ func convertCategories(categories []category, exRefs map[string]ExternalReferenc
 		for _, ref := range c.References {
 			exRef, ok := exRefs[ref.ExternalReferenceID]
 			if !ok {
-				log.Printf(`[WARN] External_Reference not found. External_Reference_ID: %s`, ref.ExternalReferenceID)
+				slog.Warn("External_Reference not found", slog.String("external_reference_id", ref.ExternalReferenceID))
 				continue
 			}
 			references = append(references, Reference{
@@ -398,7 +398,7 @@ func convertViews(views []view, exRefs map[string]ExternalReference) []View {
 		for _, ref := range v.References {
 			exRef, ok := exRefs[ref.ExternalReferenceID]
 			if !ok {
-				log.Printf(`[WARN] External_Reference not found. External_Reference_ID: %s`, ref.ExternalReferenceID)
+				slog.Warn("External_Reference not found", slog.String("external_reference_id", ref.ExternalReferenceID))
 				continue
 			}
 			references = append(references, Reference{

--- a/pkg/fetch/mitre/emb3d/emb3d.go
+++ b/pkg/fetch/mitre/emb3d/emb3d.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -72,7 +72,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch MITRE EMB3D")
+	slog.Info("Fetch MITRE EMB3D")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 
 	if err := options.fetchThreats(client); err != nil {

--- a/pkg/fetch/mitre/v4/v4.go
+++ b/pkg/fetch/mitre/v4/v4.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch MITRE CVE V4 List")
+	slog.Info("Fetch MITRE CVE V4 List")
 	h := make(http.Header)
 	h.Set("Accept-Encoding", "gzip")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL, utilhttp.WithRequestHeader(h))

--- a/pkg/fetch/mitre/v5/v5.go
+++ b/pkg/fetch/mitre/v5/v5.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -76,7 +76,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch MITRE CVE V5 List")
+	slog.Info("Fetch MITRE CVE V5 List")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch mitre data")

--- a/pkg/fetch/msf/msf.go
+++ b/pkg/fetch/msf/msf.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -73,7 +73,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Metasploit Framework")
+	slog.Info("Fetch Metasploit Framework")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch msf data")
@@ -124,18 +124,18 @@ func Fetch(opts ...Option) error {
 			s := fmt.Sprintf("%.0f", v)
 			i, err := strconv.Atoi(s)
 			if err != nil {
-				log.Printf(`[WARN] failed to convert rport in %s. strconv.Atoi(%s) = %s`, m.Name, s, err)
+				slog.Warn("failed to convert rport", slog.String("name", m.Name), slog.String("value", s), slog.Any("err", err))
 			}
 			module.Rport = &i
 		case string:
 			i, err := strconv.Atoi(v)
 			if err != nil {
-				log.Printf(`[WARN] failed to convert rport in %s. strconv.Atoi(%s) = %s`, m.Name, v, err)
+				slog.Warn("failed to convert rport", slog.String("name", m.Name), slog.String("value", v), slog.Any("err", err))
 			}
 			module.Rport = &i
 		case nil:
 		default:
-			log.Printf(`[WARN] unexpected rport type in %s. accepts: ["int", "float64", "string", "nil"], received: "%T"`, m.Name, v)
+			slog.Warn("unexpected rport type", slog.String("name", m.Name), slog.String("expected", "int, float64, string, nil"), slog.String("actual", fmt.Sprintf("%T", v)))
 		}
 
 		for k, note := range m.Notes {
@@ -148,13 +148,13 @@ func Fetch(opts ...Option) error {
 				for _, e := range v {
 					s, ok := e.(string)
 					if !ok {
-						log.Printf(`[WARN] unexpected notes element type in %s. accepts: ["string"], received: "%T"`, m.Name, e)
+						slog.Warn("unexpected notes element type", slog.String("name", m.Name), slog.String("expected", "string"), slog.String("actual", fmt.Sprintf("%T", e)))
 						continue
 					}
 					module.Notes[k] = append(module.Notes[k], s)
 				}
 			default:
-				log.Printf(`[WARN] unexpected notes type in %s. accepts: ["string", "[]string", "[]interface{}"], received: "%T"`, m.Name, v)
+				slog.Warn("unexpected notes type", slog.String("name", m.Name), slog.String("expected", "string, []string, []any"), slog.String("actual", fmt.Sprintf("%T", v)))
 			}
 		}
 
@@ -165,17 +165,17 @@ func Fetch(opts ...Option) error {
 			for _, e := range v {
 				s, ok := e.(string)
 				if !ok {
-					log.Printf(`[WARN] unexpected session_types element type in %s. accepts: ["string"], received: "%T"`, m.Name, e)
+					slog.Warn("unexpected session_types element type", slog.String("name", m.Name), slog.String("expected", "string"), slog.String("actual", fmt.Sprintf("%T", e)))
 					continue
 				}
 				module.SessionTypes = append(module.SessionTypes, s)
 			}
 		case bool:
 			if v {
-				log.Printf(`[WARN] unexpected session_types value in %s. accepts: ["[]string", "[]interface{}", "bool(false)"], received: "true"`, m.Name)
+				slog.Warn("unexpected session_types value", slog.String("name", m.Name))
 			}
 		default:
-			log.Printf(`[WARN] unexpected session_types type in %s. accepts: ["[]string", "[]interface{}", "bool"], received: "%T"`, m.Name, v)
+			slog.Warn("unexpected session_types type", slog.String("name", m.Name), slog.String("expected", "[]string, []any, bool"), slog.String("actual", fmt.Sprintf("%T", v)))
 		}
 
 		switch v := m.NeedsCleanup.(type) {
@@ -183,7 +183,7 @@ func Fetch(opts ...Option) error {
 			module.NeedsCleanup = &v
 		case nil:
 		default:
-			log.Printf(`[WARN] unexpected needs_cleanup type in %s. accepts: ["bool", "nil"], received: "%T"`, m.Name, v)
+			slog.Warn("unexpected needs_cleanup type", slog.String("name", m.Name), slog.String("expected", "bool, nil"), slog.String("actual", fmt.Sprintf("%T", v)))
 		}
 
 		modules = append(modules, module)

--- a/pkg/fetch/ncsc/csaf/csaf.go
+++ b/pkg/fetch/ncsc/csaf/csaf.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -98,7 +98,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Netherlands Cyber Security Center CSAF")
+	slog.Info("Fetch Netherlands Cyber Security Center CSAF")
 	if err := options.fetch(); err != nil {
 		return errors.Wrap(err, "fetch")
 	}

--- a/pkg/fetch/nozominetworks/csaf/csaf.go
+++ b/pkg/fetch/nozominetworks/csaf/csaf.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -98,7 +98,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Nozomi Networks CSAF")
+	slog.Info("Fetch Nozomi Networks CSAF")
 	if err := options.fetch(); err != nil {
 		return errors.Wrap(err, "fetch")
 	}

--- a/pkg/fetch/npm/db/db.go
+++ b/pkg/fetch/npm/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -69,7 +69,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch NPM DB")
+	slog.Info("Fetch NPM DB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/npm/ghsa/ghsa.go
+++ b/pkg/fetch/npm/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch NPM GHSA")
+	slog.Info("Fetch NPM GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/npm/glsa/glsa.go
+++ b/pkg/fetch/npm/glsa/glsa.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch NPM GLSA")
+	slog.Info("Fetch NPM GLSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/npm/osv/osv.go
+++ b/pkg/fetch/npm/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch NPM OSV")
+	slog.Info("Fetch NPM OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/nuclei/api/api.go
+++ b/pkg/fetch/nuclei/api/api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -73,7 +73,7 @@ func Fetch(apikey string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Nuclei Public & Early Templates from API")
+	slog.Info("Fetch Nuclei Public & Early Templates from API")
 	if err := options.fetch(apikey); err != nil {
 		return errors.Wrap(err, "fetch")
 	}

--- a/pkg/fetch/nuclei/repository/repository.go
+++ b/pkg/fetch/nuclei/repository/repository.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Nuclei Templates from GitHub Repository")
+	slog.Info("Fetch Nuclei Templates from GitHub Repository")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch nuclei data")

--- a/pkg/fetch/nuget/ghsa/ghsa.go
+++ b/pkg/fetch/nuget/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Nuget GHSA")
+	slog.Info("Fetch Nuget GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/nuget/glsa/glsa.go
+++ b/pkg/fetch/nuget/glsa/glsa.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Nuget GLSA")
+	slog.Info("Fetch Nuget GLSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/nuget/osv/osv.go
+++ b/pkg/fetch/nuget/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Nuget OSV")
+	slog.Info("Fetch Nuget OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/nvd/api/cpe/cpe.go
+++ b/pkg/fetch/nvd/api/cpe/cpe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -181,7 +181,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch NVD CPE API. dir: %s", options.dir)
+	slog.Info("Fetch NVD CPE API", slog.String("dir", options.dir))
 
 	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(time.Duration(options.retryWaitMin)*time.Second), utilhttp.WithClientRetryWaitMax(time.Duration(options.retryWaitMax)*time.Second), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
 

--- a/pkg/fetch/nvd/api/cpematch/cpematch.go
+++ b/pkg/fetch/nvd/api/cpematch/cpematch.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -181,7 +181,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch NVD CPE match API. dir: %s", options.dir)
+	slog.Info("Fetch NVD CPE match API", slog.String("dir", options.dir))
 
 	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(time.Duration(options.retryWaitMin)*time.Second), utilhttp.WithClientRetryWaitMax(time.Duration(options.retryWaitMax)*time.Second), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
 

--- a/pkg/fetch/nvd/api/cve/cve.go
+++ b/pkg/fetch/nvd/api/cve/cve.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -178,7 +178,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch NVD CVE API. dir: %s", options.dir)
+	slog.Info("Fetch NVD CVE API", slog.String("dir", options.dir))
 
 	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(time.Duration(options.retryWaitMin)*time.Second), utilhttp.WithClientRetryWaitMax(time.Duration(options.retryWaitMax)*time.Second), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
 

--- a/pkg/fetch/nvd/feed/cpe/v1/v1.go
+++ b/pkg/fetch/nvd/feed/cpe/v1/v1.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -77,7 +77,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf(`[INFO] Fetch NVD CPE Dictionary`)
+	slog.Info("Fetch NVD CPE Dictionary")
 	cpeDict, err := options.fetch()
 	if err != nil {
 		return errors.Wrap(err, "fetch cpe dictionary")
@@ -157,7 +157,7 @@ func (opts options) fetch() ([]CPEDictItem, error) {
 			if item.Deprecated != "" {
 				b, err := strconv.ParseBool(item.Deprecated)
 				if err != nil {
-					log.Printf(`[WARN] unexpected Deprecated Value in %s. accepts: ["true", "false"], received: "%s"`, item.Cpe23Item.Name, item.Deprecated)
+					slog.Warn("unexpected Deprecated Value", slog.String("name", item.Cpe23Item.Name), slog.String("expected", "true, false"), slog.String("actual", item.Deprecated))
 				} else {
 					c.Deprecated = b
 				}

--- a/pkg/fetch/nvd/feed/cpe/v2/v2.go
+++ b/pkg/fetch/nvd/feed/cpe/v2/v2.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -76,7 +76,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf(`[INFO] Fetch NVD CPE Dictionary Feed 2.0`)
+	slog.Info("Fetch NVD CPE Dictionary Feed 2.0")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.baseURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch cpe dictionary feed 2.0")

--- a/pkg/fetch/nvd/feed/cpematch/v1/v1.go
+++ b/pkg/fetch/nvd/feed/cpematch/v1/v1.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -77,7 +77,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf(`[INFO] Fetch NVD CPE Match Feed 1.0`)
+	slog.Info("Fetch NVD CPE Match Feed 1.0")
 	cpeMatch, err := options.fetch()
 	if err != nil {
 		return errors.Wrap(err, "fetch cpe match feed 1.0")

--- a/pkg/fetch/nvd/feed/cpematch/v2/v2.go
+++ b/pkg/fetch/nvd/feed/cpematch/v2/v2.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -76,7 +76,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf(`[INFO] Fetch NVD CPE Match Feed 2.0`)
+	slog.Info("Fetch NVD CPE Match Feed 2.0")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.baseURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch cpe match feed 2.0")

--- a/pkg/fetch/nvd/feed/cve/v1/v1.go
+++ b/pkg/fetch/nvd/feed/cve/v1/v1.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -97,7 +97,7 @@ func Fetch(opts ...Option) error {
 		}
 		feedname := strings.TrimSuffix(strings.TrimPrefix(path.Base(uu.Path), "nvdcve-1.1-"), ".json.gz")
 
-		log.Printf("[INFO] Fetch NVD CVE Feed 1.1 %s", feedname)
+		slog.Info("Fetch NVD CVE Feed 1.1", slog.String("feed", feedname))
 		cves, err := options.fetch(u)
 		if err != nil {
 			return errors.Wrapf(err, "fetch nvd cve %s feed 1.1", feedname)

--- a/pkg/fetch/nvd/feed/cve/v2/v2.go
+++ b/pkg/fetch/nvd/feed/cve/v2/v2.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -97,7 +97,7 @@ func Fetch(opts ...Option) error {
 		}
 		feedname := strings.TrimSuffix(strings.TrimPrefix(path.Base(uu.Path), "nvdcve-2.0-"), ".json.gz")
 
-		log.Printf("[INFO] Fetch NVD CVE Feed 2.0 %s", feedname)
+		slog.Info("Fetch NVD CVE Feed 2.0", slog.String("feed", feedname))
 		cves, err := options.fetch(u)
 		if err != nil {
 			return errors.Wrapf(err, "fetch nvd cve %s feed 2.0", feedname)

--- a/pkg/fetch/ocaml/osv/osv.go
+++ b/pkg/fetch/ocaml/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch OCaml OSV")
+	slog.Info("Fetch OCaml OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/openeuler/csaf/csaf.go
+++ b/pkg/fetch/openeuler/csaf/csaf.go
@@ -7,7 +7,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -101,7 +101,7 @@ func Fetch(opts ...Option) error {
 
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 	for _, kind := range []string{"cve", "advisories"} {
-		log.Printf("[INFO] Fetch openEuler %s Security Advisories (CSAF)", kind)
+		slog.Info("Fetch openEuler Security Advisories (CSAF)", slog.String("kind", kind))
 		is, err := options.fetchCSAFIndex(client, kind)
 		if err != nil {
 			return errors.Wrapf(err, "fetch %s index", kind)

--- a/pkg/fetch/openeuler/cvrf/cvrf.go
+++ b/pkg/fetch/openeuler/cvrf/cvrf.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -99,7 +99,7 @@ func Fetch(opts ...Option) error {
 
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 	for _, kind := range []string{"cvrf", "hotpatch_cvrf"} {
-		log.Printf("[INFO] Fetch openEuler %s Security Advisories (CVRF)", kind)
+		slog.Info("Fetch openEuler Security Advisories (CVRF)", slog.String("kind", kind))
 		is, err := options.fetchCVRFIndex(client, kind)
 		if err != nil {
 			return errors.Wrapf(err, "fetch %s index", kind)

--- a/pkg/fetch/openeuler/osv/osv.go
+++ b/pkg/fetch/openeuler/osv/osv.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -96,7 +96,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch openEuler Security Advisories (OSV)")
+	slog.Info("Fetch openEuler Security Advisories (OSV)")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 	ids, err := options.fetchList(client)
 	if err != nil {

--- a/pkg/fetch/oracle/linux/linux.go
+++ b/pkg/fetch/oracle/linux/linux.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -73,7 +73,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Oracle Linux")
+	slog.Info("Fetch Oracle Linux")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.advisoryURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch advisory")
@@ -90,7 +90,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrap(err, "decode xml")
 	}
 
-	log.Printf("[INFO] Fetch Oracle Linux Definitions")
+	slog.Info("Fetch Oracle Linux Definitions")
 	bar := progressbar.Default(int64(len(root.Definitions.Definition)))
 	for _, def := range root.Definitions.Definition {
 		if err := util.Write(filepath.Join(options.dir, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -100,7 +100,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Printf("[INFO] Fetch Oracle Linux Tests")
+	slog.Info("Fetch Oracle Linux Tests")
 	bar = progressbar.Default(int64(len(root.Tests.RpminfoTest) + len(root.Tests.Textfilecontent54Test)))
 	for _, test := range root.Tests.RpminfoTest {
 		if err := util.Write(filepath.Join(options.dir, "tests", "rpminfo_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -116,7 +116,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Printf("[INFO] Fetch Oracle Linux Objects")
+	slog.Info("Fetch Oracle Linux Objects")
 	bar = progressbar.Default(int64(len(root.Objects.RpminfoObject) + len(root.Objects.Textfilecontent54Object)))
 	for _, object := range root.Objects.RpminfoObject {
 		if err := util.Write(filepath.Join(options.dir, "objects", "rpminfo_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -132,7 +132,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Printf("[INFO] Fetch Oracle Linux States")
+	slog.Info("Fetch Oracle Linux States")
 	bar = progressbar.Default(int64(len(root.States.RpminfoState) + len(root.States.Textfilecontent54State)))
 	for _, state := range root.States.RpminfoState {
 		if err := util.Write(filepath.Join(options.dir, "states", "rpminfo_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {

--- a/pkg/fetch/oracle/olam/olam.go
+++ b/pkg/fetch/oracle/olam/olam.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -73,7 +73,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Oracle Linux Automation Manager")
+	slog.Info("Fetch Oracle Linux Automation Manager")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.baseURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch advisory")
@@ -90,7 +90,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrap(err, "decode xml")
 	}
 
-	log.Printf("[INFO] Fetch Oracle Linux Automation Manager Definitions")
+	slog.Info("Fetch Oracle Linux Automation Manager Definitions")
 	bar := progressbar.Default(int64(len(root.Definitions.Definition)))
 	for _, def := range root.Definitions.Definition {
 		if err := util.Write(filepath.Join(options.dir, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -100,7 +100,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Printf("[INFO] Fetch Oracle Linux Automation Manager Tests")
+	slog.Info("Fetch Oracle Linux Automation Manager Tests")
 	bar = progressbar.Default(int64(len(root.Tests.RpminfoTest) + len(root.Tests.Textfilecontent54Test)))
 	for _, test := range root.Tests.RpminfoTest {
 		if err := util.Write(filepath.Join(options.dir, "tests", "rpminfo_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -116,7 +116,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Printf("[INFO] Fetch Oracle Linux Automation Manager Objects")
+	slog.Info("Fetch Oracle Linux Automation Manager Objects")
 	bar = progressbar.Default(int64(len(root.Objects.RpminfoObject) + len(root.Objects.Textfilecontent54Object)))
 	for _, object := range root.Objects.RpminfoObject {
 		if err := util.Write(filepath.Join(options.dir, "objects", "rpminfo_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -132,7 +132,7 @@ func Fetch(opts ...Option) error {
 	}
 	_ = bar.Close()
 
-	log.Printf("[INFO] Fetch Oracle Linux Automation Manager States")
+	slog.Info("Fetch Oracle Linux Automation Manager States")
 	bar = progressbar.Default(int64(len(root.States.RpminfoState) + len(root.States.Textfilecontent54State)))
 	for _, state := range root.States.RpminfoState {
 		if err := util.Write(filepath.Join(options.dir, "states", "rpminfo_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {

--- a/pkg/fetch/oracle/openstack/openstack.go
+++ b/pkg/fetch/oracle/openstack/openstack.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -99,7 +99,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Oracle Linux OpenStack")
+	slog.Info("Fetch Oracle Linux OpenStack")
 	if err := options.fetch(); err != nil {
 		return errors.Wrap(err, "fetch")
 	}

--- a/pkg/fetch/oracle/vm/vm.go
+++ b/pkg/fetch/oracle/vm/vm.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -99,7 +99,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Oracle VM")
+	slog.Info("Fetch Oracle VM")
 	if err := options.fetch(); err != nil {
 		return errors.Wrap(err, "fetch")
 	}

--- a/pkg/fetch/oss-fuzz/osv/osv.go
+++ b/pkg/fetch/oss-fuzz/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch OSS-Fuzz OSV")
+	slog.Info("Fetch OSS-Fuzz OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/ox/csaf/csaf.go
+++ b/pkg/fetch/ox/csaf/csaf.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -100,7 +100,7 @@ func Fetch(opts ...Option) error {
 
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 	for _, d := range []string{"appsuite", "dovecot"} {
-		log.Printf("[INFO] Fetch Open-Xchange(OX) %s CSAF", d)
+		slog.Info("Fetch Open-Xchange(OX) CSAF", slog.String("dir", d))
 		if err := options.fetch(client, d); err != nil {
 			return errors.Wrapf(err, "fetch %s", d)
 		}

--- a/pkg/fetch/paloalto/csaf/csaf.go
+++ b/pkg/fetch/paloalto/csaf/csaf.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -99,7 +99,7 @@ func Fetch(ids []string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Palo Alto Networks Security Advisories (CSAF)")
+	slog.Info("Fetch Palo Alto Networks Security Advisories (CSAF)")
 
 	us := make([]string, 0, len(ids))
 	for _, id := range ids {

--- a/pkg/fetch/paloalto/json/json.go
+++ b/pkg/fetch/paloalto/json/json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -96,7 +96,7 @@ func Fetch(ids []string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Palo Alto Networks Security Advisories (JSON)")
+	slog.Info("Fetch Palo Alto Networks Security Advisories (JSON)")
 
 	us := make([]string, 0, len(ids))
 	for _, id := range ids {

--- a/pkg/fetch/paloalto/list/list.go
+++ b/pkg/fetch/paloalto/list/list.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Palo Alto Networks Security Advisories (list)")
+	slog.Info("Fetch Palo Alto Networks Security Advisories (list)")
 
 	var advs []Advisory
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))

--- a/pkg/fetch/perl/db/db.go
+++ b/pkg/fetch/perl/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -69,7 +69,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Perl DB")
+	slog.Info("Fetch Perl DB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/photon/cve/cve.go
+++ b/pkg/fetch/photon/cve/cve.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -73,7 +73,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Photon CVE")
+	slog.Info("Fetch Photon CVE")
 
 	versions, err := options.fetchVersions()
 	if err != nil {

--- a/pkg/fetch/photon/oval/oval.go
+++ b/pkg/fetch/photon/oval/oval.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -76,7 +76,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Photon OVAL")
+	slog.Info("Fetch Photon OVAL")
 
 	ovals, err := options.walkIndexOf()
 	if err != nil {
@@ -86,13 +86,13 @@ func Fetch(opts ...Option) error {
 	for _, ovalname := range ovals {
 		ver := strings.TrimPrefix(strings.TrimSuffix(ovalname, ".xml.gz"), "com.vmware.phsa-photon")
 
-		log.Printf("[INFO] Fetch Photon %s OVAL", ver)
+		slog.Info("Fetch Photon OVAL", slog.String("version", ver))
 		root, err := options.fetch(ovalname)
 		if err != nil {
 			return errors.Wrapf(err, "fetch alma %s oval", ver)
 		}
 
-		log.Printf("[INFO] Fetch Photon %s Definitions", ver)
+		slog.Info("Fetch Photon Definitions", slog.String("version", ver))
 		bar := progressbar.Default(int64(len(root.Definitions.Definition)))
 		for _, def := range root.Definitions.Definition {
 			if err := util.Write(filepath.Join(options.dir, ver, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -102,7 +102,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Photon %s Tests", ver)
+		slog.Info("Fetch Photon Tests", slog.String("version", ver))
 		bar = progressbar.Default(int64(len(root.Tests.RpminfoTest)))
 		for _, test := range root.Tests.RpminfoTest {
 			if err := util.Write(filepath.Join(options.dir, ver, "tests", "rpminfo_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -112,7 +112,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Photon %s Objects", ver)
+		slog.Info("Fetch Photon Objects", slog.String("version", ver))
 		bar = progressbar.Default(int64(len(root.Objects.RpminfoObject)))
 		for _, object := range root.Objects.RpminfoObject {
 			if err := util.Write(filepath.Join(options.dir, ver, "objects", "rpminfo_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -122,7 +122,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Photon %s States", ver)
+		slog.Info("Fetch Photon States", slog.String("version", ver))
 		bar = progressbar.Default(int64(len(root.States.RpminfoState)))
 		for _, state := range root.States.RpminfoState {
 			if err := util.Write(filepath.Join(options.dir, ver, "states", "rpminfo_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {

--- a/pkg/fetch/pip/db/db.go
+++ b/pkg/fetch/pip/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -69,7 +69,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Pip DB")
+	slog.Info("Fetch Pip DB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/pip/ghsa/ghsa.go
+++ b/pkg/fetch/pip/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Pip GHSA")
+	slog.Info("Fetch Pip GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/pip/glsa/glsa.go
+++ b/pkg/fetch/pip/glsa/glsa.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Pip GLSA")
+	slog.Info("Fetch Pip GLSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/pip/osv/osv.go
+++ b/pkg/fetch/pip/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Pip OSV")
+	slog.Info("Fetch Pip OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/pub/ghsa/ghsa.go
+++ b/pkg/fetch/pub/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Pub GHSA")
+	slog.Info("Fetch Pub GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/pub/osv/osv.go
+++ b/pkg/fetch/pub/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Pub OSV")
+	slog.Info("Fetch Pub OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/r/db/db.go
+++ b/pkg/fetch/r/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -69,7 +69,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch RConsortium DB")
+	slog.Info("Fetch RConsortium DB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/r/osv/osv.go
+++ b/pkg/fetch/r/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch RConsortium OSV")
+	slog.Info("Fetch RConsortium OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/redhat/appstream-lifecycle/appstream-lifecycle.go
+++ b/pkg/fetch/redhat/appstream-lifecycle/appstream-lifecycle.go
@@ -3,7 +3,7 @@ package appstreamlifecycle
 import (
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Print("[INFO] Fetch RHEL Application Streams Life Cycle")
+	slog.Info("Fetch RHEL Application Streams Life Cycle")
 
 	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 	if err := options.extractAppStream(c); err != nil {

--- a/pkg/fetch/redhat/csaf/csaf.go
+++ b/pkg/fetch/redhat/csaf/csaf.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -103,7 +103,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch RedHat CSAF")
+	slog.Info("Fetch RedHat CSAF")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 
 	at, err := options.fetchArchiveDate(client)
@@ -111,17 +111,17 @@ func Fetch(opts ...Option) error {
 		return errors.Wrap(err, "fetch archive date")
 	}
 
-	log.Printf("[INFO] Fetch RedHat CSAF %s Archive", at.Format("2006-01-02"))
+	slog.Info("Fetch RedHat CSAF Archive", slog.String("date", at.Format("2006-01-02")))
 	if err := options.fetchArchive(client, at); err != nil {
 		return errors.Wrap(err, "fetch archive")
 	}
 
-	log.Println("[INFO] Fetch RedHat CSAF Changes")
+	slog.Info("Fetch RedHat CSAF Changes")
 	if err := options.fetchChanges(client, at); err != nil {
 		return errors.Wrap(err, "fetch changes")
 	}
 
-	log.Println("[INFO] Fetch RedHat CSAF Deletions")
+	slog.Info("Fetch RedHat CSAF Deletions")
 	if err := options.fetchDeletions(client, at); err != nil {
 		return errors.Wrap(err, "fetch deletions")
 	}

--- a/pkg/fetch/redhat/cve/cve.go
+++ b/pkg/fetch/redhat/cve/cve.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -99,16 +99,16 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch RedHat CVE API")
+	slog.Info("Fetch RedHat CVE API")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 
-	log.Printf("[INFO] Fetch RedHat 1996...%d CVEs", time.Now().Year())
+	slog.Info("Fetch RedHat CVEs", slog.Int("from", 1996), slog.Int("to", time.Now().Year()))
 	urls, err := options.list(client)
 	if err != nil {
 		return errors.Wrap(err, "list cve url")
 	}
 
-	log.Println("[INFO] Fetch RedHat CVEs")
+	slog.Info("Fetch RedHat CVEs")
 	if err := client.PipelineGet(urls, options.concurrency, options.wait, false, func(resp *http.Response) error {
 		defer resp.Body.Close()
 

--- a/pkg/fetch/redhat/cvrf/cvrf.go
+++ b/pkg/fetch/redhat/cvrf/cvrf.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch RedHat CVRF")
+	slog.Info("Fetch RedHat CVRF")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch archive cvrf")

--- a/pkg/fetch/redhat/osv/osv.go
+++ b/pkg/fetch/redhat/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch RedHat OSV")
+	slog.Info("Fetch RedHat OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/redhat/oval/v1/v1.go
+++ b/pkg/fetch/redhat/oval/v1/v1.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch RedHat OVALv1")
+	slog.Info("Fetch RedHat OVALv1")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch archive ovalv1")
@@ -118,7 +118,7 @@ func Fetch(opts ...Option) error {
 			return errors.Wrap(err, "decode oval")
 		}
 
-		log.Printf("[INFO] Fetch RedHat %s Definitions", v)
+		slog.Info("Fetch RedHat Definitions", slog.String("version", v))
 		bar := progressbar.Default(int64(len(root.Definitions.Definition)))
 		for _, def := range root.Definitions.Definition {
 			if err := util.Write(filepath.Join(options.dir, v, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -128,7 +128,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch RedHat %s Tests", v)
+		slog.Info("Fetch RedHat Tests", slog.String("version", v))
 		bar = progressbar.Default(int64(len(root.Tests.RpminfoTest) + len(root.Tests.UnameTest) + len(root.Tests.Textfilecontent54Test) + len(root.Tests.RpmverifyfileTest)))
 		for _, test := range root.Tests.RpminfoTest {
 			if err := util.Write(filepath.Join(options.dir, v, "tests", "rpminfo_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -156,7 +156,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch RedHat %s Objects", v)
+		slog.Info("Fetch RedHat Objects", slog.String("version", v))
 		bar = progressbar.Default(int64(len(root.Objects.RpminfoObject) + 1 + len(root.Objects.Textfilecontent54Object) + 1))
 		for _, object := range root.Objects.RpminfoObject {
 			if err := util.Write(filepath.Join(options.dir, v, "objects", "rpminfo_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -184,7 +184,7 @@ func Fetch(opts ...Option) error {
 		_ = bar.Add(1)
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch RedHat %s States", v)
+		slog.Info("Fetch RedHat States", slog.String("version", v))
 		bar = progressbar.Default(int64(len(root.States.RpminfoState) + len(root.States.UnameState) + len(root.States.Textfilecontent54State) + len(root.States.RpmverifyfileState)))
 		for _, state := range root.States.RpminfoState {
 			if err := util.Write(filepath.Join(options.dir, v, "states", "rpminfo_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {
@@ -212,7 +212,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch RedHat %s Variables", v)
+		slog.Info("Fetch RedHat Variables", slog.String("version", v))
 		bar = progressbar.Default(1)
 		if root.Variables.LocalVariable.ID != "" {
 			if err := util.Write(filepath.Join(options.dir, v, "variables", "local_variable", fmt.Sprintf("%s.json", root.Variables.LocalVariable.ID)), root.Variables.LocalVariable); err != nil {

--- a/pkg/fetch/redhat/oval/v2/v2.go
+++ b/pkg/fetch/redhat/oval/v2/v2.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -76,7 +76,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch RedHat OVAL")
+	slog.Info("Fetch RedHat OVAL")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.feedURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch feed")
@@ -103,7 +103,7 @@ func Fetch(opts ...Option) error {
 		name := strings.TrimSuffix(file, ".oval.xml.bz2")
 		v := strings.TrimPrefix(path.Base(path.Clean(d)), "RHEL")
 
-		log.Printf("[INFO] Fetch RedHat %s %s OVAL", v, name)
+		slog.Info("Fetch RedHat OVAL", slog.String("version", v), slog.String("name", name))
 		r, err := func() (*root, error) {
 			resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(u)
 			if err != nil {
@@ -127,7 +127,7 @@ func Fetch(opts ...Option) error {
 			return errors.Wrap(err, "fetch")
 		}
 
-		log.Printf("[INFO] Fetch RedHat %s %s Definitions", v, name)
+		slog.Info("Fetch RedHat Definitions", slog.String("version", v), slog.String("name", name))
 		bar := progressbar.Default(int64(len(r.Definitions.Definition)))
 		for _, def := range r.Definitions.Definition {
 			if err := util.Write(filepath.Join(options.dir, v, name, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -137,7 +137,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch RedHat %s %s Tests", v, name)
+		slog.Info("Fetch RedHat Tests", slog.String("version", v), slog.String("name", name))
 		bar = progressbar.Default(int64(len(r.Tests.RpminfoTest) + len(r.Tests.RpmverifyfileTest) + len(r.Tests.Textfilecontent54Test) + len(r.Tests.UnameTest)))
 		for _, test := range r.Tests.RpminfoTest {
 			if err := util.Write(filepath.Join(options.dir, v, name, "tests", "rpminfo_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -165,7 +165,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch RedHat %s %s Objects", v, name)
+		slog.Info("Fetch RedHat Objects", slog.String("version", v), slog.String("name", name))
 		bar = progressbar.Default(int64(len(r.Objects.RpminfoObject) + 1 + len(r.Objects.Textfilecontent54Object) + 1))
 		for _, object := range r.Objects.RpminfoObject {
 			if err := util.Write(filepath.Join(options.dir, v, name, "objects", "rpminfo_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -193,7 +193,7 @@ func Fetch(opts ...Option) error {
 		_ = bar.Add(1)
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch RedHat %s %s States", v, name)
+		slog.Info("Fetch RedHat States", slog.String("version", v), slog.String("name", name))
 		bar = progressbar.Default(int64(len(r.States.RpminfoState) + len(r.States.RpmverifyfileState) + len(r.States.Textfilecontent54State) + len(r.States.UnameState)))
 		for _, state := range r.States.RpminfoState {
 			if err := util.Write(filepath.Join(options.dir, v, name, "states", "rpminfo_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {
@@ -221,7 +221,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch RedHat %s %s Variables", v, name)
+		slog.Info("Fetch RedHat Variables", slog.String("version", v), slog.String("name", name))
 		bar = progressbar.Default(1)
 		if r.Variables.LocalVariable.ID != "" {
 			if err := util.Write(filepath.Join(options.dir, v, name, "variables", "local_variable", fmt.Sprintf("%s.json", r.Variables.LocalVariable.ID)), r.Variables.LocalVariable); err != nil {

--- a/pkg/fetch/redhat/package-manifest/package-manifest.go
+++ b/pkg/fetch/redhat/package-manifest/package-manifest.go
@@ -3,7 +3,7 @@ package packagemanifest
 import (
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -96,7 +96,7 @@ Red Hat, as the licensor of this document, waives the right to enforce, and agre
 	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 
 	for _, major := range majors {
-		log.Printf("[INFO] Fetch RHEL %s Package Manifest", major)
+		slog.Info("Fetch RHEL Package Manifest", slog.String("version", major))
 		u := fmt.Sprintf(options.baseURL, major)
 
 		resp, err := c.Get(u)

--- a/pkg/fetch/redhat/repository2cpe/repository2cpe.go
+++ b/pkg/fetch/redhat/repository2cpe/repository2cpe.go
@@ -3,7 +3,7 @@ package repository2cpe
 import (
 	"encoding/json/v2"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -72,7 +72,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Redhat Repository to CPE")
+	slog.Info("Fetch Redhat Repository to CPE")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repositoryToCPEURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository to cpe")

--- a/pkg/fetch/redhat/vex/vex.go
+++ b/pkg/fetch/redhat/vex/vex.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -103,7 +103,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch RedHat CSAF VEX")
+	slog.Info("Fetch RedHat CSAF VEX")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 
 	at, err := options.fetchArchiveDate(client)
@@ -111,17 +111,17 @@ func Fetch(opts ...Option) error {
 		return errors.Wrap(err, "fetch archive date")
 	}
 
-	log.Printf("[INFO] Fetch RedHat CSAF VEX %s Archive", at.Format("2006-01-02"))
+	slog.Info("Fetch RedHat CSAF VEX Archive", slog.String("date", at.Format("2006-01-02")))
 	if err := options.fetchArchive(client, at); err != nil {
 		return errors.Wrap(err, "fetch archive")
 	}
 
-	log.Println("[INFO] Fetch RedHat CSAF VEX Changes")
+	slog.Info("Fetch RedHat CSAF VEX Changes")
 	if err := options.fetchChanges(client, at); err != nil {
 		return errors.Wrap(err, "fetch changes")
 	}
 
-	log.Println("[INFO] Fetch RedHat CSAF VEX Deletions")
+	slog.Info("Fetch RedHat CSAF VEX Deletions")
 	if err := options.fetchDeletions(client, at); err != nil {
 		return errors.Wrap(err, "fetch deletions")
 	}

--- a/pkg/fetch/rocky/errata/errata.go
+++ b/pkg/fetch/rocky/errata/errata.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -86,7 +86,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Rocky Linux Errata")
+	slog.Info("Fetch Rocky Linux Errata")
 
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 	bar := progressbar.Default(-1, "Paging Rocky Linux Errata")

--- a/pkg/fetch/rocky/osv/osv.go
+++ b/pkg/fetch/rocky/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Rocky Linux OSV")
+	slog.Info("Fetch Rocky Linux OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/rootio/rootio.go
+++ b/pkg/fetch/rootio/rootio.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -71,7 +71,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Root.io")
+	slog.Info("Fetch Root.io")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch")

--- a/pkg/fetch/rubygems/db/db.go
+++ b/pkg/fetch/rubygems/db/db.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -69,7 +69,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Rubygems DB")
+	slog.Info("Fetch Rubygems DB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/rubygems/ghsa/ghsa.go
+++ b/pkg/fetch/rubygems/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Rubygems GHSA")
+	slog.Info("Fetch Rubygems GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/rubygems/glsa/glsa.go
+++ b/pkg/fetch/rubygems/glsa/glsa.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Rubygems GLSA")
+	slog.Info("Fetch Rubygems GLSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.repoURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch repository")

--- a/pkg/fetch/rubygems/osv/osv.go
+++ b/pkg/fetch/rubygems/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Rubygems OSV")
+	slog.Info("Fetch Rubygems OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/seal/osv/osv.go
+++ b/pkg/fetch/seal/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Seal OSV")
+	slog.Info("Fetch Seal OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/sick/csaf/csaf.go
+++ b/pkg/fetch/sick/csaf/csaf.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -95,7 +95,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch SICK Security Advisories (CSAF)")
+	slog.Info("Fetch SICK Security Advisories (CSAF)")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 	us, err := options.fetchFeed(client)
 	if err != nil {

--- a/pkg/fetch/siemens/csaf/csaf.go
+++ b/pkg/fetch/siemens/csaf/csaf.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -97,7 +97,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Siemens Security Advisories (CSAF)")
+	slog.Info("Fetch Siemens Security Advisories (CSAF)")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientCheckRetry(checkRetry))
 	us, err := options.fetchFeed(client)
 	if err != nil {

--- a/pkg/fetch/snort/snort.go
+++ b/pkg/fetch/snort/snort.go
@@ -6,7 +6,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"regexp"
@@ -76,7 +76,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Snort Rules")
+	slog.Info("Fetch Snort Rules")
 	rules, err := options.fetch()
 	if err != nil {
 		return errors.Wrap(err, "fetch snort rules")

--- a/pkg/fetch/suse/csaf/csaf.go
+++ b/pkg/fetch/suse/csaf/csaf.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -76,7 +76,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch SUSE CSAF")
+	slog.Info("Fetch SUSE CSAF")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.baseURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch suse csaf")

--- a/pkg/fetch/suse/csaf_vex/csaf_vex.go
+++ b/pkg/fetch/suse/csaf_vex/csaf_vex.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch SUSE CSAF VEX")
+	slog.Info("Fetch SUSE CSAF VEX")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.baseURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch suse csaf vex")

--- a/pkg/fetch/suse/cvrf/cvrf.go
+++ b/pkg/fetch/suse/cvrf/cvrf.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch SUSE CVRF")
+	slog.Info("Fetch SUSE CVRF")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.baseURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch suse cvrf")

--- a/pkg/fetch/suse/cvrf_cve/cvrf_cve.go
+++ b/pkg/fetch/suse/cvrf_cve/cvrf_cve.go
@@ -9,7 +9,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -78,7 +78,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch SUSE CVRF CVE")
+	slog.Info("Fetch SUSE CVRF CVE")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientCheckRetry(checkRetry)).Get(options.baseURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch suse cvrf cve")

--- a/pkg/fetch/suse/osv/osv.go
+++ b/pkg/fetch/suse/osv/osv.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -76,7 +76,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch SUSE OSV")
+	slog.Info("Fetch SUSE OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.baseURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch suse osv")

--- a/pkg/fetch/suse/oval/oval.go
+++ b/pkg/fetch/suse/oval/oval.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"maps"
 	"net/http"
 	"net/url"
@@ -102,7 +102,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch SUSE OVAL")
+	slog.Info("Fetch SUSE OVAL")
 	ovals, err := options.walkIndexOf()
 	if err != nil {
 		return errors.Wrap(err, "walk index of")

--- a/pkg/fetch/swift/ghsa/ghsa.go
+++ b/pkg/fetch/swift/ghsa/ghsa.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Swift GHSA")
+	slog.Info("Fetch Swift GHSA")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch ghsa data")

--- a/pkg/fetch/swift/osv/osv.go
+++ b/pkg/fetch/swift/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Swift OSV")
+	slog.Info("Fetch Swift OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/ubuntu/cve/cve.go
+++ b/pkg/fetch/ubuntu/cve/cve.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -97,7 +97,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Ubuntu CVEs")
+	slog.Info("Fetch Ubuntu CVEs")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 
 	header := make(http.Header)

--- a/pkg/fetch/ubuntu/notice/notice.go
+++ b/pkg/fetch/ubuntu/notice/notice.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -98,7 +98,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Ubuntu Notices")
+	slog.Info("Fetch Ubuntu Notices")
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 
 	header := make(http.Header)

--- a/pkg/fetch/ubuntu/osv/osv.go
+++ b/pkg/fetch/ubuntu/osv/osv.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Ubuntu OSV")
+	slog.Info("Fetch Ubuntu OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/ubuntu/oval/oval.go
+++ b/pkg/fetch/ubuntu/oval/oval.go
@@ -5,7 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -79,7 +79,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Ubuntu OVAL")
+	slog.Info("Fetch Ubuntu OVAL")
 	ovals, err := options.walkIndexOf()
 	if err != nil {
 		return errors.Wrap(err, "walk index of")
@@ -91,7 +91,7 @@ func Fetch(opts ...Option) error {
 			return errors.Errorf("unexpected oval name. expected: \"<release>/<service>\", actual: %q", name)
 		}
 
-		log.Printf("[INFO] Fetch Ubuntu CVE %s/%s", release, service)
+		slog.Info("Fetch Ubuntu CVE OVAL", slog.String("release", release), slog.String("service", service))
 		r, err := func() (*cveroot, error) {
 			u, err := url.JoinPath(options.baseURL, href)
 			if err != nil {
@@ -120,7 +120,7 @@ func Fetch(opts ...Option) error {
 			return errors.Wrap(err, "fetch")
 		}
 
-		log.Printf("[INFO] Fetch Ubuntu CVE %s/%s Definitions", release, service)
+		slog.Info("Fetch Ubuntu CVE OVAL Definitions", slog.String("release", release), slog.String("service", service))
 		bar := progressbar.Default(int64(len(r.Definitions.Definition)))
 		for _, def := range r.Definitions.Definition {
 			if err := util.Write(filepath.Join(options.dir, release, "cve", service, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -130,7 +130,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu CVE %s/%s Tests", release, service)
+		slog.Info("Fetch Ubuntu CVE OVAL Tests", slog.String("release", release), slog.String("service", service))
 		bar = progressbar.Default(int64(len(r.Tests.Textfilecontent54Test)))
 		for _, test := range r.Tests.Textfilecontent54Test {
 			if err := util.Write(filepath.Join(options.dir, release, "cve", service, "tests", "textfilecontent54_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -140,7 +140,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu CVE %s/%s Objects", release, service)
+		slog.Info("Fetch Ubuntu CVE OVAL Objects", slog.String("release", release), slog.String("service", service))
 		bar = progressbar.Default(int64(len(r.Objects.Textfilecontent54Object)))
 		for _, object := range r.Objects.Textfilecontent54Object {
 			if err := util.Write(filepath.Join(options.dir, release, "cve", service, "objects", "textfilecontent54_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -150,7 +150,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu CVE %s/%s States", release, service)
+		slog.Info("Fetch Ubuntu CVE OVAL States", slog.String("release", release), slog.String("service", service))
 		bar = progressbar.Default(int64(len(r.States.Textfilecontent54State)))
 		for _, state := range r.States.Textfilecontent54State {
 			if err := util.Write(filepath.Join(options.dir, release, "cve", service, "states", "textfilecontent54_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {
@@ -160,7 +160,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu CVE %s/%s Variables", release, service)
+		slog.Info("Fetch Ubuntu CVE OVAL Variables", slog.String("release", release), slog.String("service", service))
 		bar = progressbar.Default(int64(len(r.Variables.ConstantVariable)))
 		for _, variable := range r.Variables.ConstantVariable {
 			if err := util.Write(filepath.Join(options.dir, release, "cve", service, "variables", "constant_variable", fmt.Sprintf("%s.json", variable.ID)), variable); err != nil {
@@ -177,7 +177,7 @@ func Fetch(opts ...Option) error {
 			return errors.Errorf("unexpected oval name. expected: \"<release>/<service>\", actual: %q", name)
 		}
 
-		log.Printf("[INFO] Fetch Ubuntu PKG %s/%s", release, service)
+		slog.Info("Fetch Ubuntu PKG OVAL", slog.String("release", release), slog.String("service", service))
 		r, err := func() (*pkgroot, error) {
 			u, err := url.JoinPath(options.baseURL, href)
 			if err != nil {
@@ -206,7 +206,7 @@ func Fetch(opts ...Option) error {
 			return errors.Wrap(err, "fetch")
 		}
 
-		log.Printf("[INFO] Fetch Ubuntu PKG %s/%s Definitions", release, service)
+		slog.Info("Fetch Ubuntu PKG OVAL Definitions", slog.String("release", release), slog.String("service", service))
 		bar := progressbar.Default(int64(len(r.Definitions.Definition)))
 		for _, def := range r.Definitions.Definition {
 			if err := util.Write(filepath.Join(options.dir, release, "pkg", service, "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -216,7 +216,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu PKG %s/%s Tests", release, service)
+		slog.Info("Fetch Ubuntu PKG OVAL Tests", slog.String("release", release), slog.String("service", service))
 		bar = progressbar.Default(int64(len(r.Tests.Textfilecontent54Test)))
 		for _, test := range r.Tests.Textfilecontent54Test {
 			if err := util.Write(filepath.Join(options.dir, release, "pkg", service, "tests", "textfilecontent54_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -226,7 +226,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu PKG %s/%s Objects", release, service)
+		slog.Info("Fetch Ubuntu PKG OVAL Objects", slog.String("release", release), slog.String("service", service))
 		bar = progressbar.Default(int64(len(r.Objects.Textfilecontent54Object)))
 		for _, object := range r.Objects.Textfilecontent54Object {
 			if err := util.Write(filepath.Join(options.dir, release, "pkg", service, "objects", "textfilecontent54_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -236,7 +236,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu PKG %s/%s States", release, service)
+		slog.Info("Fetch Ubuntu PKG OVAL States", slog.String("release", release), slog.String("service", service))
 		bar = progressbar.Default(int64(len(r.States.Textfilecontent54State)))
 		for _, state := range r.States.Textfilecontent54State {
 			if err := util.Write(filepath.Join(options.dir, release, "pkg", service, "states", "textfilecontent54_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {
@@ -246,7 +246,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu PKG %s/%s Variables", release, service)
+		slog.Info("Fetch Ubuntu PKG OVAL Variables", slog.String("release", release), slog.String("service", service))
 		bar = progressbar.Default(int64(len(r.Variables.ConstantVariable)))
 		for _, variable := range r.Variables.ConstantVariable {
 			if err := util.Write(filepath.Join(options.dir, release, "pkg", service, "variables", "constant_variable", fmt.Sprintf("%s.json", variable.ID)), variable); err != nil {
@@ -258,7 +258,7 @@ func Fetch(opts ...Option) error {
 	}
 
 	for release, href := range ovals.USN {
-		log.Printf("[INFO] Fetch Ubuntu USN %s", release)
+		slog.Info("Fetch Ubuntu USN", slog.String("release", release))
 		r, err := func() (*usnroot, error) {
 			u, err := url.JoinPath(options.baseURL, href)
 			if err != nil {
@@ -287,7 +287,7 @@ func Fetch(opts ...Option) error {
 			return errors.Wrap(err, "fetch")
 		}
 
-		log.Printf("[INFO] Fetch Ubuntu USN %s Definitions", release)
+		slog.Info("Fetch Ubuntu USN Definitions", slog.String("release", release))
 		bar := progressbar.Default(int64(len(r.Definitions.Definition)))
 		for _, def := range r.Definitions.Definition {
 			if err := util.Write(filepath.Join(options.dir, release, "usn", "definitions", fmt.Sprintf("%s.json", def.ID)), def); err != nil {
@@ -297,7 +297,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu USN %s Tests", release)
+		slog.Info("Fetch Ubuntu USN Tests", slog.String("release", release))
 		bar = progressbar.Default(int64(len(r.Tests.Textfilecontent54Test)))
 		for _, test := range r.Tests.Textfilecontent54Test {
 			if err := util.Write(filepath.Join(options.dir, release, "usn", "tests", "textfilecontent54_test", fmt.Sprintf("%s.json", test.ID)), test); err != nil {
@@ -307,7 +307,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu USN %s Objects", release)
+		slog.Info("Fetch Ubuntu USN Objects", slog.String("release", release))
 		bar = progressbar.Default(int64(len(r.Objects.Textfilecontent54Object)))
 		for _, object := range r.Objects.Textfilecontent54Object {
 			if err := util.Write(filepath.Join(options.dir, release, "usn", "objects", "textfilecontent54_object", fmt.Sprintf("%s.json", object.ID)), object); err != nil {
@@ -317,7 +317,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu USN %s States", release)
+		slog.Info("Fetch Ubuntu USN States", slog.String("release", release))
 		bar = progressbar.Default(int64(len(r.States.Textfilecontent54State)))
 		for _, state := range r.States.Textfilecontent54State {
 			if err := util.Write(filepath.Join(options.dir, release, "usn", "states", "textfilecontent54_state", fmt.Sprintf("%s.json", state.ID)), state); err != nil {
@@ -327,7 +327,7 @@ func Fetch(opts ...Option) error {
 		}
 		_ = bar.Close()
 
-		log.Printf("[INFO] Fetch Ubuntu USN %s Variables", release)
+		slog.Info("Fetch Ubuntu USN Variables", slog.String("release", release))
 		bar = progressbar.Default(int64(len(r.Variables.ConstantVariable)))
 		for _, v := range r.Variables.ConstantVariable {
 			if err := util.Write(filepath.Join(options.dir, release, "usn", "variables", "constant_variable", fmt.Sprintf("%s.json", v.ID)), v); err != nil {
@@ -387,7 +387,7 @@ func (opts options) walkIndexOf() (ovals, error) {
 								if err != nil {
 									ret = fmt.Sprintf("failed to get html. err: %s", err)
 								}
-								log.Printf("[WARN] not found release. row: %s", ret)
+								slog.Warn("release not found", slog.String("row", ret))
 								return false
 							}
 							release = fmt.Sprintf("%s/main", lhs)
@@ -398,7 +398,7 @@ func (opts options) walkIndexOf() (ovals, error) {
 							if err != nil {
 								ret = fmt.Sprintf("failed to get html. err: %s", err)
 							}
-							log.Printf("[WARN] not set release. row: %s", ret)
+							slog.Warn("release not set", slog.String("row", ret))
 							return false
 						}
 
@@ -408,7 +408,7 @@ func (opts options) walkIndexOf() (ovals, error) {
 							if err != nil {
 								ret = fmt.Sprintf("failed to get html. err: %s", err)
 							}
-							log.Printf("[WARN] not found file name. row: %s", ret)
+							slog.Warn("file name not found", slog.String("row", ret))
 							return false
 						}
 
@@ -439,7 +439,7 @@ func (opts options) walkIndexOf() (ovals, error) {
 								if err != nil {
 									ret = fmt.Sprintf("failed to get html. err: %s", err)
 								}
-								log.Printf("[WARN] not found release. row: %s", ret)
+								slog.Warn("release not found", slog.String("row", ret))
 								return false
 							}
 							release = fmt.Sprintf("%s/main", lhs)
@@ -450,7 +450,7 @@ func (opts options) walkIndexOf() (ovals, error) {
 							if err != nil {
 								ret = fmt.Sprintf("failed to get html. err: %s", err)
 							}
-							log.Printf("[WARN] not set release. row: %s", ret)
+							slog.Warn("release not set", slog.String("row", ret))
 							return false
 						}
 
@@ -460,7 +460,7 @@ func (opts options) walkIndexOf() (ovals, error) {
 							if err != nil {
 								ret = fmt.Sprintf("failed to get html. err: %s", err)
 							}
-							log.Printf("[WARN] not found file name. row: %s", ret)
+							slog.Warn("file name not found", slog.String("row", ret))
 							return false
 						}
 
@@ -486,7 +486,7 @@ func (opts options) walkIndexOf() (ovals, error) {
 							if err != nil {
 								ret = fmt.Sprintf("failed to get html. err: %s", err)
 							}
-							log.Printf("[WARN] not set release. row: %s", ret)
+							slog.Warn("release not set", slog.String("row", ret))
 							return false
 						}
 
@@ -496,7 +496,7 @@ func (opts options) walkIndexOf() (ovals, error) {
 							if err != nil {
 								ret = fmt.Sprintf("failed to get html. err: %s", err)
 							}
-							log.Printf("[WARN] not found file name. row: %s", ret)
+							slog.Warn("file name not found", slog.String("row", ret))
 							return false
 						}
 

--- a/pkg/fetch/ubuntu/tracker/tracker.go
+++ b/pkg/fetch/ubuntu/tracker/tracker.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Ubuntu CVE Tracker")
+	slog.Info("Fetch Ubuntu CVE Tracker")
 	cloneDir, err := os.MkdirTemp("", "vuls-data-update")
 	if err != nil {
 		return errors.Wrapf(err, "mkdir %s", cloneDir)
@@ -258,7 +258,7 @@ func parse(r io.Reader) (Advisory, error) {
 		default:
 			lhs, rhs, ok := strings.Cut(line, "_")
 			if !ok {
-				log.Printf("[WARN] unexpected line format in %s. expected: %q, actual: %q", a.Candidate, "<prefix>_<package>: <text>", line)
+				slog.Warn("unexpected line format", slog.String("candidate", a.Candidate), slog.String("expected", "<prefix>_<package>: <text>"), slog.String("actual", line))
 				break
 			}
 
@@ -387,7 +387,7 @@ func parse(r io.Reader) (Advisory, error) {
 
 				status, note, _ := strings.Cut(strings.TrimSpace(rhs), " ")
 				if !slices.Contains([]string{"DNE", "needs-triage", "not-affected", "needed", "in-progress", "ignored", "pending", "deferred", "released"}, status) {
-					log.Printf("[WARN] unexpected package status in %s. expected: %q, actual: %q", a.Candidate, []string{"DNE", "needs-triage", "not-affected", "needed", "in-progress", "ignored", "pending", "deferred", "released"}, status)
+					slog.Warn("unexpected package status", slog.String("candidate", a.Candidate), slog.String("expected", "DNE, needs-triage, not-affected, needed, in-progress, ignored, pending, deferred, released"), slog.String("actual", status))
 					break
 				}
 

--- a/pkg/fetch/ubuntu/usndb/usndb.go
+++ b/pkg/fetch/ubuntu/usndb/usndb.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Ubuntu USN DB")
+	slog.Info("Fetch Ubuntu USN DB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch usndb data")

--- a/pkg/fetch/ubuntu/vex/vex.go
+++ b/pkg/fetch/ubuntu/vex/vex.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Ubuntu OpenVEX")
+	slog.Info("Fetch Ubuntu OpenVEX")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch vex data")

--- a/pkg/fetch/variot/exploits/exploits.go
+++ b/pkg/fetch/variot/exploits/exploits.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -101,7 +101,7 @@ func Fetch(apiToken string, opts ...Option) error {
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 	headerOption := utilhttp.WithRequestHeader(http.Header{"Authorization": []string{fmt.Sprintf("Token %s", apiToken)}})
 
-	log.Println("[INFO] Fetch VARIoT Exploits")
+	slog.Info("Fetch VARIoT Exploits")
 	if err := options.fetch(client, headerOption); err != nil {
 		return errors.Wrap(err, "fetch variot exploits")
 	}

--- a/pkg/fetch/variot/vulns/vulns.go
+++ b/pkg/fetch/variot/vulns/vulns.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -101,7 +101,7 @@ func Fetch(apiToken string, opts ...Option) error {
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
 	headerOption := utilhttp.WithRequestHeader(http.Header{"Authorization": []string{fmt.Sprintf("Token %s", apiToken)}})
 
-	log.Println("[INFO] Fetch VARIoT Vulns")
+	slog.Info("Fetch VARIoT Vulns")
 	if err := options.fetch(client, headerOption); err != nil {
 		return errors.Wrap(err, "fetch variot vulns")
 	}

--- a/pkg/fetch/vscode/osv/osv.go
+++ b/pkg/fetch/vscode/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch VSCode OSV")
+	slog.Info("Fetch VSCode OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/vulncheck/kev/kev.go
+++ b/pkg/fetch/vulncheck/kev/kev.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -76,7 +76,7 @@ func Fetch(apiToken string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch VulnCheck KEV")
+	slog.Info("Fetch VulnCheck KEV")
 
 	if err := os.MkdirAll(options.dir, 0755); err != nil {
 		return errors.Wrapf(err, "mkdir %s", options.dir)

--- a/pkg/fetch/vulncheck/nist-nvd/nist-nvd.go
+++ b/pkg/fetch/vulncheck/nist-nvd/nist-nvd.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -76,7 +76,7 @@ func Fetch(apiToken string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch VulnCheck NVD++ (nist-nvd)")
+	slog.Info("Fetch VulnCheck NVD++ (nist-nvd)")
 
 	if err := os.MkdirAll(options.dir, 0755); err != nil {
 		return errors.Wrapf(err, "mkdir %s", options.dir)

--- a/pkg/fetch/vulncheck/nist-nvd2/nist-nvd2.go
+++ b/pkg/fetch/vulncheck/nist-nvd2/nist-nvd2.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -77,7 +77,7 @@ func Fetch(apiToken string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch VulnCheck NVD++ (nist-nvd2)")
+	slog.Info("Fetch VulnCheck NVD++ (nist-nvd2)")
 
 	if err := os.MkdirAll(options.dir, 0755); err != nil {
 		return errors.Wrapf(err, "mkdir %s", options.dir)

--- a/pkg/fetch/wolfi/osv/osv.go
+++ b/pkg/fetch/wolfi/osv/osv.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -74,7 +74,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Wolfi OSV")
+	slog.Info("Fetch Wolfi OSV")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch osv data")

--- a/pkg/fetch/wolfi/secdb/secdb.go
+++ b/pkg/fetch/wolfi/secdb/secdb.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json/v2"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 
@@ -71,7 +71,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Printf("[INFO] Fetch Wolfi SecDB")
+	slog.Info("Fetch Wolfi SecDB")
 	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
 	if err != nil {
 		return errors.Wrap(err, "fetch")

--- a/pkg/fetch/wrlinux/wrlinux.go
+++ b/pkg/fetch/wrlinux/wrlinux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -73,7 +73,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	log.Println("[INFO] Fetch Wind River Linux CVE Tracker")
+	slog.Info("Fetch Wind River Linux CVE Tracker")
 	cloneDir, err := os.MkdirTemp("", "vuls-data-update")
 	if err != nil {
 		return errors.Wrapf(err, "mkdir %s", cloneDir)


### PR DESCRIPTION
Replace all usages of the standard "log" package with "log/slog" across 309 files. Convert log.Printf/Println/Print calls with [INFO]/[WARN] prefixes to slog.Info()/slog.Warn() with structured key-value attributes (slog.String, slog.Int, slog.Any).

refs #60 