### PR TITLE
fix(extract/microsoft): write datasource.json in msuc and wsusscn2

### DIFF
--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -15,11 +15,14 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
-	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
 	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
 	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
 	microsoftkbUpdateTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/update"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
 	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
 	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/msuc"
 )
@@ -76,6 +79,28 @@ func Extract(args string, opts ...Option) error {
 
 	if err := options.extract(args, uidm); err != nil {
 		return errors.Wrapf(err, "extract")
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.MicrosoftMSUC,
+		Name: new("Microsoft Update Catalog"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
 	}
 
 	return nil

--- a/pkg/extract/microsoft/msuc/testdata/golden/datasource.json
+++ b/pkg/extract/microsoft/msuc/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "microsoft-msuc",
+	"name": "Microsoft Update Catalog"
+}

--- a/pkg/extract/microsoft/wsusscn2/testdata/golden/datasource.json
+++ b/pkg/extract/microsoft/wsusscn2/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "microsoft-wsusscn2",
+	"name": "Microsoft WSUSSCN2"
+}

--- a/pkg/extract/microsoft/wsusscn2/wsusscn2.go
+++ b/pkg/extract/microsoft/wsusscn2/wsusscn2.go
@@ -12,11 +12,14 @@ import (
 
 	"github.com/pkg/errors"
 
-	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
 	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
 	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
 	microsoftkbUpdateTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/update"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
 	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
 	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/wsusscn2"
 )
@@ -55,6 +58,28 @@ func Extract(args string, opts ...Option) error {
 	slog.Info("Extract Microsoft WSUSSCN2")
 	if err := options.extract(args); err != nil {
 		return errors.Wrapf(err, "extract")
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.MicrosoftWSUSSCN2,
+		Name: new("Microsoft WSUSSCN2"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
 	}
 
 	return nil


### PR DESCRIPTION
   microsoft-msuc and microsoft-wsusscn2 extractors were missing
   datasource.json output, unlike microsoft-cvrf and microsoft-bulletin.
   Add datasource.json write to Extract() for both.