### PR TITLE
fix(extract/exploit/exploitdb): remove duplicate TestNormalizeCVEID

### DIFF
--- a/pkg/extract/exploit/exploitdb/exploitdb_test.go
+++ b/pkg/extract/exploit/exploitdb/exploitdb_test.go
@@ -80,38 +80,3 @@ func TestNormalizeCVEID(t *testing.T) {
 		})
 	}
 }
-
-func TestNormalizeCVEID(t *testing.T) {
-	tests := []struct {
-		name string
-		args string
-		want string
-	}{
-		// not a CVE ID
-		{name: "empty", args: "", want: ""},
-		{name: "non-CVE prefix", args: "OSVDB-12345", want: ""},
-		// surrounding whitespace
-		{name: "trailing space", args: "CVE-2000-0437 ", want: "CVE-2000-0437"},
-		{name: "trailing NBSP", args: "CVE-2025-62215\u00a0", want: "CVE-2025-62215"},
-		// known corrections
-		{name: "space before number", args: "CVE-2015- 5698", want: "CVE-2015-5698"},
-		{name: "soft hyphen", args: "CVE-2015-\u00ad3864", want: "CVE-2015-3864"},
-		{name: "trailing period", args: "CVE-2017-18344.", want: "CVE-2017-18344"},
-		{name: "trailing question mark", args: "CVE-2017-5715?", want: "CVE-2017-5715"},
-		{name: "non-breaking hyphen", args: "CVE-2019\u20115678", want: "CVE-2019-5678"},
-		{name: "en-dash", args: "CVE-2019\u20130708", want: "CVE-2019-0708"},
-		{name: "CVE-cve prefix typo", args: "CVE-cve : 2023-30367", want: "CVE-2023-30367"},
-		// known invalids (skip)
-		{name: "CVE-n/a", args: "CVE-n/a", want: ""},
-		{name: "CVE-na", args: "CVE-na", want: ""},
-		// valid passthrough
-		{name: "valid CVE ID", args: "CVE-2021-44228", want: "CVE-2021-44228"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := exploitdb.NormalizeCVEID(tt.args); got != tt.want {
-				t.Errorf("NormalizeCVEID(%q) = %q, want %q", tt.args, got, tt.want)
-			}
-		})
-	}
-}


### PR DESCRIPTION
## Problem

`TestNormalizeCVEID` was duplicated in `exploitdb_test.go` (lines 49 and 84), causing a `typecheck` error in golangci-lint:

```
pkg/extract/exploit/exploitdb/exploitdb_test.go:84:6: TestNormalizeCVEID redeclared in this block
```

## Fix

Remove the duplicate function definition (lines 84–117).