### PR TITLE
feat(extract/microsoft): derive Supersedes field from SupersededBy

### DIFF
--- a/pkg/extract/microsoft/bulletin/bulletin.go
+++ b/pkg/extract/microsoft/bulletin/bulletin.go
@@ -32,9 +32,9 @@ import (
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
 	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
-	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
 	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
 	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
 	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
@@ -564,6 +564,7 @@ func (e extractor) extract(rows []bulletin.Bulletin) ([]dataTypes.Data, []micros
 			},
 		})
 	}
+	microsoftutil.DeriveSupersedes(kbs)
 
 	return datas, kbs, nil
 }

--- a/pkg/extract/microsoft/bulletin/testdata/golden/microsoftkb/4014xxx/4014329.json
+++ b/pkg/extract/microsoft/bulletin/testdata/golden/microsoftkb/4014xxx/4014329.json
@@ -4,6 +4,11 @@
 	"products": [
 		"Adobe Flash Player on Windows 10 Version 1511 for x64-based Systems"
 	],
+	"supersedes": [
+		{
+			"kb_id": "4010250"
+		}
+	],
 	"data_source": {
 		"id": "microsoft-bulletin",
 		"raws": [

--- a/pkg/extract/microsoft/bulletin/testdata/golden/microsoftkb/955xxx/955069.json
+++ b/pkg/extract/microsoft/bulletin/testdata/golden/microsoftkb/955xxx/955069.json
@@ -4,6 +4,11 @@
 	"products": [
 		"Microsoft XML Core Services 3.0 on Microsoft Windows 2000 Service Pack 4"
 	],
+	"supersedes": [
+		{
+			"kb_id": "936021"
+		}
+	],
 	"data_source": {
 		"id": "microsoft-bulletin",
 		"raws": [

--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -307,7 +307,9 @@ func (e extractor) extract(c cvrf.CVRF) ([]dataTypes.Data, []microsoftkbTypes.KB
 		})
 	}
 
-	return datas, slices.Collect(maps.Values(kbm)), nil
+	kbs := slices.Collect(maps.Values(kbm))
+	microsoftutil.DeriveSupersedes(kbs)
+	return datas, kbs, nil
 }
 func collectProducts(pt cvrf.ProductTree) map[string]string {
 	m := make(map[string]string)
@@ -2033,8 +2035,8 @@ func (e extractor) collectKBs(v cvrf.Vulnerability, products map[string]string, 
 			// Mixed formats (e.g. "MS16-016, 3124280; MS16-097, 3178034") also exist;
 			// non-digit tokens (bulletin IDs) are filtered out by the isAllDigits check below.
 			var supKBIDs []string
-			for _, semiPart := range strings.Split(r.Supercedence, ";") {
-				for _, commaPart := range strings.Split(semiPart, ",") {
+			for semiPart := range strings.SplitSeq(r.Supercedence, ";") {
+				for commaPart := range strings.SplitSeq(semiPart, ",") {
 					supKBIDs = append(supKBIDs, strings.TrimSpace(commaPart))
 				}
 			}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/3135xxx/3135456.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/3135xxx/3135456.json
@@ -8,6 +8,11 @@
 		"Windows Server 2012 R2",
 		"Windows Server 2012 R2 (Server Core installation)"
 	],
+	"supersedes": [
+		{
+			"kb_id": "3087088"
+		}
+	],
 	"data_source": {
 		"id": "microsoft-cvrf",
 		"raws": [

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/3147xxx/3147461.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/3147xxx/3147461.json
@@ -4,6 +4,11 @@
 	"products": [
 		"Windows 10 for x64-based Systems"
 	],
+	"supersedes": [
+		{
+			"kb_id": "3140745"
+		}
+	],
 	"data_source": {
 		"id": "microsoft-cvrf",
 		"raws": [

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5019xxx/5019964.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5019xxx/5019964.json
@@ -7,6 +7,11 @@
 		"Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016",
 		"Microsoft .NET Framework 3.5 AND 4.6.2/4.7/4.7.1/4.7.2 on Windows Server 2016 (Server Core installation)"
 	],
+	"supersedes": [
+		{
+			"kb_id": "5018411"
+		}
+	],
 	"data_source": {
 		"id": "microsoft-cvrf",
 		"raws": [

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5020xxx/5020687.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5020xxx/5020687.json
@@ -6,6 +6,17 @@
 		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for ARM64-based Systems",
 		"Microsoft .NET Framework 4.8 on Windows 10 Version 21H2 for x64-based Systems"
 	],
+	"supersedes": [
+		{
+			"kb_id": "5017500"
+		},
+		{
+			"kb_id": "5018545"
+		},
+		{
+			"kb_id": "5018858"
+		}
+	],
 	"data_source": {
 		"id": "microsoft-cvrf",
 		"raws": [

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5027xxx/5027536.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5027xxx/5027536.json
@@ -8,6 +8,11 @@
 		"Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019",
 		"Microsoft .NET Framework 3.5 AND 4.8 on Windows Server 2019 (Server Core installation)"
 	],
+	"supersedes": [
+		{
+			"kb_id": "5022782"
+		}
+	],
 	"data_source": {
 		"id": "microsoft-cvrf",
 		"raws": [

--- a/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5027xxx/5027543.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/microsoftkb/5027xxx/5027543.json
@@ -7,6 +7,11 @@
 		"Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for 32-bit Systems Service Pack 2",
 		"Microsoft .NET Framework 3.0 Service Pack 2 on Windows Server 2008 for x64-based Systems Service Pack 2"
 	],
+	"supersedes": [
+		{
+			"kb_id": "5022734"
+		}
+	],
 	"data_source": {
 		"id": "microsoft-cvrf",
 		"raws": [

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
+	microsoftutil "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/util"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
 	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
 	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
@@ -217,6 +218,7 @@ func (o options) extract(root string, updateIDMap map[string]string) error {
 			if len(kb.KBID) <= 3 {
 				return errors.Errorf("unexpected KBID format. expected: len > 3, actual: %q", kb.KBID)
 			}
+
 			filename := filepath.Join(o.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID))
 			if _, err := os.Stat(filename); err == nil {
 				f, err := os.Open(filename)
@@ -245,6 +247,49 @@ func (o options) extract(root string, updateIDMap map[string]string) error {
 
 	if err := eg.Wait(); err != nil {
 		return errors.Wrap(err, "wait for walk")
+	}
+
+	// Phase 2: read all written KB files, derive Supersedes, write all KB files back.
+	kbDir := filepath.Join(o.dir, "microsoftkb")
+	if _, err := os.Stat(kbDir); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return errors.Wrapf(err, "stat %s", kbDir)
+		}
+		return nil
+	}
+	var kbs []microsoftkbTypes.KB
+	if err := filepath.WalkDir(kbDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", path)
+		}
+		defer f.Close()
+
+		var kb microsoftkbTypes.KB
+		if err := json.UnmarshalRead(f, &kb); err != nil {
+			return errors.Wrapf(err, "decode %s", path)
+		}
+
+		kbs = append(kbs, kb)
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", kbDir)
+	}
+
+	microsoftutil.DeriveSupersedes(kbs)
+
+	for _, kb := range kbs {
+		if err := util.Write(filepath.Join(o.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)), kb, true); err != nil {
+			return errors.Wrapf(err, "write %s", kb.KBID)
+		}
 	}
 
 	return nil

--- a/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/5025xxx/5025305.json
+++ b/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/5025xxx/5025305.json
@@ -25,6 +25,12 @@
 					"update_id": "acbe4fd0-394e-40e8-a96b-c4facae62c8b"
 				}
 			],
+			"supersedes": [
+				{
+					"kb_id": "5025239",
+					"update_id": "f39d68ab-1519-4df8-85c1-d985be7f49c3"
+				}
+			],
 			"reboot_behavior": "Can request restart",
 			"user_input": "No",
 			"connectivity": "No",

--- a/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/5026xxx/5026372.json
+++ b/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/5026xxx/5026372.json
@@ -22,6 +22,16 @@
 					"update_id": "acbe4fd0-394e-40e8-a96b-c4facae62c8b"
 				}
 			],
+			"supersedes": [
+				{
+					"kb_id": "5025239",
+					"update_id": "f39d68ab-1519-4df8-85c1-d985be7f49c3"
+				},
+				{
+					"kb_id": "5025305",
+					"update_id": "23e2eefb-e159-41df-8918-7994eee5b6f2"
+				}
+			],
 			"reboot_behavior": "Can request restart",
 			"user_input": "No",
 			"connectivity": "No",

--- a/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/5026xxx/5026446.json
+++ b/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/5026xxx/5026446.json
@@ -15,6 +15,20 @@
 			],
 			"more_info_url": "https://support.microsoft.com/help/5026446",
 			"support_url": "https://support.microsoft.com/help/5026446",
+			"supersedes": [
+				{
+					"kb_id": "5025239",
+					"update_id": "f39d68ab-1519-4df8-85c1-d985be7f49c3"
+				},
+				{
+					"kb_id": "5025305",
+					"update_id": "23e2eefb-e159-41df-8918-7994eee5b6f2"
+				},
+				{
+					"kb_id": "5026372",
+					"update_id": "0b97c243-5833-4bf3-bcf8-77063e53c42a"
+				}
+			],
 			"reboot_behavior": "Can request restart",
 			"user_input": "No",
 			"connectivity": "No",

--- a/pkg/extract/microsoft/util/util.go
+++ b/pkg/extract/microsoft/util/util.go
@@ -1,6 +1,12 @@
 package util
 
-import "strings"
+import (
+	"slices"
+	"strings"
+
+	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
+)
 
 // canonicalProductNames maps variant product names to a single canonical name.
 var canonicalProductNames = map[string]string{
@@ -52,4 +58,64 @@ func NormalizeProductName(s string) string {
 		return canonical
 	}
 	return n
+}
+
+// DeriveSupersedes populates Supersedes by inverting SupersededBy across
+// the provided KB collection. Both KB-level (KBID only) and Update-level
+// (KBID + UpdateID) supersession are handled. kbs is modified in place.
+func DeriveSupersedes(kbs []microsoftkbTypes.KB) {
+	idx := make(map[string]*microsoftkbTypes.KB, len(kbs))
+	for i := range kbs {
+		idx[kbs[i].KBID] = &kbs[i]
+	}
+
+	// KB-level: if B.SupersededBy contains {KBID: A}, then A.Supersedes gets {KBID: B}.
+	for i := range kbs {
+		for _, sup := range kbs[i].SupersededBy {
+			if sup.KBID == "" || sup.KBID == kbs[i].KBID {
+				continue
+			}
+			supKB, ok := idx[sup.KBID]
+			if !ok {
+				continue
+			}
+			if !slices.ContainsFunc(supKB.Supersedes, func(s microsoftkbSupersedesTypes.Supersedes) bool {
+				return s.KBID == kbs[i].KBID
+			}) {
+				supKB.Supersedes = append(supKB.Supersedes, microsoftkbSupersedesTypes.Supersedes{KBID: kbs[i].KBID})
+			}
+		}
+	}
+
+	// Update-level: if Update U in KB B has SupersededBy {KBID: A, UpdateID: V},
+	// then Update V in KB A gets Supersedes {KBID: B, UpdateID: U.UpdateID}.
+	// Key by (targetKBID, targetUpdateID) to avoid attaching Supersedes to the wrong
+	// KB when the same UpdateID exists across multiple KBs.
+	type updateKey struct{ KBID, UpdateID string }
+	updateSupersedes := make(map[updateKey][]microsoftkbSupersedesTypes.Supersedes)
+	for i := range kbs {
+		for _, u := range kbs[i].Updates {
+			for _, sup := range u.SupersededBy {
+				if sup.KBID == "" || sup.KBID == kbs[i].KBID || sup.UpdateID == "" {
+					continue
+				}
+				key := updateKey{KBID: sup.KBID, UpdateID: sup.UpdateID}
+				updateSupersedes[key] = append(updateSupersedes[key], microsoftkbSupersedesTypes.Supersedes{
+					KBID:     kbs[i].KBID,
+					UpdateID: u.UpdateID,
+				})
+			}
+		}
+	}
+	for i := range kbs {
+		for j, u := range kbs[i].Updates {
+			for _, e := range updateSupersedes[updateKey{KBID: kbs[i].KBID, UpdateID: u.UpdateID}] {
+				if !slices.ContainsFunc(kbs[i].Updates[j].Supersedes, func(s microsoftkbSupersedesTypes.Supersedes) bool {
+					return s.KBID == e.KBID && s.UpdateID == e.UpdateID
+				}) {
+					kbs[i].Updates[j].Supersedes = append(kbs[i].Updates[j].Supersedes, e)
+				}
+			}
+		}
+	}
 }

--- a/pkg/extract/microsoft/util/util_test.go
+++ b/pkg/extract/microsoft/util/util_test.go
@@ -1,6 +1,16 @@
 package util
 
-import "testing"
+import (
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
+	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
+	microsoftkbUpdateTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/update"
+)
 
 func TestNormalizeProductName(t *testing.T) {
 	type args struct {
@@ -201,6 +211,256 @@ func TestNormalizeProductName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NormalizeProductName(tt.args.s); got != tt.want {
 				t.Errorf("NormalizeProductName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveSupersedes(t *testing.T) {
+	tests := []struct {
+		name string
+		kbs  []microsoftkbTypes.KB
+		want []microsoftkbTypes.KB
+	}{
+		{
+			name: "basic KB-level: B superseded by A → A supersedes B",
+			kbs: []microsoftkbTypes.KB{
+				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
+				{KBID: "1"},
+			},
+			want: []microsoftkbTypes.KB{
+				{KBID: "1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2"}}},
+				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
+			},
+		},
+		{
+			name: "chain: C→B→A → B.Supersedes=[C], A.Supersedes=[B]",
+			kbs: []microsoftkbTypes.KB{
+				{KBID: "3", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "2"}}},
+				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
+				{KBID: "1"},
+			},
+			want: []microsoftkbTypes.KB{
+				{KBID: "1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2"}}},
+				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}, Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "3"}}},
+				{KBID: "3", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "2"}}},
+			},
+		},
+		{
+			name: "fan-in: B→A and C→A → A.Supersedes=[B,C]",
+			kbs: []microsoftkbTypes.KB{
+				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
+				{KBID: "3", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
+				{KBID: "1"},
+			},
+			want: []microsoftkbTypes.KB{
+				{KBID: "1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2"}, {KBID: "3"}}},
+				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
+				{KBID: "3", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
+			},
+		},
+		{
+			name: "superseding KB absent: no Supersedes added, no panic",
+			kbs: []microsoftkbTypes.KB{
+				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "99"}}},
+			},
+			want: []microsoftkbTypes.KB{
+				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "99"}}},
+			},
+		},
+		{
+			name: "self-supersession ignored",
+			kbs: []microsoftkbTypes.KB{
+				{KBID: "1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
+			},
+			want: []microsoftkbTypes.KB{
+				{KBID: "1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
+			},
+		},
+		{
+			name: "empty SupersededBy KBID ignored",
+			kbs: []microsoftkbTypes.KB{
+				{KBID: "1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: ""}}},
+			},
+			want: []microsoftkbTypes.KB{
+				{KBID: "1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: ""}}},
+			},
+		},
+		{
+			name: "KB-level deduplication: duplicate SupersededBy entry adds Supersedes only once",
+			kbs: []microsoftkbTypes.KB{
+				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}, {KBID: "1"}}},
+				{KBID: "1"},
+			},
+			want: []microsoftkbTypes.KB{
+				{KBID: "1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2"}}},
+				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}, {KBID: "1"}}},
+			},
+		},
+		{
+			name: "basic update-level: KB2/U2 superseded by KB1/U1 → KB1/U1.Supersedes=[KB2/U2]",
+			kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "2",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1", UpdateID: "U1"}}},
+					},
+				},
+				{
+					KBID:    "1",
+					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
+				},
+			},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "1",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2", UpdateID: "U2"}}},
+					},
+				},
+				{
+					KBID: "2",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1", UpdateID: "U1"}}},
+					},
+				},
+			},
+		},
+		{
+			name: "update self-supersession ignored",
+			kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "1",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1", UpdateID: "U2"}}},
+					},
+				},
+			},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "1",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1", UpdateID: "U2"}}},
+					},
+				},
+			},
+		},
+		{
+			name: "empty UpdateID in SupersededBy skips update-level",
+			kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "2",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1", UpdateID: ""}}},
+					},
+				},
+				{
+					KBID:    "1",
+					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
+				},
+			},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID:    "1",
+					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
+				},
+				{
+					KBID: "2",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1", UpdateID: ""}}},
+					},
+				},
+			},
+		},
+		{
+			name: "update-level deduplication: duplicate SupersededBy entry adds Supersedes only once",
+			kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "2",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{
+							{KBID: "1", UpdateID: "U1"},
+							{KBID: "1", UpdateID: "U1"},
+						}},
+					},
+				},
+				{
+					KBID:    "1",
+					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
+				},
+			},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "1",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2", UpdateID: "U2"}}},
+					},
+				},
+				{
+					KBID: "2",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{
+							{KBID: "1", UpdateID: "U1"},
+							{KBID: "1", UpdateID: "U1"},
+						}},
+					},
+				},
+			},
+		},
+		{
+			name: "update-level cross-KB: same UpdateID in two KBs only the matching KBID gets Supersedes",
+			kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "2",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1", UpdateID: "U1"}}},
+					},
+				},
+				// KB1 has U1 — should receive Supersedes.
+				{
+					KBID:    "1",
+					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
+				},
+				// KB3 also has U1 — must NOT receive Supersedes because SupersededBy.KBID is "1", not "3".
+				{
+					KBID:    "3",
+					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
+				},
+			},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "1",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2", UpdateID: "U2"}}},
+					},
+				},
+				{
+					KBID: "2",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1", UpdateID: "U1"}}},
+					},
+				},
+				// KB3/U1 must have no Supersedes.
+				{
+					KBID:    "3",
+					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			DeriveSupersedes(tt.kbs)
+			for i := range tt.kbs {
+				tt.kbs[i].Sort()
+			}
+			slices.SortFunc(tt.kbs, microsoftkbTypes.Compare)
+			for i := range tt.want {
+				tt.want[i].Sort()
+			}
+			slices.SortFunc(tt.want, microsoftkbTypes.Compare)
+			if diff := cmp.Diff(tt.want, tt.kbs); diff != "" {
+				t.Errorf("DeriveSupersedes() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/extract/microsoft/wsusscn2/testdata/golden/microsoftkb/5066xxx/5066835.json
+++ b/pkg/extract/microsoft/wsusscn2/testdata/golden/microsoftkb/5066xxx/5066835.json
@@ -13,6 +13,12 @@
 				"72E7624A-5B00-45D2-B92F-E561C0A6A160"
 			],
 			"support_url": "http://go.microsoft.com/fwlink/?LinkId=507418",
+			"supersedes": [
+				{
+					"kb_id": "5070881",
+					"update_id": "0f08c8e4-9998-4bf7-8f51-f3736282d656"
+				}
+			],
 			"creation_date": "2025-11-12T01:07:55Z",
 			"catalog_url": "https://www.catalog.update.microsoft.com/ScopedViewInline.aspx?updateid=17ff83de-4e31-4fa5-9741-bebce9d44c2c"
 		}

--- a/pkg/extract/microsoft/wsusscn2/wsusscn2.go
+++ b/pkg/extract/microsoft/wsusscn2/wsusscn2.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	microsoftutil "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/util"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
 	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
 	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
@@ -123,6 +124,7 @@ func (o options) extract(root string) error {
 		if len(kb.KBID) <= 3 {
 			return errors.Errorf("unexpected KBID format. expected: len > 3, actual: %q", kb.KBID)
 		}
+
 		filename := filepath.Join(o.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID))
 		if _, err := os.Stat(filename); err == nil {
 			f, err := os.Open(filename)
@@ -146,6 +148,49 @@ func (o options) extract(root string) error {
 		return nil
 	}); err != nil {
 		return errors.Wrapf(err, "walk %s", filepath.Join(root, "u"))
+	}
+
+	// Phase 2: read all written KB files, derive Supersedes, write all KB files back.
+	kbDir := filepath.Join(o.dir, "microsoftkb")
+	if _, err := os.Stat(kbDir); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return errors.Wrapf(err, "stat %s", kbDir)
+		}
+		return nil
+	}
+	var kbs []microsoftkbTypes.KB
+	if err := filepath.WalkDir(kbDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", path)
+		}
+		defer f.Close()
+
+		var kb microsoftkbTypes.KB
+		if err := json.UnmarshalRead(f, &kb); err != nil {
+			return errors.Wrapf(err, "decode %s", path)
+		}
+
+		kbs = append(kbs, kb)
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", kbDir)
+	}
+
+	microsoftutil.DeriveSupersedes(kbs)
+
+	for _, kb := range kbs {
+		if err := util.Write(filepath.Join(o.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)), kb, true); err != nil {
+			return errors.Wrapf(err, "write %s", kb.KBID)
+		}
 	}
 
 	return nil

--- a/pkg/extract/types/microsoftkb/microsoftkb.go
+++ b/pkg/extract/types/microsoftkb/microsoftkb.go
@@ -4,30 +4,32 @@ import (
 	"cmp"
 	"slices"
 
-	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
 	microsoftkbUpdateTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/update"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 )
 
 // KB represents a Microsoft Knowledge Base article as a grouping key.
 // SupersededBy at this level holds KB-level supersession info (e.g. from CVRF).
+// Supersedes is the reverse: KBs that this KB replaces, derived from SupersededBy.
 // Per-update supersession is stored in each Update's SupersededBy.
 type KB struct {
-	KBID         string                                    `json:"kb_id"`
-	URL          string                                    `json:"url,omitempty"`
-	Products     []string                                  `json:"products,omitempty"`
+	KBID         string                                      `json:"kb_id"`
+	URL          string                                      `json:"url,omitempty"`
+	Products     []string                                    `json:"products,omitempty"`
 	SupersededBy []microsoftkbSupersededByTypes.SupersededBy `json:"superseded_by,omitempty"`
+	Supersedes   []microsoftkbSupersedesTypes.Supersedes     `json:"supersedes,omitempty"`
 	Updates      []microsoftkbUpdateTypes.Update             `json:"updates,omitempty"`
-	DataSource   sourceTypes.Source                        `json:"data_source,omitzero"`
+	DataSource   sourceTypes.Source                          `json:"data_source,omitzero"`
 }
 
 func (d *KB) Sort() {
 	slices.Sort(d.Products)
 
-	for i := range d.SupersededBy {
-		d.SupersededBy[i].Sort()
-	}
 	slices.SortFunc(d.SupersededBy, microsoftkbSupersededByTypes.Compare)
+
+	slices.SortFunc(d.Supersedes, microsoftkbSupersedesTypes.Compare)
 
 	for i := range d.Updates {
 		d.Updates[i].Sort()
@@ -43,6 +45,7 @@ func Compare(x, y KB) int {
 		cmp.Compare(x.URL, y.URL),
 		slices.Compare(x.Products, y.Products),
 		slices.CompareFunc(x.SupersededBy, y.SupersededBy, microsoftkbSupersededByTypes.Compare),
+		slices.CompareFunc(x.Supersedes, y.Supersedes, microsoftkbSupersedesTypes.Compare),
 		slices.CompareFunc(x.Updates, y.Updates, microsoftkbUpdateTypes.Compare),
 		sourceTypes.Compare(x.DataSource, y.DataSource),
 	)
@@ -71,6 +74,16 @@ func (d *KB) Merge(kbs ...KB) {
 			}
 		}
 		d.SupersededBy = ss
+
+		sups := d.Supersedes
+		for _, esup := range e.Supersedes {
+			if !slices.ContainsFunc(sups, func(s microsoftkbSupersedesTypes.Supersedes) bool {
+				return microsoftkbSupersedesTypes.Compare(s, esup) == 0
+			}) {
+				sups = append(sups, esup)
+			}
+		}
+		d.Supersedes = sups
 
 		us := d.Updates
 		for _, eu := range e.Updates {

--- a/pkg/extract/types/microsoftkb/supersededby/supersededby_test.go
+++ b/pkg/extract/types/microsoftkb/supersededby/supersededby_test.go
@@ -4,28 +4,6 @@ import (
 	"testing"
 )
 
-func TestSupersededBy_Sort(t *testing.T) {
-	type fields struct {
-		KBID     string
-		UpdateID string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			d := &SupersededBy{
-				KBID:     tt.fields.KBID,
-				UpdateID: tt.fields.UpdateID,
-			}
-			d.Sort()
-		})
-	}
-}
-
 func TestCompare(t *testing.T) {
 	type args struct {
 		x SupersededBy

--- a/pkg/extract/types/microsoftkb/supersedes/supersedes.go
+++ b/pkg/extract/types/microsoftkb/supersedes/supersedes.go
@@ -1,14 +1,14 @@
-package supersededby
+package supersedes
 
 import "cmp"
 
-// SupersededBy represents a reference to a superseding update.
-type SupersededBy struct {
+// Supersedes represents a reference to a superseded (older) update.
+type Supersedes struct {
 	KBID     string `json:"kb_id,omitempty"`
 	UpdateID string `json:"update_id,omitempty"`
 }
 
-func Compare(x, y SupersededBy) int {
+func Compare(x, y Supersedes) int {
 	return cmp.Or(
 		cmp.Compare(x.KBID, y.KBID),
 		cmp.Compare(x.UpdateID, y.UpdateID),

--- a/pkg/extract/types/microsoftkb/update/update.go
+++ b/pkg/extract/types/microsoftkb/update/update.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	supersededbyTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	supersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
 )
 
 // Update represents a specific update instance identified by Update ID (UUID).
@@ -24,6 +25,7 @@ type Update struct {
 	MoreInfoURL        string                           `json:"more_info_url,omitempty"`
 	SupportURL         string                           `json:"support_url,omitempty"`
 	SupersededBy       []supersededbyTypes.SupersededBy `json:"superseded_by,omitempty"`
+	Supersedes         []supersedesTypes.Supersedes     `json:"supersedes,omitempty"`
 	RebootBehavior     string                           `json:"reboot_behavior,omitempty"`
 	UserInput          string                           `json:"user_input,omitempty"`
 	InstallationImpact string                           `json:"installation_impact,omitempty"`
@@ -39,10 +41,9 @@ func (d *Update) Sort() {
 	slices.Sort(d.Products)
 	slices.Sort(d.Languages)
 
-	for i := range d.SupersededBy {
-		d.SupersededBy[i].Sort()
-	}
 	slices.SortFunc(d.SupersededBy, supersededbyTypes.Compare)
+
+	slices.SortFunc(d.Supersedes, supersedesTypes.Compare)
 }
 
 func Compare(x, y Update) int {
@@ -60,6 +61,7 @@ func Compare(x, y Update) int {
 		cmp.Compare(x.MoreInfoURL, y.MoreInfoURL),
 		cmp.Compare(x.SupportURL, y.SupportURL),
 		slices.CompareFunc(x.SupersededBy, y.SupersededBy, supersededbyTypes.Compare),
+		slices.CompareFunc(x.Supersedes, y.Supersedes, supersedesTypes.Compare),
 		cmp.Compare(x.RebootBehavior, y.RebootBehavior),
 		cmp.Compare(x.UserInput, y.UserInput),
 		cmp.Compare(x.InstallationImpact, y.InstallationImpact),


### PR DESCRIPTION
- Add DeriveSupersedes to pkg/extract/microsoft/util, inverting SupersededBy
  to populate Supersedes at both KB-level and Update-level
- Add Supersedes field to KB and Update types
- Refactor bulletin, cvrf, msuc, wsusscn2 extractors to use DeriveSupersedes
- msuc/wsusscn2 use a two-pass approach: write SupersededBy in pass 1,
  read all KB files and derive Supersedes in pass 2
- Add TestDeriveSupersedes covering KB-level, Update-level, edge cases