### PR TITLE
fix(extract/microsoft/cvrf): handle multi-value Supercedence

### DIFF
--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -734,7 +734,9 @@ func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criter
 	//    package names (e.g. "regex-1.8.4", "h2-0.3.26"), KB references (e.g. "KB5032921")
 	//  - Placeholder versions containing "x" (e.g. "15.0.5415.xxxxxx", "5.64.x")
 	//  - Values without dots that are not parseable version numbers (e.g. "25060212643")
-	if fixedBuild[0] < '0' || fixedBuild[0] > '9' || strings.Contains(fixedBuild, "x") || !strings.Contains(fixedBuild, ".") {
+	//  - Semicolon-separated compound versions (e.g. "3.0.6920.8954; 2.0.50727.8970")
+	//    used by .NET Framework products bundling multiple framework versions
+	if fixedBuild[0] < '0' || fixedBuild[0] > '9' || strings.Contains(fixedBuild, "x") || !strings.Contains(fixedBuild, ".") || strings.Contains(fixedBuild, ";") {
 		return nil, nil
 	}
 
@@ -1991,11 +1993,26 @@ func (e extractor) collectKBs(v cvrf.Vulnerability, products map[string]string, 
 			}
 			kbm[kbID] = kb
 
-			if isAllDigits(r.Supercedence) {
-				skb := kbm[r.Supercedence]
+			// Supercedence may list multiple KBs separated by commas or semicolons.
+			// Comma-separated (e.g. "5017500, 5018858, 5018545") is common for .NET Framework products.
+			// Semicolon-separated (e.g. "3181707; 3203838") appears in older (2016-2017) data.
+			// Mixed formats (e.g. "MS16-016, 3124280; MS16-097, 3178034") also exist;
+			// non-digit tokens (bulletin IDs) are filtered out by the isAllDigits check below.
+			var supKBIDs []string
+			for _, semiPart := range strings.Split(r.Supercedence, ";") {
+				for _, commaPart := range strings.Split(semiPart, ",") {
+					supKBIDs = append(supKBIDs, strings.TrimSpace(commaPart))
+				}
+			}
+			for _, supKBID := range supKBIDs {
+				if !isAllDigits(supKBID) {
+					continue
+				}
+
+				skb := kbm[supKBID]
 				if skb.KBID == "" {
-					skb.KBID = r.Supercedence
-					skb.URL = fmt.Sprintf("https://support.microsoft.com/help/%s", r.Supercedence)
+					skb.KBID = supKBID
+					skb.URL = fmt.Sprintf("https://support.microsoft.com/help/%s", supKBID)
 					skb.DataSource = sourceTypes.Source{
 						ID:   sourceTypes.MicrosoftCVRF,
 						Raws: e.r.Paths(),
@@ -2009,7 +2026,7 @@ func (e extractor) collectKBs(v cvrf.Vulnerability, products map[string]string, 
 				if !slices.Contains(skb.Products, criterionProductName) {
 					skb.Products = append(skb.Products, criterionProductName)
 				}
-				kbm[r.Supercedence] = skb
+				kbm[supKBID] = skb
 			}
 		}
 	}

--- a/pkg/extract/microsoft/cvrf/testdata/fixtures/2022-Nov/2022/CVE-2022-41064.json
+++ b/pkg/extract/microsoft/cvrf/testdata/fixtures/2022-Nov/2022/CVE-2022-41064.json
@@ -1,0 +1,268 @@
+{
+  "document_title": "November 2022 Security Updates",
+  "document_type": "Security Update",
+  "documentpublisher": {
+    "type": "Vendor",
+    "contact_details": "secure@microsoft.com",
+    "issuing_authority": "The Microsoft Security Response Center (MSRC) identifies, monitors, resolves, and responds to security incidents and Microsoft software security vulnerabilities. For more information, see http://www.microsoft.com/security/msrc."
+  },
+  "documenttracking": {
+    "identification": {
+      "id": "CVE-2022-41064",
+      "alias": "CVE-2022-41064"
+    },
+    "status": "Final",
+    "version": "1.0",
+    "revisionhistory": {
+      "revision": {
+        "number": "58",
+        "date": "2026-02-18T03:08:36",
+        "description": "November 2022 Security Updates"
+      }
+    },
+    "initial_release_date": "2022-11-08T08:00:00",
+    "current_release_date": "2026-02-18T03:08:36"
+  },
+  "documentnotes": {
+    "note": [
+      {
+        "text": "<h2 id=\"updates-this-month\">Updates this Month</h2>\n<p>This release consists of security updates for the following products, features and roles.</p>\n<ul>\n<li>.NET Framework</li>\n<li>AMD CPU Branch</li>\n<li>Azure</li>\n<li>Azure Real Time Operating System</li>\n<li>Linux Kernel</li>\n<li>Microsoft Dynamics</li>\n<li>Microsoft Edge (Chromium-based)</li>\n<li>Microsoft Exchange Server</li>\n<li>Microsoft Graphics Component</li>\n<li>Microsoft Office</li>\n<li>Microsoft Office Excel</li>\n<li>Microsoft Office SharePoint</li>\n<li>Microsoft Office Word</li>\n<li>Network Policy Server (NPS)</li>\n<li>Open Source Software</li>\n<li>Role: Windows Hyper-V</li>\n<li>SysInternals</li>\n<li>Visual Studio</li>\n<li>Windows Advanced Local Procedure Call</li>\n<li>Windows ALPC</li>\n<li>Windows Bind Filter Driver</li>\n<li>Windows BitLocker</li>\n<li>Windows CNG Key Isolation Service</li>\n<li>Windows Devices Human Interface</li>\n<li>Windows Digital Media</li>\n<li>Windows DWM Core Library</li>\n<li>Windows Extensible File Allocation</li>\n<li>Windows Group Policy Preference Client</li>\n<li>Windows HTTP.sys</li>\n<li>Windows Kerberos</li>\n<li>Windows Mark of the Web (MOTW)</li>\n<li>Windows Netlogon</li>\n<li>Windows Network Address Translation (NAT)</li>\n<li>Windows ODBC Driver</li>\n<li>Windows Overlay Filter</li>\n<li>Windows Point-to-Point Tunneling Protocol</li>\n<li>Windows Print Spooler Components</li>\n<li>Windows Resilient File System (ReFS)</li>\n<li>Windows Scripting</li>\n<li>Windows Win32K</li>\n</ul>\n<p>Please note the following information regarding the security updates:</p>\n<h2 id=\"security-update-guide-blog-posts\">Security Update Guide Blog Posts</h2>\n<table>\n<thead>\n<tr>\n<th>Date</th>\n<th>Blog Post</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>August 9, 2022</td>\n<td><a href=\"https://aka.ms/SUGNotificationProfile2\">Security Update Guide Notification System News: Create your profile now</a></td>\n</tr>\n<tr>\n<td>January 11, 2022</td>\n<td><a href=\"https://aka.ms/SUGNotificationProfile\">Coming Soon: New Security Update Guide Notification System</a></td>\n</tr>\n<tr>\n<td>February 9, 2021</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2021/02/09/continuing-to-listen-good-news-about-the-security-update-guide-api/\">Continuing to Listen: Good News about the Security Update Guide API</a></td>\n</tr>\n<tr>\n<td>January 13, 2021</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2021/01/13/security-update-guide-supports-cves-assigned-by-industry-partners/\">Security Update Guide Supports CVEs Assigned by Industry Partners</a></td>\n</tr>\n<tr>\n<td>December 8, 2020</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2020/12/08/security-update-guide-lets-keep-the-conversation-going/\">Security Update Guide: Let’s keep the conversation going</a></td>\n</tr>\n<tr>\n<td>November 9, 2020</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2020/11/09/vulnerability-descriptions-in-the-new-version-of-the-security-update-guide/\">Vulnerability Descriptions in the New Version of the Security Update Guide</a></td>\n</tr>\n</tbody>\n</table>\n<h2 id=\"relevant-information\">Relevant Information</h2>\n<ul>\n<li>The new Hotpatching feature is now generally available. Please see <a href=\"https://docs.microsoft.com/en-us/azure/automanage/automanage-hotpatch?WT.mc_id=modinfra-18529-thmaure\">Hotpatching feature for Windows Server Azure Edition virtual machines (VMs)</a> for more information.</li>\n<li>Windows 10 updates are cumulative. The monthly security release includes all security fixes for vulnerabilities that affect Windows 10, in addition to non-security updates. The updates are available via the <a href=\"https://www.catalog.update.microsoft.com/Home.aspx\">Microsoft Update Catalog</a>. For information on lifecycle and support dates for Windows 10 operating systems, please see <a href=\"https://docs.microsoft.com/en-us/lifecycle/faq/windows\">Windows Lifecycle Facts Sheet</a>.</li>\n<li>Microsoft is improving Windows Release Notes. For more information, please see <a href=\"https://techcommunity.microsoft.com/t5/windows-it-pro-blog/what-s-next-for-windows-release-notes/ba-p/1754399\">What's next for Windows release notes</a>.</li>\n<li>A list of the latest servicing stack updates for each operating system can be found in <a href=\"https://msrc.microsoft.com/update-guide/en-us/vulnerability/ADV990001\">ADV990001</a>. This list will be updated whenever a new servicing stack update is released. It is important to install the latest servicing stack update.</li>\n<li>In addition to security changes for the vulnerabilities, updates include defense-in-depth updates to help improve security-related features.</li>\n<li>Customers running Windows 7, Windows Server 2008 R2, or Windows Server 2008 need to purchase the Extended Security Update to continue receiving security updates. See <a href=\"https://support.microsoft.com/en-us/topic/procedure-to-continue-receiving-security-updates-after-extended-support-ends-on-january-14-2020-48c59204-fe67-3f42-84fc-c3c3145ff28e\">4522133</a> for more information.</li>\n</ul>\n<h2 id=\"faqs-mitigations-and-workarounds\">FAQs, Mitigations, and Workarounds</h2>\n<p>The following CVEs have FAQs, Mitigations, or Workarounds. You can see these in more detail from the Vulnerabilities tab by selecting <strong>FAQs</strong>, <strong>Mitigations</strong> and <strong>Workarounds</strong> columns in the <strong>Edit Columns</strong> panel.</p>\n<ul>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-23824\">CVE-2022-23824</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-3602\">CVE-2022-3602</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-3786\">CVE-2022-3786</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-37966\">CVE-2022-37966</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-37967\">CVE-2022-37967</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-37992\">CVE-2022-37992</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-38014\">CVE-2022-38014</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-38015\">CVE-2022-38015</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-38023\">CVE-2022-38023</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-39253\">CVE-2022-39253</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-39327\">CVE-2022-39327</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41039\">CVE-2022-41039</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41044\">CVE-2022-41044</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41045\">CVE-2022-41045</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41047\">CVE-2022-41047</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41048\">CVE-2022-41048</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41049\">CVE-2022-41049</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41050\">CVE-2022-41050</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41051\">CVE-2022-41051</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41052\">CVE-2022-41052</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41054\">CVE-2022-41054</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41055\">CVE-2022-41055</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41057\">CVE-2022-41057</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41060\">CVE-2022-41060</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41061\">CVE-2022-41061</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41062\">CVE-2022-41062</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41063\">CVE-2022-41063</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41064\">CVE-2022-41064</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41066\">CVE-2022-41066</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41073\">CVE-2022-41073</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41085\">CVE-2022-41085</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41086\">CVE-2022-41086</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41088\">CVE-2022-41088</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41090\">CVE-2022-41090</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41091\">CVE-2022-41091</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41092\">CVE-2022-41092</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41093\">CVE-2022-41093</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41095\">CVE-2022-41095</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41096\">CVE-2022-41096</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41097\">CVE-2022-41097</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41098\">CVE-2022-41098</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41099\">CVE-2022-41099</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41100\">CVE-2022-41100</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41101\">CVE-2022-41101</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41102\">CVE-2022-41102</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41103\">CVE-2022-41103</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41104\">CVE-2022-41104</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41105\">CVE-2022-41105</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41106\">CVE-2022-41106</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41107\">CVE-2022-41107</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41109\">CVE-2022-41109</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41113\">CVE-2022-41113</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41114\">CVE-2022-41114</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41116\">CVE-2022-41116</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41118\">CVE-2022-41118</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41119\">CVE-2022-41119</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41120\">CVE-2022-41120</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41122\">CVE-2022-41122</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41125\">CVE-2022-41125</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-41128\">CVE-2022-41128</a></li>\n</ul>\n<h2 id=\"known-issues\">Known Issues</h2>\n<p>You can see these in more detail from the Deployments tab by selecting <strong>Known Issues</strong> column in the <strong>Edit Columns</strong> panel.</p>\n<p>For more information about Windows Known Issues, please see <a href=\"https://docs.microsoft.com/en-us/windows/release-information/windows-message-center\">Windows message center</a> (links to currently-supported versions of Windows are in the left pane).</p>\n<table>\n<thead>\n<tr>\n<th>KB Article</th>\n<th>Applies To</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5002258\">5002258</a></td>\n<td>Microsoft SharePoint Server 2019</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5002267\">5002267</a></td>\n<td>Microsoft SharePoint Server 2013</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5002269\">5002269</a></td>\n<td>Microsoft SharePoint Server 2016</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5002271\">5002271</a></td>\n<td>Microsoft SharePoint Server Subscription Edition</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5019959\">5019959</a></td>\n<td>Windows 10 Version 21H1</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5019966\">5019966</a></td>\n<td>Windows 10 Version 1809, Windows Server 2019</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5019980\">5019980</a></td>\n<td>Windows 11 version 22H2</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020000\">5020000</a></td>\n<td>Windows 7, Windows Server 2008 R2 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020003\">5020003</a></td>\n<td>Windows Server 2012 (Security Only)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020005\">5020005</a></td>\n<td>Windows Server 2008 (Security Only)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020009\">5020009</a></td>\n<td>Windows Server 2012 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020010\">5020010</a></td>\n<td>Windows 8.1, Windows Server 2012 R2 (Security Only)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020013\">5020013</a></td>\n<td>Windows 7, Windows Server 2008 R2 (Security Only)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020019\">5020019</a></td>\n<td>Windows Server 2008 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5020023\">5020023</a></td>\n<td>Windows 8.1, Windows Server 2012 R2 (Monthly Rollup)</td>\n</tr>\n</tbody>\n</table>\n",
+        "title": "Release Notes",
+        "audience": "Public",
+        "type": "Details",
+        "ordinal": "0"
+      },
+      {
+        "text": "The information provided in the Microsoft Knowledge Base is provided \"as is\" without warranty of any kind. Microsoft disclaims all warranties, either express or implied, including the warranties of merchantability and fitness for a particular purpose. In no event shall Microsoft Corporation or its suppliers be liable for any damages whatsoever including direct, indirect, incidental, consequential, loss of business profits or special damages, even if Microsoft Corporation or its suppliers have been advised of the possibility of such damages. Some states do not allow the exclusion or limitation of liability for consequential or incidental damages so the foregoing limitation may not apply.",
+        "title": "Legal Disclaimer",
+        "audience": "Public",
+        "type": "Legal Disclaimer",
+        "ordinal": "1"
+      }
+    ]
+  },
+  "producttree": {
+    "branch": {
+      "type": "Vendor",
+      "name": "Microsoft",
+      "branch": [
+        {
+          "type": "Product Family",
+          "name": "Windows",
+          "fullproductname": [
+            {
+              "text": "Windows Server 2019",
+              "productid": "11571"
+            },
+            {
+              "text": "Windows Server 2019 (Server Core installation)",
+              "productid": "11572"
+            },
+            {
+              "text": "Windows Server 2022",
+              "productid": "11923"
+            },
+            {
+              "text": "Windows Server 2022 (Server Core installation)",
+              "productid": "11924"
+            },
+            {
+              "text": "Windows Server 2016",
+              "productid": "10816"
+            },
+            {
+              "text": "Windows Server 2016 (Server Core installation)",
+              "productid": "10855"
+            }
+          ]
+        },
+        {
+          "type": "Product Family",
+          "name": "ESU",
+          "fullproductname": [
+            {
+              "text": "Windows Server 2008 for 32-bit Systems Service Pack 2",
+              "productid": "9312"
+            },
+            {
+              "text": "Windows Server 2008 for 32-bit Systems Service Pack 2 (Server Core installation)",
+              "productid": "10287"
+            },
+            {
+              "text": "Windows Server 2008 for x64-based Systems Service Pack 2",
+              "productid": "9318"
+            },
+            {
+              "text": "Windows Server 2008 for x64-based Systems Service Pack 2 (Server Core installation)",
+              "productid": "9344"
+            },
+            {
+              "text": "Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+              "productid": "10051"
+            },
+            {
+              "text": "Windows Server 2008 R2 for x64-based Systems Service Pack 1 (Server Core installation)",
+              "productid": "10049"
+            },
+            {
+              "text": "Windows Server 2012",
+              "productid": "10378"
+            },
+            {
+              "text": "Windows Server 2012 (Server Core installation)",
+              "productid": "10379"
+            },
+            {
+              "text": "Windows Server 2012 R2",
+              "productid": "10483"
+            },
+            {
+              "text": "Windows Server 2012 R2 (Server Core installation)",
+              "productid": "10543"
+            }
+          ]
+        }
+      ]
+    },
+    "fullproductname": [
+      {
+        "text": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for 32-bit Systems",
+        "productid": "11650-11929"
+      },
+      {
+        "text": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems",
+        "productid": "11650-11930"
+      },
+      {
+        "text": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems",
+        "productid": "11650-11931"
+      },
+      {
+        "text": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016",
+        "productid": "11723-10816"
+      },
+      {
+        "text": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for 32-bit Systems",
+        "productid": "11723-10852"
+      },
+      {
+        "text": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for x64-based Systems",
+        "productid": "11723-10853"
+      },
+      {
+        "text": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016 (Server Core installation)",
+        "productid": "11723-10855"
+      }
+    ]
+  },
+  "vulnerability": [
+    {
+      "title": ".NET Framework Information Disclosure Vulnerability",
+      "notes": {
+        "note": []
+      },
+      "cve": "CVE-2022-41064",
+      "productstatuses": {
+        "status": {
+          "type": "Known Affected",
+          "product_id": [
+            "11650-11930",
+            "11650-11929",
+            "11723-10852",
+            "11723-10816",
+            "11723-10853",
+            "11723-10855",
+            "11650-11931"
+          ]
+        }
+      },
+      "threats": {
+        "threat": [
+          {
+            "type": "Impact",
+            "description": "Information Disclosure",
+            "product_id": "11650-11930"
+          },
+          {
+            "type": "Impact",
+            "description": "Information Disclosure",
+            "product_id": "11650-11929"
+          },
+          {
+            "type": "Impact",
+            "description": "Information Disclosure",
+            "product_id": "11723-10852"
+          },
+          {
+            "type": "Impact",
+            "description": "Information Disclosure",
+            "product_id": "11723-10816"
+          },
+          {
+            "type": "Impact",
+            "description": "Information Disclosure",
+            "product_id": "11723-10853"
+          },
+          {
+            "type": "Impact",
+            "description": "Information Disclosure",
+            "product_id": "11723-10855"
+          },
+          {
+            "type": "Impact",
+            "description": "Information Disclosure",
+            "product_id": "11650-11931"
+          }
+        ]
+      },
+      "cvssscoresets": {
+        "scoreset": []
+      },
+      "remediations": {
+        "remediation": [
+          {
+            "type": "Vendor Fix",
+            "description": "5020687",
+            "supercedence": "5017500, 5018858, 5018545",
+            "product_id": [
+              "11650-11930",
+              "11650-11929",
+              "11650-11931"
+            ],
+            "url": "https://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB5020613",
+            "restart_required": "Maybe",
+            "sub_type": "Security Update",
+            "fixed_build": "4.8.04584.08"
+          },
+          {
+            "type": "Vendor Fix",
+            "description": "5019964",
+            "supercedence": "5018411",
+            "product_id": [
+              "11723-10852",
+              "11723-10816",
+              "11723-10853",
+              "11723-10855"
+            ],
+            "url": "https://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB5019964",
+            "restart_required": "Yes",
+            "sub_type": "Security Update",
+            "fixed_build": "10.0.14393.5501"
+          }
+        ]
+      },
+      "acknowledgments": {
+        "acknowledgment": []
+      },
+      "revisionhistory": {
+        "revision": [
+          {
+            "number": "1.0",
+            "date": "2022-11-08T08:00:00",
+            "description": "Information published."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/extract/microsoft/cvrf/testdata/fixtures/2023-Jun/2023/CVE-2023-29326.json
+++ b/pkg/extract/microsoft/cvrf/testdata/fixtures/2023-Jun/2023/CVE-2023-29326.json
@@ -1,0 +1,337 @@
+{
+  "document_title": "June 2023 Security Updates",
+  "document_type": "Security Update",
+  "documentpublisher": {
+    "type": "Vendor",
+    "contact_details": "secure@microsoft.com",
+    "issuing_authority": "The Microsoft Security Response Center (MSRC) identifies, monitors, resolves, and responds to security incidents and Microsoft software security vulnerabilities."
+  },
+  "documenttracking": {
+    "identification": {
+      "id": "CVE-2023-29326",
+      "alias": "CVE-2023-29326"
+    },
+    "status": "Final",
+    "version": "1.0",
+    "revisionhistory": {
+      "revision": {
+        "number": "1",
+        "date": "2023-06-13T07:00:00",
+        "description": "June 2023 Security Updates"
+      }
+    },
+    "initial_release_date": "2023-06-13T07:00:00",
+    "current_release_date": "2023-06-13T07:00:00"
+  },
+  "documentnotes": {
+    "note": []
+  },
+  "producttree": {
+    "branch": {
+      "type": "Vendor",
+      "name": "Microsoft",
+      "branch": [
+        {
+          "type": "Product Family",
+          "name": "Developer Tools",
+          "fullproductname": [
+            {
+              "text": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for 32-bit Systems",
+              "productid": "11676-11568"
+            },
+            {
+              "text": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019 (Server Core installation)",
+              "productid": "11676-11572"
+            },
+            {
+              "text": "Microsoft .NET Framework 3.5 AND 4.7.2 on Windows 10 Version 1809 for x64-based Systems",
+              "productid": "11677-11569"
+            },
+            {
+              "text": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019",
+              "productid": "11676-11571"
+            },
+            {
+              "text": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for x64-based Systems",
+              "productid": "11676-11569"
+            },
+            {
+              "text": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+              "productid": "9292-9312"
+            },
+            {
+              "text": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
+              "productid": "9292-9318"
+            },
+            {
+              "text": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+              "productid": "9195-9312"
+            },
+            {
+              "text": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
+              "productid": "9195-9318"
+            }
+          ]
+        }
+      ]
+    },
+    "fullproductname": [
+      {
+        "text": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for 32-bit Systems",
+        "productid": "11676-11568"
+      },
+      {
+        "text": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for x64-based Systems",
+        "productid": "11676-11569"
+      },
+      {
+        "text": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019",
+        "productid": "11676-11571"
+      },
+      {
+        "text": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019 (Server Core installation)",
+        "productid": "11676-11572"
+      },
+      {
+        "text": "Microsoft .NET Framework 3.5 AND 4.7.2 on Windows 10 Version 1809 for x64-based Systems",
+        "productid": "11677-11569"
+      },
+      {
+        "text": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+        "productid": "9195-9312"
+      },
+      {
+        "text": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
+        "productid": "9195-9318"
+      },
+      {
+        "text": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+        "productid": "9292-9312"
+      },
+      {
+        "text": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
+        "productid": "9292-9318"
+      }
+    ]
+  },
+  "vulnerability": [
+    {
+      "title": ".NET Framework Remote Code Execution Vulnerability",
+      "notes": {
+        "note": [
+          {
+            "text": "",
+            "title": "Description",
+            "type": "Description"
+          }
+        ]
+      },
+      "cve": "CVE-2023-29326",
+      "productstatuses": {
+        "status": {
+          "type": "Known Affected",
+          "product_id": [
+            "11676-11568",
+            "11676-11569",
+            "11676-11571",
+            "11676-11572",
+            "11677-11569",
+            "9292-9312",
+            "9292-9318",
+            "9195-9312",
+            "9195-9318"
+          ]
+        }
+      },
+      "threats": {
+        "threat": [
+          {
+            "type": "Impact",
+            "description": "Remote Code Execution",
+            "product_id": "11676-11568"
+          },
+          {
+            "type": "Impact",
+            "description": "Remote Code Execution",
+            "product_id": "11676-11569"
+          },
+          {
+            "type": "Impact",
+            "description": "Remote Code Execution",
+            "product_id": "11676-11571"
+          },
+          {
+            "type": "Impact",
+            "description": "Remote Code Execution",
+            "product_id": "11676-11572"
+          },
+          {
+            "type": "Impact",
+            "description": "Remote Code Execution",
+            "product_id": "11677-11569"
+          },
+          {
+            "type": "Impact",
+            "description": "Remote Code Execution",
+            "product_id": "9292-9312"
+          },
+          {
+            "type": "Impact",
+            "description": "Remote Code Execution",
+            "product_id": "9292-9318"
+          },
+          {
+            "type": "Impact",
+            "description": "Remote Code Execution",
+            "product_id": "9195-9312"
+          },
+          {
+            "type": "Impact",
+            "description": "Remote Code Execution",
+            "product_id": "9195-9318"
+          },
+          {
+            "type": "Exploit Status",
+            "description": "Important",
+            "product_id": "11676-11568"
+          },
+          {
+            "type": "Exploit Status",
+            "description": "Important",
+            "product_id": "11676-11569"
+          },
+          {
+            "type": "Exploit Status",
+            "description": "Important",
+            "product_id": "11676-11571"
+          },
+          {
+            "type": "Exploit Status",
+            "description": "Important",
+            "product_id": "11676-11572"
+          },
+          {
+            "type": "Exploit Status",
+            "description": "Important",
+            "product_id": "11677-11569"
+          },
+          {
+            "type": "Exploit Status",
+            "description": "Important",
+            "product_id": "9292-9312"
+          },
+          {
+            "type": "Exploit Status",
+            "description": "Important",
+            "product_id": "9292-9318"
+          },
+          {
+            "type": "Exploit Status",
+            "description": "Important",
+            "product_id": "9195-9312"
+          },
+          {
+            "type": "Exploit Status",
+            "description": "Important",
+            "product_id": "9195-9318"
+          }
+        ]
+      },
+      "cvssscoresets": {
+        "scoreset": [
+          {
+            "base_score": "7.8",
+            "temporal_score": "6.8",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+            "product_id": "11676-11568"
+          },
+          {
+            "base_score": "7.8",
+            "temporal_score": "6.8",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+            "product_id": "11676-11569"
+          },
+          {
+            "base_score": "7.8",
+            "temporal_score": "6.8",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+            "product_id": "11676-11571"
+          },
+          {
+            "base_score": "7.8",
+            "temporal_score": "6.8",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+            "product_id": "11676-11572"
+          },
+          {
+            "base_score": "7.8",
+            "temporal_score": "6.8",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+            "product_id": "11677-11569"
+          },
+          {
+            "base_score": "7.8",
+            "temporal_score": "6.8",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+            "product_id": "9292-9312"
+          },
+          {
+            "base_score": "7.8",
+            "temporal_score": "6.8",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+            "product_id": "9292-9318"
+          },
+          {
+            "base_score": "7.8",
+            "temporal_score": "6.8",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+            "product_id": "9195-9312"
+          },
+          {
+            "base_score": "7.8",
+            "temporal_score": "6.8",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+            "product_id": "9195-9318"
+          }
+        ]
+      },
+      "remediations": {
+        "remediation": [
+          {
+            "type": "Vendor Fix",
+            "description": "5027536",
+            "supercedence": "5022782",
+            "product_id": [
+              "11676-11568",
+              "11676-11569",
+              "11676-11571",
+              "11676-11572",
+              "11677-11569"
+            ],
+            "url": "https://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB5027124",
+            "restart_required": "Maybe",
+            "sub_type": "Security Update",
+            "fixed_build": "4.8.4644.0"
+          },
+          {
+            "type": "Vendor Fix",
+            "description": "5027543",
+            "supercedence": "5022734",
+            "product_id": [
+              "9292-9312",
+              "9292-9318",
+              "9195-9312",
+              "9195-9318"
+            ],
+            "url": "https://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB5027139",
+            "restart_required": "Maybe",
+            "sub_type": "Monthly Rollup",
+            "fixed_build": "3.0.6920.8954; 2.0.50727.8970"
+          }
+        ]
+      },
+      "acknowledgments": {},
+      "revisionhistory": {}
+    }
+  ]
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2022/CVE-2022-41064.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2022/CVE-2022-41064.json
@@ -1,0 +1,170 @@
+{
+	"id": "CVE-2022-41064",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-41064",
+				"title": ".NET Framework Information Disclosure Vulnerability",
+				"references": [
+					{
+						"source": "secure@microsoft.com",
+						"url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-41064"
+					}
+				],
+				"published": "2022-11-08T08:00:00Z",
+				"modified": "2026-02-18T03:08:36Z",
+				"optional": {
+					"impact": "Information Disclosure"
+				}
+			},
+			"segments": [
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for 32-bit Systems"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for x64-based Systems"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016 (Server Core installation)"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for 32-bit Systems"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "microsoft",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for 32-bit Systems",
+									"kb_id": "5019964"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for 32-bit Systems"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for x64-based Systems",
+									"kb_id": "5019964"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for x64-based Systems"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016",
+									"kb_id": "5019964"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016 (Server Core installation)",
+									"kb_id": "5019964"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016 (Server Core installation)"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for 32-bit Systems",
+									"kb_id": "5020687"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for 32-bit Systems"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems",
+									"kb_id": "5020687"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems",
+									"kb_id": "5020687"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2022-Nov/2022/CVE-2022-41064.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2023/CVE-2023-29326.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2023/CVE-2023-29326.json
@@ -1,0 +1,224 @@
+{
+	"id": "CVE-2023-29326",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-29326",
+				"title": ".NET Framework Remote Code Execution Vulnerability",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "secure@microsoft.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+							"base_score": 7.8,
+							"base_severity": "HIGH",
+							"temporal_score": 6.8,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.8,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "secure@microsoft.com",
+						"url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-29326"
+					}
+				],
+				"published": "2023-06-13T07:00:00Z",
+				"modified": "2023-06-13T07:00:00Z",
+				"optional": {
+					"exploit_status": "Important",
+					"impact": "Remote Code Execution"
+				}
+			},
+			"segments": [
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.5 AND 4.7.2 on Windows 10 Version 1809 for x64-based Systems"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for 32-bit Systems"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for x64-based Systems"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019 (Server Core installation)"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "microsoft",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+									"kb_id": "5027543"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
+									"kb_id": "5027543"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+									"kb_id": "5027543"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
+									"kb_id": "5027543"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.5 AND 4.7.2 on Windows 10 Version 1809 for x64-based Systems",
+									"kb_id": "5027536"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.5 AND 4.7.2 on Windows 10 Version 1809 for x64-based Systems"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for 32-bit Systems",
+									"kb_id": "5027536"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for 32-bit Systems"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for x64-based Systems",
+									"kb_id": "5027536"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for x64-based Systems"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019",
+									"kb_id": "5027536"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "kb",
+								"kb": {
+									"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019 (Server Core installation)",
+									"kb_id": "5027536"
+								}
+							}
+						]
+					},
+					"tag": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019 (Server Core installation)"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2023-Jun/2023/CVE-2023-29326.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5017xxx/5017500.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5017xxx/5017500.json
@@ -1,0 +1,20 @@
+{
+	"kb_id": "5017500",
+	"url": "https://support.microsoft.com/help/5017500",
+	"products": [
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for 32-bit Systems",
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems",
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5020687"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2022-Nov/2022/CVE-2022-41064.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5018xxx/5018411.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5018xxx/5018411.json
@@ -1,0 +1,21 @@
+{
+	"kb_id": "5018411",
+	"url": "https://support.microsoft.com/help/5018411",
+	"products": [
+		"Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for 32-bit Systems",
+		"Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for x64-based Systems",
+		"Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016",
+		"Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016 (Server Core installation)"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5019964"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2022-Nov/2022/CVE-2022-41064.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5018xxx/5018545.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5018xxx/5018545.json
@@ -1,0 +1,20 @@
+{
+	"kb_id": "5018545",
+	"url": "https://support.microsoft.com/help/5018545",
+	"products": [
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for 32-bit Systems",
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems",
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5020687"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2022-Nov/2022/CVE-2022-41064.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5018xxx/5018858.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5018xxx/5018858.json
@@ -1,0 +1,20 @@
+{
+	"kb_id": "5018858",
+	"url": "https://support.microsoft.com/help/5018858",
+	"products": [
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for 32-bit Systems",
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems",
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5020687"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2022-Nov/2022/CVE-2022-41064.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5019xxx/5019964.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5019xxx/5019964.json
@@ -1,0 +1,16 @@
+{
+	"kb_id": "5019964",
+	"url": "https://support.microsoft.com/help/5019964",
+	"products": [
+		"Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for 32-bit Systems",
+		"Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for x64-based Systems",
+		"Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016",
+		"Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016 (Server Core installation)"
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2022-Nov/2022/CVE-2022-41064.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5020xxx/5020687.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5020xxx/5020687.json
@@ -1,0 +1,15 @@
+{
+	"kb_id": "5020687",
+	"url": "https://support.microsoft.com/help/5020687",
+	"products": [
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for 32-bit Systems",
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems",
+		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems"
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2022-Nov/2022/CVE-2022-41064.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5022xxx/5022734.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5022xxx/5022734.json
@@ -1,0 +1,21 @@
+{
+	"kb_id": "5022734",
+	"url": "https://support.microsoft.com/help/5022734",
+	"products": [
+		"Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+		"Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
+		"Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+		"Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5027543"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2023-Jun/2023/CVE-2023-29326.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5022xxx/5022782.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5022xxx/5022782.json
@@ -1,0 +1,22 @@
+{
+	"kb_id": "5022782",
+	"url": "https://support.microsoft.com/help/5022782",
+	"products": [
+		"Microsoft .NET Framework 3.5 AND 4.7.2 on Windows 10 Version 1809 for x64-based Systems",
+		"Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for 32-bit Systems",
+		"Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for x64-based Systems",
+		"Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019",
+		"Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019 (Server Core installation)"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5027536"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2023-Jun/2023/CVE-2023-29326.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5027xxx/5027536.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5027xxx/5027536.json
@@ -1,0 +1,17 @@
+{
+	"kb_id": "5027536",
+	"url": "https://support.microsoft.com/help/5027536",
+	"products": [
+		"Microsoft .NET Framework 3.5 AND 4.7.2 on Windows 10 Version 1809 for x64-based Systems",
+		"Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for 32-bit Systems",
+		"Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for x64-based Systems",
+		"Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019",
+		"Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019 (Server Core installation)"
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2023-Jun/2023/CVE-2023-29326.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5027xxx/5027543.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5027xxx/5027543.json
@@ -1,0 +1,16 @@
+{
+	"kb_id": "5027543",
+	"url": "https://support.microsoft.com/help/5027543",
+	"products": [
+		"Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+		"Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
+		"Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+		"Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2"
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2023-Jun/2023/CVE-2023-29326.json"
+		]
+	}
+}


### PR DESCRIPTION
   In collectKBs(), Supercedence values can be comma-separated
   (e.g. "5017500, 5018858, 5018545") or semicolon-separated
   (e.g. "3181707; 3203838"). Previously, isAllDigits() rejected
   these multi-value strings entirely, silently dropping 1,072
   supersession relationships across 123 months of CVRF data.

   Split Supercedence on ";" then "," before checking each token
   with isAllDigits(), so valid KB IDs are extracted while
   non-numeric tokens (MS bulletin refs, HTML fragments) are
   still correctly filtered out.

   Also explicitly skip semicolon-separated FixedBuild values
   (e.g. "3.0.6920.8954; 2.0.50727.8970") in buildFixedBuildCriterion
   to prevent them from passing the existing validation checks.

   Add test fixtures CVE-2022-41064 (comma Supercedence) and
   CVE-2023-29326 (semicolon FixedBuild) with corresponding
   golden files.

   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>