### PR TITLE
feat(extract/microsoft/cvrf): detect from ProductStatuses fallback

### DIFF
--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -590,6 +590,9 @@ func appendOrMergeSegment[T any](
 func buildDetections(v cvrf.Vulnerability, products map[string]string) (map[ecosystemTypes.Ecosystem][]conditionTypes.Condition, error) {
 	conditionsByEcosystem := make(map[ecosystemTypes.Ecosystem][]conditionTypes.Condition)
 
+	// Track which product IDs are covered by Vendor Fix remediations.
+	coveredProductIDs := make(map[string]struct{})
+
 	for _, r := range v.Remediations.Remediation {
 		switch r.Type {
 		case "Vendor Fix":
@@ -602,6 +605,13 @@ func buildDetections(v cvrf.Vulnerability, products map[string]string) (map[ecos
 				if isCBLMarinerOrAzureLinux(productName) {
 					continue
 				}
+
+				// Mark the product as covered so that the ProductStatuses fallback
+				// does not incorrectly register it as unfixed. This must happen
+				// before the nil check below because some Vendor Fix entries
+				// (e.g. "Click to Run") carry neither a KB ID nor a FixedBuild,
+				// yet the product IS fixed via an auto-update channel.
+				coveredProductIDs[pid] = struct{}{}
 
 				tag := segmentTypes.DetectionTag(productName)
 				criterionProductName := microsoftutil.NormalizeProductName(productName)
@@ -624,25 +634,7 @@ func buildDetections(v cvrf.Vulnerability, products map[string]string) (map[ecos
 					cns = append(cns, *fixedBuildCriterion)
 				}
 
-				conditions := conditionsByEcosystem[ecosystemTypes.EcosystemTypeMicrosoft]
-				for _, cn := range cns {
-					switch idx := slices.IndexFunc(conditions, func(c conditionTypes.Condition) bool {
-						return c.Tag == tag
-					}); idx {
-					case -1:
-						conditions = append(conditions, conditionTypes.Condition{
-							Criteria: criteriaTypes.Criteria{Operator: criteriaTypes.CriteriaOperatorTypeOR, Criterions: []criterionTypes.Criterion{cn}},
-							Tag:      tag,
-						})
-					default:
-						if !slices.ContainsFunc(conditions[idx].Criteria.Criterions, func(e criterionTypes.Criterion) bool {
-							return criterionTypes.Compare(e, cn) == 0
-						}) {
-							conditions[idx].Criteria.Criterions = append(conditions[idx].Criteria.Criterions, cn)
-						}
-					}
-				}
-				conditionsByEcosystem[ecosystemTypes.EcosystemTypeMicrosoft] = conditions
+				appendConditions(conditionsByEcosystem, tag, cns)
 			}
 		case "Release Notes", "Known Issue", "Mitigation", "Workaround":
 		default:
@@ -650,7 +642,72 @@ func buildDetections(v cvrf.Vulnerability, products map[string]string) (map[ecos
 		}
 	}
 
+	// For products listed in ProductStatuses but not covered by any Vendor Fix
+	// remediation, use fixedBuildOverrides if available (e.g. Edge), otherwise
+	// register as unfixed.
+	for _, pid := range v.ProductStatuses.Status.ProductID {
+		if _, ok := coveredProductIDs[pid]; ok {
+			continue
+		}
+
+		productName, ok := products[pid]
+		if !ok {
+			return nil, errors.Errorf("product ID %q not found in product tree for %s", pid, v.CVE)
+		}
+
+		if isCBLMarinerOrAzureLinux(productName) {
+			continue
+		}
+
+		tag := segmentTypes.DetectionTag(productName)
+		criterionProductName := microsoftutil.NormalizeProductName(productName)
+
+		fixedBuildCriterion, err := buildFixedBuildCriterion(v.CVE, criterionProductName, "")
+		if err != nil {
+			return nil, errors.Wrap(err, "build fixed build criterion")
+		}
+
+		if fixedBuildCriterion != nil {
+			appendConditions(conditionsByEcosystem, tag, []criterionTypes.Criterion{*fixedBuildCriterion})
+			continue
+		}
+
+		appendConditions(conditionsByEcosystem, tag, []criterionTypes.Criterion{{
+			Type: criterionTypes.CriterionTypeVersion,
+			Version: &vcTypes.Criterion{
+				Vulnerable: true,
+				FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassUnfixed},
+				Package: criterionpackageTypes.Package{
+					Type:   criterionpackageTypes.PackageTypeBinary,
+					Binary: &binaryTypes.Package{Name: criterionProductName},
+				},
+			},
+		}})
+	}
+
 	return conditionsByEcosystem, nil
+}
+
+func appendConditions(conditionsByEcosystem map[ecosystemTypes.Ecosystem][]conditionTypes.Condition, tag segmentTypes.DetectionTag, cns []criterionTypes.Criterion) {
+	conditions := conditionsByEcosystem[ecosystemTypes.EcosystemTypeMicrosoft]
+	for _, cn := range cns {
+		switch idx := slices.IndexFunc(conditions, func(c conditionTypes.Condition) bool {
+			return c.Tag == tag
+		}); idx {
+		case -1:
+			conditions = append(conditions, conditionTypes.Condition{
+				Criteria: criteriaTypes.Criteria{Operator: criteriaTypes.CriteriaOperatorTypeOR, Criterions: []criterionTypes.Criterion{cn}},
+				Tag:      tag,
+			})
+		default:
+			if !slices.ContainsFunc(conditions[idx].Criteria.Criterions, func(e criterionTypes.Criterion) bool {
+				return criterionTypes.Compare(e, cn) == 0
+			}) {
+				conditions[idx].Criteria.Criterions = append(conditions[idx].Criteria.Criterions, cn)
+			}
+		}
+	}
+	conditionsByEcosystem[ecosystemTypes.EcosystemTypeMicrosoft] = conditions
 }
 func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criterionTypes.Criterion, error) {
 	// Generic cleanup

--- a/pkg/extract/microsoft/cvrf/testdata/fixtures/2021-Apr/2021/CVE-2021-21202.json
+++ b/pkg/extract/microsoft/cvrf/testdata/fixtures/2021-Apr/2021/CVE-2021-21202.json
@@ -1,0 +1,142 @@
+{
+	"document_title": "April 2021 Security Updates",
+	"document_type": "Security Update",
+	"documentpublisher": {
+		"type": "Vendor",
+		"contact_details": "secure@microsoft.com",
+		"issuing_authority": "The Microsoft Security Response Center (MSRC) identifies, monitors, resolves, and responds to security incidents and Microsoft software security vulnerabilities. For more information, see http://www.microsoft.com/security/msrc."
+	},
+	"documenttracking": {
+		"identification": {
+			"id": "CVE-2021-21202",
+			"alias": "CVE-2021-21202"
+		},
+		"status": "Final",
+		"version": "1.0",
+		"revisionhistory": {
+			"revision": {
+				"number": "25",
+				"date": "2026-02-18T03:12:39",
+				"description": "April 2021 Security Updates"
+			}
+		},
+		"initial_release_date": "2021-04-13T07:00:00",
+		"current_release_date": "2026-02-18T03:12:39"
+	},
+	"documentnotes": {
+		"note": [
+			{
+				"text": "<h2>Updates this Month</h2>\n<p>This release consists of security updates for the following products, features and roles.</p>\n<ul>\n<li>Azure AD Web Sign-in</li>\n<li>Azure DevOps</li>\n<li>Azure Sphere</li>\n<li>Microsoft Edge (Chromium-based)</li>\n<li>Microsoft Exchange Server</li>\n<li>Microsoft Graphics Component</li>\n<li>Microsoft Internet Messaging API</li>\n<li>Microsoft NTFS</li>\n<li>Microsoft Office Excel</li>\n<li>Microsoft Office Outlook</li>\n<li>Microsoft Office SharePoint</li>\n<li>Microsoft Office Word</li>\n<li>Microsoft Windows Codecs Library</li>\n<li>Microsoft Windows Speech</li>\n<li>Open Source Software</li>\n<li>Role: DNS Server</li>\n<li>Role: Hyper-V</li>\n<li>Visual Studio</li>\n<li>Visual Studio Code</li>\n<li>Visual Studio Code - GitHub Pull Requests and Issues Extension</li>\n<li>Visual Studio Code - Kubernetes Tools</li>\n<li>Visual Studio Code - Maven for Java Extension</li>\n<li>Windows Application Compatibility Cache</li>\n<li>Windows AppX Deployment Extensions</li>\n<li>Windows Console Driver</li>\n<li>Windows Diagnostic Hub</li>\n<li>Windows Early Launch Antimalware Driver</li>\n<li>Windows ELAM</li>\n<li>Windows Event Tracing</li>\n<li>Windows Installer</li>\n<li>Windows Kernel</li>\n<li>Windows Media Player</li>\n<li>Windows Network File System</li>\n<li>Windows Overlay Filter</li>\n<li>Windows Portmapping</li>\n<li>Windows Registry</li>\n<li>Windows Remote Procedure Call Runtime</li>\n<li>Windows Resource Manager</li>\n<li>Windows Secure Kernel Mode</li>\n<li>Windows Services and Controller App</li>\n<li>Windows SMB Server</li>\n<li>Windows TCP/IP</li>\n<li>Windows Win32K</li>\n<li>Windows WLAN Auto Config Service</li>\n</ul>\n<p>Please note the following information regarding the security updates:</p>\n<h2>Security Update Guide Blog Posts</h2>\n<table>\n<thead>\n<tr>\n<th>Date</th>\n<th>Blog Post</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>February 9, 2021</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2021/02/09/continuing-to-listen-good-news-about-the-security-update-guide-api/\">Continuing to Listen: Good News about the Security Update Guide API</a></td>\n</tr>\n<tr>\n<td>January 13, 2021</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2021/01/13/security-update-guide-supports-cves-assigned-by-industry-partners/\">Security Update Guide Supports CVEs Assigned by Industry Partners</a></td>\n</tr>\n<tr>\n<td>December 8, 2020</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2020/12/08/security-update-guide-lets-keep-the-conversation-going/\">Security Update Guide: Let’s keep the conversation going</a></td>\n</tr>\n<tr>\n<td>November 9, 2020</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2020/11/09/vulnerability-descriptions-in-the-new-version-of-the-security-update-guide/\">Vulnerability Descriptions in the New Version of the Security Update Guide</a></td>\n</tr>\n</tbody>\n</table>\n<h2>Relevant Information</h2>\n<ul>\n<li>Windows 10 updates are cumulative. The monthly security release includes all security fixes for vulnerabilities that affect Windows 10, in addition to non-security updates. The updates are available via the <a href=\"https://www.catalog.update.microsoft.com/Home.aspx\">Microsoft Update Catalog</a>. For information on lifecycle and support dates for Windows 10 operating systems, please see <a href=\"https://docs.microsoft.com/en-us/lifecycle/faq/windows\">Windows Lifecycle Facts Sheet</a>.</li>\n<li>Microsoft is improving Windows Release Notes. For more information, please see <a href=\"https://techcommunity.microsoft.com/t5/windows-it-pro-blog/what-s-next-for-windows-release-notes/ba-p/1754399\">What's next for Windows release notes</a>.</li>\n<li>A list of the latest servicing stack updates for each operating system can be found in <a href=\"https://msrc.microsoft.com/update-guide/en-us/vulnerability/ADV990001\">ADV990001</a>. This list will be updated whenever a new servicing stack update is released. It is important to install the latest servicing stack update.</li>\n<li>In addition to security changes for the vulnerabilities, updates include defense-in-depth updates to help improve security-related features.</li>\n<li>Customers running Windows 7, Windows Server 2008 R2, or Windows Server 2008 need to purchase the Extended Security Update to continue receiving security updates. See <a href=\"https://support.microsoft.com/en-us/topic/procedure-to-continue-receiving-security-updates-after-extended-support-ends-on-january-14-2020-48c59204-fe67-3f42-84fc-c3c3145ff28e\">4522133</a> for more information.</li>\n</ul>\n<h2>FAQs, Mitigations, and Workarounds</h2>\n<p>The following CVEs have FAQs, Mitigations, or Workarounds. You can see these in more detail from the Vulnerabilities tab by selecting <strong>FAQs</strong>, <strong>Mitigations</strong> and <strong>Workarounds</strong> columns in the <strong>Edit Columns</strong> panel.</p>\n<ul>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-21194\">CVE-2021-21194</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-21195\">CVE-2021-21195</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-21196\">CVE-2021-21196</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-21197\">CVE-2021-21197</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-21198\">CVE-2021-21198</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-21199\">CVE-2021-21199</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-26416\">CVE-2021-26416</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-26417\">CVE-2021-26417</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-27067\">CVE-2021-27067</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-27079\">CVE-2021-27079</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-27093\">CVE-2021-27093</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-27095\">CVE-2021-27095</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28309\">CVE-2021-28309</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28315\">CVE-2021-28315</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28317\">CVE-2021-28317</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28318\">CVE-2021-28318</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28323\">CVE-2021-28323</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28324\">CVE-2021-28324</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28325\">CVE-2021-28325</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28328\">CVE-2021-28328</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28435\">CVE-2021-28435</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28437\">CVE-2021-28437</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28441\">CVE-2021-28441</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28442\">CVE-2021-28442</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28444\">CVE-2021-28444</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28446\">CVE-2021-28446</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28449\">CVE-2021-28449</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28451\">CVE-2021-28451</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28452\">CVE-2021-28452</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28453\">CVE-2021-28453</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28454\">CVE-2021-28454</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28456\">CVE-2021-28456</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28460\">CVE-2021-28460</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28464\">CVE-2021-28464</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28466\">CVE-2021-28466</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28468\">CVE-2021-28468</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28480\">CVE-2021-28480</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28481\">CVE-2021-28481</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28482\">CVE-2021-28482</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-28483\">CVE-2021-28483</a></li>\n</ul>\n<h2>Known Issues</h2>\n<p>You can see these in more detail from the Deployments tab by selecting <strong>Known Issues</strong> column in the <strong>Edit Columns</strong> panel.</p>\n<p>For more information about Windows Known Issues, please see <a href=\"https://docs.microsoft.com/en-us/windows/release-information/windows-message-center\">Windows message center</a> (links to currently-supported versions of Windows are in the left pane).</p>\n<table>\n<thead>\n<tr>\n<th>KB Article</th>\n<th>Applies To</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/4504715\">4504715</a></td>\n<td>SharePoint Server 2019 Language Pack</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/4504716\">4504716</a></td>\n<td>SharePoint Server 2019</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001330\">5001330</a></td>\n<td>Windows 10, Version 2004, Windows Server, Version 2004, Windows 10, Version 20H2, Windows Server, Version 20H2</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001332\">5001332</a></td>\n<td>Windows Server 2008 (Security-only update)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001335\">5001335</a></td>\n<td>Windows 7, Windows Server 2008 R2 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001337\">5001337</a></td>\n<td>Windows 10, Version 1909, Windows Server, Version 1909</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001342\">5001342</a></td>\n<td>Windows 10, Version 1809, Windows Server 2019</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001347\">5001347</a></td>\n<td>Windows 10, Version 1607, Windows Server 2016</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001382\">5001382</a></td>\n<td>Windows 8.1, Windows RT 8.1, Windows Server 2012 R2 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001383\">5001383</a></td>\n<td>Windows Server 2012 (Security-only update)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001387\">5001387</a></td>\n<td>Windows Server 2012 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001389\">5001389</a></td>\n<td>Windows Server 2008 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001392\">5001392</a></td>\n<td>Windows 7, Windows Server 2008 R2 (Security-only update)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001393\">5001393</a></td>\n<td>Windows 8.1, Windows RT 8.1, Windows Server 2012 R2 (Security-only update)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5001779\">5001779</a></td>\n<td>Microsoft Exchange Server 2019, 2016, 2013</td>\n</tr>\n</tbody>\n</table>\n",
+				"title": "Release Notes",
+				"audience": "Public",
+				"type": "Details",
+				"ordinal": "0"
+			},
+			{
+				"text": "The information provided in the Microsoft Knowledge Base is provided \"as is\" without warranty of any kind. Microsoft disclaims all warranties, either express or implied, including the warranties of merchantability and fitness for a particular purpose. In no event shall Microsoft Corporation or its suppliers be liable for any damages whatsoever including direct, indirect, incidental, consequential, loss of business profits or special damages, even if Microsoft Corporation or its suppliers have been advised of the possibility of such damages. Some states do not allow the exclusion or limitation of liability for consequential or incidental damages so the foregoing limitation may not apply.",
+				"title": "Legal Disclaimer",
+				"audience": "Public",
+				"type": "Legal Disclaimer",
+				"ordinal": "1"
+			}
+		]
+	},
+	"producttree": {
+		"branch": {
+			"type": "Vendor",
+			"name": "Microsoft",
+			"branch": [
+				{
+					"type": "Product Family",
+					"name": "Browser",
+					"fullproductname": [
+						{
+							"text": "Microsoft Edge (Chromium-based)",
+							"productid": "11655"
+						}
+					]
+				}
+			]
+		},
+		"fullproductname": [
+			{
+				"text": "Microsoft Edge (Chromium-based)",
+				"productid": "11655"
+			}
+		]
+	},
+	"vulnerability": [
+		{
+			"ordinal": "18",
+			"title": "Chromium: CVE-2021-21202 Use after free in extensions",
+			"notes": {
+				"note": [
+					{
+						"text": "<p>This CVE was assigned by Chrome.  Microsoft Edge (Chromium-based) ingests Chromium, which addresses this vulnerability. Please see <a href=\"https://chromereleases.googleblog.com/2021\">Google Chrome Releases</a> for more information.</p>\n",
+						"title": "Description",
+						"type": "Description",
+						"ordinal": "0"
+					},
+					{
+						"text": "<p><strong>What is the version information for this release?</strong></p>\n<table>\n<thead>\n<tr>\n<th>Microsoft Edge Version</th>\n<th>Date Released</th>\n<th>Based on Chromium Version</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>90.0.818.39</td>\n<td>4/15/2021</td>\n<td>90.0.4430.72</td>\n</tr>\n</tbody>\n</table>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "<p><strong>Why is this Chrome CVE included in the Security Update Guide?</strong></p>\n<p>The vulnerability assigned to this CVE is in Chromium Open Source Software (OSS) which is consumed by Microsoft Edge (Chromium-based).  It is being documented in the Security Update Guide to announce that the latest version of Microsoft Edge (Chromium-based) is no longer vulnerable.  Please see <a href=\"https://msrc-blog.microsoft.com/2021/01/13/security-update-guide-supports-cves-assigned-by-industry-partners/\">Security Update Guide Supports CVEs Assigned by Industry Partners</a> for more information.</p>\n<p><strong>How can I see the version of the browser?</strong></p>\n<ol>\n<li>In your Microsoft Edge browser, click on the 3 dots (...) on the very right-hand side of the window</li>\n<li>Click on <strong>Help and Feedback</strong></li>\n<li>Click on <strong>About Microsoft Edge</strong></li>\n</ol>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "Microsoft Edge (Chromium-based)",
+						"title": "Microsoft Edge (Chromium-based)",
+						"type": "Tag",
+						"ordinal": "20"
+					},
+					{
+						"text": "Chrome",
+						"title": "Chrome",
+						"type": "CNA",
+						"ordinal": "30"
+					}
+				]
+			},
+			"cve": "CVE-2021-21202",
+			"productstatuses": {
+				"status": {
+					"type": "Known Affected",
+					"product_id": [
+						"11655"
+					]
+				}
+			},
+			"threats": {
+				"threat": [
+					{
+						"type": "Impact",
+						"product_id": "11655"
+					},
+					{
+						"type": "Severity",
+						"product_id": "11655"
+					},
+					{
+						"type": "Exploit Status",
+						"description": "DOS:N/A"
+					}
+				]
+			},
+			"revisionhistory": {
+				"revision": [
+					{
+						"number": "1.0",
+						"date": "2021-04-15T18:40:01",
+						"description": "<p>Information published.</p>\n"
+					}
+				]
+			}
+		}
+	]
+}

--- a/pkg/extract/microsoft/cvrf/testdata/fixtures/2022-Nov/2022/CVE-2022-37966.json
+++ b/pkg/extract/microsoft/cvrf/testdata/fixtures/2022-Nov/2022/CVE-2022-37966.json
@@ -1,0 +1,575 @@
+{
+	"document_title": "November 2022 Security Updates",
+	"document_type": "Security Update",
+	"documentpublisher": {
+		"type": "Vendor",
+		"contact_details": "secure@microsoft.com",
+		"issuing_authority": "The Microsoft Security Response Center (MSRC) identifies, monitors, resolves, and responds to security incidents and Microsoft software security vulnerabilities. For more information, see http://www.microsoft.com/security/msrc."
+	},
+	"documenttracking": {
+		"identification": {
+			"id": "CVE-2022-37966",
+			"alias": "CVE-2022-37966"
+		},
+		"status": "Final",
+		"version": "1.0",
+		"revisionhistory": {
+			"revision": {
+				"number": "58",
+				"date": "2026-02-18T03:08:36",
+				"description": "November 2022 Security Updates"
+			}
+		},
+		"initial_release_date": "2022-11-08T08:00:00",
+		"current_release_date": "2026-02-18T03:08:36"
+	},
+	"documentnotes": {
+		"note": [
+			{
+				"text": "<h2 id=\"updates-this-month\">Updates this Month</h2>\n<p>This release consists of security updates for the following products, features and roles.</p>\n<ul>\n<li>.NET Framework</li>\n<li>AMD CPU Branch</li>\n<li>Azure</li>\n<li>Azure Real Time Operating System</li>\n<li>Linux Kernel</li>\n<li>Microsoft Dynamics</li>\n<li>Microsoft Edge (Chromium-based)</li>\n<li>Microsoft Exchange Server</li>\n<li>Microsoft Graphics Component</li>\n<li>Microsoft Office</li>\n<li>Microsoft Office Excel</li>\n<li>Microsoft Office SharePoint</li>\n<li>Microsoft Office Word</li>\n<li>Network Policy Server (NPS)</li>\n<li>Open Source Software</li>\n<li>Role: Windows Hyper-V</li>\n<li>SysInternals</li>\n<li>Visual Studio</li>\n<li>Windows Advanced Local Procedure Call</li>\n<li>Windows ALPC</li>\n<li>Windows Bind Filter Driver</li>\n<li>Windows BitLocker</li>\n<li>Windows CNG Key Isolation Service</li>\n<li>Windows Devices Human Interface</li>\n<li>Windows Digital Media</li>\n<li>Windows DWM Core Library</li>\n<li>Windows Extensible File Allocation</li>\n<li>Windows Group Policy Preference Client</li>\n<li>Windows HTTP.sys</li>\n<li>Windows Kerberos</li>\n<li>Windows Mark of the Web (MOTW)</li>\n<li>Windows Netlogon</li>\n<li>Windows Network Address Translation (NAT)</li>\n<li>Windows ODBC Driver</li>\n<li>Windows Overlay Filter</li>\n<li>Windows Point-to-Point Tunneling Protocol</li>\n<li>Windows Print Spooler Components</li>\n<li>Windows Resilient File System (ReFS)</li>\n<li>Windows Scripting</li>\n<li>Windows Win32K</li>\n</ul>\n<p>Please note the following information regarding the security updates:</p>\n<h2 id=\"security-update-guide-blog-posts\">Security Update Guide Blog Posts</h2>\n<table>\n<thead>\n<tr>\n<th>Date</th>\n<th>Blog Post</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>August 9, 2022</td>\n<td><a href=\"https://aka.ms/SUGNotificationProfile2\">Security Update Guide Notification System News: Create your profile now</a></td>\n</tr>\n<tr>\n<td>January 11, 2022</td>\n<td><a href=\"https://aka.ms/SUGNotificationProfile\">Coming Soon: New Security Update Guide Notification System</a></td>\n</tr>\n<tr>\n<td>February 9, 2021</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2021/02/09/continuing-to-listen-good-news-about-the-security-update-guide-api/\">Continuing to Listen: Good News about the Security Update Guide API</a></td>\n</tr>\n<tr>\n<td>January 13, 2021</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2021/01/13/security-update-guide-supports-cves-assigned-by-industry-partners/\">Security Update Guide Supports CVEs Assigned by Industry Partners</a></td>\n</tr>\n<tr>\n<td>December 8, 2020</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2020/12/08/security-update-guide-lets-keep-the-conversation-going/\">Security Update Guide: Let’s keep the conversation going</a></td>\n</tr>\n<tr>\n<td>November 9, 2020</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2020/11/09/vulnerability-descriptions-in-the-new-version-of-the-security-update-guide/\">Vulnerability Descriptions in the New Version of the Security Update Guide</a></td>\n</tr>\n</tbody>\n</table>\n<h2 id=\"relevant-information\">Relevant Information</h2>\n<ul>\n<li>The new Hotpatching feature is now generally available. Please see <a href=\"https://docs.microsoft.com/en-us/azure/automanage/automanage-hotpatch?WT.mc_id=modinfra-18529-thmaure\">Hotpatching feature for Windows Server Azure Edition virtual machines (VMs)</a> for more information.</li>\n<li>Windows 10 updates are cumulative. The monthly security release includes all security fixes for vulnerabilities that affect Windows 10, in addition to non-security updates. The updates are available via the <a href=\"https://www.catalog.update.microsoft.com/Home.aspx\">Microsoft Update Catalog</a>. For information on lifecycle and support dates for Windows 10 operating systems, please see <a href=\"https://docs.microsoft.com/en-us/lifecycle/faq/windows\">Windows Lifecycle Facts Sheet</a>.</li>\n<li>Microsoft is improving Windows Release Notes. For more information, please see <a href=\"https://techcommunity.microsoft.com/t5/windows-it-pro-blog/what-s-next-for-windows-release-notes/ba-p/1754399\">What's next for Windows release notes</a>.</li>\n<li>A list of the latest servicing stack updates for each operating system can be found in <a href=\"https://msrc.microsoft.com/update-guide/en-us/vulnerability/ADV990001\">ADV990001</a>. This list will be updated whenever a new servicing stack update is released. It is important to install the latest servicing stack update.</li>\n<li>In addition to security changes for the vulnerabilities, updates include defense-in-depth updates to help improve security-related features.</li>\n<li>Customers running Windows 7, Windows Server 2008 R2, or Windows Server 2008 need to purchase the Extended Security Update to continue receiving security updates. See <a href=\"https://support.microsoft.com/en-us/topic/procedure-to-continue-receiving-security-updates-after-extended-support-ends-on-january-14-2020-48c59204-fe67-3f42-84fc-c3c3145ff28e\">4522133</a> for more information.</li>\n</ul>\n<h2 id=\"faqs-mitigations-and-workarounds\">FAQs, Mitigations, and Workarounds</h2>\n<p>The following CVEs have FAQs, Mitigations, or Workarounds. You can see these in more detail from the Vulnerabilities tab by selecting <strong>FAQs</strong>, <strong>Mitigations</strong> and <strong>Workarounds</strong> columns in the <strong>Edit Columns</strong> panel.</p>\n<ul>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-23824\">CVE-2022-23824</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-3602\">CVE-2022-3602</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-3786\">CVE-2022-3786</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-37966\">CVE-2022-37966</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-37967\">CVE-2022-37967</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-37992\">CVE-2022-37992</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-38014\">CVE-2022-38014</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-38015\">CVE-2022-38015</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-38023\">CVE-2022-38023</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-39253\">CVE-2022-39253</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-39327\">CVE-2022-39327</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41039\">CVE-2022-41039</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41044\">CVE-2022-41044</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41045\">CVE-2022-41045</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41047\">CVE-2022-41047</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41048\">CVE-2022-41048</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41049\">CVE-2022-41049</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41050\">CVE-2022-41050</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41051\">CVE-2022-41051</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41052\">CVE-2022-41052</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41054\">CVE-2022-41054</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41055\">CVE-2022-41055</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41057\">CVE-2022-41057</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41060\">CVE-2022-41060</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41061\">CVE-2022-41061</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41062\">CVE-2022-41062</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41063\">CVE-2022-41063</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41064\">CVE-2022-41064</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41066\">CVE-2022-41066</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41073\">CVE-2022-41073</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41085\">CVE-2022-41085</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41086\">CVE-2022-41086</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41088\">CVE-2022-41088</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41090\">CVE-2022-41090</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41091\">CVE-2022-41091</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41092\">CVE-2022-41092</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41093\">CVE-2022-41093</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41095\">CVE-2022-41095</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41096\">CVE-2022-41096</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41097\">CVE-2022-41097</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41098\">CVE-2022-41098</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41099\">CVE-2022-41099</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41100\">CVE-2022-41100</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41101\">CVE-2022-41101</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41102\">CVE-2022-41102</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41103\">CVE-2022-41103</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41104\">CVE-2022-41104</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41105\">CVE-2022-41105</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41106\">CVE-2022-41106</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41107\">CVE-2022-41107</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41109\">CVE-2022-41109</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41113\">CVE-2022-41113</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41114\">CVE-2022-41114</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41116\">CVE-2022-41116</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41118\">CVE-2022-41118</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41119\">CVE-2022-41119</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41120\">CVE-2022-41120</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41122\">CVE-2022-41122</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41125\">CVE-2022-41125</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41128\">CVE-2022-41128</a></li>\n</ul>\n<h2 id=\"known-issues\">Known Issues</h2>\n<p>You can see these in more detail from the Deployments tab by selecting <strong>Known Issues</strong> column in the <strong>Edit Columns</strong> panel.</p>\n<p>For more information about Windows Known Issues, please see <a href=\"https://docs.microsoft.com/en-us/windows/release-information/windows-message-center\">Windows message center</a> (links to currently-supported versions of Windows are in the left pane).</p>\n<table>\n<thead>\n<tr>\n<th>KB Article</th>\n<th>Applies To</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5002258\">5002258</a></td>\n<td>Microsoft SharePoint Server 2019</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5002267\">5002267</a></td>\n<td>Microsoft SharePoint Server 2013</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5002269\">5002269</a></td>\n<td>Microsoft SharePoint Server 2016</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5002271\">5002271</a></td>\n<td>Microsoft SharePoint Server Subscription Edition</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5019959\">5019959</a></td>\n<td>Windows 10 Version 21H1</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5019966\">5019966</a></td>\n<td>Windows 10 Version 1809, Windows Server 2019</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5019980\">5019980</a></td>\n<td>Windows 11 version 22H2</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020000\">5020000</a></td>\n<td>Windows 7, Windows Server 2008 R2 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020003\">5020003</a></td>\n<td>Windows Server 2012 (Security Only)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020005\">5020005</a></td>\n<td>Windows Server 2008 (Security Only)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020009\">5020009</a></td>\n<td>Windows Server 2012 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020010\">5020010</a></td>\n<td>Windows 8.1, Windows Server 2012 R2 (Security Only)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020013\">5020013</a></td>\n<td>Windows 7, Windows Server 2008 R2 (Security Only)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020019\">5020019</a></td>\n<td>Windows Server 2008 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020023\">5020023</a></td>\n<td>Windows 8.1, Windows Server 2012 R2 (Monthly Rollup)</td>\n</tr>\n</tbody>\n</table>\n",
+				"title": "Release Notes",
+				"audience": "Public",
+				"type": "Details",
+				"ordinal": "0"
+			},
+			{
+				"text": "The information provided in the Microsoft Knowledge Base is provided \"as is\" without warranty of any kind. Microsoft disclaims all warranties, either express or implied, including the warranties of merchantability and fitness for a particular purpose. In no event shall Microsoft Corporation or its suppliers be liable for any damages whatsoever including direct, indirect, incidental, consequential, loss of business profits or special damages, even if Microsoft Corporation or its suppliers have been advised of the possibility of such damages. Some states do not allow the exclusion or limitation of liability for consequential or incidental damages so the foregoing limitation may not apply.",
+				"title": "Legal Disclaimer",
+				"audience": "Public",
+				"type": "Legal Disclaimer",
+				"ordinal": "1"
+			}
+		]
+	},
+	"producttree": {
+		"branch": {
+			"type": "Vendor",
+			"name": "Microsoft",
+			"branch": [
+				{
+					"type": "Product Family",
+					"name": "Windows",
+					"fullproductname": [
+						{
+							"text": "Windows Server 2019",
+							"productid": "11571"
+						},
+						{
+							"text": "Windows Server 2019 (Server Core installation)",
+							"productid": "11572"
+						},
+						{
+							"text": "Windows Server 2022",
+							"productid": "11923"
+						},
+						{
+							"text": "Windows Server 2022 (Server Core installation)",
+							"productid": "11924"
+						},
+						{
+							"text": "Windows Server 2016",
+							"productid": "10816"
+						},
+						{
+							"text": "Windows Server 2016 (Server Core installation)",
+							"productid": "10855"
+						}
+					]
+				},
+				{
+					"type": "Product Family",
+					"name": "ESU",
+					"fullproductname": [
+						{
+							"text": "Windows Server 2008 for 32-bit Systems Service Pack 2",
+							"productid": "9312"
+						},
+						{
+							"text": "Windows Server 2008 for 32-bit Systems Service Pack 2 (Server Core installation)",
+							"productid": "10287"
+						},
+						{
+							"text": "Windows Server 2008 for x64-based Systems Service Pack 2",
+							"productid": "9318"
+						},
+						{
+							"text": "Windows Server 2008 for x64-based Systems Service Pack 2 (Server Core installation)",
+							"productid": "9344"
+						},
+						{
+							"text": "Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+							"productid": "10051"
+						},
+						{
+							"text": "Windows Server 2008 R2 for x64-based Systems Service Pack 1 (Server Core installation)",
+							"productid": "10049"
+						},
+						{
+							"text": "Windows Server 2012",
+							"productid": "10378"
+						},
+						{
+							"text": "Windows Server 2012 (Server Core installation)",
+							"productid": "10379"
+						},
+						{
+							"text": "Windows Server 2012 R2",
+							"productid": "10483"
+						},
+						{
+							"text": "Windows Server 2012 R2 (Server Core installation)",
+							"productid": "10543"
+						}
+					]
+				}
+			]
+		},
+		"fullproductname": [
+			{
+				"text": "Windows Server 2008 R2 for x64-based Systems Service Pack 1 (Server Core installation)",
+				"productid": "10049"
+			},
+			{
+				"text": "Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+				"productid": "10051"
+			},
+			{
+				"text": "Windows Server 2008 for 32-bit Systems Service Pack 2 (Server Core installation)",
+				"productid": "10287"
+			},
+			{
+				"text": "Windows Server 2012",
+				"productid": "10378"
+			},
+			{
+				"text": "Windows Server 2012 (Server Core installation)",
+				"productid": "10379"
+			},
+			{
+				"text": "Windows Server 2012 R2",
+				"productid": "10483"
+			},
+			{
+				"text": "Windows Server 2012 R2 (Server Core installation)",
+				"productid": "10543"
+			},
+			{
+				"text": "Windows Server 2016",
+				"productid": "10816"
+			},
+			{
+				"text": "Windows Server 2016 (Server Core installation)",
+				"productid": "10855"
+			},
+			{
+				"text": "Windows Server 2019",
+				"productid": "11571"
+			},
+			{
+				"text": "Windows Server 2019 (Server Core installation)",
+				"productid": "11572"
+			},
+			{
+				"text": "Windows Server 2022",
+				"productid": "11923"
+			},
+			{
+				"text": "Windows Server 2022 (Server Core installation)",
+				"productid": "11924"
+			},
+			{
+				"text": "Windows Server 2008 for 32-bit Systems Service Pack 2",
+				"productid": "9312"
+			},
+			{
+				"text": "Windows Server 2008 for x64-based Systems Service Pack 2",
+				"productid": "9318"
+			},
+			{
+				"text": "Windows Server 2008 for x64-based Systems Service Pack 2 (Server Core installation)",
+				"productid": "9344"
+			}
+		]
+	},
+	"vulnerability": [
+		{
+			"ordinal": "6",
+			"title": "Windows Kerberos RC4-HMAC Elevation of Privilege Vulnerability",
+			"notes": {
+				"note": [
+					{
+						"title": "Description",
+						"type": "Description",
+						"ordinal": "0"
+					},
+					{
+						"text": "<p><strong>How could an attacker exploit this vulnerability?</strong></p>\n<p>An unauthenticated attacker could conduct an attack that could leverage cryptographic protocol vulnerabilities in RFC 4757 (Kerberos encryption type RC4-HMAC-MD5) and MS-PAC (Privilege Attribute Certificate Data Structure specification) to bypass security features in a Windows AD environment.</p>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "<p><strong>Where can I find more information about these changes?</strong></p>\n<p>For more information please see <a href=\"https://support.microsoft.com/help/5021131\">How to manage the Kerberos Protocol changes related to CVE-2022-37966</a>.</p>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "<p><strong>I am running Windows Server 2022 Datacenter: Azure Edition (Server Core) but the hotpatch (Windows Server 2022 Datacenter: Azure Edition (Hotpatch)) for it is not listed in the Security Updates table. Is there an update that I can apply for this edition of Windows Server 2022?</strong></p>\n<p>The update to address this vulnerability for Windows Server 2022 Datacenter: Azure Edition (Server Core) is not hotpatchable and is therefore not included in the November Hotpatch KB (5019080). Customers running Windows Server 2022 Datacenter: Azure Edition (Server Core) as a domain controller should install the update for Windows Server 2022 (5019081). This update will require a computer restart.</p>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "<p><strong>What privileges could be gained by an attacker who successfully exploited the vulnerability?</strong></p>\n<p>An attacker who successfully exploited this vulnerability could gain administrator privileges.</p>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "<p><strong>According to the CVSS metric, the attack complexity is high (AC:H). What does that mean for this vulnerability?</strong></p>\n<p>Successful exploitation of this vulnerability requires an attacker to gather information specific to the environment of the targeted component.</p>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "<p><strong>There is a known issue documented in the security updates that address this vulnerability, where Kerberos authentication might fail for user, computer, service, and GMSA accounts when serviced by Windows domain controllers that have installed Windows security updates released on November 8, 2022. Has an update been released that addresses this known issue?</strong></p>\n<p>Yes. The issue is addressed by out-of-band updates released to <a href=\"https://www.catalog.update.microsoft.com/Home.aspx\">Microsoft Update Catalog</a> on and after November 17, 2022. Customers who have not already installed the security updates released on November 8, 2022 should install the out-of-band updates instead. Customers who have already installed the November 8, 2022 Windows security updates and who are experiencing issues should install the out-of-band updates.</p>\n<p>For more information about these updates please see the OS version specific info on <a href=\"http://aka.ms/wrh\">Windows release health</a> at the following links:</p>\n<ul>\n<li><a href=\"https://learn.microsoft.com/en/windows/release-health/status-windows-11-22h2#2953msgdesc\">https://learn.microsoft.com/en/windows/release-health/status-windows-11-22h2#2953msgdesc</a></li>\n<li><a href=\"https://learn.microsoft.com/en/windows/release-health/status-windows-11-21h2#2953msgdesc\">https://learn.microsoft.com/en/windows/release-health/status-windows-11-21h2#2953msgdesc</a></li>\n<li><a href=\"https://learn.microsoft.com/en/windows/release-health/status-windows-server-2022#2953msgdesc\">https://learn.microsoft.com/en/windows/release-health/status-windows-server-2022#2953msgdesc</a></li>\n<li><a href=\"https://learn.microsoft.com/en/windows/release-health/status-windows-10-22h2#2953msgdesc\">https://learn.microsoft.com/en/windows/release-health/status-windows-10-22h2#2953msgdesc</a></li>\n<li><a href=\"https://learn.microsoft.com/en/windows/release-health/status-windows-10-21h2#2953msgdesc\">https://learn.microsoft.com/en/windows/release-health/status-windows-10-21h2#2953msgdesc</a></li>\n<li><a href=\"https://learn.microsoft.com/en/windows/release-health/status-windows-10-21h1#2953msgdesc%5D\">https://learn.microsoft.com/en/windows/release-health/status-windows-10-21h1#2953msgdesc</a></li>\n<li><a href=\"%5Bhttps://learn.microsoft.com/en/windows/release-health/status-windows-10-20h2#2953msgdesc\">https://learn.microsoft.com/en/windows/release-health/status-windows-10-20h2#2953msgdesc</a></li>\n<li><a href=\"https://learn.microsoft.com/en/windows/release-health/status-windows-10-1809-and-windows-server-2019#2953msgdesc\">https://learn.microsoft.com/en/windows/release-health/status-windows-10-1809-and-windows-server-2019#2953msgdesc</a></li>\n</ul>\n<p>For more information please see the <strong>Known Issues</strong> section of <a href=\"https://support.microsoft.com/help/5021131\">How to manage the Kerberos Protocol changes related to CVE-2022-37966</a>.</p>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "Windows Kerberos",
+						"title": "Windows Kerberos",
+						"type": "Tag",
+						"ordinal": "20"
+					},
+					{
+						"text": "Microsoft",
+						"title": "Microsoft",
+						"type": "CNA",
+						"ordinal": "30"
+					},
+					{
+						"text": "Yes",
+						"title": "Customer Action Required",
+						"type": "Other",
+						"ordinal": "40"
+					}
+				]
+			},
+			"cve": "CVE-2022-37966",
+			"productstatuses": {
+				"status": {
+					"type": "Known Affected",
+					"product_id": [
+						"11571",
+						"11572",
+						"11923",
+						"11924",
+						"10816",
+						"10855",
+						"9312",
+						"10287",
+						"9318",
+						"9344",
+						"10051",
+						"10049",
+						"10378",
+						"10379",
+						"10483",
+						"10543"
+					]
+				}
+			},
+			"threats": {
+				"threat": [
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "11571"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "11572"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "11923"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "11924"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "10816"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "10855"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "9312"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "10287"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "9318"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "9344"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "10051"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "10049"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "10378"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "10379"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "10483"
+					},
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "10543"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "11571"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "11572"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "11923"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "11924"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "10816"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "10855"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "9312"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "10287"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "9318"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "9344"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "10051"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "10049"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "10378"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "10379"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "10483"
+					},
+					{
+						"type": "Severity",
+						"description": "Critical",
+						"product_id": "10543"
+					},
+					{
+						"type": "Exploit Status",
+						"description": "Publicly Disclosed:No;Exploited:No;Latest Software Release:Exploitation More Likely;DOS:N/A"
+					}
+				]
+			},
+			"cvssscoresets": {
+				"scoreset": [
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "11571"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "11572"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "11923"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "11924"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "10816"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "10855"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "9312"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "10287"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "9318"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "9344"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "10051"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "10049"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "10378"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "10379"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "10483"
+					},
+					{
+						"base_score": "8.1",
+						"temporal_score": "7.1",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "10543"
+					}
+				]
+			},
+			"acknowledgments": {
+				"acknowledgment": [
+					{},
+					{}
+				]
+			},
+			"revisionhistory": {
+				"revision": [
+					{
+						"number": "1.0",
+						"date": "2022-11-08T08:00:00",
+						"description": "<p>Information published.</p>\n"
+					},
+					{
+						"number": "2.0",
+						"date": "2022-11-17T08:00:00",
+						"description": "<p>To address a known issue where Kerberos authentication might fail for user, computer, service, and GMSA accounts when serviced by Windows domain controllers that have installed Windows security updates released on November 8, 2022, Microsoft is announcing the availability of out-of-band Windows updates available on the <a href=\"https://www.catalog.update.microsoft.com/Home.aspx\">Microsoft Update Catalog</a>. For more information see the FAQs section of this CVE and the Known Issues section of <a href=\"https://support.microsoft.com/help/5021131\">How to manage the Kerberos Protocol changes related to CVE-2022-37966</a>.</p>\n"
+					}
+				]
+			}
+		}
+	]
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2021/CVE-2021-21202.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2021/CVE-2021-21202.json
@@ -1,0 +1,73 @@
+{
+	"id": "CVE-2021-21202",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2021-21202",
+				"title": "Chromium: CVE-2021-21202 Use after free in extensions",
+				"description": "<p>This CVE was assigned by Chrome.  Microsoft Edge (Chromium-based) ingests Chromium, which addresses this vulnerability. Please see <a href=\"https://chromereleases.googleblog.com/2021\">Google Chrome Releases</a> for more information.</p>",
+				"references": [
+					{
+						"source": "secure@microsoft.com",
+						"url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-21202"
+					}
+				],
+				"published": "2021-04-13T07:00:00Z",
+				"modified": "2026-02-18T03:12:39Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft Edge (Chromium-based)"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "microsoft",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Microsoft Edge (Chromium-based)"
+										}
+									},
+									"affected": {
+										"type": "microsoft-edge",
+										"range": [
+											{
+												"lt": "90.0.818.39"
+											}
+										],
+										"fixed": [
+											"90.0.818.39"
+										]
+									}
+								}
+							}
+						]
+					},
+					"tag": "Microsoft Edge (Chromium-based)"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2021-Apr/2021/CVE-2021-21202.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2022/CVE-2022-37966.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2022/CVE-2022-37966.json
@@ -1,0 +1,489 @@
+{
+	"id": "CVE-2022-37966",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-37966",
+				"title": "Windows Kerberos RC4-HMAC Elevation of Privilege Vulnerability",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secure@microsoft.com",
+						"vendor": "Critical"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secure@microsoft.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+							"base_score": 8.1,
+							"base_severity": "HIGH",
+							"temporal_score": 7.1,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.1,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "secure@microsoft.com",
+						"url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-37966"
+					}
+				],
+				"published": "2022-11-08T08:00:00Z",
+				"modified": "2026-02-18T03:08:36Z",
+				"optional": {
+					"impact": "Elevation of Privilege"
+				}
+			},
+			"segments": [
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2008 R2 for x64-based Systems Service Pack 1"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2008 R2 for x64-based Systems Service Pack 1 (Server Core installation)"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2008 for 32-bit Systems Service Pack 2"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2008 for 32-bit Systems Service Pack 2 (Server Core installation)"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2008 for x64-based Systems Service Pack 2"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2008 for x64-based Systems Service Pack 2 (Server Core installation)"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2012"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2012 (Server Core installation)"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2012 R2"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2012 R2 (Server Core installation)"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2016"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2016 (Server Core installation)"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2019"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2019 (Server Core installation)"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2022"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Windows Server 2022 (Server Core installation)"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "microsoft",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2008 R2 for x64-based Systems Service Pack 1"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2008 R2 for x64-based Systems Service Pack 1"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2008 R2 for x64-based Systems Service Pack 1 (Server Core installation)"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2008 R2 for x64-based Systems Service Pack 1 (Server Core installation)"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2008 for 32-bit Systems Service Pack 2"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2008 for 32-bit Systems Service Pack 2"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2008 for 32-bit Systems Service Pack 2 (Server Core installation)"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2008 for 32-bit Systems Service Pack 2 (Server Core installation)"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2008 for x64-based Systems Service Pack 2"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2008 for x64-based Systems Service Pack 2"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2008 for x64-based Systems Service Pack 2 (Server Core installation)"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2008 for x64-based Systems Service Pack 2 (Server Core installation)"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2012"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2012"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2012 (Server Core installation)"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2012 (Server Core installation)"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2012 R2"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2012 R2"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2012 R2 (Server Core installation)"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2012 R2 (Server Core installation)"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2016"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2016"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2016 (Server Core installation)"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2016 (Server Core installation)"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2019"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2019"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2019 (Server Core installation)"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2019 (Server Core installation)"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2022"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2022"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unfixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Windows Server 2022 (Server Core installation)"
+										}
+									}
+								}
+							}
+						]
+					},
+					"tag": "Windows Server 2022 (Server Core installation)"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2022-Nov/2022/CVE-2022-37966.json"
+		]
+	}
+}


### PR DESCRIPTION
   When CVRF entries lack remediations, build detections from
   ProductStatuses instead of skipping them:

   - Edge: use existing fixedBuildOverrides for version-based detection
   - Other "Known Affected" products: register as ClassUnfixed (Microsoft intentionally omits Vendor Fix for these)