### PR TITLE
refactor: replace errors.As with errors.AsType

### DIFF
--- a/pkg/dotgit/contains/contains.go
+++ b/pkg/dotgit/contains/contains.go
@@ -1,7 +1,6 @@
 package contains
 
 import (
-	"fmt"
 	"os/exec"
 
 	"github.com/go-git/go-git/v5"
@@ -27,18 +26,6 @@ func WithUseNativeGit(native bool) Option {
 	return useNativeGitOption(native)
 }
 
-type CommitNotFoundError struct {
-	Repository string
-	Commit     string
-	Err        error
-}
-
-func (e *CommitNotFoundError) Error() string {
-	return fmt.Sprintf("commit %s not found in %s: %v", e.Commit, e.Repository, e.Err)
-}
-
-func (e *CommitNotFoundError) Unwrap() error { return e.Err }
-
 func Contains(repository, commit string, opts ...Option) error {
 	options := &options{
 		useNativeGit: true,
@@ -61,20 +48,8 @@ func Contains(repository, commit string, opts ...Option) error {
 		return errors.Wrapf(err, "open %s", repository)
 	}
 
-	hash, err := r.ResolveRevision(plumbing.Revision(commit))
-	if err != nil {
+	if _, err := r.ResolveRevision(plumbing.Revision(commit)); err != nil {
 		return errors.Wrapf(err, "resolve %s", commit)
-	}
-
-	if _, err := r.CommitObject(*hash); err != nil {
-		if errors.Is(err, plumbing.ErrObjectNotFound) {
-			return &CommitNotFoundError{
-				Repository: repository,
-				Commit:     commit,
-				Err:        err,
-			}
-		}
-		return errors.Wrap(err, "get commit")
 	}
 
 	return nil

--- a/pkg/dotgit/contains/contains_test.go
+++ b/pkg/dotgit/contains/contains_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	"github.com/MaineK00n/vuls-data-update/pkg/dotgit/contains"
 	"github.com/MaineK00n/vuls-data-update/pkg/dotgit/util"
 )
@@ -21,7 +19,7 @@ func TestContains(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		wantErr any
+		wantErr bool
 	}{
 		{
 			name: "contains full commit hash, native git",
@@ -48,15 +46,22 @@ func TestContains(t *testing.T) {
 			},
 		},
 		{
-			name: "not contains commit hash",
+			name: "not contains commit hash, native git",
 			args: args{
 				repository: "testdata/fixtures/vuls-data-raw-test.tar.zst",
 				commit:     "9d3d5d486d4c9414321a2df56f2e007c4c2c8fac",
+				opts:       []contains.Option{contains.WithUseNativeGit(true)},
 			},
-			wantErr: func() any {
-				var err *contains.CommitNotFoundError
-				return err
+			wantErr: true,
+		},
+		{
+			name: "not contains commit hash, go-git",
+			args: args{
+				repository: "testdata/fixtures/vuls-data-raw-test.tar.zst",
+				commit:     "9d3d5d486d4c9414321a2df56f2e007c4c2c8fac",
+				opts:       []contains.Option{contains.WithUseNativeGit(false)},
 			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -72,18 +77,12 @@ func TestContains(t *testing.T) {
 				t.Errorf("extract %s. err: %v", tt.args.repository, err)
 			}
 
-			err = contains.Contains(filepath.Join(dir, strings.TrimSuffix(filepath.Base(tt.args.repository), ".tar.zst")), tt.args.commit)
+			err = contains.Contains(filepath.Join(dir, strings.TrimSuffix(filepath.Base(tt.args.repository), ".tar.zst")), tt.args.commit, tt.args.opts...)
 			switch {
-			case err != nil && tt.wantErr == nil:
+			case err != nil && !tt.wantErr:
 				t.Errorf("unexpected err: %v", err)
-			case err == nil && tt.wantErr != nil:
+			case err == nil && tt.wantErr:
 				t.Error("expected error has not occurred")
-			default:
-				if err != nil {
-					if !errors.As(err, &tt.wantErr) {
-						t.Errorf("expected error %T, but got %T", tt.wantErr, err)
-					}
-				}
 			}
 		})
 	}

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/affected.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/affected.go
@@ -2,6 +2,7 @@ package affected
 
 import (
 	"cmp"
+	stderrors "errors"
 	"slices"
 
 	"github.com/pkg/errors"
@@ -34,8 +35,7 @@ func (a Affected) Accept(family ecosystemTypes.Ecosystem, v string) (bool, error
 		if r.Equal != "" {
 			n, err := a.Type.Compare(family, r.Equal, v)
 			if err != nil {
-				var compareErr *rangeTypes.CompareError
-				if errors.As(err, &compareErr) {
+				if _, ok := stderrors.AsType[*rangeTypes.CompareError](err); ok {
 					continue
 				}
 				return false, errors.Wrapf(err, "compare (type: %s, v1: %s, v2: %s)", a.Type, r.Equal, v)
@@ -47,8 +47,7 @@ func (a Affected) Accept(family ecosystemTypes.Ecosystem, v string) (bool, error
 		if r.GreaterEqual != "" {
 			n, err := a.Type.Compare(family, r.GreaterEqual, v)
 			if err != nil {
-				var compareErr *rangeTypes.CompareError
-				if errors.As(err, &compareErr) {
+				if _, ok := stderrors.AsType[*rangeTypes.CompareError](err); ok {
 					continue
 				}
 				return false, errors.Wrapf(err, "compare (type: %s, v1: %s, v2: %s)", a.Type, r.GreaterEqual, v)
@@ -60,8 +59,7 @@ func (a Affected) Accept(family ecosystemTypes.Ecosystem, v string) (bool, error
 		if r.GreaterThan != "" {
 			n, err := a.Type.Compare(family, r.GreaterThan, v)
 			if err != nil {
-				var compareErr *rangeTypes.CompareError
-				if errors.As(err, &compareErr) {
+				if _, ok := stderrors.AsType[*rangeTypes.CompareError](err); ok {
 					continue
 				}
 				return false, errors.Wrapf(err, "compare (type: %s, v1: %s, v2: %s)", a.Type, r.GreaterThan, v)
@@ -73,8 +71,7 @@ func (a Affected) Accept(family ecosystemTypes.Ecosystem, v string) (bool, error
 		if r.LessEqual != "" {
 			n, err := a.Type.Compare(family, r.LessEqual, v)
 			if err != nil {
-				var compareErr *rangeTypes.CompareError
-				if errors.As(err, &compareErr) {
+				if _, ok := stderrors.AsType[*rangeTypes.CompareError](err); ok {
 					continue
 				}
 				return false, errors.Wrapf(err, "compare (type: %s, v1: %s, v2: %s)", a.Type, r.LessEqual, v)
@@ -86,8 +83,7 @@ func (a Affected) Accept(family ecosystemTypes.Ecosystem, v string) (bool, error
 		if r.LessThan != "" {
 			n, err := a.Type.Compare(family, r.LessThan, v)
 			if err != nil {
-				var compareErr *rangeTypes.CompareError
-				if errors.As(err, &compareErr) {
+				if _, ok := stderrors.AsType[*rangeTypes.CompareError](err); ok {
 					continue
 				}
 				return false, errors.Wrapf(err, "compare (type: %s, v1: %s, v2: %s)", a.Type, r.LessThan, v)

--- a/pkg/fetch/cisco/csaf/csaf.go
+++ b/pkg/fetch/cisco/csaf/csaf.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"log"
@@ -149,8 +150,7 @@ func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, erro
 
 	var csaf CSAF
 	if err := json.Unmarshal(body, &csaf); err != nil {
-		var syntaxErr *jsontext.SyntacticError
-		if errors.As(err, &syntaxErr) {
+		if syntaxErr, ok := stderrors.AsType[*jsontext.SyntacticError](err); ok {
 			return true, errors.Wrap(syntaxErr, "unmarshal json")
 		}
 		return false, errors.Wrap(err, "unmarshal json")

--- a/pkg/fetch/openeuler/csaf/csaf.go
+++ b/pkg/fetch/openeuler/csaf/csaf.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"log"
@@ -166,8 +167,7 @@ func (o options) fetchCSAF(client *utilhttp.Client, kind string, is []string) er
 
 			var csaf CSAF
 			if err := json.UnmarshalRead(resp.Body, &csaf); err != nil {
-				var syntaxErr *jsontext.SyntacticError
-				if errors.As(err, &syntaxErr) {
+				if _, ok := stderrors.AsType[*jsontext.SyntacticError](err); ok {
 					// e.g.
 					// https://repo.openeuler.org/security/data/csaf/cve/2024/csaf-openeuler-cve-2024-50187.json
 					return nil

--- a/pkg/fetch/suse/cvrf_cve/cvrf_cve.go
+++ b/pkg/fetch/suse/cvrf_cve/cvrf_cve.go
@@ -6,6 +6,7 @@ import (
 	"compress/bzip2"
 	"context"
 	"encoding/xml"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"log"
@@ -159,8 +160,7 @@ func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, erro
 
 		var adv CVRF
 		if err := xml.Unmarshal(bs, &adv); err != nil {
-			var syntaxErr *xml.SyntaxError
-			if errors.As(err, &syntaxErr) {
+			if syntaxErr, ok := stderrors.AsType[*xml.SyntaxError](err); ok {
 				return true, errors.Wrapf(syntaxErr, "decode xml. file: %q, body: %q", hdr.Name, string(bs))
 			}
 			return false, errors.Wrap(err, "decode xml")


### PR DESCRIPTION
Use the generic errors.AsType function introduced in Go 1.26 instead of the two-step var declaration + errors.As pattern.