### PR TITLE
feat(extract/jvn/feed/rss): implement extractor

### DIFF
--- a/pkg/extract/jvn/feed/rss/rss.go
+++ b/pkg/extract/jvn/feed/rss/rss.go
@@ -1,13 +1,47 @@
 package rss
 
 import (
+	"fmt"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"path/filepath"
+	"slices"
+	"strings"
+	"time"
 
+	"github.com/knqyf263/go-cpe/naming"
 	"github.com/pkg/errors"
 
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
+	advisoryContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory/content"
+	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
+	detectionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection"
+	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
+	criteriaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria"
+	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
+	vcTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion"
+	fixstatusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/fixstatus"
+	packageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/package"
+	cpePackageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/package/cpe"
+	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
+	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
+	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	v2Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v2"
+	v30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
+	v31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	utiltime "github.com/MaineK00n/vuls-data-update/pkg/extract/util/time"
+	fetchTypes "github.com/MaineK00n/vuls-data-update/pkg/fetch/jvn/feed/rss"
 )
 
 type options struct {
@@ -30,7 +64,7 @@ func WithDir(dir string) Option {
 
 func Extract(args string, opts ...Option) error {
 	options := &options{
-		dir: filepath.Join(util.CacheDir(), "extract", "", ""),
+		dir: filepath.Join(util.CacheDir(), "extract", "jvn", "feed", "rss"),
 	}
 
 	for _, o := range opts {
@@ -55,10 +89,209 @@ func Extract(args string, opts ...Option) error {
 			return nil
 		}
 
+		r := utiljson.NewJSONReader()
+		var fetched fetchTypes.Item
+		if err := r.Read(path, args, &fetched); err != nil {
+			return errors.Wrapf(err, "read %s", path)
+		}
+
+		data, err := extract(fetched, r.Paths())
+		if err != nil {
+			return errors.Wrapf(err, "extract %s", path)
+		}
+
+		splitted, err := util.Split(string(data.ID), "-", "-")
+		if err != nil {
+			return errors.Wrapf(err, "unexpected ID format. expected: %q, actual: %q", "JVNDB-yyyy-\\d{6}", data.ID)
+		}
+
+		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", data.ID)), data, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", data.ID)))
+		}
+
 		return nil
 	}); err != nil {
 		return errors.Wrapf(err, "walk %s", args)
 	}
 
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.JVNFeedRSS,
+		Name: new("Japan Vulnerability Notes: JVN Feed RSS"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{URL: u}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
 	return nil
+}
+
+func extract(fetched fetchTypes.Item, raws []string) (dataTypes.Data, error) {
+	// Build CVSS severity
+	var ss []severityTypes.Severity
+	for _, cvss := range fetched.CVSS {
+		if cvss.Vector == "" {
+			continue
+		}
+		switch cvss.Version {
+		case "2.0":
+			v2, err := v2Types.Parse(cvss.Vector)
+			if err != nil {
+				return dataTypes.Data{}, errors.Wrapf(err, "parse cvss v2 %q", cvss.Vector)
+			}
+			ss = append(ss, severityTypes.Severity{
+				Type:   severityTypes.SeverityTypeCVSSv2,
+				Source: "jvndb.jvn.jp",
+				CVSSv2: v2,
+			})
+		case "3.0":
+			v30, err := v30Types.Parse(cvss.Vector)
+			if err != nil {
+				return dataTypes.Data{}, errors.Wrapf(err, "parse cvss v3.0 %q", cvss.Vector)
+			}
+			ss = append(ss, severityTypes.Severity{
+				Type:    severityTypes.SeverityTypeCVSSv30,
+				Source:  "jvndb.jvn.jp",
+				CVSSv30: v30,
+			})
+		case "3.1":
+			v31, err := v31Types.Parse(cvss.Vector)
+			if err != nil {
+				return dataTypes.Data{}, errors.Wrapf(err, "parse cvss v3.1 %q", cvss.Vector)
+			}
+			ss = append(ss, severityTypes.Severity{
+				Type:    severityTypes.SeverityTypeCVSSv31,
+				Source:  "jvndb.jvn.jp",
+				CVSSv31: v31,
+			})
+		default:
+			return dataTypes.Data{}, errors.Errorf("unknown CVSS version %q, vector %q", cvss.Version, cvss.Vector)
+		}
+	}
+
+	// Build CWE from references (entries with ID starting with "CWE-" and no Source)
+	var cweIDs []string
+	for _, ref := range fetched.References {
+		if ref.Source == "" && strings.HasPrefix(ref.ID, "CWE-") {
+			cweIDs = append(cweIDs, ref.ID)
+		}
+	}
+	var cwes []cweTypes.CWE
+	if len(cweIDs) > 0 {
+		cwes = []cweTypes.CWE{{
+			Source: "jvndb.jvn.jp",
+			CWE:    cweIDs,
+		}}
+	}
+
+	// Build references (exclude CWE entries)
+	var refs []referenceTypes.Reference
+	for _, ref := range fetched.References {
+		if ref.Source == "" || ref.Text == "" {
+			continue
+		}
+		refs = append(refs, referenceTypes.Reference{
+			Source: "jvndb.jvn.jp",
+			URL:    ref.Text,
+		})
+	}
+
+	// Build CPE-based detections (convert CPE 2.2 URI to CPE 2.3 FS format)
+	var criterions []criterionTypes.Criterion
+	for _, cpe := range fetched.CPE {
+		if cpe.Text == "" {
+			continue
+		}
+		wfn, err := naming.UnbindURI(cpe.Text)
+		if err != nil {
+			slog.Warn("skip invalid CPE URI", slog.String("cpe", cpe.Text), slog.Any("err", err))
+			continue
+		}
+		criterions = append(criterions, criterionTypes.Criterion{
+			Type: criterionTypes.CriterionTypeVersion,
+			Version: &vcTypes.Criterion{
+				Vulnerable: true,
+				FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassUnknown},
+				Package: packageTypes.Package{
+					Type: packageTypes.PackageTypeCPE,
+					CPE:  new(cpePackageTypes.CPE(naming.BindToFS(wfn))),
+				},
+			},
+		})
+	}
+
+	var segments []segmentTypes.Segment
+	var detections []detectionTypes.Detection
+	if len(criterions) > 0 {
+		segments = []segmentTypes.Segment{{
+			Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+		}}
+		detections = []detectionTypes.Detection{{
+			Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+			Conditions: []conditionTypes.Condition{{
+				Criteria: criteriaTypes.Criteria{
+					Operator:   criteriaTypes.CriteriaOperatorTypeOR,
+					Criterions: criterions,
+				},
+			}},
+		}}
+	}
+
+	// Build vulnerabilities from CVE references (merge references for same CVE ID)
+	vulnMap := make(map[string]vulnerabilityTypes.Vulnerability)
+	for _, ref := range fetched.References {
+		if !strings.HasPrefix(ref.ID, "CVE-") {
+			continue
+		}
+		if _, ok := vulnMap[ref.ID]; !ok {
+			vulnMap[ref.ID] = vulnerabilityTypes.Vulnerability{
+				Content: vulnerabilityContentTypes.Content{
+					ID: vulnerabilityContentTypes.VulnerabilityID(ref.ID),
+				},
+				Segments: segments,
+			}
+		}
+		if ref.Text != "" {
+			v := vulnMap[ref.ID]
+			v.Content.References = append(v.Content.References, referenceTypes.Reference{
+				Source: "jvndb.jvn.jp",
+				URL:    ref.Text,
+			})
+			vulnMap[ref.ID] = v
+		}
+	}
+
+	return dataTypes.Data{
+		ID: dataTypes.RootID(fetched.Identifier),
+		Advisories: []advisoryTypes.Advisory{{
+			Content: advisoryContentTypes.Content{
+				ID:          advisoryContentTypes.AdvisoryID(fetched.Identifier),
+				Title:       fetched.Title,
+				Description: fetched.Description,
+				Severity:    ss,
+				CWE:         cwes,
+				References:  refs,
+				Published:   utiltime.Parse([]string{time.RFC3339, "2006-01-02T15:04-07:00"}, fetched.Issued),
+				Modified:    utiltime.Parse([]string{time.RFC3339, "2006-01-02T15:04-07:00"}, fetched.Modified),
+			},
+			Segments: segments,
+		}},
+		Vulnerabilities: slices.Collect(maps.Values(vulnMap)),
+		Detections:      detections,
+		DataSource: sourceTypes.Source{
+			ID:   sourceTypes.JVNFeedRSS,
+			Raws: raws,
+		},
+	}, nil
 }

--- a/pkg/extract/jvn/feed/rss/rss.go
+++ b/pkg/extract/jvn/feed/rss/rss.go
@@ -251,24 +251,26 @@ func extract(fetched fetchTypes.Item, raws []string) (dataTypes.Data, error) {
 	// Build vulnerabilities from CVE references (merge references for same CVE ID)
 	vulnMap := make(map[string]vulnerabilityTypes.Vulnerability)
 	for _, ref := range fetched.References {
-		if !strings.HasPrefix(ref.ID, "CVE-") {
-			continue
-		}
-		if _, ok := vulnMap[ref.ID]; !ok {
-			vulnMap[ref.ID] = vulnerabilityTypes.Vulnerability{
-				Content: vulnerabilityContentTypes.Content{
-					ID: vulnerabilityContentTypes.VulnerabilityID(ref.ID),
-				},
-				Segments: segments,
+		switch ref.Source {
+		case "CVE", "NVD":
+			if _, ok := vulnMap[ref.ID]; !ok {
+				vulnMap[ref.ID] = vulnerabilityTypes.Vulnerability{
+					Content: vulnerabilityContentTypes.Content{
+						ID: vulnerabilityContentTypes.VulnerabilityID(ref.ID),
+					},
+					Segments: segments,
+				}
 			}
-		}
-		if ref.Text != "" {
-			v := vulnMap[ref.ID]
-			v.Content.References = append(v.Content.References, referenceTypes.Reference{
-				Source: "jvndb.jvn.jp",
-				URL:    ref.Text,
-			})
-			vulnMap[ref.ID] = v
+			if ref.Text != "" {
+				v := vulnMap[ref.ID]
+				v.Content.References = append(v.Content.References, referenceTypes.Reference{
+					Source: "jvndb.jvn.jp",
+					URL:    ref.Text,
+				})
+				vulnMap[ref.ID] = v
+			}
+		default:
+			continue
 		}
 	}
 

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2021/JVNDB-2021-018345.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2021/JVNDB-2021-018345.json
@@ -1,0 +1,124 @@
+{
+	"id": "JVNDB-2021-018345",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2021-018345",
+				"title": "Android における脆弱性",
+				"description": "Android には、不特定の脆弱性が存在します。\r\n\r\n",
+				"severity": [
+					{
+						"type": "cvss_v2",
+						"source": "jvndb.jvn.jp",
+						"cvss_v2": {
+							"vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+							"base_score": 4.6,
+							"nvd_base_severity": "MEDIUM",
+							"temporal_score": 4.6,
+							"nvd_temporal_severity": "MEDIUM",
+							"environmental_score": 4.6,
+							"nvd_environmental_severity": "MEDIUM"
+						}
+					},
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+							"base_score": 7.8,
+							"base_severity": "HIGH",
+							"temporal_score": 7.8,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.8,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-noinfo"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22292"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://security.samsungmobile.com/securityUpdate.smsb?year=2022&month=2"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-22292"
+					}
+				],
+				"published": "2023-06-01T11:12:00+09:00",
+				"modified": "2023-06-01T11:12:00+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-22292",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22292"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-22292"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"package": {
+										"type": "cpe",
+										"cpe": "cpe:2.3:o:google:android:*:*:*:*:*:*:*:*"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss",
+		"raws": [
+			"fixtures/2021/JVNDB-2021-018345.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-000001.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-000001.json
@@ -1,0 +1,79 @@
+{
+	"id": "JVNDB-2022-000001",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2022-000001",
+				"title": "キヤノン製レーザープリンターおよびスモールオフィス向け複合機におけるクロスサイトスクリプティングの脆弱性",
+				"description": "キヤノン株式会社が提供するレーザープリンターおよびスモールオフィス向け複合機には、格納型クロスサイトスクリプティング (CWE-79) の脆弱性が存在します。\r\n\r\nこの脆弱性情報は、情報セキュリティ早期警戒パートナーシップに基づき下記の方が IPA に報告し、JPCERT/CC が開発者との調整を行いました。\r\n報告者: 株式会社イエラエセキュリティ 村島 正浩 氏",
+				"severity": [
+					{
+						"type": "cvss_v2",
+						"source": "jvndb.jvn.jp",
+						"cvss_v2": {
+							"vector": "AV:N/AC:M/Au:S/C:N/I:P/A:N",
+							"base_score": 3.5,
+							"nvd_base_severity": "LOW",
+							"temporal_score": 3.5,
+							"nvd_temporal_severity": "LOW",
+							"environmental_score": 3.5,
+							"nvd_environmental_severity": "LOW"
+						}
+					},
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+							"base_score": 4.8,
+							"base_severity": "MEDIUM",
+							"temporal_score": 4.8,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 4.8,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-79"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://jvn.jp/jp/JVN64806328/index.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877"
+					}
+				],
+				"published": "2022-01-19T12:05:00+09:00",
+				"modified": "2022-01-19T12:05:00+09:00"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2021-20877",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877"
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss",
+		"raws": [
+			"fixtures/2022/JVNDB-2022-000001.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-017708.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-017708.json
@@ -1,0 +1,107 @@
+{
+	"id": "JVNDB-2022-017708",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2022-017708",
+				"title": "Linux の Linux Kernel における NULL ポインタデリファレンスに関する脆弱性",
+				"description": "Linux の Linux Kernel には、NULL ポインタデリファレンスに関する脆弱性が存在します。\r\n",
+				"severity": [
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+							"base_score": 5.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-476"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23006"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23006"
+					}
+				],
+				"published": "2023-10-16T17:18:00+09:00",
+				"modified": "2023-10-16T17:18:00+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-23006",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23006"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23006"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"package": {
+										"type": "cpe",
+										"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss",
+		"raws": [
+			"fixtures/2022/JVNDB-2022-017708.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-020469.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-020469.json
@@ -1,0 +1,107 @@
+{
+	"id": "JVNDB-2022-020469",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2022-020469",
+				"title": "アップルの macOS における脆弱性",
+				"description": "アップルの macOS には、不特定の脆弱性が存在します。\r\n",
+				"severity": [
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+							"base_score": 9.8,
+							"base_severity": "CRITICAL",
+							"temporal_score": 9.8,
+							"temporal_severity": "CRITICAL",
+							"environmental_score": 9.8,
+							"environmental_severity": "CRITICAL"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-noinfo"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46723"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46723"
+					}
+				],
+				"published": "2023-11-02T11:30:00+09:00",
+				"modified": "2023-11-02T11:30:00+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-46723",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46723"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46723"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"package": {
+										"type": "cpe",
+										"cpe": "cpe:2.3:o:apple:macos:*:*:*:*:*:*:*:*"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss",
+		"raws": [
+			"fixtures/2022/JVNDB-2022-020469.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-000001.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-000001.json
@@ -1,0 +1,136 @@
+{
+	"id": "JVNDB-2023-000001",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2023-000001",
+				"title": "ruby-git における複数のコードインジェクションの脆弱性",
+				"description": "ruby-git は、Git リポジトリの作成、読み取り、および操作に使用できる Ruby ライブラリです。ruby-git には、複数のコードインジェクション (CWE-94) の脆弱性が存在します。\r\n\r\nこの脆弱性情報は、情報セキュリティ早期警戒パートナーシップに基づき下記の方が IPA に報告し、JPCERT/CC が開発者との調整を行いました。\r\n報告者: 株式会社ディー・エヌ・エー 国分佑樹 氏",
+				"severity": [
+					{
+						"type": "cvss_v2",
+						"source": "jvndb.jvn.jp",
+						"cvss_v2": {
+							"vector": "AV:N/AC:M/Au:S/C:P/I:P/A:P",
+							"base_score": 6,
+							"nvd_base_severity": "MEDIUM",
+							"temporal_score": 6,
+							"nvd_temporal_severity": "MEDIUM",
+							"environmental_score": 6,
+							"nvd_environmental_severity": "MEDIUM"
+						}
+					},
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:L",
+							"base_score": 5.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-94"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://jvn.jp/jp/JVN16765254/index.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46648"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-47318"
+					}
+				],
+				"published": "2023-01-05T12:02:00+09:00",
+				"modified": "2023-11-03T12:02:00+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-46648",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46648"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-47318",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-47318"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"package": {
+										"type": "cpe",
+										"cpe": "cpe:2.3:a:misc:ruby-git_ruby-git:*:*:*:*:*:*:*:*"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss",
+		"raws": [
+			"fixtures/2023/JVNDB-2023-000001.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-002068.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-002068.json
@@ -56,22 +56,6 @@
 	"vulnerabilities": [
 		{
 			"content": {
-				"id": "CVE-2022-25026 & CVE-2022-25027: Vulnerabilities in Rocket TRUfusion Enterprise",
-				"references": [
-					{
-						"source": "jvndb.jvn.jp",
-						"url": "https://labs.nettitude.com/blog/cve-2022-25026-cve-2022-25027-vulnerabilities-in-rocket-trufusion-enterprise/"
-					}
-				]
-			},
-			"segments": [
-				{
-					"ecosystem": "cpe"
-				}
-			]
-		},
-		{
-			"content": {
 				"id": "CVE-2022-25027",
 				"references": [
 					{

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-002068.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-002068.json
@@ -1,0 +1,127 @@
+{
+	"id": "JVNDB-2023-002068",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2023-002068",
+				"title": "Rocket TRUfusion Portal におけるパスワード管理機能に関する脆弱性",
+				"description": "Rocket TRUfusion Portal には、パスワード管理機能に関する脆弱性が存在します。\r\n\r\n",
+				"severity": [
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+							"base_score": 7.5,
+							"base_severity": "HIGH",
+							"temporal_score": 7.5,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.5,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-640"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://labs.nettitude.com/blog/cve-2022-25026-cve-2022-25027-vulnerabilities-in-rocket-trufusion-enterprise/"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25027"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-25027"
+					}
+				],
+				"published": "2023-06-08T16:22:00+09:00",
+				"modified": "2023-06-08T16:22:00+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-25026 & CVE-2022-25027: Vulnerabilities in Rocket TRUfusion Enterprise",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://labs.nettitude.com/blog/cve-2022-25026-cve-2022-25027-vulnerabilities-in-rocket-trufusion-enterprise/"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2022-25027",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25027"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-25027"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"package": {
+										"type": "cpe",
+										"cpe": "cpe:2.3:a:rocketsoftware:trufusion_enterprise:*:*:*:*:*:*:*:*"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss",
+		"raws": [
+			"fixtures/2023/JVNDB-2023-002068.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-004814.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-004814.json
@@ -1,0 +1,111 @@
+{
+	"id": "JVNDB-2023-004814",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2023-004814",
+				"title": "resumebuilder の WordPress 用 resume builder におけるクロスサイトスクリプティングの脆弱性",
+				"description": "resumebuilder の WordPress 用 resume builder には、クロスサイトスクリプティングの脆弱性が存在します。",
+				"severity": [
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+							"base_score": 5.4,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.4,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.4,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-79"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0078"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://wpscan.com/vulnerability/e667854f-56f8-4dbe-9573-6652a8aacc2c"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-0078"
+					}
+				],
+				"published": "2023-11-02T11:57:00+09:00",
+				"modified": "2023-11-02T11:57:00+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-0078",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0078"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-0078"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"package": {
+										"type": "cpe",
+										"cpe": "cpe:2.3:a:resumebuilder:resume_builder:*:*:*:*:*:*:*:*"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss",
+		"raws": [
+			"fixtures/2023/JVNDB-2023-004814.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/datasource.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "jvn-feed-rss",
+	"name": "Japan Vulnerability Notes: JVN Feed RSS"
+}


### PR DESCRIPTION
 - Parse CVSS v2/v3.0/v3.1 severity from vector strings
 - Extract CWE IDs and references from RSS item references
 - Build CVE vulnerabilities with merged references for same CVE ID
 - Convert CPE 2.2 URI to CPE 2.3 FS format for detection criteria
 - Set FixStatus to "unknown" for CPE-based criteria
 - Skip invalid CPE URIs with warning log
 - Add golden test data

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>