### PR TITLE
feat(ci/push-log): add workflow to record main sync timestamps

### DIFF
--- a/.github/workflows/push-log.yml
+++ b/.github/workflows/push-log.yml
@@ -1,0 +1,17 @@
+name: Log Push to Main
+run-name: "#${{ github.run_number }} | ${{ github.sha }} | forced:${{ github.event.forced }} | @${{ github.actor }}"
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  log:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    steps:
+      - name: Log push event
+        run: echo "Push detected."


### PR DESCRIPTION
## Summary

The `main` branch is operated by force-pushing (resetting to nightly HEAD), which means push timestamps are not recorded anywhere in Git history. This PR adds a lightweight GitHub Actions workflow that triggers on every push to `main`, providing a timestamped audit trail via the Actions run history.

## What this adds

- `.github/workflows/push-log.yml` — A minimal workflow triggered on `push` to `main`
  - `run-name` captures run number, commit SHA, force-push flag, and actor for at-a-glance visibility in the Actions UI
  - Uses `ubuntu-slim` (single-CPU container runner) to minimize resource usage
  - No checkout, no external actions — just `echo "Push detected."`

## Security considerations

- **Least privilege**: Top-level `permissions: {}` with only `contents: read` granted at the job level
- **No script injection**: `${{ }}` expressions are only used in `run-name` (UI display context, not shell execution)
- **No third-party actions**: Zero supply-chain attack surface
- **No secrets**: No credentials or tokens are referenced