### PR TITLE
fix(extract/exploit/exploitdb): normalize malformed CVE IDs in codes field

### DIFF
--- a/pkg/extract/exploit/exploitdb/exploitdb.go
+++ b/pkg/extract/exploit/exploitdb/exploitdb.go
@@ -113,6 +113,42 @@ func Extract(args string, opts ...Option) error {
 	return nil
 }
 
+// normalizeCVEID trims surrounding whitespace from a token in the free-text
+// codes field, then applies known corrections. Returns the corrected CVE ID,
+// or "" if the token is not a CVE ID or is known to have no corresponding CVE.
+func normalizeCVEID(code string) string {
+	code = strings.TrimSpace(code)
+	if !strings.HasPrefix(code, "CVE-") {
+		return ""
+	}
+	// corrections maps known malformed CVE IDs to their correct form.
+	// An empty value means the ID is known to be invalid with no corresponding CVE (skip without error).
+	corrections := map[string]string{
+		"CVE-2015- 5698":       "CVE-2015-5698",  // space before number
+		"CVE-2015-\u00ad3864":  "CVE-2015-3864",  // soft hyphen (\u00ad)
+		"CVE-2017-18344.":      "CVE-2017-18344", // trailing period
+		"CVE-2017-5715?":       "CVE-2017-5715",  // trailing question mark
+		"CVE-2019\u20115678":   "CVE-2019-5678",  // non-breaking hyphen (\u2011)
+		"CVE-2019\u20130708":   "CVE-2019-0708",  // en-dash (\u2013)
+		"CVE-2019\u201314343":  "CVE-2019-14343", // en-dash (\u2013)
+		"CVE-2019\u201314345":  "CVE-2019-14345", // en-dash (\u2013)
+		"CVE-2019\u20139193":   "CVE-2019-9193",  // en-dash (\u2013)
+		"CVE-2021\u201326723":  "CVE-2021-26723", // en-dash (\u2013)
+		"CVE-2021\u201327673":  "CVE-2021-27673", // en-dash (\u2013)
+		"CVE-2021\u201342171":  "CVE-2021-42171", // en-dash (\u2013)
+		"CVE-2022\u201325765":  "CVE-2022-25765", // en-dash (\u2013)
+		"CVE-cve 2019-5786":    "CVE-2019-5786",  // "CVE-cve" prefix typo
+		"CVE-cve 2020-6418":    "CVE-2020-6418",  // "CVE-cve" prefix typo
+		"CVE-cve : 2023-30367": "CVE-2023-30367", // "CVE-cve :" prefix typo
+		"CVE-n/a":              "",               // not a real CVE ID
+		"CVE-na":               "",               // not a real CVE ID
+	}
+	if corrected, ok := corrections[code]; ok {
+		return corrected
+	}
+	return code
+}
+
 func extract(args string) (map[string]dataTypes.Data, error) {
 	cveExploits := make(map[string]dataTypes.Data)
 
@@ -180,7 +216,8 @@ func extract(args string) (map[string]dataTypes.Data, error) {
 			}
 
 			for code := range strings.SplitSeq(entry.codes, ";") {
-				if !strings.HasPrefix(code, "CVE-") {
+				code = normalizeCVEID(code)
+				if code == "" {
 					continue
 				}
 

--- a/pkg/extract/exploit/exploitdb/exploitdb_test.go
+++ b/pkg/extract/exploit/exploitdb/exploitdb_test.go
@@ -42,3 +42,38 @@ func TestExtract(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeCVEID(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		// not a CVE ID
+		{name: "empty", args: "", want: ""},
+		{name: "non-CVE prefix", args: "OSVDB-12345", want: ""},
+		// surrounding whitespace
+		{name: "trailing space", args: "CVE-2000-0437 ", want: "CVE-2000-0437"},
+		{name: "trailing NBSP", args: "CVE-2025-62215\u00a0", want: "CVE-2025-62215"},
+		// known corrections
+		{name: "space before number", args: "CVE-2015- 5698", want: "CVE-2015-5698"},
+		{name: "soft hyphen", args: "CVE-2015-\u00ad3864", want: "CVE-2015-3864"},
+		{name: "trailing period", args: "CVE-2017-18344.", want: "CVE-2017-18344"},
+		{name: "trailing question mark", args: "CVE-2017-5715?", want: "CVE-2017-5715"},
+		{name: "non-breaking hyphen", args: "CVE-2019\u20115678", want: "CVE-2019-5678"},
+		{name: "en-dash", args: "CVE-2019\u20130708", want: "CVE-2019-0708"},
+		{name: "CVE-cve prefix typo", args: "CVE-cve : 2023-30367", want: "CVE-2023-30367"},
+		// known invalids (skip)
+		{name: "CVE-n/a", args: "CVE-n/a", want: ""},
+		{name: "CVE-na", args: "CVE-na", want: ""},
+		// valid passthrough
+		{name: "valid CVE ID", args: "CVE-2021-44228", want: "CVE-2021-44228"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := exploitdb.NormalizeCVEID(tt.args); got != tt.want {
+				t.Errorf("NormalizeCVEID(%q) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/extract/exploit/exploitdb/export_test.go
+++ b/pkg/extract/exploit/exploitdb/export_test.go
@@ -1,0 +1,3 @@
+package exploitdb
+
+func NormalizeCVEID(s string) string { return normalizeCVEID(s) }

--- a/pkg/extract/exploit/exploitdb/testdata/fixtures/exploits/52300.json
+++ b/pkg/extract/exploit/exploitdb/testdata/fixtures/exploits/52300.json
@@ -1,0 +1,13 @@
+{
+	"id": "52300",
+	"file": "exploits/windows/remote/52300.py",
+	"description": "Windows 2024.15 - Unauthenticated Desktop Screenshot Capture",
+	"date_published": "2025-05-25",
+	"author": "Chokri Hammedi",
+	"type": "remote",
+	"platform": "windows",
+	"date_added": "2025-05-25",
+	"date_updated": "2025-05-25",
+	"verified": "0",
+	"codes": "CVE-n/a"
+}

--- a/pkg/extract/exploit/exploitdb/testdata/fixtures/papers/46944.json
+++ b/pkg/extract/exploit/exploitdb/testdata/fixtures/papers/46944.json
@@ -1,0 +1,14 @@
+{
+	"id": "46944",
+	"file": "docs/english/46944-a-debugging-primer-with-cve-2019-0708.pdf",
+	"description": "A Debugging Primer with CVE-2019-0708",
+	"date_published": "2019-05-30",
+	"author": "Bruce Lee",
+	"platform": "windows",
+	"language": "english",
+	"date_added": "2019-05-30",
+	"date_updated": "2019-05-30",
+	"verified": "0",
+	"codes": "CVE-2019–0708",
+	"source_url": "https://medium.com/@straightblast426/a-debugging-primer-with-cve-2019-0708-ccfa266682f6"
+}

--- a/pkg/extract/exploit/exploitdb/testdata/golden/data/2019/CVE-2019-0708.json
+++ b/pkg/extract/exploit/exploitdb/testdata/golden/data/2019/CVE-2019-0708.json
@@ -1,0 +1,31 @@
+{
+	"id": "CVE-2019-0708",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2019-0708",
+				"exploit": [
+					{
+						"source": "www.exploit-db.com",
+						"description": "A Debugging Primer with CVE-2019-0708",
+						"published": "2019-05-30T00:00:00Z",
+						"modified": "2019-05-30T00:00:00Z",
+						"link": "https://www.exploit-db.com/papers/46944",
+						"exploit_db": {
+							"id": "46944",
+							"author": "Bruce Lee",
+							"platform": "windows",
+							"raw_url": "https://www.exploit-db.com/raw/46944"
+						}
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "exploit-exploitdb",
+		"raws": [
+			"fixtures/papers/46944.json"
+		]
+	}
+}


### PR DESCRIPTION
## What

ExploitDB's free-text `codes` field contains CVE IDs with various formatting issues that caused `extract exploit-exploitdb` to fail.

Fixes: https://github.com/vulsio/vuls-data-db/actions/runs/24819192738

## Changes

- Replace a general normalization function with a 1:1 `cveIDCorrections` map of known bad → correct CVE IDs, placed just above `extract()` for locality
- IDs not in the map flow through as-is; unknown malformed IDs will surface as failures at the `db add` step
- Add test fixtures and golden files covering representative correction and skip cases

## Known corrections (all patterns found by scanning the full ExploitDB raw dataset)

| Original | Result |
|---|---|
| `CVE-2015- 5698` (space before number) | `CVE-2015-5698` |
| `CVE-2015-\u00ad3864` (soft hyphen) | `CVE-2015-3864` |
| `CVE-2017-18344.` (trailing period) | `CVE-2017-18344` |
| `CVE-2017-5715?` (trailing `?`) | `CVE-2017-5715` |
| `CVE-2019‑5678` (non-breaking hyphen) | `CVE-2019-5678` |
| `CVE-2019–0708` and 4 others (en-dash) | correct IDs |
| `CVE-2021–26723` and 2 others (en-dash) | correct IDs |
| `CVE-2022–25765` (en-dash) | `CVE-2022-25765` |
| `CVE-2025-62215\u00a0` (trailing NBSP) | `CVE-2025-62215` |
| `CVE-cve 2019-5786`, `CVE-cve 2020-6418`, `CVE-cve : 2023-30367` | correct IDs |
| `CVE-n/a`, `CVE-na` | skipped (no corresponding CVE) |