### PR TITLE
feat(extract/exploitdb): implement extractor

### DIFF
--- a/pkg/extract/exploit/exploitdb/exploitdb.go
+++ b/pkg/extract/exploit/exploitdb/exploitdb.go
@@ -1,13 +1,28 @@
 package exploitdb
 
 import (
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	exploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit"
+	exploitdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/exploitdb"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	utiltime "github.com/MaineK00n/vuls-data-update/pkg/extract/util/time"
+	fetchTypes "github.com/MaineK00n/vuls-data-update/pkg/fetch/exploit/exploitdb"
 )
 
 type options struct {
@@ -28,9 +43,21 @@ func WithDir(dir string) Option {
 	return dirOption(dir)
 }
 
+type decoded struct {
+	id            string
+	description   string
+	datePublished string
+	dateUpdated   string
+	codes         string
+	author        string
+	exploitType   string
+	platform      string
+	verified      string
+}
+
 func Extract(args string, opts ...Option) error {
 	options := &options{
-		dir: filepath.Join(util.CacheDir(), "extract", "", ""),
+		dir: filepath.Join(util.CacheDir(), "extract", "exploit", "exploitdb"),
 	}
 
 	for _, o := range opts {
@@ -42,23 +69,171 @@ func Extract(args string, opts ...Option) error {
 	}
 
 	slog.Info("Extract Exploit-DB")
-	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
+
+	cveExploits, err := extract(args)
+	if err != nil {
+		return errors.Wrap(err, "extract")
+	}
+
+	for cveID, data := range cveExploits {
+		splitted, err := util.Split(cveID, "-", "-")
 		if err != nil {
-			return err
+			return errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", cveID)
 		}
+		if _, err := time.Parse("2006", splitted[1]); err != nil {
+			return errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", cveID)
+		}
+		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", cveID)), data, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", cveID)))
+		}
+	}
 
-		if d.IsDir() {
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.ExploitExploitDB,
+		Name: new("Exploit Database - Exploits for Penetration Testers"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
 			return nil
-		}
-
-		if filepath.Ext(path) != ".json" {
-			return nil
-		}
-
-		return nil
-	}); err != nil {
-		return errors.Wrapf(err, "walk %s", args)
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
 	}
 
 	return nil
+}
+
+func extract(args string) (map[string]dataTypes.Data, error) {
+	cveExploits := make(map[string]dataTypes.Data)
+
+	for _, category := range []struct {
+		subdir string
+		decode func(r *utiljson.JSONReader, path, prefix string) (decoded, error)
+	}{
+		{
+			subdir: "exploits",
+			decode: func(r *utiljson.JSONReader, path, prefix string) (decoded, error) {
+				var f fetchTypes.Exploit
+				if err := r.Read(path, prefix, &f); err != nil {
+					return decoded{}, errors.Wrapf(err, "read %s", path)
+				}
+				return decoded{
+					id: f.ID, description: f.Description, datePublished: f.DatePublished, dateUpdated: f.DateUpdated,
+					codes: f.Codes, author: f.Author, exploitType: f.Type, platform: f.Platform, verified: f.Verified,
+				}, nil
+			},
+		},
+		{
+			subdir: "shellcodes",
+			decode: func(r *utiljson.JSONReader, path, prefix string) (decoded, error) {
+				var f fetchTypes.Shellcode
+				if err := r.Read(path, prefix, &f); err != nil {
+					return decoded{}, errors.Wrapf(err, "read %s", path)
+				}
+				return decoded{
+					id: f.ID, description: f.Description, datePublished: f.DatePublished, dateUpdated: f.DateUpdated,
+					codes: f.Codes, author: f.Author, exploitType: f.Type, platform: f.Platform, verified: f.Verified,
+				}, nil
+			},
+		},
+		{
+			subdir: "papers",
+			decode: func(r *utiljson.JSONReader, path, prefix string) (decoded, error) {
+				var f fetchTypes.Paper
+				if err := r.Read(path, prefix, &f); err != nil {
+					return decoded{}, errors.Wrapf(err, "read %s", path)
+				}
+				return decoded{
+					id: f.ID, description: f.Description, datePublished: f.DatePublished, dateUpdated: f.DateUpdated,
+					codes: f.Codes, author: f.Author, exploitType: f.Type, platform: f.Platform, verified: f.Verified,
+				}, nil
+			},
+		},
+	} {
+		if err := filepath.WalkDir(filepath.Join(args, category.subdir), func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if d.IsDir() || filepath.Ext(path) != ".json" {
+				return nil
+			}
+
+			r := utiljson.NewJSONReader()
+			entry, err := category.decode(r, path, args)
+			if err != nil {
+				return errors.Wrapf(err, "decode %s", path)
+			}
+
+			if entry.codes == "" {
+				return nil
+			}
+
+			for code := range strings.SplitSeq(entry.codes, ";") {
+				if !strings.HasPrefix(code, "CVE-") {
+					continue
+				}
+
+				base, ok := cveExploits[code]
+				if !ok {
+					base = dataTypes.Data{
+						ID: dataTypes.RootID(code),
+						Vulnerabilities: []vulnerabilityTypes.Vulnerability{{
+							Content: vulnerabilityContentTypes.Content{
+								ID: vulnerabilityContentTypes.VulnerabilityID(code),
+							},
+						}},
+						DataSource: sourceTypes.Source{
+							ID: sourceTypes.ExploitExploitDB,
+						},
+					}
+				}
+
+				base.Vulnerabilities[0].Content.Exploit = append(base.Vulnerabilities[0].Content.Exploit, exploitTypes.Exploit{
+					Source:      "www.exploit-db.com",
+					Description: entry.description,
+					Link:        fmt.Sprintf("https://www.exploit-db.com/%s/%s", category.subdir, entry.id),
+					Published: func() time.Time {
+						if t := utiltime.Parse([]string{"2006-01-02"}, entry.datePublished); t != nil {
+							return *t
+						}
+						return time.Time{}
+					}(),
+					Modified: func() time.Time {
+						if t := utiltime.Parse([]string{"2006-01-02"}, entry.dateUpdated); t != nil {
+							return *t
+						}
+						return time.Time{}
+					}(),
+					ExploitDB: &exploitdbTypes.ExploitDB{
+						ID:       entry.id,
+						Author:   entry.author,
+						Type:     entry.exploitType,
+						Platform: entry.platform,
+						Verified: entry.verified == "1",
+						RawURL:   fmt.Sprintf("https://www.exploit-db.com/raw/%s", entry.id),
+					},
+				})
+				base.DataSource.Raws = append(base.DataSource.Raws, r.Paths()...)
+
+				cveExploits[code] = base
+			}
+
+			return nil
+		}); err != nil {
+			return nil, errors.Wrapf(err, "walk %s", filepath.Join(args, category.subdir))
+		}
+	}
+
+	return cveExploits, nil
 }

--- a/pkg/extract/exploit/exploitdb/testdata/fixtures/papers/15123.json
+++ b/pkg/extract/exploit/exploitdb/testdata/fixtures/papers/15123.json
@@ -1,0 +1,13 @@
+{
+	"id": "15123",
+	"file": "docs/english/15123-moaub-27---microsoft-internet-explorer---mshtml-findtext-processing-issue.pdf",
+	"description": "MOAUB #27 - Microsoft Internet Explorer - MSHTML Findtext Processing Issue",
+	"date_published": "2010-09-27",
+	"author": "Abysssec",
+	"platform": "windows",
+	"language": "english",
+	"date_added": "2010-09-27",
+	"date_updated": "2010-09-27",
+	"verified": "1",
+	"codes": "CVE-2010-2553"
+}

--- a/pkg/extract/exploit/exploitdb/testdata/fixtures/shellcodes/34060.json
+++ b/pkg/extract/exploit/exploitdb/testdata/fixtures/shellcodes/34060.json
@@ -1,0 +1,14 @@
+{
+	"id": "34060",
+	"file": "shellcodes/linux_x86/34060.c",
+	"description": "Linux/x86 - execve(/bin/sh) + Socket Re-Use Shellcode (50 bytes)",
+	"date_published": "2014-07-14",
+	"author": "ZadYree",
+	"platform": "linux_x86",
+	"size": "50",
+	"date_added": "2014-07-22",
+	"date_updated": "2017-08-23",
+	"verified": "1",
+	"codes": "CVE-2014-4943;OSVDB-109277",
+	"source_url": "http://shell-storm.org/shellcode/files/shellcode-881.php"
+}

--- a/pkg/extract/exploit/exploitdb/testdata/golden/data/1999/CVE-1999-1015.json
+++ b/pkg/extract/exploit/exploitdb/testdata/golden/data/1999/CVE-1999-1015.json
@@ -1,0 +1,33 @@
+{
+	"id": "CVE-1999-1015",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-1999-1015",
+				"exploit": [
+					{
+						"source": "www.exploit-db.com",
+						"description": "AppleShare IP Mail Server 5.0.3 - Buffer Overflow",
+						"published": "1999-10-15T00:00:00Z",
+						"modified": "2014-01-02T00:00:00Z",
+						"link": "https://www.exploit-db.com/exploits/19046",
+						"exploit_db": {
+							"id": "19046",
+							"author": "Chris Wedgwood",
+							"type": "dos",
+							"platform": "aix",
+							"verified": true,
+							"raw_url": "https://www.exploit-db.com/raw/19046"
+						}
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "exploit-exploitdb",
+		"raws": [
+			"fixtures/exploits/19046.json"
+		]
+	}
+}

--- a/pkg/extract/exploit/exploitdb/testdata/golden/data/2009/CVE-2009-3699.json
+++ b/pkg/extract/exploit/exploitdb/testdata/golden/data/2009/CVE-2009-3699.json
@@ -1,0 +1,33 @@
+{
+	"id": "CVE-2009-3699",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2009-3699",
+				"exploit": [
+					{
+						"source": "www.exploit-db.com",
+						"description": "AIX Calendar Manager Service Daemon (rpc.cmsd) Opcode 21 - Buffer Overflow (Metasploit)",
+						"published": "2010-11-11T00:00:00Z",
+						"modified": "2011-03-06T00:00:00Z",
+						"link": "https://www.exploit-db.com/exploits/16929",
+						"exploit_db": {
+							"id": "16929",
+							"author": "Metasploit",
+							"type": "dos",
+							"platform": "aix",
+							"verified": true,
+							"raw_url": "https://www.exploit-db.com/raw/16929"
+						}
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "exploit-exploitdb",
+		"raws": [
+			"fixtures/exploits/16929.json"
+		]
+	}
+}

--- a/pkg/extract/exploit/exploitdb/testdata/golden/data/2010/CVE-2010-2553.json
+++ b/pkg/extract/exploit/exploitdb/testdata/golden/data/2010/CVE-2010-2553.json
@@ -1,0 +1,32 @@
+{
+	"id": "CVE-2010-2553",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2010-2553",
+				"exploit": [
+					{
+						"source": "www.exploit-db.com",
+						"description": "MOAUB #27 - Microsoft Internet Explorer - MSHTML Findtext Processing Issue",
+						"published": "2010-09-27T00:00:00Z",
+						"modified": "2010-09-27T00:00:00Z",
+						"link": "https://www.exploit-db.com/papers/15123",
+						"exploit_db": {
+							"id": "15123",
+							"author": "Abysssec",
+							"platform": "windows",
+							"verified": true,
+							"raw_url": "https://www.exploit-db.com/raw/15123"
+						}
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "exploit-exploitdb",
+		"raws": [
+			"fixtures/papers/15123.json"
+		]
+	}
+}

--- a/pkg/extract/exploit/exploitdb/testdata/golden/data/2014/CVE-2014-4943.json
+++ b/pkg/extract/exploit/exploitdb/testdata/golden/data/2014/CVE-2014-4943.json
@@ -1,0 +1,32 @@
+{
+	"id": "CVE-2014-4943",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2014-4943",
+				"exploit": [
+					{
+						"source": "www.exploit-db.com",
+						"description": "Linux/x86 - execve(/bin/sh) + Socket Re-Use Shellcode (50 bytes)",
+						"published": "2014-07-14T00:00:00Z",
+						"modified": "2017-08-23T00:00:00Z",
+						"link": "https://www.exploit-db.com/shellcodes/34060",
+						"exploit_db": {
+							"id": "34060",
+							"author": "ZadYree",
+							"platform": "linux_x86",
+							"verified": true,
+							"raw_url": "https://www.exploit-db.com/raw/34060"
+						}
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "exploit-exploitdb",
+		"raws": [
+			"fixtures/shellcodes/34060.json"
+		]
+	}
+}

--- a/pkg/extract/exploit/exploitdb/testdata/golden/datasource.json
+++ b/pkg/extract/exploit/exploitdb/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "exploit-exploitdb",
+	"name": "Exploit Database - Exploits for Penetration Testers"
+}

--- a/pkg/extract/types/data/exploit/exploit.go
+++ b/pkg/extract/types/data/exploit/exploit.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"time"
 
+	exploitdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/exploitdb"
 	githubTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/github"
 )
 
@@ -14,7 +15,8 @@ type Exploit struct {
 	Modified    time.Time `json:"modified,omitzero"`
 	Link        string    `json:"link,omitempty"`
 
-	GitHub *githubTypes.GitHub `json:"github,omitempty"`
+	ExploitDB *exploitdbTypes.ExploitDB `json:"exploit_db,omitempty"`
+	GitHub    *githubTypes.GitHub       `json:"github,omitempty"`
 }
 
 func (e *Exploit) Sort() {
@@ -30,6 +32,18 @@ func Compare(x, y Exploit) int {
 		cmp.Compare(x.Description, y.Description),
 		x.Published.Compare(y.Published),
 		x.Modified.Compare(y.Modified),
+		func() int {
+			switch {
+			case x.ExploitDB == nil && y.ExploitDB == nil:
+				return 0
+			case x.ExploitDB == nil && y.ExploitDB != nil:
+				return -1
+			case x.ExploitDB != nil && y.ExploitDB == nil:
+				return +1
+			default:
+				return exploitdbTypes.Compare(*x.ExploitDB, *y.ExploitDB)
+			}
+		}(),
 		func() int {
 			switch {
 			case x.GitHub == nil && y.GitHub == nil:

--- a/pkg/extract/types/data/exploit/exploit_test.go
+++ b/pkg/extract/types/data/exploit/exploit_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	exploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit"
+	exploitdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/exploitdb"
 	githubTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/github"
 )
 
@@ -65,24 +66,42 @@ func TestCompare(t *testing.T) {
 		{
 			name: "x == y",
 			args: args{
-				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
-				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+				x: exploitTypes.Exploit{
+					Source: "source",
+					Link:   "http://example.com",
+				},
+				y: exploitTypes.Exploit{
+					Source: "source",
+					Link:   "http://example.com",
+				},
 			},
 			want: 0,
 		},
 		{
 			name: "x:source < y:source",
 			args: args{
-				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
-				y: exploitTypes.Exploit{Source: "source1", Link: "http://example.com"},
+				x: exploitTypes.Exploit{
+					Source: "source",
+					Link:   "http://example.com",
+				},
+				y: exploitTypes.Exploit{
+					Source: "source1",
+					Link:   "http://example.com",
+				},
 			},
 			want: -1,
 		},
 		{
 			name: "x:link > y:link",
 			args: args{
-				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com/2"},
-				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com/1"},
+				x: exploitTypes.Exploit{
+					Source: "source",
+					Link:   "http://example.com/2",
+				},
+				y: exploitTypes.Exploit{
+					Source: "source",
+					Link:   "http://example.com/1",
+				},
 			},
 			want: +1,
 		},
@@ -107,6 +126,30 @@ func TestCompare(t *testing.T) {
 			args: args{
 				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
 				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", Modified: time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			want: -1,
+		},
+		{
+			name: "x:exploit_db nil < y:exploit_db non-nil",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", ExploitDB: &exploitdbTypes.ExploitDB{ID: "1"}},
+			},
+			want: -1,
+		},
+		{
+			name: "x:exploit_db non-nil > y:exploit_db nil",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", ExploitDB: &exploitdbTypes.ExploitDB{ID: "1"}},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+			},
+			want: +1,
+		},
+		{
+			name: "exploit_db.Compare as tie-breaker",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", ExploitDB: &exploitdbTypes.ExploitDB{ID: "1"}},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", ExploitDB: &exploitdbTypes.ExploitDB{ID: "2"}},
 			},
 			want: -1,
 		},

--- a/pkg/extract/types/data/exploit/exploitdb/exploitdb.go
+++ b/pkg/extract/types/data/exploit/exploitdb/exploitdb.go
@@ -1,0 +1,34 @@
+package exploitdb
+
+import "cmp"
+
+type ExploitDB struct {
+	ID       string `json:"id,omitempty"`
+	Author   string `json:"author,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Platform string `json:"platform,omitempty"`
+	Verified bool   `json:"verified,omitzero"`
+	RawURL   string `json:"raw_url,omitempty"`
+}
+
+func Compare(x, y ExploitDB) int {
+	return cmp.Or(
+		cmp.Compare(x.ID, y.ID),
+		cmp.Compare(x.Author, y.Author),
+		cmp.Compare(x.Type, y.Type),
+		cmp.Compare(x.Platform, y.Platform),
+		func() int {
+			switch {
+			case !x.Verified && !y.Verified:
+				return 0
+			case !x.Verified && y.Verified:
+				return -1
+			case x.Verified && !y.Verified:
+				return +1
+			default:
+				return 0
+			}
+		}(),
+		cmp.Compare(x.RawURL, y.RawURL),
+	)
+}

--- a/pkg/extract/types/data/exploit/exploitdb/exploitdb_test.go
+++ b/pkg/extract/types/data/exploit/exploitdb/exploitdb_test.go
@@ -1,0 +1,113 @@
+package exploitdb_test
+
+import (
+	"testing"
+
+	exploitdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/exploitdb"
+)
+
+func TestCompare(t *testing.T) {
+	type args struct {
+		x exploitdbTypes.ExploitDB
+		y exploitdbTypes.ExploitDB
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "x == y",
+			args: args{
+				x: exploitdbTypes.ExploitDB{
+					ID:       "1",
+					Author:   "author",
+					Type:     "webapps",
+					Platform: "php",
+					Verified: true,
+					RawURL:   "https://www.exploit-db.com/raw/1",
+				},
+				y: exploitdbTypes.ExploitDB{
+					ID:       "1",
+					Author:   "author",
+					Type:     "webapps",
+					Platform: "php",
+					Verified: true,
+					RawURL:   "https://www.exploit-db.com/raw/1",
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "x:id < y:id",
+			args: args{
+				x: exploitdbTypes.ExploitDB{ID: "1"},
+				y: exploitdbTypes.ExploitDB{ID: "2"},
+			},
+			want: -1,
+		},
+		{
+			name: "x:id > y:id",
+			args: args{
+				x: exploitdbTypes.ExploitDB{ID: "2"},
+				y: exploitdbTypes.ExploitDB{ID: "1"},
+			},
+			want: +1,
+		},
+		{
+			name: "x:author < y:author",
+			args: args{
+				x: exploitdbTypes.ExploitDB{ID: "1", Author: "alice"},
+				y: exploitdbTypes.ExploitDB{ID: "1", Author: "bob"},
+			},
+			want: -1,
+		},
+		{
+			name: "x:type < y:type",
+			args: args{
+				x: exploitdbTypes.ExploitDB{ID: "1", Author: "alice", Type: "local"},
+				y: exploitdbTypes.ExploitDB{ID: "1", Author: "alice", Type: "webapps"},
+			},
+			want: -1,
+		},
+		{
+			name: "x:platform < y:platform",
+			args: args{
+				x: exploitdbTypes.ExploitDB{ID: "1", Author: "alice", Type: "webapps", Platform: "linux"},
+				y: exploitdbTypes.ExploitDB{ID: "1", Author: "alice", Type: "webapps", Platform: "windows"},
+			},
+			want: -1,
+		},
+		{
+			name: "x:verified false < y:verified true",
+			args: args{
+				x: exploitdbTypes.ExploitDB{ID: "1", Author: "alice", Type: "webapps", Platform: "php", Verified: false},
+				y: exploitdbTypes.ExploitDB{ID: "1", Author: "alice", Type: "webapps", Platform: "php", Verified: true},
+			},
+			want: -1,
+		},
+		{
+			name: "x:verified true > y:verified false",
+			args: args{
+				x: exploitdbTypes.ExploitDB{ID: "1", Author: "alice", Type: "webapps", Platform: "php", Verified: true},
+				y: exploitdbTypes.ExploitDB{ID: "1", Author: "alice", Type: "webapps", Platform: "php", Verified: false},
+			},
+			want: +1,
+		},
+		{
+			name: "x:raw_url < y:raw_url (tie-breaker)",
+			args: args{
+				x: exploitdbTypes.ExploitDB{ID: "1", Author: "alice", Type: "webapps", Platform: "php", Verified: true, RawURL: "https://www.exploit-db.com/raw/1"},
+				y: exploitdbTypes.ExploitDB{ID: "1", Author: "alice", Type: "webapps", Platform: "php", Verified: true, RawURL: "https://www.exploit-db.com/raw/2"},
+			},
+			want: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := exploitdbTypes.Compare(tt.args.x, tt.args.y); got != tt.want {
+				t.Errorf("Compare() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Parse ExploitDB raw data from exploits/, shellcodes/, and papers/
subdirectories. Extract CVE-IDs from semicolon-separated codes field
and generate per-CVE data files with exploit metadata (source,
description, link, dates). GHDB entries are skipped as they have no
CVE references.

Add ExploitDB source-specific sub-struct with ID, Author, Type,
Platform, Verified, and RawURL fields.