### PR TITLE
feat(extract/enisa/kev): implement extractor

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -34,6 +34,7 @@ import (
 	debianOVAL "github.com/MaineK00n/vuls-data-update/pkg/extract/debian/oval"
 	debianSecurityTrackerAPI "github.com/MaineK00n/vuls-data-update/pkg/extract/debian/tracker/api"
 	debianSecurityTrackerSalsa "github.com/MaineK00n/vuls-data-update/pkg/extract/debian/tracker/salsa"
+	enisaKEV "github.com/MaineK00n/vuls-data-update/pkg/extract/enisa/kev"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/eol"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/epss"
 	erlangGHSA "github.com/MaineK00n/vuls-data-update/pkg/extract/erlang/ghsa"
@@ -157,6 +158,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdCWE(),
 		newCmdDebianOVAL(), newCmdDebianSecurityTrackerAPI(), newCmdDebianSecurityTrackerSalsa(), newCmdDebianOSV(),
 		newCmdEOL(),
+		newCmdENISAKEV(),
 		newCmdEPSS(),
 		newCmdErlangGHSA(), newCmdErlangOSV(),
 		newCmdExploitExploitDB(), newCmdExploitGitHub(), newCmdExploitInTheWild(), newCmdExploitTrickest(),
@@ -876,6 +878,31 @@ func newCmdEOL() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&options.dir, "dir", "d", filepath.Join(util.CacheDir(), "extract", "eol"), "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdENISAKEV() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "enisa", "kev"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "enisa-kev <Raw ENISA KEV Repository PATH>",
+		Short: "Extract ENISA KEV data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract enisa-kev vuls-data-raw-enisa-kev
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := enisaKEV.Extract(args[0], enisaKEV.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract enisa kev")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
 
 	return cmd
 }

--- a/pkg/extract/enisa/kev/kev.go
+++ b/pkg/extract/enisa/kev/kev.go
@@ -1,0 +1,184 @@
+package kev
+
+import (
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+
+	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
+	advisoryContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory/content"
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
+	kevTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev"
+	enisaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev/enisa"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	utiltime "github.com/MaineK00n/vuls-data-update/pkg/extract/util/time"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/enisa/kev"
+)
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "enisa", "kev"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract ENISA Known Exploited Vulnerabilities")
+	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		r := utiljson.NewJSONReader()
+		var fetched kev.Vulnerability
+		if err := r.Read(path, args, &fetched); err != nil {
+			return errors.Wrapf(err, "read json %s", path)
+		}
+
+		extracted := extract(fetched, r.Paths())
+
+		splitted, err := util.Split(fetched.EUVDID, "-", "-")
+		if err != nil {
+			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.EUVDID)
+		}
+		if _, err := time.Parse("2006", splitted[1]); err != nil {
+			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.EUVDID)
+		}
+		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", extracted.ID)), extracted, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", extracted.ID)))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", args)
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.ENISAKEV,
+		Name: new("ENISA Known Exploited Vulnerabilities"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+func sanitize(s string) string {
+	if s == "-" {
+		return ""
+	}
+	return s
+}
+
+func extract(fetched kev.Vulnerability, raws []string) dataTypes.Data {
+	return dataTypes.Data{
+		ID: dataTypes.RootID(fetched.EUVDID),
+		Advisories: []advisoryTypes.Advisory{{
+			Content: advisoryContentTypes.Content{
+				ID: advisoryContentTypes.AdvisoryID(fetched.EUVDID),
+				KEV: &kevTypes.KEV{
+					VendorProject: fetched.VendorProject,
+					Product:       fetched.Product,
+					Notes:         sanitize(fetched.Notes),
+					ENISA: func() *enisaTypes.ENISA {
+						e := enisaTypes.ENISA{
+							DateReported: func() time.Time {
+								if t := utiltime.Parse([]string{"02/01/06"}, fetched.DateReported); t != nil {
+									return *t
+								}
+								return time.Time{}
+							}(),
+							PatchedSince:           sanitize(fetched.PatchedSince),
+							OriginSource:           sanitize(fetched.OriginSource),
+							ExploitationType:       sanitize(fetched.ExploitationType),
+							ThreatActorsExploiting: sanitize(fetched.ThreatActorsExploiting),
+						}
+						if (e == enisaTypes.ENISA{}) {
+							return nil
+						}
+						return &e
+					}(),
+				},
+			},
+		}},
+		Vulnerabilities: func() []vulnerabilityTypes.Vulnerability {
+			if fetched.CVEID == "" {
+				return nil
+			}
+			return []vulnerabilityTypes.Vulnerability{{
+				Content: vulnerabilityContentTypes.Content{
+					ID:          vulnerabilityContentTypes.VulnerabilityID(fetched.CVEID),
+					Title:       sanitize(fetched.VulnerabilityName),
+					Description: sanitize(fetched.ShortDescription),
+					CWE: func() []cweTypes.CWE {
+						if sanitize(fetched.CWEs) == "" {
+							return nil
+						}
+						return []cweTypes.CWE{{
+							Source: "enisa.europa.eu/kev",
+							CWE:    []string{sanitize(fetched.CWEs)},
+						}}
+					}(),
+				},
+			}}
+		}(),
+		DataSource: sourceTypes.Source{
+			ID:   sourceTypes.ENISAKEV,
+			Raws: raws,
+		},
+	}
+}

--- a/pkg/extract/enisa/kev/kev_test.go
+++ b/pkg/extract/enisa/kev/kev_test.go
@@ -1,0 +1,44 @@
+package kev_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/enisa/kev"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := kev.Extract(tt.args, kev.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			}
+
+			ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+			if err != nil {
+				t.Error("unexpected error:", err)
+			}
+			gp, err := filepath.Abs(dir)
+			if err != nil {
+				t.Error("unexpected error:", err)
+			}
+			utiltest.Diff(t, ep, gp)
+		})
+	}
+}

--- a/pkg/extract/enisa/kev/testdata/fixtures/2024/CVE-2024-9380.json
+++ b/pkg/extract/enisa/kev/testdata/fixtures/2024/CVE-2024-9380.json
@@ -1,0 +1,15 @@
+{
+	"cveID": "CVE-2024-9380",
+	"euvdID": "EUVD-2024-49898",
+	"vendorProject": "Ivanti",
+	"product": "CSA (Cloud Services Appliance)",
+	"vulnerabilityName": "-",
+	"dateReported": "17/01/25",
+	"patchedSince": "tbc",
+	"originSource": "cnw",
+	"shortDescription": "-",
+	"exploitationType": "-",
+	"threatActorsExploiting": "-",
+	"cwes": "-",
+	"notes": "-"
+}

--- a/pkg/extract/enisa/kev/testdata/golden/data/2024/EUVD-2024-49898.json
+++ b/pkg/extract/enisa/kev/testdata/golden/data/2024/EUVD-2024-49898.json
@@ -1,0 +1,32 @@
+{
+	"id": "EUVD-2024-49898",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-2024-49898",
+				"kev": {
+					"vendor_project": "Ivanti",
+					"product": "CSA (Cloud Services Appliance)",
+					"enisa": {
+						"date_reported": "2025-01-17T00:00:00Z",
+						"patched_since": "tbc",
+						"origin_source": "cnw"
+					}
+				}
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-9380"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-kev",
+		"raws": [
+			"fixtures/2024/CVE-2024-9380.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/kev/testdata/golden/datasource.json
+++ b/pkg/extract/enisa/kev/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "enisa-kev",
+	"name": "ENISA Known Exploited Vulnerabilities"
+}

--- a/pkg/extract/types/data/advisory/content/content.go
+++ b/pkg/extract/types/data/advisory/content/content.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
+	kevTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 )
@@ -16,6 +17,7 @@ type Content struct {
 	Description string                     `json:"description,omitempty"`
 	Severity    []severityTypes.Severity   `json:"severity,omitempty"`
 	CWE         []cweTypes.CWE             `json:"cwe,omitempty"`
+	KEV         *kevTypes.KEV              `json:"kev,omitempty"`
 	References  []referenceTypes.Reference `json:"references,omitempty"`
 	Published   *time.Time                 `json:"published,omitempty"`
 	Modified    *time.Time                 `json:"modified,omitempty"`
@@ -32,6 +34,10 @@ func (c *Content) Sort() {
 	}
 	slices.SortFunc(c.CWE, cweTypes.Compare)
 
+	if c.KEV != nil {
+		c.KEV.Sort()
+	}
+
 	slices.SortFunc(c.References, referenceTypes.Compare)
 }
 
@@ -42,6 +48,18 @@ func Compare(x, y Content) int {
 		cmp.Compare(x.Description, y.Description),
 		slices.CompareFunc(x.Severity, y.Severity, severityTypes.Compare),
 		slices.CompareFunc(x.CWE, y.CWE, cweTypes.Compare),
+		func() int {
+			switch {
+			case x.KEV == nil && y.KEV == nil:
+				return 0
+			case x.KEV == nil && y.KEV != nil:
+				return -1
+			case x.KEV != nil && y.KEV == nil:
+				return +1
+			default:
+				return kevTypes.Compare(*x.KEV, *y.KEV)
+			}
+		}(),
 		slices.CompareFunc(x.References, y.References, referenceTypes.Compare),
 		func() int {
 			switch {

--- a/pkg/extract/types/data/kev/enisa/enisa.go
+++ b/pkg/extract/types/data/kev/enisa/enisa.go
@@ -1,0 +1,24 @@
+package enisa
+
+import (
+	"cmp"
+	"time"
+)
+
+type ENISA struct {
+	DateReported           time.Time `json:"date_reported,omitzero"`
+	PatchedSince           string    `json:"patched_since,omitempty"`
+	OriginSource           string    `json:"origin_source,omitempty"`
+	ExploitationType       string    `json:"exploitation_type,omitempty"`
+	ThreatActorsExploiting string    `json:"threat_actors_exploiting,omitempty"`
+}
+
+func Compare(x, y ENISA) int {
+	return cmp.Or(
+		x.DateReported.Compare(y.DateReported),
+		cmp.Compare(x.PatchedSince, y.PatchedSince),
+		cmp.Compare(x.OriginSource, y.OriginSource),
+		cmp.Compare(x.ExploitationType, y.ExploitationType),
+		cmp.Compare(x.ThreatActorsExploiting, y.ThreatActorsExploiting),
+	)
+}

--- a/pkg/extract/types/data/kev/enisa/enisa_test.go
+++ b/pkg/extract/types/data/kev/enisa/enisa_test.go
@@ -1,0 +1,62 @@
+package enisa_test
+
+import (
+	"testing"
+	"time"
+
+	enisaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev/enisa"
+)
+
+func TestCompare(t *testing.T) {
+	type args struct {
+		x enisaTypes.ENISA
+		y enisaTypes.ENISA
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "x == y",
+			args: args{
+				x: enisaTypes.ENISA{
+					DateReported:     time.Date(2025, time.January, 17, 0, 0, 0, 0, time.UTC),
+					PatchedSince:     "tbc",
+					OriginSource:     "cnw",
+					ExploitationType: "ransomware",
+				},
+				y: enisaTypes.ENISA{
+					DateReported:     time.Date(2025, time.January, 17, 0, 0, 0, 0, time.UTC),
+					PatchedSince:     "tbc",
+					OriginSource:     "cnw",
+					ExploitationType: "ransomware",
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "x:dateReported < y:dateReported",
+			args: args{
+				x: enisaTypes.ENISA{DateReported: time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)},
+				y: enisaTypes.ENISA{DateReported: time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			want: -1,
+		},
+		{
+			name: "x:exploitationType > y:exploitationType",
+			args: args{
+				x: enisaTypes.ENISA{ExploitationType: "ransomware"},
+				y: enisaTypes.ENISA{ExploitationType: "apt"},
+			},
+			want: +1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := enisaTypes.Compare(tt.args.x, tt.args.y); got != tt.want {
+				t.Errorf("Compare() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/extract/types/data/kev/kev.go
+++ b/pkg/extract/types/data/kev/kev.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"time"
 
+	enisaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev/enisa"
 	vulncheckTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev/vulncheck"
 )
 
@@ -17,6 +18,7 @@ type KEV struct {
 	DueDate                    time.Time `json:"due_date,omitzero"`
 
 	VulnCheck *vulncheckTypes.VulnCheck `json:"vulncheck,omitempty"`
+	ENISA     *enisaTypes.ENISA         `json:"enisa,omitempty"`
 }
 
 func (k *KEV) Sort() {
@@ -44,6 +46,18 @@ func Compare(x, y KEV) int {
 				return +1
 			default:
 				return vulncheckTypes.Compare(*x.VulnCheck, *y.VulnCheck)
+			}
+		}(),
+		func() int {
+			switch {
+			case x.ENISA == nil && y.ENISA == nil:
+				return 0
+			case x.ENISA == nil && y.ENISA != nil:
+				return -1
+			case x.ENISA != nil && y.ENISA == nil:
+				return +1
+			default:
+				return enisaTypes.Compare(*x.ENISA, *y.ENISA)
 			}
 		}(),
 	)

--- a/pkg/extract/types/data/kev/kev_test.go
+++ b/pkg/extract/types/data/kev/kev_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	kevTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev"
+	enisaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev/enisa"
 	vulncheckTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev/vulncheck"
 	reportedExploitationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev/vulncheck/reportedexploitation"
 	xdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev/vulncheck/xdb"
@@ -144,6 +145,42 @@ func TestCompare(t *testing.T) {
 				},
 			},
 			want: +1,
+		},
+		{
+			name: "x has ENISA, y does not",
+			args: args{
+				x: kevTypes.KEV{
+					ENISA: &enisaTypes.ENISA{
+						OriginSource: "cnw",
+					},
+				},
+				y: kevTypes.KEV{},
+			},
+			want: +1,
+		},
+		{
+			name: "neither has ENISA",
+			args: args{
+				x: kevTypes.KEV{VendorProject: "Ivanti"},
+				y: kevTypes.KEV{VendorProject: "Ivanti"},
+			},
+			want: 0,
+		},
+		{
+			name: "both have ENISA, x:date_reported < y:date_reported",
+			args: args{
+				x: kevTypes.KEV{
+					ENISA: &enisaTypes.ENISA{
+						DateReported: time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
+					},
+				},
+				y: kevTypes.KEV{
+					ENISA: &enisaTypes.ENISA{
+						DateReported: time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			want: -1,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -50,6 +50,7 @@ const (
 	EndoflifeDateAPI           SourceID = "endoflife-date-api"
 	EndoflifeDateProducts      SourceID = "endoflife-date-products"
 	EOL                        SourceID = "eol"
+	ENISAKEV                   SourceID = "enisa-kev"
 	EPSS                       SourceID = "epss"
 	ErlangGHSA                 SourceID = "erlang-ghsa"
 	ErlangOSV                  SourceID = "erlang-osv"


### PR DESCRIPTION
   Extract ENISA Known Exploited Vulnerabilities into normalized format.
   - Advisory Content holds EUVD ID and KEV data (ENISA-specific fields)
   - Vulnerability Content holds CVE ID with title/description/CWE
   - Add KEV field to Advisory Content type
   - Add ENISA sub-type under kev/enisa/ (following VulnCheck pattern)
   - Register extract enisa-kev command