### PR TITLE
 fix(extract/microsoft/cvrf): handle 2026-Apr data issues

### DIFF
--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -64,9 +64,9 @@ import (
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
 	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
-	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
 	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
 	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
 	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
@@ -805,8 +805,8 @@ func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criter
 			}
 			return rangeTypes.RangeTypeMicrosoftDefenderSecurityIntelligence, nil
 
-		// Windows Defender Antimalware Platform
-		case "Windows Defender Antimalware Platform":
+		// Microsoft Defender Antimalware Platform
+		case "Microsoft Defender Antimalware Platform":
 			if _, err := defenderwindowsversion.NewVersion(fixedBuild); err != nil {
 				return rangeTypes.RangeTypeUnknown, errors.Wrap(err, "defenderwindowsversion.NewVersion")
 			}
@@ -1050,10 +1050,12 @@ func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criter
 			"Microsoft SQL Server 2022 for x64-based Systems (CU 21)",
 			"Microsoft SQL Server 2022 for x64-based Systems (CU 22)",
 			"Microsoft SQL Server 2022 for x64-based Systems (CU 23)",
+			"Microsoft SQL Server 2022 for x64-based Systems (CU 24)",
 			"Microsoft SQL Server 2022 for x64-based Systems (CU 5)",
 			"Microsoft SQL Server 2022 for x64-based Systems (CU 8)",
 			"Microsoft SQL Server 2022 for x64-based Systems (GDR)",
 			"Microsoft SQL Server 2025 for x64-based Systems (CU2)",
+			"Microsoft SQL Server 2025 for x64-based Systems (CU3)",
 			"Microsoft SQL Server 2025 for x64-based Systems (GDR)",
 			"SQL Server 2019 for Linux Containers",
 			"SQL Server Integration Services for Visual Studio 2019",
@@ -1598,7 +1600,7 @@ var fixedBuildOverrides = map[[3]string]string{
 	{"CVE-2021-38660", "Microsoft Excel 2013 Service Pack 1 (64-bit editions)", "5381.1000"}:  "15.0.5381.1000",
 	{"CVE-2021-38655", "Microsoft Excel 2016 (32-bit edition)", "5215.1000"}:                  "16.0.5215.1000",
 	{"CVE-2021-38655", "Microsoft Excel 2016 (64-bit edition)", "5215.1000"}:                  "16.0.5215.1000",
-	{"CVE-2021-38655", "Office Online Server", "10378.20000"}:                       "16.0.10378.20000",
+	{"CVE-2021-38655", "Office Online Server", "10378.20000"}:                                 "16.0.10378.20000",
 	{"CVE-2021-38655", "Microsoft Office Web Apps Server 2013 Service Pack 1", "5381.1000"}:   "15.0.5381.1000",
 	// 2021-Jul (Office 2019 for Mac, FixedBuild "16.51.210711.01" has extra dot in build segment, should be "16.51.21071101")
 	{"CVE-2021-34501", "Microsoft Office 2019 for Mac", "16.51.210711.01"}: "16.51.21071101",
@@ -1738,6 +1740,9 @@ var fixedBuildOverrides = map[[3]string]string{
 	{"CVE-2026-23674", "Windows Server 2012 (Server Core installation)", "1.000"}:    "",
 	{"CVE-2026-23674", "Windows Server 2012 R2", "1.000"}:                            "",
 	{"CVE-2026-23674", "Windows Server 2012 R2 (Server Core installation)", "1.000"}: "",
+	// 2026-Apr (IE Cumulative, FixedBuild "1.000" is a revision number, not a Windows OS build)
+	{"CVE-2026-32077", "Windows Server 2012 R2", "1.000"}:                            "",
+	{"CVE-2026-32077", "Windows Server 2012 R2 (Server Core installation)", "1.000"}: "",
 	// 2021-Oct (IE Cumulative, FixedBuild "1.001" is a revision number, not a Windows OS build)
 	{"CVE-2021-41342", "Windows 7 for 32-bit Systems Service Pack 1", "1.001"}:                 "",
 	{"CVE-2021-41342", "Windows 7 for x64-based Systems Service Pack 1", "1.001"}:              "",

--- a/pkg/extract/microsoft/cvrf/cvrf_test.go
+++ b/pkg/extract/microsoft/cvrf/cvrf_test.go
@@ -4,84 +4,148 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/cvrf"
+	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
+	vcTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion"
+	affectedTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected"
+	affectedrangeTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range"
+	fixstatusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/fixstatus"
+	packageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/package"
+	binaryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/package/binary"
 	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
 )
 
+func fixedVersionCriterion(productName, fixedBuild string, rangeType affectedrangeTypes.RangeType) *criterionTypes.Criterion {
+	return &criterionTypes.Criterion{
+		Type: criterionTypes.CriterionTypeVersion,
+		Version: &vcTypes.Criterion{
+			Vulnerable: true,
+			FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed},
+			Package: packageTypes.Package{
+				Type:   packageTypes.PackageTypeBinary,
+				Binary: &binaryTypes.Package{Name: productName},
+			},
+			Affected: &affectedTypes.Affected{
+				Type:  rangeType,
+				Range: []affectedrangeTypes.Range{{LessThan: fixedBuild}},
+				Fixed: []string{fixedBuild},
+			},
+		},
+	}
+}
+
 func TestBuildFixedBuildCriterion(t *testing.T) {
+	type args struct {
+		cveID         string
+		productName   string
+		rawFixedBuild string
+	}
 	tests := []struct {
-		name        string
-		cveID       string
-		productName string
-		fixedBuild  string
-		wantNil     bool
-		wantErr     bool
+		name    string
+		args    args
+		want    *criterionTypes.Criterion
+		wantErr bool
 	}{
 		{
-			name:        "SQL Server 2022 CU 24",
-			cveID:       "CVE-2026-32176",
-			productName: "Microsoft SQL Server 2022 for x64-based Systems (CU 24)",
-			fixedBuild:  "16.0.4250.1",
+			name: "SQL Server 2022 CU 24",
+			args: args{
+				cveID:         "CVE-2026-32176",
+				productName:   "Microsoft SQL Server 2022 for x64-based Systems (CU 24)",
+				rawFixedBuild: "16.0.4250.1",
+			},
+			want: fixedVersionCriterion(
+				"Microsoft SQL Server 2022 for x64-based Systems (CU 24)",
+				"16.0.4250.1",
+				affectedrangeTypes.RangeTypeMicrosoftSQLServer,
+			),
 		},
 		{
-			name:        "SQL Server 2025 CU3",
-			cveID:       "CVE-2026-32176",
-			productName: "Microsoft SQL Server 2025 for x64-based Systems (CU3)",
-			fixedBuild:  "17.0.4030.1",
+			name: "SQL Server 2025 CU3",
+			args: args{
+				cveID:         "CVE-2026-32176",
+				productName:   "Microsoft SQL Server 2025 for x64-based Systems (CU3)",
+				rawFixedBuild: "17.0.4030.1",
+			},
+			want: fixedVersionCriterion(
+				"Microsoft SQL Server 2025 for x64-based Systems (CU3)",
+				"17.0.4030.1",
+				affectedrangeTypes.RangeTypeMicrosoftSQLServer,
+			),
 		},
 		{
-			name:        "Microsoft Defender Antimalware Platform",
-			cveID:       "CVE-2026-33825",
-			productName: "Microsoft Defender Antimalware Platform",
-			fixedBuild:  "4.18.26030.3011",
+			name: "Microsoft Defender Antimalware Platform",
+			args: args{
+				cveID:         "CVE-2026-33825",
+				productName:   "Microsoft Defender Antimalware Platform",
+				rawFixedBuild: "4.18.26030.3011",
+			},
+			want: fixedVersionCriterion(
+				"Microsoft Defender Antimalware Platform",
+				"4.18.26030.3011",
+				affectedrangeTypes.RangeTypeMicrosoftDefenderWindows,
+			),
 		},
 		{
-			name:        "CVE-2026-32077 Windows Server 2012 R2 IE Cumulative 1.000 skipped",
-			cveID:       "CVE-2026-32077",
-			productName: "Windows Server 2012 R2",
-			fixedBuild:  "1.000",
-			wantNil:     true,
+			name: "CVE-2026-32077 Windows Server 2012 R2 IE Cumulative 1.000 skipped",
+			args: args{
+				cveID:         "CVE-2026-32077",
+				productName:   "Windows Server 2012 R2",
+				rawFixedBuild: "1.000",
+			},
+			want: nil,
 		},
 		{
-			name:        "CVE-2026-32077 Windows Server 2012 R2 Server Core IE Cumulative 1.000 skipped",
-			cveID:       "CVE-2026-32077",
-			productName: "Windows Server 2012 R2 (Server Core installation)",
-			fixedBuild:  "1.000",
-			wantNil:     true,
+			name: "CVE-2026-32077 Windows Server 2012 R2 Server Core IE Cumulative 1.000 skipped",
+			args: args{
+				cveID:         "CVE-2026-32077",
+				productName:   "Windows Server 2012 R2 (Server Core installation)",
+				rawFixedBuild: "1.000",
+			},
+			want: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := cvrf.BuildFixedBuildCriterion(tt.cveID, tt.productName, tt.fixedBuild)
+			got, err := cvrf.BuildFixedBuildCriterion(tt.args.cveID, tt.args.productName, tt.args.rawFixedBuild)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildFixedBuildCriterion() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if tt.wantNil && got != nil {
-				t.Errorf("BuildFixedBuildCriterion() = %v, want nil", got)
-			}
-			if !tt.wantNil && !tt.wantErr && got == nil {
-				t.Errorf("BuildFixedBuildCriterion() = nil, want non-nil Criterion")
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("BuildFixedBuildCriterion() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
 func TestFixedBuildOverrides(t *testing.T) {
-	overrides := cvrf.FixedBuildOverrides
-	entries := [][3]string{
-		{"CVE-2026-32077", "Windows Server 2012 R2", "1.000"},
-		{"CVE-2026-32077", "Windows Server 2012 R2 (Server Core installation)", "1.000"},
+	tests := []struct {
+		name string
+		key  [3]string
+		want string
+	}{
+		{
+			name: "CVE-2026-32077 Windows Server 2012 R2",
+			key:  [3]string{"CVE-2026-32077", "Windows Server 2012 R2", "1.000"},
+			want: "",
+		},
+		{
+			name: "CVE-2026-32077 Windows Server 2012 R2 Server Core",
+			key:  [3]string{"CVE-2026-32077", "Windows Server 2012 R2 (Server Core installation)", "1.000"},
+			want: "",
+		},
 	}
-	for _, key := range entries {
-		t.Run(key[0]+"/"+key[1], func(t *testing.T) {
-			got, ok := overrides[key]
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := cvrf.FixedBuildOverrides[tt.key]
 			if !ok {
-				t.Errorf("fixedBuildOverrides missing entry %v", key)
+				t.Errorf("fixedBuildOverrides missing entry %v", tt.key)
 				return
 			}
-			if got != "" {
-				t.Errorf("fixedBuildOverrides[%v] = %q, want empty string (skip)", key, got)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("fixedBuildOverrides[%v] mismatch (-want +got):\n%s", tt.key, diff)
 			}
 		})
 	}

--- a/pkg/extract/microsoft/cvrf/cvrf_test.go
+++ b/pkg/extract/microsoft/cvrf/cvrf_test.go
@@ -8,6 +8,85 @@ import (
 	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
 )
 
+func TestBuildFixedBuildCriterion(t *testing.T) {
+	tests := []struct {
+		name        string
+		cveID       string
+		productName string
+		fixedBuild  string
+		wantNil     bool
+		wantErr     bool
+	}{
+		{
+			name:        "SQL Server 2022 CU 24",
+			cveID:       "CVE-2026-32176",
+			productName: "Microsoft SQL Server 2022 for x64-based Systems (CU 24)",
+			fixedBuild:  "16.0.4250.1",
+		},
+		{
+			name:        "SQL Server 2025 CU3",
+			cveID:       "CVE-2026-32176",
+			productName: "Microsoft SQL Server 2025 for x64-based Systems (CU3)",
+			fixedBuild:  "17.0.4030.1",
+		},
+		{
+			name:        "Microsoft Defender Antimalware Platform",
+			cveID:       "CVE-2026-33825",
+			productName: "Microsoft Defender Antimalware Platform",
+			fixedBuild:  "4.18.26030.3011",
+		},
+		{
+			name:        "CVE-2026-32077 Windows Server 2012 R2 IE Cumulative 1.000 skipped",
+			cveID:       "CVE-2026-32077",
+			productName: "Windows Server 2012 R2",
+			fixedBuild:  "1.000",
+			wantNil:     true,
+		},
+		{
+			name:        "CVE-2026-32077 Windows Server 2012 R2 Server Core IE Cumulative 1.000 skipped",
+			cveID:       "CVE-2026-32077",
+			productName: "Windows Server 2012 R2 (Server Core installation)",
+			fixedBuild:  "1.000",
+			wantNil:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cvrf.BuildFixedBuildCriterion(tt.cveID, tt.productName, tt.fixedBuild)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BuildFixedBuildCriterion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantNil && got != nil {
+				t.Errorf("BuildFixedBuildCriterion() = %v, want nil", got)
+			}
+			if !tt.wantNil && !tt.wantErr && got == nil {
+				t.Errorf("BuildFixedBuildCriterion() = nil, want non-nil Criterion")
+			}
+		})
+	}
+}
+
+func TestFixedBuildOverrides(t *testing.T) {
+	overrides := cvrf.FixedBuildOverrides
+	entries := [][3]string{
+		{"CVE-2026-32077", "Windows Server 2012 R2", "1.000"},
+		{"CVE-2026-32077", "Windows Server 2012 R2 (Server Core installation)", "1.000"},
+	}
+	for _, key := range entries {
+		t.Run(key[0]+"/"+key[1], func(t *testing.T) {
+			got, ok := overrides[key]
+			if !ok {
+				t.Errorf("fixedBuildOverrides missing entry %v", key)
+				return
+			}
+			if got != "" {
+				t.Errorf("fixedBuildOverrides[%v] = %q, want empty string (skip)", key, got)
+			}
+		})
+	}
+}
+
 func TestExtract(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/extract/microsoft/cvrf/cvrf_test.go
+++ b/pkg/extract/microsoft/cvrf/cvrf_test.go
@@ -17,25 +17,6 @@ import (
 	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
 )
 
-func fixedVersionCriterion(productName, fixedBuild string, rangeType affectedrangeTypes.RangeType) *criterionTypes.Criterion {
-	return &criterionTypes.Criterion{
-		Type: criterionTypes.CriterionTypeVersion,
-		Version: &vcTypes.Criterion{
-			Vulnerable: true,
-			FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed},
-			Package: packageTypes.Package{
-				Type:   packageTypes.PackageTypeBinary,
-				Binary: &binaryTypes.Package{Name: productName},
-			},
-			Affected: &affectedTypes.Affected{
-				Type:  rangeType,
-				Range: []affectedrangeTypes.Range{{LessThan: fixedBuild}},
-				Fixed: []string{fixedBuild},
-			},
-		},
-	}
-}
-
 func TestBuildFixedBuildCriterion(t *testing.T) {
 	type args struct {
 		cveID         string
@@ -55,11 +36,22 @@ func TestBuildFixedBuildCriterion(t *testing.T) {
 				productName:   "Microsoft SQL Server 2022 for x64-based Systems (CU 24)",
 				rawFixedBuild: "16.0.4250.1",
 			},
-			want: fixedVersionCriterion(
-				"Microsoft SQL Server 2022 for x64-based Systems (CU 24)",
-				"16.0.4250.1",
-				affectedrangeTypes.RangeTypeMicrosoftSQLServer,
-			),
+			want: &criterionTypes.Criterion{
+				Type: criterionTypes.CriterionTypeVersion,
+				Version: &vcTypes.Criterion{
+					Vulnerable: true,
+					FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed},
+					Package: packageTypes.Package{
+						Type:   packageTypes.PackageTypeBinary,
+						Binary: &binaryTypes.Package{Name: "Microsoft SQL Server 2022 for x64-based Systems (CU 24)"},
+					},
+					Affected: &affectedTypes.Affected{
+						Type:  affectedrangeTypes.RangeTypeMicrosoftSQLServer,
+						Range: []affectedrangeTypes.Range{{LessThan: "16.0.4250.1"}},
+						Fixed: []string{"16.0.4250.1"},
+					},
+				},
+			},
 		},
 		{
 			name: "SQL Server 2025 CU3",
@@ -68,11 +60,22 @@ func TestBuildFixedBuildCriterion(t *testing.T) {
 				productName:   "Microsoft SQL Server 2025 for x64-based Systems (CU3)",
 				rawFixedBuild: "17.0.4030.1",
 			},
-			want: fixedVersionCriterion(
-				"Microsoft SQL Server 2025 for x64-based Systems (CU3)",
-				"17.0.4030.1",
-				affectedrangeTypes.RangeTypeMicrosoftSQLServer,
-			),
+			want: &criterionTypes.Criterion{
+				Type: criterionTypes.CriterionTypeVersion,
+				Version: &vcTypes.Criterion{
+					Vulnerable: true,
+					FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed},
+					Package: packageTypes.Package{
+						Type:   packageTypes.PackageTypeBinary,
+						Binary: &binaryTypes.Package{Name: "Microsoft SQL Server 2025 for x64-based Systems (CU3)"},
+					},
+					Affected: &affectedTypes.Affected{
+						Type:  affectedrangeTypes.RangeTypeMicrosoftSQLServer,
+						Range: []affectedrangeTypes.Range{{LessThan: "17.0.4030.1"}},
+						Fixed: []string{"17.0.4030.1"},
+					},
+				},
+			},
 		},
 		{
 			name: "Microsoft Defender Antimalware Platform",
@@ -81,11 +84,22 @@ func TestBuildFixedBuildCriterion(t *testing.T) {
 				productName:   "Microsoft Defender Antimalware Platform",
 				rawFixedBuild: "4.18.26030.3011",
 			},
-			want: fixedVersionCriterion(
-				"Microsoft Defender Antimalware Platform",
-				"4.18.26030.3011",
-				affectedrangeTypes.RangeTypeMicrosoftDefenderWindows,
-			),
+			want: &criterionTypes.Criterion{
+				Type: criterionTypes.CriterionTypeVersion,
+				Version: &vcTypes.Criterion{
+					Vulnerable: true,
+					FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed},
+					Package: packageTypes.Package{
+						Type:   packageTypes.PackageTypeBinary,
+						Binary: &binaryTypes.Package{Name: "Microsoft Defender Antimalware Platform"},
+					},
+					Affected: &affectedTypes.Affected{
+						Type:  affectedrangeTypes.RangeTypeMicrosoftDefenderWindows,
+						Range: []affectedrangeTypes.Range{{LessThan: "4.18.26030.3011"}},
+						Fixed: []string{"4.18.26030.3011"},
+					},
+				},
+			},
 		},
 		{
 			name: "CVE-2026-32077 Windows Server 2012 R2 IE Cumulative 1.000 skipped",

--- a/pkg/extract/microsoft/cvrf/export_test.go
+++ b/pkg/extract/microsoft/cvrf/export_test.go
@@ -1,0 +1,4 @@
+package cvrf
+
+var BuildFixedBuildCriterion = buildFixedBuildCriterion
+var FixedBuildOverrides = fixedBuildOverrides

--- a/pkg/extract/microsoft/cvrf/export_test.go
+++ b/pkg/extract/microsoft/cvrf/export_test.go
@@ -1,4 +1,6 @@
 package cvrf
 
-var BuildFixedBuildCriterion = buildFixedBuildCriterion
-var FixedBuildOverrides = fixedBuildOverrides
+var (
+	BuildFixedBuildCriterion = buildFixedBuildCriterion
+	FixedBuildOverrides      = fixedBuildOverrides
+)

--- a/pkg/extract/microsoft/util/util.go
+++ b/pkg/extract/microsoft/util/util.go
@@ -18,6 +18,7 @@ var canonicalProductNames = map[string]string{
 	"Microsoft Teams for Mac, Classic Edition":                                                     "Microsoft Teams for Mac",
 	"Microsoft Teams for Mac, New Edition":                                                         "Microsoft Teams for Mac",
 	"Azure File Sync v18":                                                                          "Azure File Sync v18.0",
+	"Windows Defender Antimalware Platform":                                                        "Microsoft Defender Antimalware Platform",
 
 	// Bulletin→CVRF product name unification (legacy products with "Microsoft " prefix)
 	"Microsoft Azure Kubernetes Service":                          "Azure Kubernetes Service",

--- a/pkg/extract/microsoft/util/util_test.go
+++ b/pkg/extract/microsoft/util/util_test.go
@@ -187,6 +187,11 @@ func TestNormalizeProductName(t *testing.T) {
 			want: "Windows 11 Version 25H2 for ARM64-based Systems",
 		},
 		{
+			name: "Windows Defender Antimalware Platform canonicalized to Microsoft branding",
+			args: args{s: "Windows Defender Antimalware Platform"},
+			want: "Microsoft Defender Antimalware Platform",
+		},
+		{
 			name: "Azure File Sync v18 canonicalized",
 			args: args{s: "Azure File Sync v18"},
 			want: "Azure File Sync v18.0",


### PR DESCRIPTION
 - Add CVE-2026-32077 IE Cumulative FixedBuild "1.000" overrides (KB5082806 package revision, not a Windows OS build number)
 - Add Microsoft SQL Server 2022 (CU 24) and 2025 (CU3) to buildFixedBuildCriterion
 - Canonicalize "Windows Defender Antimalware Platform" to "Microsoft Defender Antimalware Platform"

refs https://github.com/vulsio/vuls-data-db/actions/runs/24554277243