### PR TITLE
feat(extract/trickest): implement extractor

### DIFF
--- a/pkg/extract/exploit/trickest/testdata/golden/data/2022/CVE-2022-0185.json
+++ b/pkg/extract/exploit/trickest/testdata/golden/data/2022/CVE-2022-0185.json
@@ -1,0 +1,606 @@
+{
+  "id": "CVE-2022-0185",
+  "vulnerabilities": [
+    {
+      "content": {
+        "id": "CVE-2022-0185",
+        "exploit": [
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/ARPSyndicate/cvemon",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/Ch4nc3n/PublicExploitation",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/Crusaders-of-Rust/CVE-2022-0185",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/EGI-Federation/SVG-advisories",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/Metarget/metarget",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/Mr-xn/Penetration_Testing_POC",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/arveske/Github-language-trends",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/bigpick/cve-reading-list",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/binganao/vulns-2022",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/bsauce/kernel-exploit-factory",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/bsauce/kernel-security-learning",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/chenaotian/CVE-2022-0185",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/chenaotian/CVE-2022-25636",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/discordianfish/cve-2022-0185-crash-poc",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/featherL/CVE-2022-0185-exploit",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/hac425xxx/heap-exploitation-in-real-world",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/hardenedvault/ved",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/hktalent/TOP",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/joydo/CVE-Writeups",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/khaclep007/CVE-2022-0185",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/nestybox/sysbox",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/nestybox/sysbox-ee",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/nomi-sec/PoC-in-GitHub",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/shahparkhan/cve-2022-0185",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/veritas501/CVE-2022-0185-PipeVersion",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/veritas501/pipe-primitive",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://github.com/xairy/linux-kernel-exploitation",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          },
+          {
+            "source": "trickest.com",
+            "description": "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length. An unprivileged (in case of unprivileged user namespaces enabled, otherwise needs namespaced CAP_SYS_ADMIN privilege) local user able to open a filesystem that does not support the Filesystem Context API (and thus fallbacks to legacy handling) could use this flaw to escalate their privileges on the system.",
+            "link": "https://www.willsroot.io/2022/01/cve-2022-0185.html",
+            "trickest": {
+              "tags": [
+                {
+                  "label": "Product",
+                  "message": "kernel"
+                },
+                {
+                  "label": "Version",
+                  "message": "n/a"
+                },
+                {
+                  "label": "Vulnerability",
+                  "message": "Integer Overflow or Wraparound CWE-190"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "data_source": {
+    "id": "exploit-trickest",
+    "raws": [
+      "fixtures/2022/CVE-2022-0185.json"
+    ]
+  }
+}

--- a/pkg/extract/exploit/trickest/testdata/golden/datasource.json
+++ b/pkg/extract/exploit/trickest/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "exploit-trickest",
+	"name": "Trickest CVE Repository"
+}

--- a/pkg/extract/exploit/trickest/trickest.go
+++ b/pkg/extract/exploit/trickest/trickest.go
@@ -1,13 +1,29 @@
 package trickest
 
 import (
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"path/filepath"
+	"slices"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	exploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit"
+	trickestTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/trickest"
+	trickestTagTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/trickest/tag"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	fetchTypes "github.com/MaineK00n/vuls-data-update/pkg/fetch/exploit/trickest"
 )
 
 type options struct {
@@ -30,7 +46,7 @@ func WithDir(dir string) Option {
 
 func Extract(args string, opts ...Option) error {
 	options := &options{
-		dir: filepath.Join(util.CacheDir(), "extract", "", ""),
+		dir: filepath.Join(util.CacheDir(), "extract", "exploit", "trickest"),
 	}
 
 	for _, o := range opts {
@@ -42,17 +58,30 @@ func Extract(args string, opts ...Option) error {
 	}
 
 	slog.Info("Extract Exploit Trickest")
+
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if d.IsDir() {
+		if d.IsDir() || filepath.Ext(path) != ".json" {
 			return nil
 		}
 
-		if filepath.Ext(path) != ".json" {
-			return nil
+		data, err := extract(path, args)
+		if err != nil {
+			return errors.Wrapf(err, "extract %s", path)
+		}
+
+		splitted, err := util.Split(string(data.ID), "-", "-")
+		if err != nil {
+			return errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", data.ID)
+		}
+		if _, err := time.Parse("2006", splitted[1]); err != nil {
+			return errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", data.ID)
+		}
+		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", data.ID)), data, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", data.ID)))
 		}
 
 		return nil
@@ -60,5 +89,72 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "walk %s", args)
 	}
 
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.ExploitTrickest,
+		Name: new("Trickest CVE Repository"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
 	return nil
+}
+
+func extract(path, args string) (dataTypes.Data, error) {
+	r := utiljson.NewJSONReader()
+	var f fetchTypes.Exploit
+	if err := r.Read(path, args, &f); err != nil {
+		return dataTypes.Data{}, errors.Wrapf(err, "read %s", path)
+	}
+
+	tags := make([]trickestTagTypes.Tag, 0, len(f.Tags))
+	for _, t := range f.Tags {
+		tags = append(tags, trickestTagTypes.Tag{
+			Label:   t.Label,
+			Message: t.Message,
+		})
+	}
+
+	var exploits []exploitTypes.Exploit
+	for _, url := range append(f.Poc.GitHubs, f.Poc.References...) {
+		exploits = append(exploits, exploitTypes.Exploit{
+			Source:      "trickest.com",
+			Description: strings.TrimSpace(f.Description),
+			Link:        url,
+			Trickest: func() *trickestTypes.Trickest {
+				if len(tags) > 0 {
+					return &trickestTypes.Trickest{Tags: slices.Clone(tags)}
+				}
+				return nil
+			}(),
+		})
+	}
+
+	return dataTypes.Data{
+		ID: dataTypes.RootID(f.ID),
+		Vulnerabilities: []vulnerabilityTypes.Vulnerability{{
+			Content: vulnerabilityContentTypes.Content{
+				ID:      vulnerabilityContentTypes.VulnerabilityID(f.ID),
+				Exploit: exploits,
+			},
+		}},
+		DataSource: sourceTypes.Source{
+			ID:   sourceTypes.ExploitTrickest,
+			Raws: r.Paths(),
+		},
+	}, nil
 }

--- a/pkg/extract/types/data/exploit/exploit.go
+++ b/pkg/extract/types/data/exploit/exploit.go
@@ -7,6 +7,7 @@ import (
 	exploitdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/exploitdb"
 	githubTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/github"
 	inthewildTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/inthewild"
+	trickestTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/trickest"
 )
 
 type Exploit struct {
@@ -19,11 +20,15 @@ type Exploit struct {
 	ExploitDB *exploitdbTypes.ExploitDB `json:"exploit_db,omitempty"`
 	GitHub    *githubTypes.GitHub       `json:"github,omitempty"`
 	InTheWild *inthewildTypes.InTheWild `json:"inthewild,omitempty"`
+	Trickest  *trickestTypes.Trickest   `json:"trickest,omitempty"`
 }
 
 func (e *Exploit) Sort() {
 	if e.GitHub != nil {
 		e.GitHub.Sort()
+	}
+	if e.Trickest != nil {
+		e.Trickest.Sort()
 	}
 }
 
@@ -68,6 +73,18 @@ func Compare(x, y Exploit) int {
 				return +1
 			default:
 				return inthewildTypes.Compare(*x.InTheWild, *y.InTheWild)
+			}
+		}(),
+		func() int {
+			switch {
+			case x.Trickest == nil && y.Trickest == nil:
+				return 0
+			case x.Trickest == nil && y.Trickest != nil:
+				return -1
+			case x.Trickest != nil && y.Trickest == nil:
+				return +1
+			default:
+				return trickestTypes.Compare(*x.Trickest, *y.Trickest)
 			}
 		}(),
 	)

--- a/pkg/extract/types/data/exploit/exploit_test.go
+++ b/pkg/extract/types/data/exploit/exploit_test.go
@@ -9,6 +9,8 @@ import (
 	exploitdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/exploitdb"
 	githubTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/github"
 	inthewildTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/inthewild"
+	trickestTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/trickest"
+	trickestTagTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/trickest/tag"
 )
 
 func TestExploit_Sort(t *testing.T) {
@@ -31,6 +33,27 @@ func TestExploit_Sort(t *testing.T) {
 				GitHub: &githubTypes.GitHub{
 					Owner:  "owner",
 					Topics: []string{"cve", "exploit", "poc"},
+				},
+			},
+		},
+		{
+			name: "sorts trickest tags",
+			input: exploitTypes.Exploit{
+				Source: "trickest.com",
+				Trickest: &trickestTypes.Trickest{
+					Tags: []trickestTagTypes.Tag{
+						{Label: "epss", Message: "low"},
+						{Label: "cvss", Message: "high"},
+					},
+				},
+			},
+			want: exploitTypes.Exploit{
+				Source: "trickest.com",
+				Trickest: &trickestTypes.Trickest{
+					Tags: []trickestTagTypes.Tag{
+						{Label: "cvss", Message: "high"},
+						{Label: "epss", Message: "low"},
+					},
 				},
 			},
 		},
@@ -67,42 +90,24 @@ func TestCompare(t *testing.T) {
 		{
 			name: "x == y",
 			args: args{
-				x: exploitTypes.Exploit{
-					Source: "source",
-					Link:   "http://example.com",
-				},
-				y: exploitTypes.Exploit{
-					Source: "source",
-					Link:   "http://example.com",
-				},
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
 			},
 			want: 0,
 		},
 		{
 			name: "x:source < y:source",
 			args: args{
-				x: exploitTypes.Exploit{
-					Source: "source",
-					Link:   "http://example.com",
-				},
-				y: exploitTypes.Exploit{
-					Source: "source1",
-					Link:   "http://example.com",
-				},
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+				y: exploitTypes.Exploit{Source: "source1", Link: "http://example.com"},
 			},
 			want: -1,
 		},
 		{
 			name: "x:link > y:link",
 			args: args{
-				x: exploitTypes.Exploit{
-					Source: "source",
-					Link:   "http://example.com/2",
-				},
-				y: exploitTypes.Exploit{
-					Source: "source",
-					Link:   "http://example.com/1",
-				},
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com/2"},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com/1"},
 			},
 			want: +1,
 		},
@@ -199,6 +204,30 @@ func TestCompare(t *testing.T) {
 			args: args{
 				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", InTheWild: &inthewildTypes.InTheWild{Type: "exploited"}},
 				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", InTheWild: &inthewildTypes.InTheWild{Type: "exploited", Source: "src"}},
+			},
+			want: -1,
+		},
+		{
+			name: "x:trickest nil < y:trickest non-nil",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", Trickest: &trickestTypes.Trickest{Tags: []trickestTagTypes.Tag{{Label: "cvss", Message: "high"}}}},
+			},
+			want: -1,
+		},
+		{
+			name: "x:trickest non-nil > y:trickest nil",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", Trickest: &trickestTypes.Trickest{Tags: []trickestTagTypes.Tag{{Label: "cvss", Message: "high"}}}},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+			},
+			want: +1,
+		},
+		{
+			name: "trickest.Compare as tie-breaker",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", Trickest: &trickestTypes.Trickest{Tags: []trickestTagTypes.Tag{{Label: "cvss", Message: "high"}}}},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", Trickest: &trickestTypes.Trickest{Tags: []trickestTagTypes.Tag{{Label: "cvss", Message: "high"}, {Label: "epss", Message: "low"}}}},
 			},
 			want: -1,
 		},

--- a/pkg/extract/types/data/exploit/trickest/tag/tag.go
+++ b/pkg/extract/types/data/exploit/trickest/tag/tag.go
@@ -1,0 +1,15 @@
+package tag
+
+import "cmp"
+
+type Tag struct {
+	Label   string `json:"label,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func Compare(x, y Tag) int {
+	return cmp.Or(
+		cmp.Compare(x.Label, y.Label),
+		cmp.Compare(x.Message, y.Message),
+	)
+}

--- a/pkg/extract/types/data/exploit/trickest/trickest.go
+++ b/pkg/extract/types/data/exploit/trickest/trickest.go
@@ -1,0 +1,19 @@
+package trickest
+
+import (
+	"slices"
+
+	trickestTagTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/trickest/tag"
+)
+
+type Trickest struct {
+	Tags []trickestTagTypes.Tag `json:"tags,omitempty"`
+}
+
+func (t *Trickest) Sort() {
+	slices.SortFunc(t.Tags, trickestTagTypes.Compare)
+}
+
+func Compare(x, y Trickest) int {
+	return slices.CompareFunc(x.Tags, y.Tags, trickestTagTypes.Compare)
+}


### PR DESCRIPTION
Process per file (one JSON file per CVE ID).
Extract both PoC GitHub URLs and reference URLs as separate Exploit entries.
Each entry includes Trickest-specific metadata (tags with label/message pairs).