### PR TITLE
feat(microsoft): use nested AND criteria with covered-based KB eval

### DIFF
--- a/pkg/extract/microsoft/bulletin/bulletin.go
+++ b/pkg/extract/microsoft/bulletin/bulletin.go
@@ -469,14 +469,25 @@ func (e extractor) extract(rows []bulletin.Bulletin) ([]dataTypes.Data, []micros
 			}); idx {
 			case -1:
 				g.conditions = append(g.conditions, conditionTypes.Condition{
-					Criteria: criteriaTypes.Criteria{Operator: criteriaTypes.CriteriaOperatorTypeOR, Criterions: []criterionTypes.Criterion{cn}},
-					Tag:      segmentTypes.DetectionTag(pn),
+					Criteria: criteriaTypes.Criteria{
+						Operator: criteriaTypes.CriteriaOperatorTypeOR,
+						Criterias: []criteriaTypes.Criteria{{
+							Operator:   criteriaTypes.CriteriaOperatorTypeAND,
+							Criterions: []criterionTypes.Criterion{cn},
+						}},
+					},
+					Tag: segmentTypes.DetectionTag(pn),
 				})
 			default:
-				if !slices.ContainsFunc(g.conditions[idx].Criteria.Criterions, func(e criterionTypes.Criterion) bool {
+				if len(g.conditions[idx].Criteria.Criterias) == 0 {
+					g.conditions[idx].Criteria.Criterias = []criteriaTypes.Criteria{{
+						Operator: criteriaTypes.CriteriaOperatorTypeAND,
+					}}
+				}
+				if !slices.ContainsFunc(g.conditions[idx].Criteria.Criterias[0].Criterions, func(e criterionTypes.Criterion) bool {
 					return e.KB != nil && e.KB.KBID == row.ComponentKB
 				}) {
-					g.conditions[idx].Criteria.Criterions = append(g.conditions[idx].Criteria.Criterions, cn)
+					g.conditions[idx].Criteria.Criterias[0].Criterions = append(g.conditions[idx].Criteria.Criterias[0].Criterions, cn)
 				}
 			}
 

--- a/pkg/extract/microsoft/bulletin/testdata/golden/data/08/MS08-069.json
+++ b/pkg/extract/microsoft/bulletin/testdata/golden/data/08/MS08-069.json
@@ -91,13 +91,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft XML Core Services 3.0 on Microsoft Windows 2000 Service Pack 4",
-									"kb_id": "955069"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft XML Core Services 3.0 on Microsoft Windows 2000 Service Pack 4",
+											"kb_id": "955069"
+										}
+									}
+								]
 							}
 						]
 					},

--- a/pkg/extract/microsoft/bulletin/testdata/golden/data/14/MS14-010.json
+++ b/pkg/extract/microsoft/bulletin/testdata/golden/data/14/MS14-010.json
@@ -5198,13 +5198,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 10 on Windows 7 for 32-bit Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 10 on Windows 7 for 32-bit Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5213,13 +5218,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 10 on Windows 7 for x64-based Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 10 on Windows 7 for x64-based Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5228,13 +5238,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 10 on Windows 8 for 32-bit Systems",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 10 on Windows 8 for 32-bit Systems",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5243,13 +5258,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 10 on Windows 8 for x64-based Systems",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 10 on Windows 8 for x64-based Systems",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5258,13 +5278,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 10 on Windows RT",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 10 on Windows RT",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5273,13 +5298,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 10 on Windows Server 2008 R2 for x64-based Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 10 on Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5288,13 +5318,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 10 on Windows Server 2012",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 10 on Windows Server 2012",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5303,13 +5338,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 9 on Windows 7 for 32-bit Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 9 on Windows 7 for 32-bit Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5318,13 +5358,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 9 on Windows 7 for x64-based Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 9 on Windows 7 for x64-based Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5333,13 +5378,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 9 on Windows Server 2008 R2 for x64-based Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 9 on Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5348,13 +5398,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 9 on Windows Server 2008 for 32-bit Systems Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 9 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5363,13 +5418,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 9 on Windows Server 2008 for x64-based Systems Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 9 on Windows Server 2008 for x64-based Systems Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5378,13 +5438,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 9 on Windows Vista Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 9 on Windows Vista Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5393,13 +5458,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 9 on Windows Vista x64 Edition Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 9 on Windows Vista x64 Edition Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5408,13 +5478,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 6.0 on Microsoft Windows Server 2003 Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 6.0 on Microsoft Windows Server 2003 Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5423,13 +5498,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 6.0 on Microsoft Windows Server 2003 for Itanium-based Systems Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 6.0 on Microsoft Windows Server 2003 for Itanium-based Systems Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5438,13 +5518,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 6.0 on Microsoft Windows Server 2003 x64 Edition Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 6.0 on Microsoft Windows Server 2003 x64 Edition Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5453,13 +5538,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 6.0 on Microsoft Windows XP Professional x64 Edition Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 6.0 on Microsoft Windows XP Professional x64 Edition Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5468,13 +5558,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 6.0 on Microsoft Windows XP Service Pack 3",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 6.0 on Microsoft Windows XP Service Pack 3",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5483,13 +5578,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 11 on Windows 7 for 32-bit Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 11 on Windows 7 for 32-bit Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5498,13 +5598,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 11 on Windows 7 for x64-based Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 11 on Windows 7 for x64-based Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5513,13 +5618,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 11 on Windows 8.1 for 32-bit Systems",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 11 on Windows 8.1 for 32-bit Systems",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5528,13 +5638,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 11 on Windows 8.1 for x64-based Systems",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 11 on Windows 8.1 for x64-based Systems",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5543,13 +5658,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 11 on Windows RT 8.1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 11 on Windows RT 8.1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5558,13 +5678,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 11 on Windows Server 2008 R2 for x64-based Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 11 on Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5573,13 +5698,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 11 on Windows Server 2012 R2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 11 on Windows Server 2012 R2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5588,13 +5718,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 7 on Microsoft Windows Server 2003 Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 7 on Microsoft Windows Server 2003 Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5603,13 +5738,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 7 on Microsoft Windows Server 2003 for Itanium-based Systems Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 7 on Microsoft Windows Server 2003 for Itanium-based Systems Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5618,13 +5758,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 7 on Microsoft Windows Server 2003 x64 Edition Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 7 on Microsoft Windows Server 2003 x64 Edition Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5633,13 +5778,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 7 on Microsoft Windows XP Professional x64 Edition Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 7 on Microsoft Windows XP Professional x64 Edition Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5648,13 +5798,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 7 on Microsoft Windows XP Service Pack 3",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 7 on Microsoft Windows XP Service Pack 3",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5663,13 +5818,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 7 on Windows Server 2008 for 32-bit Systems Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 7 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5678,13 +5838,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 7 on Windows Server 2008 for Itanium-based Systems Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 7 on Windows Server 2008 for Itanium-based Systems Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5693,13 +5858,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 7 on Windows Server 2008 for x64-based Systems Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 7 on Windows Server 2008 for x64-based Systems Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5708,13 +5878,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 7 on Windows Vista Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 7 on Windows Vista Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5723,13 +5898,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 7 on Windows Vista x64 Edition Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 7 on Windows Vista x64 Edition Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5738,13 +5918,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Microsoft Windows Server 2003 Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Microsoft Windows Server 2003 Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5753,13 +5938,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Microsoft Windows Server 2003 x64 Edition Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Microsoft Windows Server 2003 x64 Edition Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5768,13 +5958,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Microsoft Windows XP Professional x64 Edition Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Microsoft Windows XP Professional x64 Edition Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5783,13 +5978,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Microsoft Windows XP Service Pack 3",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Microsoft Windows XP Service Pack 3",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5798,13 +5998,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Windows 7 for 32-bit Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Windows 7 for 32-bit Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5813,13 +6018,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Windows 7 for x64-based Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Windows 7 for x64-based Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5828,13 +6038,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Windows Server 2008 R2 for Itanium-based Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Windows Server 2008 R2 for Itanium-based Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5843,13 +6058,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Windows Server 2008 R2 for x64-based Systems Service Pack 1",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5858,13 +6078,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Windows Server 2008 for 32-bit Systems Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5873,13 +6098,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Windows Server 2008 for x64-based Systems Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Windows Server 2008 for x64-based Systems Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5888,13 +6118,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Windows Vista Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Windows Vista Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -5903,13 +6138,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Internet Explorer 8 on Windows Vista x64 Edition Service Pack 2",
-									"kb_id": "2909921"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Internet Explorer 8 on Windows Vista x64 Edition Service Pack 2",
+											"kb_id": "2909921"
+										}
+									}
+								]
 							}
 						]
 					},

--- a/pkg/extract/microsoft/bulletin/testdata/golden/data/17/MS17-023.json
+++ b/pkg/extract/microsoft/bulletin/testdata/golden/data/17/MS17-023.json
@@ -38,13 +38,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Adobe Flash Player on Windows 10 Version 1511 for x64-based Systems",
-									"kb_id": "4014329"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Adobe Flash Player on Windows 10 Version 1511 for x64-based Systems",
+											"kb_id": "4014329"
+										}
+									}
+								]
 							}
 						]
 					},

--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -690,16 +690,36 @@ func buildDetections(v cvrf.Vulnerability, products map[string]string) (map[ecos
 
 func appendConditions(conditionsByEcosystem map[ecosystemTypes.Ecosystem][]conditionTypes.Condition, tag segmentTypes.DetectionTag, cns []criterionTypes.Criterion) {
 	conditions := conditionsByEcosystem[ecosystemTypes.EcosystemTypeMicrosoft]
+
+	idx := slices.IndexFunc(conditions, func(c conditionTypes.Condition) bool {
+		return c.Tag == tag
+	})
+	if idx == -1 {
+		conditions = append(conditions, conditionTypes.Condition{
+			Criteria: criteriaTypes.Criteria{Operator: criteriaTypes.CriteriaOperatorTypeOR},
+			Tag:      tag,
+		})
+		idx = len(conditions) - 1
+	}
+
 	for _, cn := range cns {
-		switch idx := slices.IndexFunc(conditions, func(c conditionTypes.Condition) bool {
-			return c.Tag == tag
-		}); idx {
-		case -1:
-			conditions = append(conditions, conditionTypes.Condition{
-				Criteria: criteriaTypes.Criteria{Operator: criteriaTypes.CriteriaOperatorTypeOR, Criterions: []criterionTypes.Criterion{cn}},
-				Tag:      tag,
-			})
+		switch cn.Type {
+		case criterionTypes.CriterionTypeKB:
+			// KB criterions go under a nested AND sub-criteria so that
+			// dual-track KBs (Monthly Rollup + Security Only) require ALL
+			// to be unapplied before reporting a vulnerability.
+			if len(conditions[idx].Criteria.Criterias) == 0 {
+				conditions[idx].Criteria.Criterias = []criteriaTypes.Criteria{{
+					Operator: criteriaTypes.CriteriaOperatorTypeAND,
+				}}
+			}
+			if !slices.ContainsFunc(conditions[idx].Criteria.Criterias[0].Criterions, func(e criterionTypes.Criterion) bool {
+				return criterionTypes.Compare(e, cn) == 0
+			}) {
+				conditions[idx].Criteria.Criterias[0].Criterions = append(conditions[idx].Criteria.Criterias[0].Criterions, cn)
+			}
 		default:
+			// Version criterions go directly under the top-level OR.
 			if !slices.ContainsFunc(conditions[idx].Criteria.Criterions, func(e criterionTypes.Criterion) bool {
 				return criterionTypes.Compare(e, cn) == 0
 			}) {
@@ -707,6 +727,7 @@ func appendConditions(conditionsByEcosystem map[ecosystemTypes.Ecosystem][]condi
 			}
 		}
 	}
+
 	conditionsByEcosystem[ecosystemTypes.EcosystemTypeMicrosoft] = conditions
 }
 func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criterionTypes.Criterion, error) {

--- a/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2016/CVE-2016-0088.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2016/CVE-2016-0088.json
@@ -60,13 +60,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Windows 10 for x64-based Systems",
-									"kb_id": "3147461"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Windows 10 for x64-based Systems",
+											"kb_id": "3147461"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -75,13 +80,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Windows 8.1 for x64-based Systems",
-									"kb_id": "3135456"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Windows 8.1 for x64-based Systems",
+											"kb_id": "3135456"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -90,13 +100,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Windows Server 2012",
-									"kb_id": "3135456"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Windows Server 2012",
+											"kb_id": "3135456"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -105,13 +120,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Windows Server 2012 (Server Core installation)",
-									"kb_id": "3135456"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Windows Server 2012 (Server Core installation)",
+											"kb_id": "3135456"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -120,13 +140,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Windows Server 2012 R2",
-									"kb_id": "3135456"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Windows Server 2012 R2",
+											"kb_id": "3135456"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -135,13 +160,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Windows Server 2012 R2 (Server Core installation)",
-									"kb_id": "3135456"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Windows Server 2012 R2 (Server Core installation)",
+											"kb_id": "3135456"
+										}
+									}
+								]
 							}
 						]
 					},

--- a/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2022/CVE-2022-41064.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2022/CVE-2022-41064.json
@@ -56,13 +56,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for 32-bit Systems",
-									"kb_id": "5019964"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for 32-bit Systems",
+											"kb_id": "5019964"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -71,13 +76,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for x64-based Systems",
-									"kb_id": "5019964"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows 10 Version 1607 for x64-based Systems",
+											"kb_id": "5019964"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -86,13 +96,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016",
-									"kb_id": "5019964"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016",
+											"kb_id": "5019964"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -101,13 +116,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016 (Server Core installation)",
-									"kb_id": "5019964"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016 (Server Core installation)",
+											"kb_id": "5019964"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -116,13 +136,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for 32-bit Systems",
-									"kb_id": "5020687"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for 32-bit Systems",
+											"kb_id": "5020687"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -131,13 +156,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems",
-									"kb_id": "5020687"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems",
+											"kb_id": "5020687"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -146,13 +176,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems",
-									"kb_id": "5020687"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems",
+											"kb_id": "5020687"
+										}
+									}
+								]
 							}
 						]
 					},

--- a/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2023/CVE-2023-29326.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2023/CVE-2023-29326.json
@@ -80,13 +80,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
-									"kb_id": "5027543"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+											"kb_id": "5027543"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -95,13 +100,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
-									"kb_id": "5027543"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 2.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
+											"kb_id": "5027543"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -110,13 +120,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
-									"kb_id": "5027543"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
+											"kb_id": "5027543"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -125,13 +140,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
-									"kb_id": "5027543"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2",
+											"kb_id": "5027543"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -140,13 +160,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.5 AND 4.7.2 on Windows 10 Version 1809 for x64-based Systems",
-									"kb_id": "5027536"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.5 AND 4.7.2 on Windows 10 Version 1809 for x64-based Systems",
+											"kb_id": "5027536"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -155,13 +180,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for 32-bit Systems",
-									"kb_id": "5027536"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for 32-bit Systems",
+											"kb_id": "5027536"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -170,13 +200,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for x64-based Systems",
-									"kb_id": "5027536"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows 10 Version 1809 for x64-based Systems",
+											"kb_id": "5027536"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -185,13 +220,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019",
-									"kb_id": "5027536"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019",
+											"kb_id": "5027536"
+										}
+									}
+								]
 							}
 						]
 					},
@@ -200,13 +240,18 @@
 				{
 					"criteria": {
 						"operator": "OR",
-						"criterions": [
+						"criterias": [
 							{
-								"type": "kb",
-								"kb": {
-									"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019 (Server Core installation)",
-									"kb_id": "5027536"
-								}
+								"operator": "AND",
+								"criterions": [
+									{
+										"type": "kb",
+										"kb": {
+											"product": "Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019 (Server Core installation)",
+											"kb_id": "5027536"
+										}
+									}
+								]
 							}
 						]
 					},

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/criterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/criterion.go
@@ -209,11 +209,11 @@ func (c Criterion) Contains(query Query, repositories []string) (bool, error) {
 			return false, nil
 		}
 
-		isAccepted, err := c.KB.Accept(*query.KB)
+		byCovered, byUnapplied, err := c.KB.Accept(*query.KB)
 		if err != nil {
 			return false, errors.Wrap(err, "kb criterion accept")
 		}
-		return isAccepted, nil
+		return byCovered || byUnapplied, nil
 	default:
 		return false, errors.Errorf("unexpected criterion type. expected: %q, actual: %q", []CriterionType{CriterionTypeVersion, CriterionTypeNoneExist, CriterionTypeKB}, c.Type)
 	}
@@ -224,10 +224,19 @@ type FilteredCriterion struct {
 	Accepts   AcceptQueries `json:"accepts,omitzero"`
 }
 
+// KB records which evaluation path accepted the KB criterion (i.e., detected
+// the vulnerability). Covered=true means the KB was accepted via covered-based
+// evaluation (the KB was NOT in the covered set, so it is vulnerable).
+// Unapplied=true means the KB was accepted via unapplied-based evaluation.
+type KB struct {
+	Covered   bool `json:"covered,omitempty"`
+	Unapplied bool `json:"unapplied,omitempty"`
+}
+
 type AcceptQueries struct {
 	Version   []int `json:"version,omitempty"`
 	NoneExist bool  `json:"none_exist,omitempty"`
-	KB        bool  `json:"kb,omitempty"`
+	KB        KB    `json:"kb,omitzero"`
 }
 
 func (c Criterion) Accept(query Query, repositories []string) (FilteredCriterion, error) {
@@ -278,13 +287,13 @@ func (c Criterion) Accept(query Query, repositories []string) (FilteredCriterion
 			return FilteredCriterion{Criterion: c, Accepts: AcceptQueries{}}, nil
 		}
 
-		isAccepted, err := c.KB.Accept(*query.KB)
+		byCovered, byUnapplied, err := c.KB.Accept(*query.KB)
 		if err != nil {
 			return FilteredCriterion{}, errors.Wrap(err, "kb criterion accept")
 		}
 		return FilteredCriterion{
 			Criterion: c,
-			Accepts:   AcceptQueries{KB: isAccepted},
+			Accepts:   AcceptQueries{KB: KB{Covered: byCovered, Unapplied: byUnapplied}},
 		}, nil
 	default:
 		return FilteredCriterion{}, errors.Errorf("unexpected criterion type. expected: %q, actual: %q", []CriterionType{CriterionTypeVersion, CriterionTypeNoneExist, CriterionTypeKB}, c.Type)
@@ -298,7 +307,7 @@ func (fc FilteredCriterion) Affected() (bool, error) {
 	case CriterionTypeNoneExist:
 		return fc.Accepts.NoneExist, nil
 	case CriterionTypeKB:
-		return fc.Accepts.KB, nil
+		return fc.Accepts.KB.Covered || fc.Accepts.KB.Unapplied, nil
 	default:
 		return false, errors.Errorf("unexpected criterion type. expected: %q, actual: %q", []CriterionType{CriterionTypeVersion, CriterionTypeNoneExist, CriterionTypeKB}, fc.Criterion.Type)
 	}

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/criterion_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/criterion_test.go
@@ -215,7 +215,8 @@ func TestCriterion_Contains(t *testing.T) {
 			args: args{
 				query: criterionTypes.Query{
 					KB: &kbcTypes.Query{
-						UnappliedKBs: []string{"5025239", "5025305"},
+						AcceptProducts: []string{"Windows 10"},
+						UnappliedKBs:   []string{"5025239", "5025305"},
 					},
 				},
 			},
@@ -233,7 +234,8 @@ func TestCriterion_Contains(t *testing.T) {
 			args: args{
 				query: criterionTypes.Query{
 					KB: &kbcTypes.Query{
-						UnappliedKBs: []string{"5025305"},
+						AcceptProducts: []string{"Windows 10"},
+						UnappliedKBs:   []string{"5025305"},
 					},
 				},
 			},
@@ -525,7 +527,8 @@ func TestCriterion_Accept(t *testing.T) {
 			args: args{
 				query: criterionTypes.Query{
 					KB: &kbcTypes.Query{
-						UnappliedKBs: []string{"5025239", "5025305"},
+						AcceptProducts: []string{"Windows 10"},
+						UnappliedKBs:   []string{"5025239", "5025305"},
 					},
 				},
 			},
@@ -537,7 +540,7 @@ func TestCriterion_Accept(t *testing.T) {
 						KBID:    "5025239",
 					},
 				},
-				Accepts: criterionTypes.AcceptQueries{KB: true},
+				Accepts: criterionTypes.AcceptQueries{KB: criterionTypes.KB{Unapplied: true}},
 			},
 		},
 		{
@@ -552,7 +555,8 @@ func TestCriterion_Accept(t *testing.T) {
 			args: args{
 				query: criterionTypes.Query{
 					KB: &kbcTypes.Query{
-						UnappliedKBs: []string{"5025305"},
+						AcceptProducts: []string{"Windows 10"},
+						UnappliedKBs:   []string{"5025305"},
 					},
 				},
 			},
@@ -564,7 +568,7 @@ func TestCriterion_Accept(t *testing.T) {
 						KBID:    "5025239",
 					},
 				},
-				Accepts: criterionTypes.AcceptQueries{KB: false},
+				Accepts: criterionTypes.AcceptQueries{KB: criterionTypes.KB{}},
 			},
 		},
 		{
@@ -782,7 +786,7 @@ func TestFilteredCriterion_Affected(t *testing.T) {
 						KBID:    "5025239",
 					},
 				},
-				Accepts: criterionTypes.AcceptQueries{KB: true},
+				Accepts: criterionTypes.AcceptQueries{KB: criterionTypes.KB{Unapplied: true}},
 			},
 			want: true,
 		},
@@ -796,7 +800,7 @@ func TestFilteredCriterion_Affected(t *testing.T) {
 						KBID:    "5025239",
 					},
 				},
-				Accepts: criterionTypes.AcceptQueries{KB: false},
+				Accepts: criterionTypes.AcceptQueries{KB: criterionTypes.KB{}},
 			},
 			want: false,
 		},

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/kbcriterion/kbcriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/kbcriterion/kbcriterion.go
@@ -3,6 +3,8 @@ package kbcriterion
 import (
 	"cmp"
 	"slices"
+
+	"github.com/pkg/errors"
 )
 
 type Criterion struct {
@@ -20,9 +22,37 @@ func Compare(x, y Criterion) int {
 }
 
 type Query struct {
+	// AcceptProducts restricts KB criterion matching to only those criteria
+	// whose Product is in this set. This prevents a KB criterion for an
+	// unrelated product (e.g., ARM64 variant) from being accepted when
+	// the host runs a different product (e.g., x64 variant).
+	// Callers must provide at least one product; Accept returns an error
+	// when this slice is empty.
+	AcceptProducts []string
+
+	// CoveredKBs is the set of KBs covered by an applied superseding KB.
+	// When non-empty, the KB criterion uses covered-based evaluation:
+	// a KB is considered vulnerable when it is NOT in CoveredKBs. This
+	// treats undiscovered KBs (not found by chain walking) as "not covered"
+	// (conservatively vulnerable) rather than "not unapplied."
+	CoveredKBs []string
+
+	// UnappliedKBs is the set of KBs discovered by supersession chain
+	// walking that are not covered by any applied KB. Used as a fallback
+	// when CoveredKBs is empty: a KB is considered vulnerable when it IS
+	// in UnappliedKBs.
 	UnappliedKBs []string
 }
 
-func (c Criterion) Accept(query Query) (bool, error) {
-	return slices.Contains(query.UnappliedKBs, c.KBID), nil
+func (c Criterion) Accept(query Query) (byCovered, byUnapplied bool, err error) {
+	if len(query.AcceptProducts) == 0 {
+		return false, false, errors.New("AcceptProducts must not be empty")
+	}
+	if !slices.Contains(query.AcceptProducts, c.Product) {
+		return false, false, nil
+	}
+	if len(query.CoveredKBs) > 0 {
+		return !slices.Contains(query.CoveredKBs, c.KBID), false, nil
+	}
+	return false, slices.Contains(query.UnappliedKBs, c.KBID), nil
 }

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/kbcriterion/kbcriterion_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/kbcriterion/kbcriterion_test.go
@@ -100,11 +100,12 @@ func TestCompare(t *testing.T) {
 
 func TestCriterion_Accept(t *testing.T) {
 	tests := []struct {
-		name      string
-		criterion kbcriterionTypes.Criterion
-		query     kbcriterionTypes.Query
-		want      bool
-		wantErr   bool
+		name          string
+		criterion     kbcriterionTypes.Criterion
+		query         kbcriterionTypes.Query
+		wantCovered   bool
+		wantUnapplied bool
+		wantErr       bool
 	}{
 		{
 			name: "kbid in unapplied list",
@@ -113,9 +114,10 @@ func TestCriterion_Accept(t *testing.T) {
 				KBID:    "5025239",
 			},
 			query: kbcriterionTypes.Query{
-				UnappliedKBs: []string{"5025239", "5025305"},
+				AcceptProducts: []string{"Windows 10"},
+				UnappliedKBs:   []string{"5025239", "5025305"},
 			},
-			want: true,
+			wantUnapplied: true,
 		},
 		{
 			name: "kbid not in unapplied list",
@@ -124,9 +126,9 @@ func TestCriterion_Accept(t *testing.T) {
 				KBID:    "5025239",
 			},
 			query: kbcriterionTypes.Query{
-				UnappliedKBs: []string{"5025305", "5025306"},
+				AcceptProducts: []string{"Windows 10"},
+				UnappliedKBs:   []string{"5025305", "5025306"},
 			},
-			want: false,
 		},
 		{
 			name: "empty unapplied list",
@@ -135,9 +137,9 @@ func TestCriterion_Accept(t *testing.T) {
 				KBID:    "5025239",
 			},
 			query: kbcriterionTypes.Query{
-				UnappliedKBs: []string{},
+				AcceptProducts: []string{"Windows 10"},
+				UnappliedKBs:   []string{},
 			},
-			want: false,
 		},
 		{
 			name: "nil unapplied list",
@@ -145,19 +147,91 @@ func TestCriterion_Accept(t *testing.T) {
 				Product: "Windows 10",
 				KBID:    "5025239",
 			},
-			query: kbcriterionTypes.Query{},
-			want:  false,
+			query: kbcriterionTypes.Query{
+				AcceptProducts: []string{"Windows 10"},
+			},
+		},
+		{
+			name: "product not in AcceptProducts is rejected",
+			criterion: kbcriterionTypes.Criterion{
+				Product: "Windows Server 2012 R2",
+				KBID:    "5025239",
+			},
+			query: kbcriterionTypes.Query{
+				AcceptProducts: []string{"Windows 10"},
+				UnappliedKBs:   []string{"5025239"},
+			},
+		},
+		{
+			name: "empty AcceptProducts returns error",
+			criterion: kbcriterionTypes.Criterion{
+				Product: "Windows 10",
+				KBID:    "5025239",
+			},
+			query: kbcriterionTypes.Query{
+				UnappliedKBs: []string{"5025239"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "covered-based: KB not in covered list is vulnerable",
+			criterion: kbcriterionTypes.Criterion{
+				Product: "Windows 10",
+				KBID:    "5025239",
+			},
+			query: kbcriterionTypes.Query{
+				AcceptProducts: []string{"Windows 10"},
+				CoveredKBs:     []string{"5025305"},
+			},
+			wantCovered: true,
+		},
+		{
+			name: "covered-based: KB in covered list is not vulnerable",
+			criterion: kbcriterionTypes.Criterion{
+				Product: "Windows 10",
+				KBID:    "5025239",
+			},
+			query: kbcriterionTypes.Query{
+				AcceptProducts: []string{"Windows 10"},
+				CoveredKBs:     []string{"5025239", "5025305"},
+			},
+		},
+		{
+			name: "covered-based: undiscovered KB treated as not covered",
+			criterion: kbcriterionTypes.Criterion{
+				Product: "Windows 10",
+				KBID:    "9999999",
+			},
+			query: kbcriterionTypes.Query{
+				AcceptProducts: []string{"Windows 10"},
+				CoveredKBs:     []string{"5025239"},
+			},
+			wantCovered: true,
+		},
+		{
+			name: "covered-based: product filter still applies",
+			criterion: kbcriterionTypes.Criterion{
+				Product: "Windows Server 2012 R2",
+				KBID:    "5025239",
+			},
+			query: kbcriterionTypes.Query{
+				AcceptProducts: []string{"Windows 10"},
+				CoveredKBs:     []string{"5025305"},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.criterion.Accept(tt.query)
+			gotCovered, gotUnapplied, err := tt.criterion.Accept(tt.query)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Accept() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("Accept() = %v, want %v", got, tt.want)
+			if gotCovered != tt.wantCovered {
+				t.Errorf("Accept() byCovered = %v, want %v", gotCovered, tt.wantCovered)
+			}
+			if gotUnapplied != tt.wantUnapplied {
+				t.Errorf("Accept() byUnapplied = %v, want %v", gotUnapplied, tt.wantUnapplied)
 			}
 		})
 	}


### PR DESCRIPTION
KB criterions are now grouped under AND sub-criteria within the top-level OR, ensuring dual-track KBs (Monthly Rollup / Security Only) are correctly evaluated together instead of independently.

Add covered-based evaluation: when CoveredKBs are available, KBs not in the covered set are conservatively treated as vulnerable, fixing regressions on legacy OSes (Server 2008, Win7) where chain walking alone was insufficient.

- Add AcceptProducts filter to restrict KB criterion by product
- Add KB struct with Covered/Unapplied fields
- Accept() returns (byCovered, byUnapplied, error) for transparent evaluation path tracking