### PR TITLE
fix(extract/nuclei/repository): normalize malformed CVE IDs in classification.cve-id

### DIFF
--- a/pkg/extract/nuclei/repository/export_test.go
+++ b/pkg/extract/nuclei/repository/export_test.go
@@ -1,0 +1,3 @@
+package repository
+
+func NormalizeCVEID(s string) string { return normalizeCVEID(s) }

--- a/pkg/extract/nuclei/repository/repository.go
+++ b/pkg/extract/nuclei/repository/repository.go
@@ -101,6 +101,14 @@ func Extract(args string, opts ...Option) error {
 	return nil
 }
 
+func normalizeCVEID(s string) string {
+	upper := strings.ToUpper(strings.TrimSpace(s))
+	if !strings.HasPrefix(upper, "CVE-") {
+		return ""
+	}
+	return upper
+}
+
 func extract(args string) (map[string]dataTypes.Data, error) {
 	cveExploits := make(map[string]dataTypes.Data)
 
@@ -123,7 +131,10 @@ func extract(args string) (map[string]dataTypes.Data, error) {
 			return nil
 		}
 
-		cveID := *f.Info.Classification.CVEID
+		cveID := normalizeCVEID(*f.Info.Classification.CVEID)
+		if cveID == "" {
+			return nil
+		}
 
 		rel, err := filepath.Rel(args, path)
 		if err != nil {

--- a/pkg/extract/nuclei/repository/repository_test.go
+++ b/pkg/extract/nuclei/repository/repository_test.go
@@ -45,3 +45,28 @@ func TestExtract(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeCVEID(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		// valid
+		{name: "valid CVE ID", args: "CVE-2024-8852", want: "CVE-2024-8852"},
+		// lowercase normalization
+		{name: "lowercase cve", args: "cve-2024-8852", want: "CVE-2024-8852"},
+		// surrounding whitespace
+		{name: "trailing space", args: "CVE-2024-8852 ", want: "CVE-2024-8852"},
+		// non-CVE (skip)
+		{name: "CWE prefix", args: "CWE-200", want: ""},
+		{name: "empty", args: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := repository.NormalizeCVEID(tt.args); got != tt.want {
+				t.Errorf("NormalizeCVEID(%q) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/extract/nuclei/repository/testdata/fixtures/http/cves/2024/CVE-2024-8852.json
+++ b/pkg/extract/nuclei/repository/testdata/fixtures/http/cves/2024/CVE-2024-8852.json
@@ -1,0 +1,75 @@
+{
+	"id": "CVE-2024-8852",
+	"info": {
+		"name": "All-in-One WP Migration < 7.87 - Unauthenticated Information Disclosure",
+		"author": "FLX",
+		"tags": "cve,cve2024,wpscan,wp,wordpress,wp-plugin,all-in-one-wp-migration,disclosure,vkev",
+		"description": "The All-in-One WP Migration and Backup plugin for WordPress is vulnerable to unauthenticated information disclosure due to its error.log file being publicly accessible in versions before 7.87.\n",
+		"impact": "An unauthenticated attacker can access the error.log file, which may contain sensitive information such as full server path disclosures, backup filenames, and other debugging details. This information could be used in further attacks.\n",
+		"reference": [
+			"https://wpscan.com/vulnerability/9f533098-8435-4ee1-a423-5142070ceefc/",
+			"https://wordpress.org/plugins/all-in-one-wp-migration/#developers"
+		],
+		"severity": "medium",
+		"metadata": {
+			"fofa-query": "body=\"/wp-content/plugins/all-in-one-wp-migration\"",
+			"verified": true
+		},
+		"classification": {
+			"cve-id": "cve-2024-8852",
+			"cwe-id": "CWE-532",
+			"cvss-metrics": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+			"cvss-score": 5.3
+		},
+		"remediation": "Update the All-in-One WP Migration and Backup plugin to version 7.87 or later.\n"
+	},
+	"flow": "http(1) && http(2)",
+	"http": [
+		{
+			"matchers": [
+				{
+					"type": "dsl",
+					"condition": "and",
+					"dsl": [
+						"status_code == 200",
+						"compare_versions(version, '< 7.87')"
+					],
+					"internal": true
+				}
+			],
+			"extractors": [
+				{
+					"name": "version",
+					"type": "regex",
+					"regex": [
+						"(?mi)Stable tag: ([0-9.]+)"
+					],
+					"group": 1,
+					"part": "body",
+					"internal": true
+				}
+			],
+			"path": [
+				"{{BaseURL}}/wp-content/plugins/all-in-one-wp-migration/readme.txt"
+			],
+			"method": "GET"
+		},
+		{
+			"matchers": [
+				{
+					"type": "dsl",
+					"condition": "and",
+					"dsl": [
+						"status_code == 200",
+						"contains_all(body, 'Number', 'Message')",
+						"contains(tolower(header), 'text/plain')"
+					]
+				}
+			],
+			"path": [
+				"{{BaseURL}}/wp-content/plugins/all-in-one-wp-migration/storage/error.log"
+			],
+			"method": "GET"
+		}
+	]
+}

--- a/pkg/extract/nuclei/repository/testdata/fixtures/http/exposed-panels/veeam-backup-manager-login.json
+++ b/pkg/extract/nuclei/repository/testdata/fixtures/http/exposed-panels/veeam-backup-manager-login.json
@@ -1,0 +1,61 @@
+{
+	"id": "veeam-backup-manager-login",
+	"info": {
+		"name": "Veeam Backup Enterprise Manager Login - Detect",
+		"author": "Charles D",
+		"tags": "veeam,panel,enterprise-manager,login,detect,discovery",
+		"description": "Veeam Backup Enterprise Manager Login\n",
+		"severity": "info",
+		"metadata": {
+			"fofa-query": [
+				"title=\"veeam backup enterprise manager\"",
+				"icon_hash=\"169658321\""
+			],
+			"max-request": 1,
+			"shodan-query": [
+				"title:\"veeam backup enterprise manager\"",
+				"http.favicon.hash:169658321",
+				"\"Set-Cookie: .ASPXANONYMOUS\" http.html:\"Veeam\""
+			],
+			"verified": true
+		},
+		"classification": {
+			"cve-id": "CWE-200",
+			"cvss-metrics": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
+		}
+	},
+	"http": [
+		{
+			"matchers": [
+				{
+					"type": "word",
+					"part": "body",
+					"words": [
+						"Veeam Backup Enterprise Manager : Login"
+					]
+				},
+				{
+					"type": "status",
+					"status": [
+						200
+					]
+				}
+			],
+			"extractors": [
+				{
+					"name": "version",
+					"type": "regex",
+					"regex": [
+						"login.bundle.js\\?v=([\\d\\.]+)"
+					],
+					"group": 1
+				}
+			],
+			"matchers-condition": "and",
+			"path": [
+				"{{BaseURL}}/login.aspx"
+			],
+			"method": "GET"
+		}
+	]
+}

--- a/pkg/extract/nuclei/repository/testdata/golden/data/2024/CVE-2024-8852.json
+++ b/pkg/extract/nuclei/repository/testdata/golden/data/2024/CVE-2024-8852.json
@@ -1,0 +1,27 @@
+{
+	"id": "CVE-2024-8852",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-8852",
+				"exploit": [
+					{
+						"source": "nuclei.projectdiscovery.io",
+						"description": "The All-in-One WP Migration and Backup plugin for WordPress is vulnerable to unauthenticated information disclosure due to its error.log file being publicly accessible in versions before 7.87.",
+						"link": "https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2024/CVE-2024-8852.yaml",
+						"nuclei": {
+							"template_id": "CVE-2024-8852",
+							"verified": true
+						}
+					}
+				]
+			}
+		}
+	],
+	"data_source": {
+		"id": "nuclei-repository",
+		"raws": [
+			"fixtures/http/cves/2024/CVE-2024-8852.json"
+		]
+	}
+}


### PR DESCRIPTION
## Problem

CI was failing with:
```
unexpected CVE ID format. expected: "CVE-yyyy-\d{4,}", actual: "CWE-200"
```

Two malformed values exist in the raw data's `info.classification.cve-id` field:

| Raw value | Issue | Action |
|---|---|---|
| `CWE-200` | Not a CVE ID | Skip silently |
| `cve-2024-8852` | Lowercase prefix | Normalize to `CVE-2024-8852` |

## Fix

Add `normalizeCVEID(s string) string` in `extract/nuclei/repository`:
- `strings.TrimSpace` to handle surrounding whitespace
- `strings.ToUpper` + `strings.HasPrefix("CVE-")` check
- Returns `""` (skip) for non-CVE values

## Tests

- `export_test.go` exposes `NormalizeCVEID` for black-box testing
- `TestNormalizeCVEID` covers: valid, lowercase, whitespace, CWE prefix, empty
- Added fixtures for both skip (`CWE-200`) and normalize (`cve-2024-8852`) cases