### PR TITLE
feat(extract/nuclei/repository): implement extractor

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -76,6 +76,7 @@ import (
 	npmGHSA "github.com/MaineK00n/vuls-data-update/pkg/extract/npm/ghsa"
 	npmGLSA "github.com/MaineK00n/vuls-data-update/pkg/extract/npm/glsa"
 	npmOSV "github.com/MaineK00n/vuls-data-update/pkg/extract/npm/osv"
+	nucleiRepository "github.com/MaineK00n/vuls-data-update/pkg/extract/nuclei/repository"
 	nugetGHSA "github.com/MaineK00n/vuls-data-update/pkg/extract/nuget/ghsa"
 	nugetGLSA "github.com/MaineK00n/vuls-data-update/pkg/extract/nuget/glsa"
 	nugetOSV "github.com/MaineK00n/vuls-data-update/pkg/extract/nuget/osv"
@@ -179,6 +180,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdNetBSD(),
 		newCmdNpmGHSA(), newCmdNpmGLSA(), newCmdNpmOSV(), newCmdNpmDB(),
 		newCmdNugetGHSA(), newCmdNugetGLSA(), newCmdNugetOSV(),
+		newCmdNucleiRepository(),
 		newCmdNVDAPICVE(), newCmdNVDAPICPE(), newCmdNVDFeedCVEv1(), newCmdNVDFeedCPEv1(), newCmdNVDFeedCPEMATCHv1(), newCmdNVDFeedCVEv2(), newCmdNVDFeedCPEv2(), newCmdNVDFeedCPEMATCHv2(),
 		newCmdOracleLinux(),
 		newCmdOSSFuzzOSV(),
@@ -1978,6 +1980,31 @@ func newCmdNugetOSV() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&options.dir, "dir", "d", filepath.Join(util.CacheDir(), "extract", "nuget", "osv"), "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdNucleiRepository() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "nuclei", "repository"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "nuclei-repository <Raw Nuclei Templates Repository PATH>",
+		Short: "Extract Nuclei Templates Repository data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract nuclei-repository vuls-data-raw-nuclei-repository
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := nucleiRepository.Extract(args[0], nucleiRepository.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract nuclei repository")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
 
 	return cmd
 }

--- a/pkg/extract/nuclei/repository/repository.go
+++ b/pkg/extract/nuclei/repository/repository.go
@@ -1,0 +1,185 @@
+package repository
+
+import (
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	exploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit"
+	nucleiTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/nuclei"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	fetchTypes "github.com/MaineK00n/vuls-data-update/pkg/fetch/nuclei/repository"
+)
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "nuclei", "repository"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract Nuclei Templates Repository")
+
+	cveExploits, err := extract(args)
+	if err != nil {
+		return errors.Wrap(err, "extract")
+	}
+
+	for cveID, data := range cveExploits {
+		splitted, err := util.Split(cveID, "-", "-")
+		if err != nil {
+			return errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", cveID)
+		}
+		if _, err := time.Parse("2006", splitted[1]); err != nil {
+			return errors.Errorf("unexpected CVE ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", cveID)
+		}
+		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", cveID)), data, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", cveID)))
+		}
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.NucleiRepository,
+		Name: new("Nuclei Templates Repository"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+func extract(args string) (map[string]dataTypes.Data, error) {
+	cveExploits := make(map[string]dataTypes.Data)
+
+	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		r := utiljson.NewJSONReader()
+		var f fetchTypes.Template
+		if err := r.Read(path, args, &f); err != nil {
+			return errors.Wrapf(err, "read %s", path)
+		}
+
+		if f.Info.Classification == nil || f.Info.Classification.CVEID == nil {
+			return nil
+		}
+
+		cveID := *f.Info.Classification.CVEID
+
+		rel, err := filepath.Rel(args, path)
+		if err != nil {
+			return errors.Wrapf(err, "get relative path of %s from %s", path, args)
+		}
+
+		exploit := exploitTypes.Exploit{
+			Source: "nuclei.projectdiscovery.io",
+			Link:   fmt.Sprintf("https://github.com/projectdiscovery/nuclei-templates/blob/main/%s.yaml", strings.TrimSuffix(filepath.ToSlash(rel), ".json")),
+			Description: func() string {
+				if f.Info.Description == nil {
+					return ""
+				}
+				return strings.TrimSpace(*f.Info.Description)
+			}(),
+			Nuclei: &nucleiTypes.Nuclei{
+				TemplateID: f.ID,
+				Verified: func() bool {
+					if f.Info.Metadata == nil {
+						return false
+					}
+					switch v := (*f.Info.Metadata)["verified"].(type) {
+					case bool:
+						return v
+					case string:
+						b, _ := strconv.ParseBool(v)
+						return b
+					default:
+						return false
+					}
+				}(),
+			},
+		}
+
+		base, ok := cveExploits[cveID]
+		if !ok {
+			base = dataTypes.Data{
+				ID: dataTypes.RootID(cveID),
+				Vulnerabilities: []vulnerabilityTypes.Vulnerability{{
+					Content: vulnerabilityContentTypes.Content{
+						ID: vulnerabilityContentTypes.VulnerabilityID(cveID),
+					},
+				}},
+				DataSource: sourceTypes.Source{
+					ID: sourceTypes.NucleiRepository,
+				},
+			}
+		}
+		base.Vulnerabilities[0].Content.Exploit = append(base.Vulnerabilities[0].Content.Exploit, exploit)
+		base.DataSource.Raws = append(base.DataSource.Raws, r.Paths()...)
+		cveExploits[cveID] = base
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrapf(err, "walk %s", args)
+	}
+
+	return cveExploits, nil
+}

--- a/pkg/extract/nuclei/repository/repository_test.go
+++ b/pkg/extract/nuclei/repository/repository_test.go
@@ -1,0 +1,44 @@
+package repository_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/nuclei/repository"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := repository.Extract(tt.args, repository.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			}
+
+			ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+			if err != nil {
+				t.Error("unexpected error:", err)
+			}
+			gp, err := filepath.Abs(dir)
+			if err != nil {
+				t.Error("unexpected error:", err)
+			}
+			utiltest.Diff(t, ep, gp)
+		})
+	}
+}

--- a/pkg/extract/nuclei/repository/testdata/fixtures/cloud/gcp/loadbalancing/gcloud-lb-backend-unsecured.json
+++ b/pkg/extract/nuclei/repository/testdata/fixtures/cloud/gcp/loadbalancing/gcloud-lb-backend-unsecured.json
@@ -1,0 +1,93 @@
+{
+	"id": "gcloud-lb-backend-unsecured",
+	"info": {
+		"name": "Unsecured Backend Services in Google Cloud Load Balancers",
+		"author": "princechaddha",
+		"tags": "cloud,devops,gcp,gcloud,google-cloud-load-balancer,gcp-cloud-config",
+		"description": "Ensure that the backend services associated with your Google Cloud load balancers are protected with edge security policies provided by the Cloud Armor service in order to shield your backend services from a range of potential attacks. Edge security policies let you control access to your cloud resources at the Google Cloud Platform (GCP) network edge.\n",
+		"impact": "Without edge security policies, backend services are vulnerable to a variety of network-based attacks, which can compromise data integrity and availability.\n",
+		"reference": [
+			"https://cloud.google.com/armor/docs/security-policy-overview"
+		],
+		"severity": "medium",
+		"remediation": "Attach an edge security policy to your backend services via the Google Cloud Console or using the Cloud Armor APIs to enhance security at your network's edge.\n"
+	},
+	"flow": "code(1)\nfor(let projectId of iterate(template.projectIds)){\n  set(\"projectId\", projectId)\n  code(2)\n  for(let urlMapName of iterate(template.urlMaps)){\n    set(\"urlMapName\", urlMapName)\n    code(3)\n    for(let backendService of iterate(template.backendServices)){\n      set(\"backendService\", backendService)\n      code(4)\n    }\n  }\n}\n",
+	"code": [
+		{
+			"extractors": [
+				{
+					"name": "projectIds",
+					"type": "json",
+					"json": [
+						".[].projectId"
+					],
+					"internal": true
+				}
+			],
+			"engine": [
+				"sh",
+				"bash"
+			],
+			"source": "gcloud projects list --format=\"json(projectId)\"\n"
+		},
+		{
+			"extractors": [
+				{
+					"name": "urlMaps",
+					"type": "json",
+					"json": [
+						".[].name"
+					],
+					"internal": true
+				}
+			],
+			"engine": [
+				"sh",
+				"bash"
+			],
+			"source": "gcloud compute url-maps list --project $projectId --format=\"json(name)\"\n"
+		},
+		{
+			"extractors": [
+				{
+					"name": "backendServices",
+					"type": "json",
+					"json": [
+						".defaultService"
+					],
+					"internal": true
+				}
+			],
+			"engine": [
+				"sh",
+				"bash"
+			],
+			"source": "gcloud compute url-maps describe $urlMapName --format=\"json(defaultService)\"\n"
+		},
+		{
+			"matchers": [
+				{
+					"type": "word",
+					"words": [
+						"null"
+					]
+				}
+			],
+			"extractors": [
+				{
+					"type": "dsl",
+					"dsl": [
+						"\"Unsecured Backend Service \" + backendService + \" for URL Map \" + urlMapName + \" in Project \" + projectId"
+					]
+				}
+			],
+			"engine": [
+				"sh",
+				"bash"
+			],
+			"source": "gcloud compute backend-services describe $backendService --format=\"json(securityPolicy)\"\n"
+		}
+	],
+	"self-contained": true
+}

--- a/pkg/extract/nuclei/repository/testdata/fixtures/http/cves/2025/CVE-2025-0108-v2.json
+++ b/pkg/extract/nuclei/repository/testdata/fixtures/http/cves/2025/CVE-2025-0108-v2.json
@@ -1,0 +1,23 @@
+{
+	"id": "CVE-2025-0108-v2",
+	"info": {
+		"name": "PAN-OS Management Interface - Authentication Bypass (variant)",
+		"author": "testauthor",
+		"tags": "cve,cve2025,panos,auth-bypass",
+		"description": "Alternative template for CVE-2025-0108 authentication bypass.",
+		"metadata": {
+			"verified": "True"
+		},
+		"classification": {
+			"cve-id": "CVE-2025-0108"
+		}
+	},
+	"http": [
+		{
+			"path": [
+				"{{BaseURL}}/alternate/path"
+			],
+			"method": "GET"
+		}
+	]
+}

--- a/pkg/extract/nuclei/repository/testdata/fixtures/http/cves/2025/CVE-2025-0108.json
+++ b/pkg/extract/nuclei/repository/testdata/fixtures/http/cves/2025/CVE-2025-0108.json
@@ -1,0 +1,53 @@
+{
+	"id": "CVE-2025-0108",
+	"info": {
+		"name": "PAN-OS Management Interface - Path Confusion to Authentication Bypass",
+		"author": "halencarjunior,ritikchaddha",
+		"tags": "cve,cve2025,panos,auth-bypass,kev,vkev,vuln",
+		"description": "A vulnerability in PAN-OS management interface allows authentication bypass through path confusion between Nginx and Apache handlers.The issue occurs due to differences in path processing between Nginx and Apache, where double URL encoding combined with directory traversal can bypass authentication checks enforced by X-pan-AuthCheck header.\n",
+		"impact": "Unauthenticated attackers can exploit path confusion between Nginx and Apache to bypass authentication completely, gaining unauthorized access to the PAN-OS management interface and potentially compromising the entire firewall infrastructure.\n",
+		"reference": [
+			"https://slcyber.io/blog/nginx-apache-path-confusion-to-auth-bypass-in-pan-os/"
+		],
+		"severity": "critical",
+		"metadata": {
+			"fofa-query": "icon_hash=\"-631559155\"",
+			"max-request": 1,
+			"product": "pan-os",
+			"shodan-query": [
+				"cpe:\"cpe:2.3:o:paloaltonetworks:pan-os\"",
+				"http.favicon.hash:\"-631559155\""
+			],
+			"vendor": "paloaltonetworks",
+			"verified": true
+		},
+		"classification": {
+			"cve-id": "CVE-2025-0108",
+			"cwe-id": "CWE-287",
+			"cvss-metrics": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+			"cvss-score": 10,
+			"epss-score": 0.94115,
+			"epss-percentile": 0.99909
+		},
+		"remediation": "Upgrade to the patched version of PAN-OS as specified in the vendor security advisory.\n"
+	},
+	"http": [
+		{
+			"matchers": [
+				{
+					"type": "dsl",
+					"condition": "and",
+					"dsl": [
+						"contains_any(body, \"<title>Zero Touch Provisioning\", \"Zero Touch Provisioning (ZTP)\")",
+						"contains(header, \"text/html\")",
+						"status_code == 200"
+					]
+				}
+			],
+			"path": [
+				"{{BaseURL}}/unauth/%252e%252e/php/ztp_gate.php/PAN_help/x.css"
+			],
+			"method": "GET"
+		}
+	]
+}

--- a/pkg/extract/nuclei/repository/testdata/golden/data/2025/CVE-2025-0108.json
+++ b/pkg/extract/nuclei/repository/testdata/golden/data/2025/CVE-2025-0108.json
@@ -1,0 +1,37 @@
+{
+	"id": "CVE-2025-0108",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2025-0108",
+				"exploit": [
+					{
+						"source": "nuclei.projectdiscovery.io",
+						"description": "Alternative template for CVE-2025-0108 authentication bypass.",
+						"link": "https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2025/CVE-2025-0108-v2.yaml",
+						"nuclei": {
+							"template_id": "CVE-2025-0108-v2",
+							"verified": true
+						}
+					},
+					{
+						"source": "nuclei.projectdiscovery.io",
+						"description": "A vulnerability in PAN-OS management interface allows authentication bypass through path confusion between Nginx and Apache handlers.The issue occurs due to differences in path processing between Nginx and Apache, where double URL encoding combined with directory traversal can bypass authentication checks enforced by X-pan-AuthCheck header.",
+						"link": "https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2025/CVE-2025-0108.yaml",
+						"nuclei": {
+							"template_id": "CVE-2025-0108",
+							"verified": true
+						}
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "nuclei-repository",
+		"raws": [
+			"fixtures/http/cves/2025/CVE-2025-0108-v2.json",
+			"fixtures/http/cves/2025/CVE-2025-0108.json"
+		]
+	}
+}

--- a/pkg/extract/nuclei/repository/testdata/golden/datasource.json
+++ b/pkg/extract/nuclei/repository/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "nuclei-repository",
+	"name": "Nuclei Templates Repository"
+}

--- a/pkg/extract/types/data/exploit/exploit.go
+++ b/pkg/extract/types/data/exploit/exploit.go
@@ -7,6 +7,7 @@ import (
 	exploitdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/exploitdb"
 	githubTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/github"
 	inthewildTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/inthewild"
+	nucleiTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/nuclei"
 	trickestTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/trickest"
 )
 
@@ -20,6 +21,7 @@ type Exploit struct {
 	ExploitDB *exploitdbTypes.ExploitDB `json:"exploit_db,omitempty"`
 	GitHub    *githubTypes.GitHub       `json:"github,omitempty"`
 	InTheWild *inthewildTypes.InTheWild `json:"inthewild,omitempty"`
+	Nuclei    *nucleiTypes.Nuclei       `json:"nuclei,omitempty"`
 	Trickest  *trickestTypes.Trickest   `json:"trickest,omitempty"`
 }
 
@@ -73,6 +75,18 @@ func Compare(x, y Exploit) int {
 				return +1
 			default:
 				return inthewildTypes.Compare(*x.InTheWild, *y.InTheWild)
+			}
+		}(),
+		func() int {
+			switch {
+			case x.Nuclei == nil && y.Nuclei == nil:
+				return 0
+			case x.Nuclei == nil && y.Nuclei != nil:
+				return -1
+			case x.Nuclei != nil && y.Nuclei == nil:
+				return +1
+			default:
+				return nucleiTypes.Compare(*x.Nuclei, *y.Nuclei)
 			}
 		}(),
 		func() int {

--- a/pkg/extract/types/data/exploit/exploit_test.go
+++ b/pkg/extract/types/data/exploit/exploit_test.go
@@ -9,6 +9,7 @@ import (
 	exploitdbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/exploitdb"
 	githubTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/github"
 	inthewildTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/inthewild"
+	nucleiTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/nuclei"
 	trickestTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/trickest"
 	trickestTagTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/trickest/tag"
 )
@@ -204,6 +205,30 @@ func TestCompare(t *testing.T) {
 			args: args{
 				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", InTheWild: &inthewildTypes.InTheWild{Type: "exploited"}},
 				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", InTheWild: &inthewildTypes.InTheWild{Type: "exploited", Source: "src"}},
+			},
+			want: -1,
+		},
+		{
+			name: "x:nuclei nil < y:nuclei non-nil",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", Nuclei: &nucleiTypes.Nuclei{TemplateID: "CVE-2025-0108"}},
+			},
+			want: -1,
+		},
+		{
+			name: "x:nuclei non-nil > y:nuclei nil",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", Nuclei: &nucleiTypes.Nuclei{TemplateID: "CVE-2025-0108"}},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com"},
+			},
+			want: +1,
+		},
+		{
+			name: "nuclei.Compare as tie-breaker",
+			args: args{
+				x: exploitTypes.Exploit{Source: "source", Link: "http://example.com", Nuclei: &nucleiTypes.Nuclei{TemplateID: "CVE-2025-0108"}},
+				y: exploitTypes.Exploit{Source: "source", Link: "http://example.com", Nuclei: &nucleiTypes.Nuclei{TemplateID: "CVE-2025-0109"}},
 			},
 			want: -1,
 		},

--- a/pkg/extract/types/data/exploit/nuclei/nuclei.go
+++ b/pkg/extract/types/data/exploit/nuclei/nuclei.go
@@ -1,0 +1,26 @@
+package nuclei
+
+import "cmp"
+
+type Nuclei struct {
+	TemplateID string `json:"template_id,omitempty"`
+	Verified   bool   `json:"verified,omitzero"`
+}
+
+func Compare(x, y Nuclei) int {
+	return cmp.Or(
+		cmp.Compare(x.TemplateID, y.TemplateID),
+		func() int {
+			switch {
+			case !x.Verified && !y.Verified:
+				return 0
+			case !x.Verified && y.Verified:
+				return -1
+			case x.Verified && !y.Verified:
+				return +1
+			default:
+				return 0
+			}
+		}(),
+	)
+}

--- a/pkg/extract/types/data/exploit/nuclei/nuclei_test.go
+++ b/pkg/extract/types/data/exploit/nuclei/nuclei_test.go
@@ -1,0 +1,67 @@
+package nuclei_test
+
+import (
+	"testing"
+
+	nucleiTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit/nuclei"
+)
+
+func TestCompare(t *testing.T) {
+	type args struct {
+		x nucleiTypes.Nuclei
+		y nucleiTypes.Nuclei
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "x == y",
+			args: args{
+				x: nucleiTypes.Nuclei{TemplateID: "cve-2025-0108", Verified: true},
+				y: nucleiTypes.Nuclei{TemplateID: "cve-2025-0108", Verified: true},
+			},
+			want: 0,
+		},
+		{
+			name: "x:template_id < y:template_id",
+			args: args{
+				x: nucleiTypes.Nuclei{TemplateID: "cve-2024-0001"},
+				y: nucleiTypes.Nuclei{TemplateID: "cve-2025-0108"},
+			},
+			want: -1,
+		},
+		{
+			name: "x:template_id > y:template_id",
+			args: args{
+				x: nucleiTypes.Nuclei{TemplateID: "cve-2025-0108"},
+				y: nucleiTypes.Nuclei{TemplateID: "cve-2024-0001"},
+			},
+			want: +1,
+		},
+		{
+			name: "x:verified false < y:verified true (tie-breaker)",
+			args: args{
+				x: nucleiTypes.Nuclei{TemplateID: "cve-2025-0108", Verified: false},
+				y: nucleiTypes.Nuclei{TemplateID: "cve-2025-0108", Verified: true},
+			},
+			want: -1,
+		},
+		{
+			name: "x:verified true > y:verified false (tie-breaker)",
+			args: args{
+				x: nucleiTypes.Nuclei{TemplateID: "cve-2025-0108", Verified: true},
+				y: nucleiTypes.Nuclei{TemplateID: "cve-2025-0108", Verified: false},
+			},
+			want: +1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nucleiTypes.Compare(tt.args.x, tt.args.y); got != tt.want {
+				t.Errorf("Compare() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add Nuclei Templates Repository as a new exploit data source.

- Add nucleiTypes.Nuclei struct (TemplateID, Verified) with Compare()
- Add Nuclei field to exploit.Exploit and update Sort/Compare
- Implement extract/nuclei/repository with per-CVE aggregation via WalkDir:
  - Files without info.classification.cve-id are silently skipped
  - Link: [https://github.com/projectdiscovery/nuclei-templates/blob/main/<path>.yaml](https://github.com/projectdiscovery/nuclei-templates/blob/main/%3Cpath%3E.yaml)
  - Verified handles both bool and string types in raw metadata
- Register nuclei-repository CLI subcommand
- Add unit tests for extractor and nuclei Compare