### PR TITLE
fix(extract/microsoft/cvrf): canonical Windows 11 name

### DIFF
--- a/pkg/extract/microsoft/util/util.go
+++ b/pkg/extract/microsoft/util/util.go
@@ -11,6 +11,7 @@ var canonicalProductNames = map[string]string{
 	"Dynamics 365 Business Central 2019 Spring Update": "Dynamics 365 Business Central Spring 2019 Update",
 	"Windows 11 for x64-based Systems":                 "Windows 11 Version 21H2 for x64-based Systems",
 	"Windows 11 for ARM64-based Systems":               "Windows 11 Version 21H2 for ARM64-based Systems",
+	"Windows 11 Version 25H2 for ARM Systems":          "Windows 11 Version 25H2 for ARM64-based Systems",
 	"Microsoft Defender for Endpoint for Windows on Windows Server 2022 Datacenter: Azure Edition": "Microsoft Defender for Endpoint for Windows on Windows Server 2022",
 	"System Center Operations Manager (SCOM) 2019":                                                 "System Center Operations Manager 2019",
 	"System Center Operations Manager (SCOM) 2022":                                                 "System Center Operations Manager 2022",

--- a/pkg/extract/microsoft/util/util_test.go
+++ b/pkg/extract/microsoft/util/util_test.go
@@ -182,6 +182,11 @@ func TestNormalizeProductName(t *testing.T) {
 			want: "Microsoft Teams for Mac",
 		},
 		{
+			name: "Windows 11 Version 25H2 for ARM systems typo canonicalized",
+			args: args{s: "Windows 11 Version 25H2 for ARM systems"},
+			want: "Windows 11 Version 25H2 for ARM64-based Systems",
+		},
+		{
 			name: "Azure File Sync v18 canonicalized",
 			args: args{s: "Azure File Sync v18"},
 			want: "Azure File Sync v18.0",


### PR DESCRIPTION
Add a canonical product name mapping for the CVRF typo "Windows 11 Version 25H2 for ARM systems", which should be "Windows 11 Version 25H2 for ARM64-based Systems".

Fixes: unexpected FixedBuild format for CVE-2025-6965
(Windows 11 Version 25H2 for ARM Systems): "10.0.26200.7623"

fix https://github.com/vulsio/vuls-data-db/actions/runs/24528933914/job/71706660902