### PR TITLE
feat(extract/inthewild): implement extractor

### DIFF
--- a/pkg/extract/exploit/inthewild/inthewild.go
+++ b/pkg/extract/exploit/inthewild/inthewild.go
@@ -1,13 +1,30 @@
 package inthewild
 
 import (
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
+	advisoryContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory/content"
+	exploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit"
+	inthewildTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/inthewild"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	utiltime "github.com/MaineK00n/vuls-data-update/pkg/extract/util/time"
+	fetchTypes "github.com/MaineK00n/vuls-data-update/pkg/fetch/exploit/inthewild"
 )
 
 type options struct {
@@ -30,7 +47,7 @@ func WithDir(dir string) Option {
 
 func Extract(args string, opts ...Option) error {
 	options := &options{
-		dir: filepath.Join(util.CacheDir(), "extract", "", ""),
+		dir: filepath.Join(util.CacheDir(), "extract", "exploit", "inthewild"),
 	}
 
 	for _, o := range opts {
@@ -42,17 +59,39 @@ func Extract(args string, opts ...Option) error {
 	}
 
 	slog.Info("Extract Exploit InTheWild")
+
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if d.IsDir() {
+		if d.IsDir() || filepath.Ext(path) != ".json" {
 			return nil
 		}
 
-		if filepath.Ext(path) != ".json" {
-			return nil
+		data, err := extract(path, args)
+		if err != nil {
+			return errors.Wrapf(err, "extract %s", path)
+		}
+
+		switch {
+		case strings.HasPrefix(string(data.ID), "CVE-"):
+			splitted, err := util.Split(string(data.ID), "-", "-")
+			if err != nil {
+				return errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", data.ID)
+			}
+			if _, err := time.Parse("2006", splitted[1]); err != nil {
+				return errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", data.ID)
+			}
+			if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", data.ID)), data, true); err != nil {
+				return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", data.ID)))
+			}
+		case strings.HasPrefix(string(data.ID), "ADV"):
+			if err := util.Write(filepath.Join(options.dir, "data", "others", fmt.Sprintf("%s.json", data.ID)), data, true); err != nil {
+				return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", "others", fmt.Sprintf("%s.json", data.ID)))
+			}
+		default:
+			slog.Warn("Skip unexpected ID", "id", data.ID)
 		}
 
 		return nil
@@ -60,5 +99,84 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "walk %s", args)
 	}
 
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.ExploitInTheWild,
+		Name: new("InTheWild.io - Check if a CVE is exploited in the wild"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
 	return nil
+}
+
+func extract(path, args string) (dataTypes.Data, error) {
+	r := utiljson.NewJSONReader()
+	var f fetchTypes.Exploit
+	if err := r.Read(path, args, &f); err != nil {
+		return dataTypes.Data{}, errors.Wrapf(err, "read %s", path)
+	}
+
+	var exploits []exploitTypes.Exploit
+	for _, ref := range f.References {
+		switch ref.Type {
+		case "exploit", "exploitation":
+			exploits = append(exploits, exploitTypes.Exploit{
+				Source: "inthewild.io",
+				Link:   ref.URL,
+				Published: func() time.Time {
+					if t := utiltime.Parse([]string{"2006-01-02T15:04:05Z"}, ref.TimeStamp); t != nil {
+						return *t
+					}
+					return time.Time{}
+				}(),
+				InTheWild: &inthewildTypes.InTheWild{
+					Type:   ref.Type,
+					Source: ref.Source,
+				},
+			})
+		default:
+			slog.Warn("Skip unexpected reference type", "type", ref.Type, "url", ref.URL)
+		}
+	}
+
+	data := dataTypes.Data{
+		ID: dataTypes.RootID(f.ID),
+		DataSource: sourceTypes.Source{
+			ID:   sourceTypes.ExploitInTheWild,
+			Raws: r.Paths(),
+		},
+	}
+
+	if strings.HasPrefix(f.ID, "CVE-") {
+		data.Vulnerabilities = []vulnerabilityTypes.Vulnerability{{
+			Content: vulnerabilityContentTypes.Content{
+				ID:      vulnerabilityContentTypes.VulnerabilityID(f.ID),
+				Exploit: exploits,
+			},
+		}}
+	} else {
+		data.Advisories = []advisoryTypes.Advisory{{
+			Content: advisoryContentTypes.Content{
+				ID:      advisoryContentTypes.AdvisoryID(f.ID),
+				Exploit: exploits,
+			},
+		}}
+	}
+
+	return data, nil
 }

--- a/pkg/extract/exploit/inthewild/testdata/golden/data/2022/CVE-2022-25084.json
+++ b/pkg/extract/exploit/inthewild/testdata/golden/data/2022/CVE-2022-25084.json
@@ -1,0 +1,27 @@
+{
+	"id": "CVE-2022-25084",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-25084",
+				"exploit": [
+					{
+						"source": "inthewild.io",
+						"published": "2022-04-01T00:00:00Z",
+						"link": "https://www.fortinet.com/blog/threat-research/totolink-vulnerabilities-beastmode-mirai-campaign",
+						"inthewild": {
+							"type": "exploitation",
+							"source": "API"
+						}
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "exploit-inthewild",
+		"raws": [
+			"fixtures/2022/CVE-2022-25084.json"
+		]
+	}
+}

--- a/pkg/extract/exploit/inthewild/testdata/golden/data/2022/CVE-2022-6969.json
+++ b/pkg/extract/exploit/inthewild/testdata/golden/data/2022/CVE-2022-6969.json
@@ -1,0 +1,27 @@
+{
+	"id": "CVE-2022-6969",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-6969",
+				"exploit": [
+					{
+						"source": "inthewild.io",
+						"published": "2022-06-16T11:58:36Z",
+						"link": "https://github.com/piaoliangshu/piaoliangshusb",
+						"inthewild": {
+							"type": "exploit",
+							"source": "Github"
+						}
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "exploit-inthewild",
+		"raws": [
+			"fixtures/2022/CVE-2022-6969.json"
+		]
+	}
+}

--- a/pkg/extract/exploit/inthewild/testdata/golden/data/others/ADV200006.json
+++ b/pkg/extract/exploit/inthewild/testdata/golden/data/others/ADV200006.json
@@ -1,0 +1,27 @@
+{
+	"id": "ADV200006",
+	"advisories": [
+		{
+			"content": {
+				"id": "ADV200006",
+				"exploit": [
+					{
+						"source": "inthewild.io",
+						"published": "2020-04-14T07:00:00Z",
+						"link": "https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/ADV200006",
+						"inthewild": {
+							"type": "exploitation",
+							"source": "MS"
+						}
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "exploit-inthewild",
+		"raws": [
+			"fixtures/others/ADV200006.json"
+		]
+	}
+}

--- a/pkg/extract/exploit/inthewild/testdata/golden/datasource.json
+++ b/pkg/extract/exploit/inthewild/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "exploit-inthewild",
+	"name": "InTheWild.io - Check if a CVE is exploited in the wild"
+}

--- a/pkg/extract/types/data/advisory/content/content.go
+++ b/pkg/extract/types/data/advisory/content/content.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
+	exploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit"
 	kevTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
@@ -17,6 +18,7 @@ type Content struct {
 	Description string                     `json:"description,omitempty"`
 	Severity    []severityTypes.Severity   `json:"severity,omitempty"`
 	CWE         []cweTypes.CWE             `json:"cwe,omitempty"`
+	Exploit     []exploitTypes.Exploit     `json:"exploit,omitempty"`
 	KEV         *kevTypes.KEV              `json:"kev,omitempty"`
 	References  []referenceTypes.Reference `json:"references,omitempty"`
 	Published   *time.Time                 `json:"published,omitempty"`
@@ -34,6 +36,11 @@ func (c *Content) Sort() {
 	}
 	slices.SortFunc(c.CWE, cweTypes.Compare)
 
+	for i := range c.Exploit {
+		(&c.Exploit[i]).Sort()
+	}
+	slices.SortFunc(c.Exploit, exploitTypes.Compare)
+
 	if c.KEV != nil {
 		c.KEV.Sort()
 	}
@@ -48,6 +55,7 @@ func Compare(x, y Content) int {
 		cmp.Compare(x.Description, y.Description),
 		slices.CompareFunc(x.Severity, y.Severity, severityTypes.Compare),
 		slices.CompareFunc(x.CWE, y.CWE, cweTypes.Compare),
+		slices.CompareFunc(x.Exploit, y.Exploit, exploitTypes.Compare),
 		func() int {
 			switch {
 			case x.KEV == nil && y.KEV == nil:

--- a/pkg/extract/types/data/exploit/exploit.go
+++ b/pkg/extract/types/data/exploit/exploit.go
@@ -6,6 +6,7 @@ import (
 
 	exploitdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/exploitdb"
 	githubTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/github"
+	inthewildTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/inthewild"
 )
 
 type Exploit struct {
@@ -17,6 +18,7 @@ type Exploit struct {
 
 	ExploitDB *exploitdbTypes.ExploitDB `json:"exploit_db,omitempty"`
 	GitHub    *githubTypes.GitHub       `json:"github,omitempty"`
+	InTheWild *inthewildTypes.InTheWild `json:"inthewild,omitempty"`
 }
 
 func (e *Exploit) Sort() {
@@ -54,6 +56,18 @@ func Compare(x, y Exploit) int {
 				return +1
 			default:
 				return githubTypes.Compare(*x.GitHub, *y.GitHub)
+			}
+		}(),
+		func() int {
+			switch {
+			case x.InTheWild == nil && y.InTheWild == nil:
+				return 0
+			case x.InTheWild == nil && y.InTheWild != nil:
+				return -1
+			case x.InTheWild != nil && y.InTheWild == nil:
+				return +1
+			default:
+				return inthewildTypes.Compare(*x.InTheWild, *y.InTheWild)
 			}
 		}(),
 	)

--- a/pkg/extract/types/data/exploit/exploit_test.go
+++ b/pkg/extract/types/data/exploit/exploit_test.go
@@ -8,6 +8,7 @@ import (
 	exploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit"
 	exploitdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/exploitdb"
 	githubTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/github"
+	inthewildTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/inthewild"
 )
 
 func TestExploit_Sort(t *testing.T) {
@@ -174,6 +175,30 @@ func TestCompare(t *testing.T) {
 			args: args{
 				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", GitHub: &githubTypes.GitHub{Owner: "owner", Topics: []string{"exploit"}}},
 				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", GitHub: &githubTypes.GitHub{Owner: "owner", Topics: []string{"exploit", "poc"}}},
+			},
+			want: -1,
+		},
+		{
+			name: "x:inthewild nil < y:inthewild non-nil",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", InTheWild: &inthewildTypes.InTheWild{Type: "exploited"}},
+			},
+			want: -1,
+		},
+		{
+			name: "x:inthewild non-nil > y:inthewild nil",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", InTheWild: &inthewildTypes.InTheWild{Type: "exploited"}},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+			},
+			want: +1,
+		},
+		{
+			name: "inthewild.Compare as tie-breaker",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", InTheWild: &inthewildTypes.InTheWild{Type: "exploited"}},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", InTheWild: &inthewildTypes.InTheWild{Type: "exploited", Source: "src"}},
 			},
 			want: -1,
 		},

--- a/pkg/extract/types/data/exploit/inthewild/inthewild.go
+++ b/pkg/extract/types/data/exploit/inthewild/inthewild.go
@@ -1,0 +1,15 @@
+package inthewild
+
+import "cmp"
+
+type InTheWild struct {
+	Type   string `json:"type,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+func Compare(x, y InTheWild) int {
+	return cmp.Or(
+		cmp.Compare(x.Type, y.Type),
+		cmp.Compare(x.Source, y.Source),
+	)
+}


### PR DESCRIPTION
Add InTheWild-specific sub-struct with type and source fields.
Extract per file; CVE IDs go to data/<year>/, ADV IDs go to data/others/,
and other non-CVE IDs are skipped with a warning.