### PR TITLE
feat(extract/jvn/feed/detail): implement extractor

### DIFF
--- a/pkg/extract/jvn/feed/detail/detail.go
+++ b/pkg/extract/jvn/feed/detail/detail.go
@@ -1,13 +1,46 @@
 package detail
 
 import (
+	"fmt"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"path/filepath"
+	"slices"
+	"strings"
+	"time"
 
+	"github.com/knqyf263/go-cpe/naming"
 	"github.com/pkg/errors"
 
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
+	advisoryContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory/content"
+	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
+	detectionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection"
+	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
+	criteriaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria"
+	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
+	vcTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion"
+	packageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/package"
+	cpePackageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/package/cpe"
+	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
+	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
+	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	v2Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v2"
+	v30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
+	v31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	utiltime "github.com/MaineK00n/vuls-data-update/pkg/extract/util/time"
+	fetchTypes "github.com/MaineK00n/vuls-data-update/pkg/fetch/jvn/feed/detail"
 )
 
 type options struct {
@@ -30,7 +63,7 @@ func WithDir(dir string) Option {
 
 func Extract(args string, opts ...Option) error {
 	options := &options{
-		dir: filepath.Join(util.CacheDir(), "extract", "", ""),
+		dir: filepath.Join(util.CacheDir(), "extract", "jvn", "feed", "detail"),
 	}
 
 	for _, o := range opts {
@@ -55,10 +88,207 @@ func Extract(args string, opts ...Option) error {
 			return nil
 		}
 
+		r := utiljson.NewJSONReader()
+		var fetched fetchTypes.Vulinfo
+		if err := r.Read(path, args, &fetched); err != nil {
+			return errors.Wrapf(err, "read json %s", path)
+		}
+
+		data, err := extract(fetched, r.Paths())
+		if err != nil {
+			return errors.Wrapf(err, "extract %s", path)
+		}
+
+		splitted, err := util.Split(string(data.ID), "-", "-")
+		if err != nil {
+			return errors.Wrapf(err, "unexpected ID format. expected: %q, actual: %q", "JVNDB-yyyy-\\d{6}", data.ID)
+		}
+
+		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", data.ID)), data, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", data.ID)))
+		}
+
 		return nil
 	}); err != nil {
 		return errors.Wrapf(err, "walk %s", args)
 	}
 
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.JVNFeedDetail,
+		Name: new("Japan Vulnerability Notes: JVN Feed Detail"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{URL: u}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
 	return nil
+}
+
+func extract(fetched fetchTypes.Vulinfo, raws []string) (dataTypes.Data, error) {
+	// Build CVSS severity
+	var ss []severityTypes.Severity
+	for _, cvss := range fetched.VulinfoData.Impact.Cvss {
+		if cvss.Vector == "" {
+			continue
+		}
+		switch cvss.Version {
+		case "2.0":
+			v2, err := v2Types.Parse(cvss.Vector)
+			if err != nil {
+				return dataTypes.Data{}, errors.Wrapf(err, "parse cvss v2 %q", cvss.Vector)
+			}
+			ss = append(ss, severityTypes.Severity{
+				Type:   severityTypes.SeverityTypeCVSSv2,
+				Source: "jvndb.jvn.jp",
+				CVSSv2: v2,
+			})
+		case "3.0":
+			v30, err := v30Types.Parse(cvss.Vector)
+			if err != nil {
+				return dataTypes.Data{}, errors.Wrapf(err, "parse cvss v3.0 %q", cvss.Vector)
+			}
+			ss = append(ss, severityTypes.Severity{
+				Type:    severityTypes.SeverityTypeCVSSv30,
+				Source:  "jvndb.jvn.jp",
+				CVSSv30: v30,
+			})
+		case "3.1":
+			v31, err := v31Types.Parse(cvss.Vector)
+			if err != nil {
+				return dataTypes.Data{}, errors.Wrapf(err, "parse cvss v3.1 %q", cvss.Vector)
+			}
+			ss = append(ss, severityTypes.Severity{
+				Type:    severityTypes.SeverityTypeCVSSv31,
+				Source:  "jvndb.jvn.jp",
+				CVSSv31: v31,
+			})
+		default:
+			return dataTypes.Data{}, errors.Errorf("unknown CVSS version %q, vector %q", cvss.Version, cvss.Vector)
+		}
+	}
+
+	// Build CWE from related items
+	var cweIDs []string
+	for _, item := range fetched.VulinfoData.Related.RelatedItem {
+		if item.Type == "cwe" && strings.HasPrefix(item.VulinfoID, "CWE-") {
+			cweIDs = append(cweIDs, item.VulinfoID)
+		}
+	}
+	var cwes []cweTypes.CWE
+	if len(cweIDs) > 0 {
+		cwes = []cweTypes.CWE{{
+			Source: "jvndb.jvn.jp",
+			CWE:    cweIDs,
+		}}
+	}
+
+	// Build references from related items (exclude CWE entries)
+	var refs []referenceTypes.Reference
+	for _, item := range fetched.VulinfoData.Related.RelatedItem {
+		if item.Type == "cwe" || item.URL == "" {
+			continue
+		}
+		refs = append(refs, referenceTypes.Reference{
+			Source: "jvndb.jvn.jp",
+			URL:    item.URL,
+		})
+	}
+
+	// Build CPE-based detections (convert CPE 2.2 URI to CPE 2.3 FS format)
+	var criterions []criterionTypes.Criterion
+	for _, item := range fetched.VulinfoData.Affected.AffectedItem {
+		if item.Cpe == nil || item.Cpe.Text == "" {
+			continue
+		}
+		wfn, err := naming.UnbindURI(item.Cpe.Text)
+		if err != nil {
+			return dataTypes.Data{}, errors.Wrapf(err, "parse CPE URI %q", item.Cpe.Text)
+		}
+		criterions = append(criterions, criterionTypes.Criterion{
+			Type: criterionTypes.CriterionTypeVersion,
+			Version: &vcTypes.Criterion{
+				Vulnerable: true,
+				Package: packageTypes.Package{
+					Type: packageTypes.PackageTypeCPE,
+					CPE:  new(cpePackageTypes.CPE(naming.BindToFS(wfn))),
+				},
+			},
+		})
+	}
+
+	var segments []segmentTypes.Segment
+	var detections []detectionTypes.Detection
+	if len(criterions) > 0 {
+		segments = []segmentTypes.Segment{{
+			Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+		}}
+		detections = []detectionTypes.Detection{{
+			Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+			Conditions: []conditionTypes.Condition{{
+				Criteria: criteriaTypes.Criteria{
+					Operator:   criteriaTypes.CriteriaOperatorTypeOR,
+					Criterions: criterions,
+				},
+			}},
+		}}
+	}
+
+	// Build vulnerabilities from CVE references (merge references for same CVE ID)
+	vulnMap := make(map[string]vulnerabilityTypes.Vulnerability)
+	for _, item := range fetched.VulinfoData.Related.RelatedItem {
+		if !strings.HasPrefix(item.VulinfoID, "CVE-") {
+			continue
+		}
+		if _, ok := vulnMap[item.VulinfoID]; !ok {
+			vulnMap[item.VulinfoID] = vulnerabilityTypes.Vulnerability{
+				Content: vulnerabilityContentTypes.Content{
+					ID: vulnerabilityContentTypes.VulnerabilityID(item.VulinfoID),
+				},
+				Segments: segments,
+			}
+		}
+		if item.URL != "" {
+			v := vulnMap[item.VulinfoID]
+			v.Content.References = append(v.Content.References, referenceTypes.Reference{
+				Source: "jvndb.jvn.jp",
+				URL:    item.URL,
+			})
+			vulnMap[item.VulinfoID] = v
+		}
+	}
+
+	return dataTypes.Data{
+		ID: dataTypes.RootID(fetched.VulinfoID),
+		Advisories: []advisoryTypes.Advisory{{
+			Content: advisoryContentTypes.Content{
+				ID:          advisoryContentTypes.AdvisoryID(fetched.VulinfoID),
+				Title:       fetched.VulinfoData.Title,
+				Description: fetched.VulinfoData.VulinfoDescription.Overview,
+				Severity:    ss,
+				CWE:         cwes,
+				References:  refs,
+				Published:   utiltime.Parse([]string{time.RFC3339}, fetched.VulinfoData.DateFirstPublished),
+				Modified:    utiltime.Parse([]string{time.RFC3339}, fetched.VulinfoData.DateLastUpdated),
+			},
+			Segments: segments,
+		}},
+		Vulnerabilities: slices.Collect(maps.Values(vulnMap)),
+		Detections:      detections,
+		DataSource: sourceTypes.Source{
+			ID:   sourceTypes.JVNFeedDetail,
+			Raws: raws,
+		},
+	}, nil
 }

--- a/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-000001.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-000001.json
@@ -1,0 +1,83 @@
+{
+	"id": "JVNDB-2022-000001",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2022-000001",
+				"title": "キヤノン製レーザープリンターおよびスモールオフィス向け複合機におけるクロスサイトスクリプティングの脆弱性",
+				"description": "キヤノン株式会社が提供するレーザープリンターおよびスモールオフィス向け複合機には、格納型クロスサイトスクリプティング (CWE-79) の脆弱性が存在します。  この脆弱性情報は、情報セキュリティ早期警戒パートナーシップに基づき下記の方が IPA に報告し、JPCERT/CC が開発者との調整を行いました。 報告者: 株式会社イエラエセキュリティ 村島 正浩 氏",
+				"severity": [
+					{
+						"type": "cvss_v2",
+						"source": "jvndb.jvn.jp",
+						"cvss_v2": {
+							"vector": "AV:N/AC:M/Au:S/C:N/I:P/A:N",
+							"base_score": 3.5,
+							"nvd_base_severity": "LOW",
+							"temporal_score": 3.5,
+							"nvd_temporal_severity": "LOW",
+							"environmental_score": 3.5,
+							"nvd_environmental_severity": "LOW"
+						}
+					},
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+							"base_score": 4.8,
+							"base_severity": "MEDIUM",
+							"temporal_score": 4.8,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 4.8,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-79"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://cweb.canon.jp/e-support/info/211221xss.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://jvn.jp/jp/JVN64806328/index.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877"
+					}
+				],
+				"published": "2022-01-19T12:05:15+09:00",
+				"modified": "2022-01-19T12:05:15+09:00"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2021-20877",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877"
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-detail",
+		"raws": [
+			"fixtures/2022/JVNDB-2022-000001.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-000002.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-000002.json
@@ -1,0 +1,162 @@
+{
+	"id": "JVNDB-2022-000002",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2022-000002",
+				"title": "WordPress 用プラグイン Quiz And Survey Master における複数の脆弱性",
+				"description": "ExpressTech が提供する WordPress 用プラグイン Quiz And Survey Master には、次の複数の脆弱性が存在します。 ・クロスサイトリクエストフォージェリ (CWE-352) - CVE-2022-0180 ・反射型クロスサイトスクリプティング (CWE-79) - CVE-2022-0181 ・格納型クロスサイトスクリプティング (CWE-79) - CVE-2022-0182  CVE-2022-0180、CVE-2022-0181 これらの脆弱性情報は、情報セキュリティ早期警戒パートナーシップに基づき下記の方が IPA に報告し、JPCERT/CC が開発者との調整を行いました。 報告者: 末吉 大輝 氏  CVE-2022-0182 この脆弱性情報は、情報セキュリティ早期警戒パートナーシップに基づき下記の方が IPA に報告し、JPCERT/CC が開発者との調整を行いました。 報告者: 三井物産セキュアディレクション株式会社 荒牧　努 氏",
+				"severity": [
+					{
+						"type": "cvss_v2",
+						"source": "jvndb.jvn.jp",
+						"cvss_v2": {
+							"vector": "AV:N/AC:L/Au:S/C:N/I:P/A:N",
+							"base_score": 4,
+							"nvd_base_severity": "MEDIUM",
+							"temporal_score": 4,
+							"nvd_temporal_severity": "MEDIUM",
+							"environmental_score": 4,
+							"nvd_environmental_severity": "MEDIUM"
+						}
+					},
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+							"base_score": 5.4,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.4,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.4,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-352",
+							"CWE-79"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://ja.wordpress.org/plugins/quiz-master-next/"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://jvn.jp/jp/JVN72788165/index.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://quizandsurveymaster.com/"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0180"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0181"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0182"
+					}
+				],
+				"published": "2022-01-12T12:08:20+09:00",
+				"modified": "2022-01-12T12:08:20+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-0180",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0180"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-0181",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0181"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-0182",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0182"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"package": {
+										"type": "cpe",
+										"cpe": "cpe:2.3:a:expresstech:quiz_and_survey_master:*:*:*:*:*:*:*:*"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-detail",
+		"raws": [
+			"fixtures/2022/JVNDB-2022-000002.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-017704.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-017704.json
@@ -1,0 +1,116 @@
+{
+	"id": "JVNDB-2022-017704",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2022-017704",
+				"title": "Linux の Linux Kernel における NULL ポインタデリファレンスに関する脆弱性",
+				"description": "Linux の Linux Kernel には、NULL ポインタデリファレンスに関する脆弱性が存在します。 ",
+				"severity": [
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+							"base_score": 5.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-476"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.16.3"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://github.com/torvalds/linux/commit/3ba880a12df5aa4488c18281701b5b1bc3d4531a"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23001"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23001"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.kernel.org"
+					}
+				],
+				"published": "2023-10-16T17:17:41+09:00",
+				"modified": "2023-10-16T17:17:41+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-23001",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23001"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23001"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"package": {
+										"type": "cpe",
+										"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-detail",
+		"raws": [
+			"fixtures/2022/JVNDB-2022-017704.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/detail/testdata/golden/data/2023/JVNDB-2023-004315.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/data/2023/JVNDB-2023-004315.json
@@ -1,0 +1,120 @@
+{
+	"id": "JVNDB-2023-004315",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2023-004315",
+				"title": "oclc の oaicat における SQL インジェクションの脆弱性",
+				"description": "oclc の oaicat には、SQL インジェクションの脆弱性が存在します。",
+				"severity": [
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+							"base_score": 9.8,
+							"base_severity": "CRITICAL",
+							"temporal_score": 9.8,
+							"temporal_severity": "CRITICAL",
+							"environmental_score": 9.8,
+							"environmental_severity": "CRITICAL"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-89"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://code.google.com/archive/p/oaicat/issues/7"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://github.com/OCLC-Research/oaicat/commit/6cc65501869fa663bcd24a70b63f41f5cfe6b3e1"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2013-10019"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://oaicat.googlecode.com/files/oaicat-1.5.62.tar.gz"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://vuldb.com/?id.221489"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2013-10019"
+					}
+				],
+				"published": "2023-10-27T17:01:51+09:00",
+				"modified": "2023-10-27T17:01:51+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2013-10019",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2013-10019"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2013-10019"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"package": {
+										"type": "cpe",
+										"cpe": "cpe:2.3:a:oclc:oaicat:*:*:*:*:*:*:*:*"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-detail",
+		"raws": [
+			"fixtures/2023/JVNDB-2023-004315.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/detail/testdata/golden/datasource.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "jvn-feed-detail",
+	"name": "Japan Vulnerability Notes: JVN Feed Detail"
+}


### PR DESCRIPTION
   - Parse CVSS v2/v3.0/v3.1 severity from vector strings
   - Extract CWE IDs and references from related items
   - Build CVE vulnerabilities with merged references for same CVE ID
   - Convert CPE 2.2 URI to CPE 2.3 FS format for detection criteria
   - Add golden test data

   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>