### PR TITLE
feat(extract/msf): implement extractor

### DIFF
--- a/pkg/extract/msf/msf.go
+++ b/pkg/extract/msf/msf.go
@@ -1,13 +1,30 @@
 package msf
 
 import (
+	"fmt"
 	"io/fs"
 	"log/slog"
+	"net/url"
 	"path/filepath"
+	"slices"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	metasploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/metasploit"
+	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	utiltime "github.com/MaineK00n/vuls-data-update/pkg/extract/util/time"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/msf"
 )
 
 type options struct {
@@ -30,7 +47,7 @@ func WithDir(dir string) Option {
 
 func Extract(args string, opts ...Option) error {
 	options := &options{
-		dir: filepath.Join(util.CacheDir(), "extract", "", ""),
+		dir: filepath.Join(util.CacheDir(), "extract", "msf"),
 	}
 
 	for _, o := range opts {
@@ -42,17 +59,73 @@ func Extract(args string, opts ...Option) error {
 	}
 
 	slog.Info("Extract Metasploit Framework")
+
+	cveModules := make(map[string]dataTypes.Data)
+
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if d.IsDir() {
+		if d.IsDir() || filepath.Ext(path) != ".json" {
 			return nil
 		}
 
-		if filepath.Ext(path) != ".json" {
-			return nil
+		r := utiljson.NewJSONReader()
+		var fetched msf.Module
+		if err := r.Read(path, args, &fetched); err != nil {
+			return errors.Wrapf(err, "read %s", path)
+		}
+
+		cveIDs, refs, err := classifyReferences(fetched.References)
+		if err != nil {
+			return errors.Wrapf(err, "classify references for %s", path)
+		}
+
+		for _, cveID := range cveIDs {
+			base, ok := cveModules[cveID]
+			if !ok {
+				base = dataTypes.Data{
+					ID: dataTypes.RootID(cveID),
+					Vulnerabilities: []vulnerabilityTypes.Vulnerability{{
+						Content: vulnerabilityContentTypes.Content{
+							ID: vulnerabilityContentTypes.VulnerabilityID(cveID),
+						},
+					}},
+					DataSource: sourceTypes.Source{
+						ID: sourceTypes.Metasploit,
+					},
+				}
+			}
+
+			base.Vulnerabilities[0].Content.Metasploit = append(base.Vulnerabilities[0].Content.Metasploit, metasploitTypes.Metasploit{
+				Type:        fetched.Type,
+				Name:        fetched.Name,
+				FullName:    fetched.Fullname,
+				Aliases:     fetched.Aliases,
+				Description: fetched.Description,
+				Rank:        fetched.Rank,
+				Author:      fetched.Author,
+				Platform:    fetched.Platform,
+				Arch:        fetched.Arch,
+				Targets:     fetched.Targets,
+				Published: func() time.Time {
+					if t := utiltime.Parse([]string{"2006-01-02", "2006-01-02 15:04:05 -0700"}, fetched.DisclosureDate); t != nil {
+						return *t
+					}
+					return time.Time{}
+				}(),
+				Modified: func() time.Time {
+					if t := utiltime.Parse([]string{"2006-01-02", "2006-01-02 15:04:05 -0700"}, fetched.ModTime); t != nil {
+						return *t
+					}
+					return time.Time{}
+				}(),
+				References: refs,
+			})
+			base.DataSource.Raws = append(base.DataSource.Raws, r.Paths()...)
+
+			cveModules[cveID] = base
 		}
 
 		return nil
@@ -60,5 +133,118 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "walk %s", args)
 	}
 
+	for cveID, data := range cveModules {
+		splitted, err := util.Split(cveID, "-", "-")
+		if err != nil {
+			return errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", cveID)
+		}
+		if _, err := time.Parse("2006", splitted[1]); err != nil {
+			return errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", cveID)
+		}
+		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", cveID)), data, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", cveID)))
+		}
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.Metasploit,
+		Name: new("Metasploit Framework"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
 	return nil
+}
+
+// classifyReferences separates CVE IDs and other references from raw MSF reference strings.
+// Raw references use prefixes: "CVE-YYYY-NNNN", "URL-https://...", "MSB-...", "EDB-...", etc.
+func classifyReferences(refs []string) ([]string, []referenceTypes.Reference, error) {
+	var (
+		cveIDs     []string
+		references []referenceTypes.Reference
+	)
+	for _, ref := range refs {
+		switch {
+		case strings.HasPrefix(ref, "CVE-"):
+			splitted, err := util.Split(ref, "-", "-")
+			if err != nil {
+				return nil, nil, errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", ref)
+			}
+			if _, err := time.Parse("2006", splitted[1]); err != nil {
+				return nil, nil, errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", ref)
+			}
+			if !slices.Contains(cveIDs, ref) {
+				cveIDs = append(cveIDs, ref)
+			}
+			references = append(references, referenceTypes.Reference{
+				Source: "rapid7/metasploit",
+				URL:    fmt.Sprintf("https://www.cve.org/CVERecord?id=%s", ref),
+			})
+		case strings.HasPrefix(ref, "URL-"):
+			references = append(references, referenceTypes.Reference{
+				Source: "rapid7/metasploit",
+				URL:    strings.TrimPrefix(ref, "URL-"),
+			})
+		case strings.HasPrefix(ref, "EDB-"):
+			references = append(references, referenceTypes.Reference{
+				Source: "rapid7/metasploit",
+				URL:    fmt.Sprintf("https://www.exploit-db.com/exploits/%s", strings.TrimPrefix(ref, "EDB-")),
+			})
+		case strings.HasPrefix(ref, "MSB-"):
+			references = append(references, referenceTypes.Reference{
+				Source: "rapid7/metasploit",
+				URL:    fmt.Sprintf("https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/%s", strings.TrimPrefix(ref, "MSB-")),
+			})
+		case strings.HasPrefix(ref, "USN-"):
+			references = append(references, referenceTypes.Reference{
+				Source: "rapid7/metasploit",
+				URL:    fmt.Sprintf("https://ubuntu.com/security/notices/USN-%s", strings.TrimPrefix(ref, "USN-")),
+			})
+		case strings.HasPrefix(ref, "BID-"):
+			references = append(references, referenceTypes.Reference{
+				Source: "rapid7/metasploit",
+				URL:    fmt.Sprintf("https://www.securityfocus.com/bid/%s", strings.TrimPrefix(ref, "BID-")),
+			})
+		case strings.HasPrefix(ref, "ZDI-"):
+			references = append(references, referenceTypes.Reference{
+				Source: "rapid7/metasploit",
+				URL:    fmt.Sprintf("https://www.zerodayinitiative.com/advisories/%s", ref),
+			})
+		case strings.HasPrefix(ref, "PACKETSTORM-"):
+			references = append(references, referenceTypes.Reference{
+				Source: "rapid7/metasploit",
+				URL:    fmt.Sprintf("https://packetstormsecurity.com/files/%s", strings.TrimPrefix(ref, "PACKETSTORM-")),
+			})
+		case strings.HasPrefix(ref, "WPVDB-"):
+			references = append(references, referenceTypes.Reference{
+				Source: "rapid7/metasploit",
+				URL:    fmt.Sprintf("https://wpscan.com/vulnerability/%s", strings.TrimPrefix(ref, "WPVDB-")),
+			})
+		default:
+			u, err := url.Parse(ref)
+			if err != nil || u.Scheme == "" || u.Host == "" {
+				return nil, nil, errors.Errorf("unknown reference format: %s", ref)
+			}
+			references = append(references, referenceTypes.Reference{
+				Source: "rapid7/metasploit",
+				URL:    ref,
+			})
+		}
+	}
+	return cveIDs, references, nil
 }

--- a/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0143.json
+++ b/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0143.json
@@ -1,0 +1,98 @@
+{
+	"id": "CVE-2017-0143",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2017-0143",
+				"metasploit": [
+					{
+						"type": "exploit",
+						"name": "SMB DOUBLEPULSAR Remote Code Execution",
+						"full_name": "exploit/windows/smb/smb_doublepulsar_rce",
+						"aliases": [
+							"exploit/windows/smb/doublepulsar_rce"
+						],
+						"description": "This module executes a Metasploit payload against the Equation Group's\n        DOUBLEPULSAR implant for SMB as popularly deployed by ETERNALBLUE.\n\n        While this module primarily performs code execution against the implant,\n        the \"Neutralize implant\" target allows you to disable the implant.",
+						"rank": 500,
+						"author": [
+							"Equation Group",
+							"Jacob Robles",
+							"Luke Jennings",
+							"Shadow Brokers",
+							"wvu <wvu@metasploit.com>",
+							"zerosum0x0"
+						],
+						"platform": "Windows",
+						"arch": "x64",
+						"targets": [
+							"Execute payload (x64)",
+							"Neutralize implant"
+						],
+						"published": "2017-04-14T00:00:00Z",
+						"modified": "2020-05-07T20:22:56Z",
+						"references": [
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0143"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0144"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0145"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0146"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0147"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0148"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://countercept.com/blog/analyzing-the-doublepulsar-kernel-dll-injection-technique/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://gist.github.com/msuiche/50a36710ee59709d8c76fa50fc987be1"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-c2-traffic-decryptor"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-detection-script"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.countercept.com/blog/doublepulsar-usermode-analysis-generic-reflective-dll-loader/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://zerosum0x0.blogspot.com/2017/04/doublepulsar-initial-smb-backdoor-ring.html"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/MS17-010"
+							}
+						]
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "metasploit",
+		"raws": [
+			"fixtures/exploit/windows/smb/smb_doublepulsar_rce.json"
+		]
+	}
+}

--- a/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0144.json
+++ b/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0144.json
@@ -1,0 +1,98 @@
+{
+	"id": "CVE-2017-0144",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2017-0144",
+				"metasploit": [
+					{
+						"type": "exploit",
+						"name": "SMB DOUBLEPULSAR Remote Code Execution",
+						"full_name": "exploit/windows/smb/smb_doublepulsar_rce",
+						"aliases": [
+							"exploit/windows/smb/doublepulsar_rce"
+						],
+						"description": "This module executes a Metasploit payload against the Equation Group's\n        DOUBLEPULSAR implant for SMB as popularly deployed by ETERNALBLUE.\n\n        While this module primarily performs code execution against the implant,\n        the \"Neutralize implant\" target allows you to disable the implant.",
+						"rank": 500,
+						"author": [
+							"Equation Group",
+							"Jacob Robles",
+							"Luke Jennings",
+							"Shadow Brokers",
+							"wvu <wvu@metasploit.com>",
+							"zerosum0x0"
+						],
+						"platform": "Windows",
+						"arch": "x64",
+						"targets": [
+							"Execute payload (x64)",
+							"Neutralize implant"
+						],
+						"published": "2017-04-14T00:00:00Z",
+						"modified": "2020-05-07T20:22:56Z",
+						"references": [
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0143"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0144"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0145"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0146"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0147"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0148"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://countercept.com/blog/analyzing-the-doublepulsar-kernel-dll-injection-technique/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://gist.github.com/msuiche/50a36710ee59709d8c76fa50fc987be1"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-c2-traffic-decryptor"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-detection-script"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.countercept.com/blog/doublepulsar-usermode-analysis-generic-reflective-dll-loader/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://zerosum0x0.blogspot.com/2017/04/doublepulsar-initial-smb-backdoor-ring.html"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/MS17-010"
+							}
+						]
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "metasploit",
+		"raws": [
+			"fixtures/exploit/windows/smb/smb_doublepulsar_rce.json"
+		]
+	}
+}

--- a/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0145.json
+++ b/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0145.json
@@ -1,0 +1,98 @@
+{
+	"id": "CVE-2017-0145",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2017-0145",
+				"metasploit": [
+					{
+						"type": "exploit",
+						"name": "SMB DOUBLEPULSAR Remote Code Execution",
+						"full_name": "exploit/windows/smb/smb_doublepulsar_rce",
+						"aliases": [
+							"exploit/windows/smb/doublepulsar_rce"
+						],
+						"description": "This module executes a Metasploit payload against the Equation Group's\n        DOUBLEPULSAR implant for SMB as popularly deployed by ETERNALBLUE.\n\n        While this module primarily performs code execution against the implant,\n        the \"Neutralize implant\" target allows you to disable the implant.",
+						"rank": 500,
+						"author": [
+							"Equation Group",
+							"Jacob Robles",
+							"Luke Jennings",
+							"Shadow Brokers",
+							"wvu <wvu@metasploit.com>",
+							"zerosum0x0"
+						],
+						"platform": "Windows",
+						"arch": "x64",
+						"targets": [
+							"Execute payload (x64)",
+							"Neutralize implant"
+						],
+						"published": "2017-04-14T00:00:00Z",
+						"modified": "2020-05-07T20:22:56Z",
+						"references": [
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0143"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0144"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0145"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0146"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0147"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0148"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://countercept.com/blog/analyzing-the-doublepulsar-kernel-dll-injection-technique/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://gist.github.com/msuiche/50a36710ee59709d8c76fa50fc987be1"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-c2-traffic-decryptor"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-detection-script"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.countercept.com/blog/doublepulsar-usermode-analysis-generic-reflective-dll-loader/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://zerosum0x0.blogspot.com/2017/04/doublepulsar-initial-smb-backdoor-ring.html"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/MS17-010"
+							}
+						]
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "metasploit",
+		"raws": [
+			"fixtures/exploit/windows/smb/smb_doublepulsar_rce.json"
+		]
+	}
+}

--- a/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0146.json
+++ b/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0146.json
@@ -1,0 +1,98 @@
+{
+	"id": "CVE-2017-0146",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2017-0146",
+				"metasploit": [
+					{
+						"type": "exploit",
+						"name": "SMB DOUBLEPULSAR Remote Code Execution",
+						"full_name": "exploit/windows/smb/smb_doublepulsar_rce",
+						"aliases": [
+							"exploit/windows/smb/doublepulsar_rce"
+						],
+						"description": "This module executes a Metasploit payload against the Equation Group's\n        DOUBLEPULSAR implant for SMB as popularly deployed by ETERNALBLUE.\n\n        While this module primarily performs code execution against the implant,\n        the \"Neutralize implant\" target allows you to disable the implant.",
+						"rank": 500,
+						"author": [
+							"Equation Group",
+							"Jacob Robles",
+							"Luke Jennings",
+							"Shadow Brokers",
+							"wvu <wvu@metasploit.com>",
+							"zerosum0x0"
+						],
+						"platform": "Windows",
+						"arch": "x64",
+						"targets": [
+							"Execute payload (x64)",
+							"Neutralize implant"
+						],
+						"published": "2017-04-14T00:00:00Z",
+						"modified": "2020-05-07T20:22:56Z",
+						"references": [
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0143"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0144"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0145"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0146"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0147"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0148"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://countercept.com/blog/analyzing-the-doublepulsar-kernel-dll-injection-technique/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://gist.github.com/msuiche/50a36710ee59709d8c76fa50fc987be1"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-c2-traffic-decryptor"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-detection-script"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.countercept.com/blog/doublepulsar-usermode-analysis-generic-reflective-dll-loader/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://zerosum0x0.blogspot.com/2017/04/doublepulsar-initial-smb-backdoor-ring.html"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/MS17-010"
+							}
+						]
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "metasploit",
+		"raws": [
+			"fixtures/exploit/windows/smb/smb_doublepulsar_rce.json"
+		]
+	}
+}

--- a/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0147.json
+++ b/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0147.json
@@ -1,0 +1,98 @@
+{
+	"id": "CVE-2017-0147",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2017-0147",
+				"metasploit": [
+					{
+						"type": "exploit",
+						"name": "SMB DOUBLEPULSAR Remote Code Execution",
+						"full_name": "exploit/windows/smb/smb_doublepulsar_rce",
+						"aliases": [
+							"exploit/windows/smb/doublepulsar_rce"
+						],
+						"description": "This module executes a Metasploit payload against the Equation Group's\n        DOUBLEPULSAR implant for SMB as popularly deployed by ETERNALBLUE.\n\n        While this module primarily performs code execution against the implant,\n        the \"Neutralize implant\" target allows you to disable the implant.",
+						"rank": 500,
+						"author": [
+							"Equation Group",
+							"Jacob Robles",
+							"Luke Jennings",
+							"Shadow Brokers",
+							"wvu <wvu@metasploit.com>",
+							"zerosum0x0"
+						],
+						"platform": "Windows",
+						"arch": "x64",
+						"targets": [
+							"Execute payload (x64)",
+							"Neutralize implant"
+						],
+						"published": "2017-04-14T00:00:00Z",
+						"modified": "2020-05-07T20:22:56Z",
+						"references": [
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0143"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0144"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0145"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0146"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0147"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0148"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://countercept.com/blog/analyzing-the-doublepulsar-kernel-dll-injection-technique/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://gist.github.com/msuiche/50a36710ee59709d8c76fa50fc987be1"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-c2-traffic-decryptor"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-detection-script"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.countercept.com/blog/doublepulsar-usermode-analysis-generic-reflective-dll-loader/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://zerosum0x0.blogspot.com/2017/04/doublepulsar-initial-smb-backdoor-ring.html"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/MS17-010"
+							}
+						]
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "metasploit",
+		"raws": [
+			"fixtures/exploit/windows/smb/smb_doublepulsar_rce.json"
+		]
+	}
+}

--- a/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0148.json
+++ b/pkg/extract/msf/testdata/golden/data/2017/CVE-2017-0148.json
@@ -1,0 +1,98 @@
+{
+	"id": "CVE-2017-0148",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2017-0148",
+				"metasploit": [
+					{
+						"type": "exploit",
+						"name": "SMB DOUBLEPULSAR Remote Code Execution",
+						"full_name": "exploit/windows/smb/smb_doublepulsar_rce",
+						"aliases": [
+							"exploit/windows/smb/doublepulsar_rce"
+						],
+						"description": "This module executes a Metasploit payload against the Equation Group's\n        DOUBLEPULSAR implant for SMB as popularly deployed by ETERNALBLUE.\n\n        While this module primarily performs code execution against the implant,\n        the \"Neutralize implant\" target allows you to disable the implant.",
+						"rank": 500,
+						"author": [
+							"Equation Group",
+							"Jacob Robles",
+							"Luke Jennings",
+							"Shadow Brokers",
+							"wvu <wvu@metasploit.com>",
+							"zerosum0x0"
+						],
+						"platform": "Windows",
+						"arch": "x64",
+						"targets": [
+							"Execute payload (x64)",
+							"Neutralize implant"
+						],
+						"published": "2017-04-14T00:00:00Z",
+						"modified": "2020-05-07T20:22:56Z",
+						"references": [
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0143"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0144"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0145"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0146"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0147"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.cve.org/CVERecord?id=CVE-2017-0148"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://countercept.com/blog/analyzing-the-doublepulsar-kernel-dll-injection-technique/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://gist.github.com/msuiche/50a36710ee59709d8c76fa50fc987be1"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-c2-traffic-decryptor"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://github.com/countercept/doublepulsar-detection-script"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://www.countercept.com/blog/doublepulsar-usermode-analysis-generic-reflective-dll-loader/"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://zerosum0x0.blogspot.com/2017/04/doublepulsar-initial-smb-backdoor-ring.html"
+							},
+							{
+								"source": "rapid7/metasploit",
+								"url": "https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/MS17-010"
+							}
+						]
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "metasploit",
+		"raws": [
+			"fixtures/exploit/windows/smb/smb_doublepulsar_rce.json"
+		]
+	}
+}

--- a/pkg/extract/msf/testdata/golden/datasource.json
+++ b/pkg/extract/msf/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "metasploit",
+	"name": "Metasploit Framework"
+}

--- a/pkg/extract/types/data/metasploit/metasploit.go
+++ b/pkg/extract/types/data/metasploit/metasploit.go
@@ -12,14 +12,22 @@ type Metasploit struct {
 	Type        string                     `json:"type,omitempty"`
 	Name        string                     `json:"name,omitempty"`
 	FullName    string                     `json:"full_name,omitempty"`
+	Aliases     []string                   `json:"aliases,omitempty"`
 	Description string                     `json:"description,omitempty"`
 	Rank        int                        `json:"rank,omitempty"`
-	Published   *time.Time                 `json:"published,omitempty"`
-	Modified    *time.Time                 `json:"modified,omitempty"`
+	Author      []string                   `json:"author,omitempty"`
+	Platform    string                     `json:"platform,omitempty"`
+	Arch        string                     `json:"arch,omitempty"`
+	Targets     []string                   `json:"targets,omitempty"`
+	Published   time.Time                  `json:"published,omitzero"`
+	Modified    time.Time                  `json:"modified,omitzero"`
 	References  []referenceTypes.Reference `json:"references,omitempty"`
 }
 
 func (m *Metasploit) Sort() {
+	slices.Sort(m.Aliases)
+	slices.Sort(m.Author)
+	slices.Sort(m.Targets)
 	slices.SortFunc(m.References, referenceTypes.Compare)
 }
 

--- a/pkg/extract/types/data/metasploit/metasploit_test.go
+++ b/pkg/extract/types/data/metasploit/metasploit_test.go
@@ -1,43 +1,58 @@
 package metasploit_test
 
 import (
+	"reflect"
 	"testing"
-	"time"
 
 	metasploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/metasploit"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
 )
 
 func TestMetasploit_Sort(t *testing.T) {
-	type fields struct {
-		Type        string
-		Name        string
-		FullName    string
-		Description string
-		Rank        int
-		Published   *time.Time
-		Modified    *time.Time
-		References  []referenceTypes.Reference
-	}
 	tests := []struct {
-		name   string
-		fields fields
+		name  string
+		input metasploitTypes.Metasploit
+		want  metasploitTypes.Metasploit
 	}{
-		// TODO: Add test cases.
+		{
+			name: "sorts all slice fields",
+			input: metasploitTypes.Metasploit{
+				Type:     "exploit",
+				Name:     "SMB DOUBLEPULSAR Remote Code Execution",
+				FullName: "exploit/windows/smb/smb_doublepulsar_rce",
+				Aliases:  []string{"exploit/windows/smb/doublepulsar_rce", "exploit/windows/smb/alias_a"},
+				Author:   []string{"zerosum0x0", "Luke Jennings", "Shadow Brokers"},
+				Targets:  []string{"Windows x64 (Native Payload)", "Windows x64", "Windows x86"},
+				References: []referenceTypes.Reference{
+					{Source: "rapid7/metasploit", URL: "https://zerosum0x0.blogspot.com"},
+					{Source: "rapid7/metasploit", URL: "https://www.cve.org/CVERecord?id=CVE-2017-0143"},
+				},
+			},
+			want: metasploitTypes.Metasploit{
+				Type:     "exploit",
+				Name:     "SMB DOUBLEPULSAR Remote Code Execution",
+				FullName: "exploit/windows/smb/smb_doublepulsar_rce",
+				Aliases:  []string{"exploit/windows/smb/alias_a", "exploit/windows/smb/doublepulsar_rce"},
+				Author:   []string{"Luke Jennings", "Shadow Brokers", "zerosum0x0"},
+				Targets:  []string{"Windows x64", "Windows x64 (Native Payload)", "Windows x86"},
+				References: []referenceTypes.Reference{
+					{Source: "rapid7/metasploit", URL: "https://www.cve.org/CVERecord?id=CVE-2017-0143"},
+					{Source: "rapid7/metasploit", URL: "https://zerosum0x0.blogspot.com"},
+				},
+			},
+		},
+		{
+			name:  "empty slices",
+			input: metasploitTypes.Metasploit{Type: "auxiliary"},
+			want:  metasploitTypes.Metasploit{Type: "auxiliary"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := &metasploitTypes.Metasploit{
-				Type:        tt.fields.Type,
-				Name:        tt.fields.Name,
-				FullName:    tt.fields.FullName,
-				Description: tt.fields.Description,
-				Rank:        tt.fields.Rank,
-				Published:   tt.fields.Published,
-				Modified:    tt.fields.Modified,
-				References:  tt.fields.References,
+			tt.input.Sort()
+			if !reflect.DeepEqual(tt.input, tt.want) {
+				t.Errorf("Sort() result mismatch:\n got  %+v\n want %+v", tt.input, tt.want)
 			}
-			m.Sort()
 		})
 	}
 }


### PR DESCRIPTION
 Add full extraction logic to convert raw Metasploit module data into
 per-CVE JSON files. Classify MSF references (CVE, EDB, MSB, URL, etc.)
 and map module metadata to structured output.

 Also extend metasploitTypes.Metasploit with additional fields:
 Aliases, Author, Platform, Arch, Targets.

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>