### PR TITLE
feat(extract/redhat/cve): implement extractor

### DIFF
--- a/pkg/extract/redhat/cve/cve.go
+++ b/pkg/extract/redhat/cve/cve.go
@@ -1,13 +1,31 @@
 package cve
 
 import (
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
+	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	cvssV2Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v2"
+	cvssV30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
+	cvssV31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	utiltime "github.com/MaineK00n/vuls-data-update/pkg/extract/util/time"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/redhat/cve"
 )
 
 type options struct {
@@ -30,7 +48,7 @@ func WithDir(dir string) Option {
 
 func Extract(args string, opts ...Option) error {
 	options := &options{
-		dir: filepath.Join(util.CacheDir(), "extract", "", ""),
+		dir: filepath.Join(util.CacheDir(), "extract", "redhat", "cve"),
 	}
 
 	for _, o := range opts {
@@ -42,17 +60,36 @@ func Extract(args string, opts ...Option) error {
 	}
 
 	slog.Info("Extract RedHat CVE")
+
+	br := utiljson.NewJSONReader()
+
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if d.IsDir() {
+		if d.IsDir() || filepath.Ext(path) != ".json" {
 			return nil
 		}
 
-		if filepath.Ext(path) != ".json" {
-			return nil
+		r := br.Copy()
+		var fetched cve.CVE
+		if err := r.Read(path, args, &fetched); err != nil {
+			return errors.Wrapf(err, "read json %s", path)
+		}
+
+		extracted, err := extract(fetched, r.Paths())
+		if err != nil {
+			return errors.Wrapf(err, "extract %s", path)
+		}
+
+		splitted, err := util.Split(fetched.Name, "-", "-")
+		if err != nil {
+			return errors.Wrapf(err, "unexpected ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", fetched.Name)
+		}
+
+		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", fetched.Name)), extracted, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", fetched.Name)))
 		}
 
 		return nil
@@ -60,5 +97,162 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "walk %s", args)
 	}
 
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.RedHatCVE,
+		Name: new("RedHat Security Data API"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r != nil {
+				return []repositoryTypes.Repository{*r}
+			}
+			return nil
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{URL: u}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
 	return nil
+}
+
+// This extractor intentionally does not produce Detections.
+//
+// The Red Hat CVE API (Security Data API) provides two types of package information:
+//
+//  1. affected_release: Lists fixed packages in NEVRA format (e.g. "curl-0:8.6.0-3.el9")
+//     alongside a CPE identifying the product (e.g. "cpe:/o:redhat:enterprise_linux:9").
+//     However, ~7% of entries use modular package format (e.g. "redis:7-9050020250115104757.9"),
+//     which identifies the module stream, not individual RPM source packages. Since the API does
+//     not provide the list of component packages within a module, these entries cannot be
+//     translated into actionable version criterions.
+//
+//  2. package_state: Lists package names with a fix_state (e.g. "Affected", "Will not fix").
+//     These have no version constraints because the packages are unfixed, meaning all versions
+//     are affected. This data could be used for detection (package name match with Affected=nil),
+//     but is not currently extracted because it shares the same CPE/ecosystem ambiguity issues.
+//
+// CPEs for layered products (e.g. "cpe:/a:redhat:logging:5.8::el9") refer to container images
+// and other non-RPM artifacts, not traditional RPM packages. Only RHEL base CPEs
+// (enterprise_linux, rhel_eus, etc.) reliably correspond to RPM packages, but even those
+// suffer from the modular package problem in affected_release.
+//
+// For reliable detection of Red Hat vulnerabilities, use the CSAF, VEX, or OVAL data sources
+// instead, which provide complete and structured product-package mappings.
+func extract(fetched cve.CVE, raws []string) (dataTypes.Data, error) {
+	ss, err := buildSeverities(fetched)
+	if err != nil {
+		return dataTypes.Data{}, errors.Wrap(err, "build severities")
+	}
+
+	return dataTypes.Data{
+		ID: dataTypes.RootID(fetched.Name),
+		Vulnerabilities: []vulnerabilityTypes.Vulnerability{{
+			Content: vulnerabilityContentTypes.Content{
+				ID:          vulnerabilityContentTypes.VulnerabilityID(fetched.Name),
+				Title:       fetched.Bugzilla.Description,
+				Description: strings.Join(fetched.Details, "\n"),
+				Severity:    ss,
+				CWE:         buildCWE(fetched),
+				References:  buildReferences(fetched),
+				Published:   utiltime.Parse([]string{"2006-01-02T15:04:05Z"}, fetched.PublicDate),
+			},
+		}},
+		DataSource: sourceTypes.Source{
+			ID:   sourceTypes.RedHatCVE,
+			Raws: raws,
+		},
+	}, nil
+}
+
+func buildSeverities(fetched cve.CVE) ([]severityTypes.Severity, error) {
+	var ss []severityTypes.Severity
+
+	if fetched.Cvss != nil && fetched.Cvss.CvssScoringVector != "" {
+		v2, err := cvssV2Types.Parse(fetched.Cvss.CvssScoringVector)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse cvss v2. vector: %s", fetched.Cvss.CvssScoringVector)
+		}
+		ss = append(ss, severityTypes.Severity{
+			Type:   severityTypes.SeverityTypeCVSSv2,
+			Source: "secalert@redhat.com",
+			CVSSv2: v2,
+		})
+	}
+
+	if fetched.Cvss3 != nil && fetched.Cvss3.Cvss3ScoringVector != "" {
+		switch {
+		case strings.HasPrefix(fetched.Cvss3.Cvss3ScoringVector, "CVSS:3.0"):
+			v30, err := cvssV30Types.Parse(fetched.Cvss3.Cvss3ScoringVector)
+			if err != nil {
+				return nil, errors.Wrapf(err, "parse cvss v3.0. vector: %s", fetched.Cvss3.Cvss3ScoringVector)
+			}
+			ss = append(ss, severityTypes.Severity{
+				Type:    severityTypes.SeverityTypeCVSSv30,
+				Source:  "secalert@redhat.com",
+				CVSSv30: v30,
+			})
+		case strings.HasPrefix(fetched.Cvss3.Cvss3ScoringVector, "CVSS:3.1"):
+			v31, err := cvssV31Types.Parse(fetched.Cvss3.Cvss3ScoringVector)
+			if err != nil {
+				return nil, errors.Wrapf(err, "parse cvss v3.1. vector: %s", fetched.Cvss3.Cvss3ScoringVector)
+			}
+			ss = append(ss, severityTypes.Severity{
+				Type:    severityTypes.SeverityTypeCVSSv31,
+				Source:  "secalert@redhat.com",
+				CVSSv31: v31,
+			})
+		default:
+			return nil, errors.Errorf("unexpected CVSS v3 vector. expected: %q, actual: %q", []string{"CVSS:3.0/...", "CVSS:3.1/..."}, fetched.Cvss3.Cvss3ScoringVector)
+		}
+	}
+
+	if fetched.ThreatSeverity != nil {
+		ss = append(ss, severityTypes.Severity{
+			Type:   severityTypes.SeverityTypeVendor,
+			Source: "secalert@redhat.com",
+			Vendor: fetched.ThreatSeverity,
+		})
+	}
+
+	return ss, nil
+}
+
+func buildCWE(fetched cve.CVE) []cweTypes.CWE {
+	if fetched.Cwe == nil || *fetched.Cwe == "" {
+		return nil
+	}
+	return []cweTypes.CWE{{
+		Source: "secalert@redhat.com",
+		CWE:    []string{*fetched.Cwe},
+	}}
+}
+
+func buildReferences(fetched cve.CVE) []referenceTypes.Reference {
+	var refs []referenceTypes.Reference
+
+	if fetched.Bugzilla.URL != "" {
+		refs = append(refs, referenceTypes.Reference{
+			Source: "secalert@redhat.com",
+			URL:    fetched.Bugzilla.URL,
+		})
+	}
+
+	for _, r := range fetched.References {
+		for u := range strings.SplitSeq(r, "\n") {
+			u = strings.TrimSpace(u)
+			if u != "" {
+				refs = append(refs, referenceTypes.Reference{
+					Source: "secalert@redhat.com",
+					URL:    u,
+				})
+			}
+		}
+	}
+
+	return refs
 }

--- a/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-48161.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-48161.json
@@ -1,0 +1,69 @@
+{
+	"id": "CVE-2023-48161",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-48161",
+				"title": "giflib: Heap-Buffer Overflow during Image Saving in DumpScreen2RGB Function",
+				"description": "Buffer Overflow vulnerability in GifLib Project GifLib v.5.2.1 allows a local attacker to obtain sensitive information via the DumpSCreen2RGB function in gif2rgb.c\nA buffer overflow flaw was found in GifLib. This issue may allow a local attacker to obtain sensitive information via the DumpSCreen2RGB function in gif2rgb.c",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Moderate"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N",
+							"base_score": 5.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-119"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2251025"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://github.com/tacetool/TACE#cve-2023-48161"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-48161"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://sourceforge.net/p/giflib/bugs/167/"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-48161"
+					}
+				],
+				"published": "2023-11-22T00:00:00Z"
+			}
+		}
+	],
+	"data_source": {
+		"id": "redhat-cve",
+		"raws": [
+			"fixtures/2023/CVE-2023-48161.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6204.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6204.json
@@ -1,0 +1,69 @@
+{
+	"id": "CVE-2023-6204",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-6204",
+				"title": "Mozilla: Out-of-bound memory access in WebGL2 blitFramebuffer",
+				"description": "On some systems—depending on the graphics settings and drivers—it was possible to force an out-of-bounds read and leak memory data into the images created on the canvas element. This vulnerability affects Firefox < 120, Firefox < 115.5, and Thunderbird < 115.5.0.\nThe Mozilla Foundation Security Advisory describes this flaw as:\nOn some systems—depending on the graphics settings and drivers—it was possible to force an out-of-bounds read and leak memory data into the images created on the canvas element.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Important"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+							"base_score": 7.5,
+							"base_severity": "HIGH",
+							"temporal_score": 7.5,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.5,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-125"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250896"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6204"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6204"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6204"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6204"
+					}
+				],
+				"published": "2023-11-21T00:00:00Z"
+			}
+		}
+	],
+	"data_source": {
+		"id": "redhat-cve",
+		"raws": [
+			"fixtures/2023/CVE-2023-6204.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6205.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6205.json
@@ -1,0 +1,69 @@
+{
+	"id": "CVE-2023-6205",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-6205",
+				"title": "Mozilla: Use-after-free in MessagePort::Entangled",
+				"description": "It was possible to cause the use of a MessagePort after it had already been freed, which could potentially have led to an exploitable crash. This vulnerability affects Firefox < 120, Firefox < 115.5, and Thunderbird < 115.5.0.\nThe Mozilla Foundation Security Advisory describes this flaw as:\nIt was possible to cause the use of a MessagePort after it had already\nbeen freed, which could potentially have led to an exploitable crash.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Important"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+							"base_score": 7.5,
+							"base_severity": "HIGH",
+							"temporal_score": 7.5,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.5,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-416"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250897"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6205"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6205"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6205"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6205"
+					}
+				],
+				"published": "2023-11-21T00:00:00Z"
+			}
+		}
+	],
+	"data_source": {
+		"id": "redhat-cve",
+		"raws": [
+			"fixtures/2023/CVE-2023-6205.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6206.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6206.json
@@ -1,0 +1,69 @@
+{
+	"id": "CVE-2023-6206",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-6206",
+				"title": "Mozilla: Clickjacking permission prompts using the fullscreen transition",
+				"description": "The black fade animation when exiting fullscreen is roughly the length of the anti-clickjacking delay on permission prompts. It was possible to use this fact to surprise users by luring them to click where the permission grant button would be about to appear. This vulnerability affects Firefox < 120, Firefox < 115.5, and Thunderbird < 115.5.0.\nThe Mozilla Foundation Security Advisory describes this flaw as:\nThe black fade animation when exiting fullscreen is roughly\nthe length of the anti-clickjacking delay on permission prompts.\nIt was possible to use this fact to surprise users by luring them\nto click where the permission grant button would be about to appear.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Important"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+							"base_score": 7.5,
+							"base_severity": "HIGH",
+							"temporal_score": 7.5,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.5,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-1021"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250898"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6206"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6206"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6206"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6206"
+					}
+				],
+				"published": "2023-11-21T00:00:00Z"
+			}
+		}
+	],
+	"data_source": {
+		"id": "redhat-cve",
+		"raws": [
+			"fixtures/2023/CVE-2023-6206.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6207.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6207.json
@@ -1,0 +1,69 @@
+{
+	"id": "CVE-2023-6207",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-6207",
+				"title": "Mozilla: Use-after-free in ReadableByteStreamQueueEntry::Buffer",
+				"description": "Ownership mismanagement led to a use-after-free in ReadableByteStreams This vulnerability affects Firefox < 120, Firefox < 115.5, and Thunderbird < 115.5.0.\nThe Mozilla Foundation Security Advisory describes this flaw as:\nOwnership mismanagement led to a use-after-free in ReadableByteStreams",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Important"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+							"base_score": 7.5,
+							"base_severity": "HIGH",
+							"temporal_score": 7.5,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.5,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-416"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250899"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6207"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6207"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6207"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6207"
+					}
+				],
+				"published": "2023-11-21T00:00:00Z"
+			}
+		}
+	],
+	"data_source": {
+		"id": "redhat-cve",
+		"raws": [
+			"fixtures/2023/CVE-2023-6207.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/cve/testdata/golden/datasource.json
+++ b/pkg/extract/redhat/cve/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "redhat-cve",
+	"name": "RedHat Security Data API"
+}


### PR DESCRIPTION
 Extract vulnerability metadata (severity, CWE, references) from the
 Red Hat CVE API (Security Data API) without producing Detections.

 Detections are intentionally omitted because the data source has
 limitations that prevent reliable package-level detection:

 - affected_release: ~7% of entries use modular package format (e.g. "redis:7-<buildid>") which identifies module streams, not individual RPM source packages.
 - CPEs for layered products (e.g. "cpe:/a:redhat:logging:5.8::el9") refer to container images, not RPM packages. Only RHEL base CPEs (enterprise_linux, rhel_eus, etc.) reliably correspond to RPMs.

 For detection, use the CSAF, VEX, or OVAL data sources instead.

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>