### PR TITLE
feat(criterion): return not-matched instead of error on empty query

### DIFF
--- a/pkg/extract/types/data/detection/condition/criteria/criterion/criterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/criterion.go
@@ -175,7 +175,7 @@ func (c Criterion) Contains(query Query, repositories []string) (bool, error) {
 			return false, errors.New("criterion is not set for version criterion")
 		}
 		if len(query.Version) == 0 {
-			return false, errors.New("query is not set for version criterion")
+			return false, nil
 		}
 
 		for _, q := range query.Version {
@@ -193,7 +193,7 @@ func (c Criterion) Contains(query Query, repositories []string) (bool, error) {
 			return false, errors.New("criterion is not set for none exist criterion")
 		}
 		if query.NoneExist == nil {
-			return false, errors.New("query is not set for none exist criterion")
+			return false, nil
 		}
 
 		isAccepted, err := c.NoneExist.Accept(*query.NoneExist, repositories)
@@ -206,7 +206,7 @@ func (c Criterion) Contains(query Query, repositories []string) (bool, error) {
 			return false, errors.New("criterion is not set for kb criterion")
 		}
 		if query.KB == nil {
-			return false, errors.New("query is not set for kb criterion")
+			return false, nil
 		}
 
 		isAccepted, err := c.KB.Accept(*query.KB)
@@ -237,7 +237,7 @@ func (c Criterion) Accept(query Query, repositories []string) (FilteredCriterion
 			return FilteredCriterion{}, errors.New("criterion is not set for version criterion")
 		}
 		if len(query.Version) == 0 {
-			return FilteredCriterion{}, errors.New("query is not set for version criterion")
+			return FilteredCriterion{Criterion: c, Accepts: AcceptQueries{}}, nil
 		}
 
 		var is []int
@@ -259,7 +259,7 @@ func (c Criterion) Accept(query Query, repositories []string) (FilteredCriterion
 			return FilteredCriterion{}, errors.New("criterion is not set for none exist criterion")
 		}
 		if query.NoneExist == nil {
-			return FilteredCriterion{}, errors.New("query is not set for none exist criterion")
+			return FilteredCriterion{Criterion: c, Accepts: AcceptQueries{}}, nil
 		}
 
 		isAccepted, err := c.NoneExist.Accept(*query.NoneExist, repositories)
@@ -275,7 +275,7 @@ func (c Criterion) Accept(query Query, repositories []string) (FilteredCriterion
 			return FilteredCriterion{}, errors.New("criterion is not set for kb criterion")
 		}
 		if query.KB == nil {
-			return FilteredCriterion{}, errors.New("query is not set for kb criterion")
+			return FilteredCriterion{Criterion: c, Accepts: AcceptQueries{}}, nil
 		}
 
 		isAccepted, err := c.KB.Accept(*query.KB)

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/criterion_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/criterion_test.go
@@ -239,6 +239,60 @@ func TestCriterion_Contains(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "version criterion with query not set",
+			fields: fields{
+				Type: criterionTypes.CriterionTypeVersion,
+				Version: &vcTypes.Criterion{
+					Vulnerable: true,
+					FixStatus:  &fixstatusType.FixStatus{Class: fixstatusType.ClassFixed},
+					Package: vcPackageTypes.Package{
+						Type:   vcPackageTypes.PackageTypeBinary,
+						Binary: &vcBinaryPackageTypes.Package{Name: "name"},
+					},
+					Affected: &affectedTypes.Affected{
+						Type:  affectedrangeType.RangeTypeRPM,
+						Range: []affectedrangeType.Range{{LessThan: "0.0.1-0.0.1.el9"}},
+						Fixed: []string{"0.0.1-0.0.1.el9"},
+					},
+				},
+			},
+			args: args{
+				query: criterionTypes.Query{},
+			},
+			want: false,
+		},
+		{
+			name: "none exist criterion with query not set",
+			fields: fields{
+				Type: criterionTypes.CriterionTypeNoneExist,
+				NoneExist: &necTypes.Criterion{
+					Type: necTypes.PackageTypeBinary,
+					Binary: &necBinaryPackageTypes.Package{
+						Name:          "name",
+						Architectures: []string{"x86_64"},
+					},
+				},
+			},
+			args: args{
+				query: criterionTypes.Query{},
+			},
+			want: false,
+		},
+		{
+			name: "kb criterion with query not set",
+			fields: fields{
+				Type: criterionTypes.CriterionTypeKB,
+				KB: &kbcTypes.Criterion{
+					Product: "Windows 10",
+					KBID:    "5025239",
+				},
+			},
+			args: args{
+				query: criterionTypes.Query{},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -511,6 +565,99 @@ func TestCriterion_Accept(t *testing.T) {
 					},
 				},
 				Accepts: criterionTypes.AcceptQueries{KB: false},
+			},
+		},
+		{
+			name: "version criterion with query not set",
+			fields: fields{
+				Type: criterionTypes.CriterionTypeVersion,
+				Version: &vcTypes.Criterion{
+					Vulnerable: true,
+					FixStatus:  &fixstatusType.FixStatus{Class: fixstatusType.ClassFixed},
+					Package: vcPackageTypes.Package{
+						Type:   vcPackageTypes.PackageTypeBinary,
+						Binary: &vcBinaryPackageTypes.Package{Name: "name"},
+					},
+					Affected: &affectedTypes.Affected{
+						Type:  affectedrangeType.RangeTypeRPM,
+						Range: []affectedrangeType.Range{{LessThan: "0.0.1-0.0.1.el9"}},
+						Fixed: []string{"0.0.1-0.0.1.el9"},
+					},
+				},
+			},
+			args: args{
+				query: criterionTypes.Query{},
+			},
+			want: criterionTypes.FilteredCriterion{
+				Criterion: criterionTypes.Criterion{
+					Type: criterionTypes.CriterionTypeVersion,
+					Version: &vcTypes.Criterion{
+						Vulnerable: true,
+						FixStatus:  &fixstatusType.FixStatus{Class: fixstatusType.ClassFixed},
+						Package: vcPackageTypes.Package{
+							Type:   vcPackageTypes.PackageTypeBinary,
+							Binary: &vcBinaryPackageTypes.Package{Name: "name"},
+						},
+						Affected: &affectedTypes.Affected{
+							Type:  affectedrangeType.RangeTypeRPM,
+							Range: []affectedrangeType.Range{{LessThan: "0.0.1-0.0.1.el9"}},
+							Fixed: []string{"0.0.1-0.0.1.el9"},
+						},
+					},
+				},
+				Accepts: criterionTypes.AcceptQueries{},
+			},
+		},
+		{
+			name: "none exist criterion with query not set",
+			fields: fields{
+				Type: criterionTypes.CriterionTypeNoneExist,
+				NoneExist: &necTypes.Criterion{
+					Type: necTypes.PackageTypeBinary,
+					Binary: &necBinaryPackageTypes.Package{
+						Name:          "name",
+						Architectures: []string{"x86_64"},
+					},
+				},
+			},
+			args: args{
+				query: criterionTypes.Query{},
+			},
+			want: criterionTypes.FilteredCriterion{
+				Criterion: criterionTypes.Criterion{
+					Type: criterionTypes.CriterionTypeNoneExist,
+					NoneExist: &necTypes.Criterion{
+						Type: necTypes.PackageTypeBinary,
+						Binary: &necBinaryPackageTypes.Package{
+							Name:          "name",
+							Architectures: []string{"x86_64"},
+						},
+					},
+				},
+				Accepts: criterionTypes.AcceptQueries{},
+			},
+		},
+		{
+			name: "kb criterion with query not set",
+			fields: fields{
+				Type: criterionTypes.CriterionTypeKB,
+				KB: &kbcTypes.Criterion{
+					Product: "Windows 10",
+					KBID:    "5025239",
+				},
+			},
+			args: args{
+				query: criterionTypes.Query{},
+			},
+			want: criterionTypes.FilteredCriterion{
+				Criterion: criterionTypes.Criterion{
+					Type: criterionTypes.CriterionTypeKB,
+					KB: &kbcTypes.Criterion{
+						Product: "Windows 10",
+						KBID:    "5025239",
+					},
+				},
+				Accepts: criterionTypes.AcceptQueries{},
 			},
 		},
 	}


### PR DESCRIPTION
Change criterion Contains() and Accept() to return false instead of an error when a query field is not set. This allows mixed-type criteria (e.g., OR(version, kb) in Microsoft CVRF) to be evaluated when only a subset of query fields is provided.

Previously, encountering a version criterion without a version query would produce an error, even in cases where the caller intentionally omits it. Now it simply reports no match.