### PR TITLE
feat(extract/types): add Mitigations and Workarounds to Content

### DIFF
--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -57,6 +57,7 @@ import (
 	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
 	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 	cvssv30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
 	cvssv31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
@@ -335,6 +336,8 @@ type productInfo struct {
 	impact        string
 	exploitStatus string
 	cvss          *severityTypes.Severity
+	mitigations   []remediationTypes.Remediation
+	workarounds   []remediationTypes.Remediation
 }
 
 func buildProductInfoMap(v cvrf.Vulnerability) (map[string]productInfo, error) {
@@ -392,6 +395,35 @@ func buildProductInfoMap(v cvrf.Vulnerability) (map[string]productInfo, error) {
 		}
 		productInfoMap[s.ProductID] = pi
 	}
+	for _, r := range v.Remediations.Remediation {
+		if r.Description == "" {
+			continue
+		}
+		productIDs := r.ProductID
+		if len(productIDs) == 0 {
+			// An empty ProductID means the remediation applies to all products in the advisory.
+			productIDs = v.ProductStatuses.Status.ProductID
+		}
+		rem := remediationTypes.Remediation{
+			Source:      "secure@microsoft.com",
+			Description: r.Description,
+		}
+		switch r.Type {
+		case "Mitigation":
+			for _, pid := range productIDs {
+				pi := productInfoMap[pid]
+				pi.mitigations = append(pi.mitigations, rem)
+				productInfoMap[pid] = pi
+			}
+		case "Workaround":
+			for _, pid := range productIDs {
+				pi := productInfoMap[pid]
+				pi.workarounds = append(pi.workarounds, rem)
+				productInfoMap[pid] = pi
+			}
+		default:
+		}
+	}
 	return productInfoMap, nil
 }
 
@@ -423,6 +455,8 @@ func buildVulnerabilities(v cvrf.Vulnerability, c cvrf.CVRF, products map[string
 			Description: description,
 			Severity:    buildSeverities(pi),
 			CWE:         cwes,
+			Mitigations: pi.mitigations,
+			Workarounds: pi.workarounds,
 			References:  refs,
 			Published:   published,
 			Modified:    modified,
@@ -486,6 +520,8 @@ func buildAdvisories(v cvrf.Vulnerability, c cvrf.CVRF, products map[string]stri
 			Description: description,
 			Severity:    buildSeverities(pi),
 			CWE:         cwes,
+			Mitigations: pi.mitigations,
+			Workarounds: pi.workarounds,
 			References:  refs,
 			Published:   published,
 			Modified:    modified,

--- a/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2016/CVE-2016-0088.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2016/CVE-2016-0088.json
@@ -13,6 +13,12 @@
 						"vendor": "Important"
 					}
 				],
+				"mitigations": [
+					{
+						"source": "secure@microsoft.com",
+						"description": "<p>The following <a href=\"https://technet.microsoft.com/library/security/dn848375.aspx#Mitigation\">mitigating factors</a> may be helpful in your situation:\nCustomers who have not enabled the Hyper-V role are not affected.</p>\n"
+					}
+				],
 				"references": [
 					{
 						"source": "secure@microsoft.com",

--- a/pkg/extract/mitre/v5/testdata/golden/data/2024/CVE-2024-39565.json
+++ b/pkg/extract/mitre/v5/testdata/golden/data/2024/CVE-2024-39565.json
@@ -38,6 +38,16 @@
 						]
 					}
 				],
+				"workarounds": [
+					{
+						"source": "juniper",
+						"description": "Methods which may reduce, but not eliminate, the risk for exploitation of these problems, and which does not mitigate or resolve the underlying problem include:\n\n• Deploying the appropriate IDP Signature on devices which do not have J-Web enabled which protect the device downstream which requires J-Web to be enabled.\n\n• Disabling J-Web and using only alternate options such as Netconf over SSH for device management\n\n• Restricting the use of J-Web to low-privileged accounts only\n\nIn addition to the recommendations listed above, it is good security practice to limit the exploitable attack surface of critical infrastructure networking equipment. Use access lists or firewall filters to limit access to the device only from trusted, administrative networks or hosts."
+					},
+					{
+						"source": "juniper",
+						"description": "There are no known workarounds for this issue other than disabling J-Web when not in use. \n\nJuniper Networks has written an effective countermeasure for this attack at IDP Signature SigPack #3675 onward, released on 07 February 2024. The signature “HTTP:PHP:LAUNCHPAD-CMD-INJ” will identify and block the attack. For best effect, customers may deploy this signature on devices where J-Web is not used."
+					}
+				],
 				"references": [
 					{
 						"source": "juniper",

--- a/pkg/extract/mitre/v5/v5.go
+++ b/pkg/extract/mitre/v5/v5.go
@@ -12,6 +12,7 @@ import (
 	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
 	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 	v2Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v2"
 	v30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
@@ -139,9 +140,9 @@ func extract(fetched v5.CVE, raws []string) (dataTypes.Data, error) {
 					}(),
 					Severity: func() []severityTypes.Severity {
 						m := make(map[string][]v5.Metric)
-						m[getSource(fetched.Containers.CNA.ProviderMetadata)] = fetched.Containers.CNA.Metrics
+						m[getSource(fetched.Containers.CNA.ProviderMetadata)] = append(m[getSource(fetched.Containers.CNA.ProviderMetadata)], fetched.Containers.CNA.Metrics...)
 						for _, c := range fetched.Containers.ADP {
-							m[getSource(c.ProviderMetadata)] = c.Metrics
+							m[getSource(c.ProviderMetadata)] = append(m[getSource(c.ProviderMetadata)], c.Metrics...)
 						}
 
 						var ss []severityTypes.Severity
@@ -201,9 +202,9 @@ func extract(fetched v5.CVE, raws []string) (dataTypes.Data, error) {
 					}(),
 					CWE: func() []cweTypes.CWE {
 						m := make(map[string][]v5.ProblemType)
-						m[getSource(fetched.Containers.CNA.ProviderMetadata)] = fetched.Containers.CNA.ProblemTypes
+						m[getSource(fetched.Containers.CNA.ProviderMetadata)] = append(m[getSource(fetched.Containers.CNA.ProviderMetadata)], fetched.Containers.CNA.ProblemTypes...)
 						for _, c := range fetched.Containers.ADP {
-							m[getSource(c.ProviderMetadata)] = c.ProblemTypes
+							m[getSource(c.ProviderMetadata)] = append(m[getSource(c.ProviderMetadata)], c.ProblemTypes...)
 						}
 
 						mm := make(map[string][]string)
@@ -226,11 +227,32 @@ func extract(fetched v5.CVE, raws []string) (dataTypes.Data, error) {
 						}
 						return cwes
 					}(),
+					Workarounds: func() []remediationTypes.Remediation {
+						m := make(map[string][]v5.Description)
+						m[getSource(fetched.Containers.CNA.ProviderMetadata)] = append(m[getSource(fetched.Containers.CNA.ProviderMetadata)], fetched.Containers.CNA.Workarounds...)
+						for _, c := range fetched.Containers.ADP {
+							m[getSource(c.ProviderMetadata)] = append(m[getSource(c.ProviderMetadata)], c.Workarounds...)
+						}
+
+						var rs []remediationTypes.Remediation
+						for source, ws := range m {
+							for _, w := range ws {
+								if (w.Lang != "" && w.Lang != "en") || w.Value == "" {
+									continue
+								}
+								rs = append(rs, remediationTypes.Remediation{
+									Source:      source,
+									Description: w.Value,
+								})
+							}
+						}
+						return rs
+					}(),
 					References: func() []referenceTypes.Reference {
 						m := make(map[string][]v5.Reference)
-						m[getSource(fetched.Containers.CNA.ProviderMetadata)] = fetched.Containers.CNA.References
+						m[getSource(fetched.Containers.CNA.ProviderMetadata)] = append(m[getSource(fetched.Containers.CNA.ProviderMetadata)], fetched.Containers.CNA.References...)
 						for _, c := range fetched.Containers.ADP {
-							m[getSource(c.ProviderMetadata)] = c.References
+							m[getSource(c.ProviderMetadata)] = append(m[getSource(c.ProviderMetadata)], c.References...)
 						}
 
 						var refs []referenceTypes.Reference

--- a/pkg/extract/redhat/csaf/csaf.go
+++ b/pkg/extract/redhat/csaf/csaf.go
@@ -33,6 +33,7 @@ import (
 	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
 	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 	cvssV2Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v2"
 	cvssV30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
@@ -245,10 +246,12 @@ type product struct {
 	repositories    []string
 }
 
-type ass struct {
-	Advisory string
-	Severity severity
-	Status   status
+type assessment struct {
+	Advisory   string
+	Severity   severity
+	Status     status
+	Mitigation string
+	Workaround string
 }
 type severity struct {
 	Cvss2  string
@@ -582,11 +585,11 @@ func walkProductTree(pt csaf.ProductTree, c2r map[string][]string) (map[csaf.Pro
 	return pm, nil
 }
 
-func walkVulnerabilities(vulns []csaf.Vulnerability, pids []csaf.ProductID) (map[string]map[csaf.ProductID]ass, map[string]vulnerabilityContentTypes.Content, error) {
-	vassm := make(map[string]map[csaf.ProductID]ass)
+func walkVulnerabilities(vulns []csaf.Vulnerability, pids []csaf.ProductID) (map[string]map[csaf.ProductID]assessment, map[string]vulnerabilityContentTypes.Content, error) {
+	vassm := make(map[string]map[csaf.ProductID]assessment)
 	vm := make(map[string]vulnerabilityContentTypes.Content)
 	for _, v := range vulns {
-		vassm[v.CVE] = make(map[csaf.ProductID]ass)
+		vassm[v.CVE] = make(map[csaf.ProductID]assessment)
 
 		if err := func() error {
 			if len(v.ProductStatus.FirstAffected) > 0 || len(v.ProductStatus.FirstFixed) > 0 || len(v.ProductStatus.LastAffected) > 0 || len(v.ProductStatus.Recommended) > 0 {
@@ -633,7 +636,7 @@ func walkVulnerabilities(vulns []csaf.Vulnerability, pids []csaf.ProductID) (map
 					switch base := vassm[v.CVE][p]; base.Status.ProductStatus {
 					case "unaffected":
 						if base.Status.AffectedStatus != "" {
-							return errors.New("already set affected_status")
+							return errors.Errorf("already set affected_status. cve: %s, product_id: %s", v.CVE, p)
 						}
 						base.Status.AffectedStatus = f.Label
 						vassm[v.CVE][p] = base
@@ -656,19 +659,31 @@ func walkVulnerabilities(vulns []csaf.Vulnerability, pids []csaf.ProductID) (map
 					return pids
 				}() {
 					switch r.Category {
-					case "mitigation", "workaround":
-						// TODO:
+					case "mitigation":
+						base := vassm[v.CVE][p]
+						if base.Mitigation != "" {
+							return errors.Errorf("already set mitigation. cve: %s, product_id: %s", v.CVE, p)
+						}
+						base.Mitigation = r.Details
+						vassm[v.CVE][p] = base
+					case "workaround":
+						base := vassm[v.CVE][p]
+						if base.Workaround != "" {
+							return errors.Errorf("already set workaround. cve: %s, product_id: %s", v.CVE, p)
+						}
+						base.Workaround = r.Details
+						vassm[v.CVE][p] = base
 					case "no_fix_planned", "none_available":
 						base := vassm[v.CVE][p]
 						if base.Status.AffectedStatus != "" {
-							return errors.New("already set affected_status")
+							return errors.Errorf("already set affected_status. cve: %s, product_id: %s", v.CVE, p)
 						}
 						base.Status.AffectedStatus = r.Details
 						vassm[v.CVE][p] = base
 					case "vendor_fix":
 						base := vassm[v.CVE][p]
 						if base.Advisory != "" {
-							return errors.New("already set advisory id")
+							return errors.Errorf("already set advisory id. cve: %s, product_id: %s", v.CVE, p)
 						}
 						base.Advisory = strings.TrimPrefix(r.URL, "https://access.redhat.com/errata/")
 						vassm[v.CVE][p] = base
@@ -759,19 +774,19 @@ func walkVulnerabilities(vulns []csaf.Vulnerability, pids []csaf.ProductID) (map
 	return vassm, vm, nil
 }
 
-func invertVassGroup(vassm map[string]map[csaf.ProductID]ass, pm map[csaf.ProductID][]product) (map[string][]csaf.ProductID, error) {
-	pidToVassGroup := make(map[csaf.ProductID]map[string]ass)
+func invertVassGroup(vassm map[string]map[csaf.ProductID]assessment, pm map[csaf.ProductID][]product) (map[string][]csaf.ProductID, error) {
+	pidToVassGroup := make(map[csaf.ProductID]map[string]assessment)
 
 	for cveID, assm := range vassm {
 		for pid, a := range assm {
 			if !slices.ContainsFunc(pm[pid], func(p product) bool { return len(p.arch) > 0 }) {
-				// Ignore ass with no arches because it does not included in detections.
+				// Ignore assessment with no arches because it is not included in detections.
 				continue
 			}
 
 			vassGroup, found := pidToVassGroup[pid]
 			if !found {
-				vassGroup = make(map[string]ass)
+				vassGroup = make(map[string]assessment)
 			}
 			vassGroup[cveID] = a
 			pidToVassGroup[pid] = vassGroup
@@ -799,7 +814,7 @@ func buildDataComponents(baseAdvisory advisoryContentTypes.Content, baseVulnerab
 	cm := make(map[string][]conditionTypes.Condition)
 
 	for vassGroupString, pids := range vassGroupToPids {
-		var vassGroup map[string]ass
+		var vassGroup map[string]assessment
 		if err := json.Unmarshal([]byte(vassGroupString), &vassGroup); err != nil {
 			return nil, nil, nil, errors.Wrap(err, "json unmarshal")
 		}
@@ -846,6 +861,18 @@ func buildDataComponents(baseAdvisory advisoryContentTypes.Content, baseVulnerab
 						return nil, nil, nil, errors.Wrap(err, "build severities")
 					}
 					base.Severity = sevs
+					if a.Mitigation != "" {
+						base.Mitigations = []remediationTypes.Remediation{{
+							Source:      "secalert@redhat.com",
+							Description: a.Mitigation,
+						}}
+					}
+					if a.Workaround != "" {
+						base.Workarounds = []remediationTypes.Remediation{{
+							Source:      "secalert@redhat.com",
+							Description: a.Workaround,
+						}}
+					}
 					base.Sort()
 
 					index := slices.IndexFunc(vs, func(v vulnerabilityTypes.Vulnerability) bool {

--- a/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2023/RHSA-2023%3A6939.json
+++ b/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2023/RHSA-2023%3A6939.json
@@ -632,6 +632,12 @@
 						]
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -768,6 +774,12 @@
 						]
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -836,6 +848,12 @@
 						]
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base, or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -902,6 +920,12 @@
 						"cwe": [
 							"CWE-176"
 						]
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base, or stability."
 					}
 				],
 				"references": [
@@ -1052,6 +1076,12 @@
 						]
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Condition 1: Unshare the cgroup namespace ((docker|podman|nerdctl) run --cgroupns=private). This is the default behavior of Docker/Podman/nerdctl on cgroup v2 hosts.\nCondition 2 (very rare): add /sys/fs/cgroup to maskedPaths"
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -1192,6 +1222,12 @@
 						]
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Avoid using an untrusted container image."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -1254,6 +1290,12 @@
 						"cwe": [
 							"CWE-176"
 						]
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base, or stability."
 					}
 				],
 				"references": [

--- a/pkg/extract/redhat/cve/cve.go
+++ b/pkg/extract/redhat/cve/cve.go
@@ -12,6 +12,7 @@ import (
 	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
 	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 	cvssV2Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v2"
 	cvssV30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
@@ -158,6 +159,7 @@ func extract(fetched cve.CVE, raws []string) (dataTypes.Data, error) {
 				Description: strings.Join(fetched.Details, "\n"),
 				Severity:    ss,
 				CWE:         buildCWE(fetched),
+				Mitigations: buildMitigations(fetched),
 				References:  buildReferences(fetched),
 				Published:   utiltime.Parse([]string{"2006-01-02T15:04:05Z"}, fetched.PublicDate),
 			},
@@ -229,6 +231,16 @@ func buildCWE(fetched cve.CVE) []cweTypes.CWE {
 	return []cweTypes.CWE{{
 		Source: "secalert@redhat.com",
 		CWE:    []string{*fetched.Cwe},
+	}}
+}
+
+func buildMitigations(fetched cve.CVE) []remediationTypes.Remediation {
+	if fetched.Mitigation == nil || fetched.Mitigation.Value == "" {
+		return nil
+	}
+	return []remediationTypes.Remediation{{
+		Source:      "secalert@redhat.com",
+		Description: fetched.Mitigation.Value,
 	}}
 }
 

--- a/pkg/extract/redhat/cve/testdata/fixtures/2024/CVE-2024-6923.json
+++ b/pkg/extract/redhat/cve/testdata/fixtures/2024/CVE-2024-6923.json
@@ -1,0 +1,337 @@
+{
+  "threat_severity" : "Moderate",
+  "public_date" : "2024-08-01T00:00:00Z",
+  "bugzilla" : {
+    "description" : "cpython: python: email module doesn't properly quotes newlines in email headers, allowing header injection",
+    "id" : "2302255",
+    "url" : "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+  },
+  "cvss3" : {
+    "cvss3_base_score" : "6.8",
+    "cvss3_scoring_vector" : "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:N",
+    "status" : "verified"
+  },
+  "details" : [ "There is a MEDIUM severity vulnerability affecting CPython.\nThe \nemail module didn’t properly quote newlines for email headers when \nserializing an email message allowing for header injection when an email\nis serialized.", "A vulnerability was found in the email module that uses Python language. The email module doesn't properly quote new lines in email headers. This flaw allows an attacker to inject email headers that could, among other possibilities, add hidden email destinations or inject content into the email, impacting data confidentiality and integrity." ],
+  "statement" : "Versions of python36:3.6/python36 as shipped with Red Hat Enterprise Linux 8 are marked as 'Not affected' as they just provide \"symlinks\" to the main python3 component, which provides the actual interpreter of the Python programming language.",
+  "affected_release" : [ {
+    "product_name" : "Red Hat Enterprise Linux 8",
+    "release_date" : "2024-08-28T00:00:00Z",
+    "advisory" : "RHSA-2024:5962",
+    "cpe" : "cpe:/a:redhat:enterprise_linux:8",
+    "package" : "python39:3.9-8100020240826142629.d47b87a4"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8",
+    "release_date" : "2024-08-28T00:00:00Z",
+    "advisory" : "RHSA-2024:5962",
+    "cpe" : "cpe:/a:redhat:enterprise_linux:8",
+    "package" : "python39-devel:3.9-8100020240826142629.d47b87a4"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8",
+    "release_date" : "2024-09-24T00:00:00Z",
+    "advisory" : "RHSA-2024:6961",
+    "cpe" : "cpe:/a:redhat:enterprise_linux:8",
+    "package" : "python3.12-0:3.12.5-2.el8_10"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8",
+    "release_date" : "2024-09-24T00:00:00Z",
+    "advisory" : "RHSA-2024:6962",
+    "cpe" : "cpe:/a:redhat:enterprise_linux:8",
+    "package" : "python3.11-0:3.11.9-7.el8_10"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8",
+    "release_date" : "2024-09-24T00:00:00Z",
+    "advisory" : "RHSA-2024:6975",
+    "cpe" : "cpe:/a:redhat:enterprise_linux:8",
+    "package" : "python3-0:3.6.8-67.el8_10"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8",
+    "release_date" : "2024-09-24T00:00:00Z",
+    "advisory" : "RHSA-2024:6975",
+    "cpe" : "cpe:/o:redhat:enterprise_linux:8",
+    "package" : "python3-0:3.6.8-67.el8_10"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8.4 Advanced Mission Critical Update Support",
+    "release_date" : "2024-09-25T00:00:00Z",
+    "advisory" : "RHSA-2024:7137",
+    "cpe" : "cpe:/a:redhat:rhel_aus:8.4",
+    "package" : "python39:3.9-8040020240902080505.63cd9eba"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8.4 Telecommunications Update Service",
+    "release_date" : "2024-09-25T00:00:00Z",
+    "advisory" : "RHSA-2024:7137",
+    "cpe" : "cpe:/a:redhat:rhel_tus:8.4",
+    "package" : "python39:3.9-8040020240902080505.63cd9eba"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8.4 Update Services for SAP Solutions",
+    "release_date" : "2024-09-25T00:00:00Z",
+    "advisory" : "RHSA-2024:7137",
+    "cpe" : "cpe:/a:redhat:rhel_e4s:8.4",
+    "package" : "python39:3.9-8040020240902080505.63cd9eba"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8.6 Advanced Mission Critical Update Support",
+    "release_date" : "2024-09-23T00:00:00Z",
+    "advisory" : "RHSA-2024:6915",
+    "cpe" : "cpe:/a:redhat:rhel_aus:8.6",
+    "package" : "python39:3.9-8060020240916062113.6a631399"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8.6 Telecommunications Update Service",
+    "release_date" : "2024-09-23T00:00:00Z",
+    "advisory" : "RHSA-2024:6915",
+    "cpe" : "cpe:/a:redhat:rhel_tus:8.6",
+    "package" : "python39:3.9-8060020240916062113.6a631399"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8.6 Update Services for SAP Solutions",
+    "release_date" : "2024-09-23T00:00:00Z",
+    "advisory" : "RHSA-2024:6915",
+    "cpe" : "cpe:/a:redhat:rhel_e4s:8.6",
+    "package" : "python39:3.9-8060020240916062113.6a631399"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8.8 Extended Update Support",
+    "release_date" : "2024-10-15T00:00:00Z",
+    "advisory" : "RHSA-2024:8103",
+    "cpe" : "cpe:/a:redhat:rhel_eus:8.8",
+    "package" : "python39:3.9-8080020240911100614.93c2fc2f"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 9",
+    "release_date" : "2024-09-03T00:00:00Z",
+    "advisory" : "RHSA-2024:6146",
+    "cpe" : "cpe:/a:redhat:enterprise_linux:9",
+    "package" : "python3.12-0:3.12.1-4.el9_4.3"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 9",
+    "release_date" : "2024-09-03T00:00:00Z",
+    "advisory" : "RHSA-2024:6163",
+    "cpe" : "cpe:/a:redhat:enterprise_linux:9",
+    "package" : "python3.9-0:3.9.18-3.el9_4.5"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 9",
+    "release_date" : "2024-09-03T00:00:00Z",
+    "advisory" : "RHSA-2024:6179",
+    "cpe" : "cpe:/a:redhat:enterprise_linux:9",
+    "package" : "python3.11-0:3.11.7-1.el9_4.5"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 9",
+    "release_date" : "2024-09-03T00:00:00Z",
+    "advisory" : "RHSA-2024:6163",
+    "cpe" : "cpe:/o:redhat:enterprise_linux:9",
+    "package" : "python3.9-0:3.9.18-3.el9_4.5"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 9.2 Extended Update Support",
+    "release_date" : "2024-09-23T00:00:00Z",
+    "advisory" : "RHSA-2024:6909",
+    "cpe" : "cpe:/a:redhat:rhel_eus:9.2",
+    "package" : "python3.9-0:3.9.16-1.el9_2.8"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 9.2 Extended Update Support",
+    "release_date" : "2024-10-01T00:00:00Z",
+    "advisory" : "RHSA-2024:7415",
+    "cpe" : "cpe:/a:redhat:rhel_eus:9.2",
+    "package" : "python3.11-0:3.11.2-2.el9_2.6"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-11-21T00:00:00Z",
+    "advisory" : "RHSA-2024:10135",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-config-sync-rhel9:1.4.7-3"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-11-21T00:00:00Z",
+    "advisory" : "RHSA-2024:10135",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-flow-collector-rhel9:1.4.7-3"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-11-21T00:00:00Z",
+    "advisory" : "RHSA-2024:10135",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-operator-bundle:1.4.7-4"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-11-21T00:00:00Z",
+    "advisory" : "RHSA-2024:10135",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-router-rhel9:2.4.3-7"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-11-21T00:00:00Z",
+    "advisory" : "RHSA-2024:10135",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-service-controller-rhel9:1.4.7-3"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-11-21T00:00:00Z",
+    "advisory" : "RHSA-2024:10135",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-site-controller-rhel9:1.4.7-3"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-09-26T00:00:00Z",
+    "advisory" : "RHSA-2024:7213",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-config-sync-rhel9:1.4.7-2"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-09-26T00:00:00Z",
+    "advisory" : "RHSA-2024:7213",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-flow-collector-rhel9:1.4.7-2"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-09-26T00:00:00Z",
+    "advisory" : "RHSA-2024:7213",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-operator-bundle:1.4.7-2"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-09-26T00:00:00Z",
+    "advisory" : "RHSA-2024:7213",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-router-rhel9:2.4.3-6"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-09-26T00:00:00Z",
+    "advisory" : "RHSA-2024:7213",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-service-controller-rhel9:1.4.7-2"
+  }, {
+    "product_name" : "Service Interconnect 1.4 for RHEL 9",
+    "release_date" : "2024-09-26T00:00:00Z",
+    "advisory" : "RHSA-2024:7213",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1.4::el9",
+    "package" : "service-interconnect/skupper-site-controller-rhel9:1.4.7-2"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-12-16T00:00:00Z",
+    "advisory" : "RHSA-2024:11109",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-config-sync-rhel9:1.5.5-4"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-12-16T00:00:00Z",
+    "advisory" : "RHSA-2024:11109",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-controller-podman-container-rhel9:1.5.5-4"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-12-16T00:00:00Z",
+    "advisory" : "RHSA-2024:11109",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-controller-podman-rhel9:1.5.5-4"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-12-16T00:00:00Z",
+    "advisory" : "RHSA-2024:11109",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-flow-collector-rhel9:1.5.5-4"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-12-16T00:00:00Z",
+    "advisory" : "RHSA-2024:11109",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-operator-bundle:1.5.5-4"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-12-16T00:00:00Z",
+    "advisory" : "RHSA-2024:11109",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-router-rhel9:2.5.3-6"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-12-16T00:00:00Z",
+    "advisory" : "RHSA-2024:11109",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-service-controller-rhel9:1.5.5-4"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-12-16T00:00:00Z",
+    "advisory" : "RHSA-2024:11109",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-site-controller-rhel9:1.5.5-4"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-09-30T00:00:00Z",
+    "advisory" : "RHSA-2024:7374",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-config-sync-rhel9:1.5.5-3"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-09-30T00:00:00Z",
+    "advisory" : "RHSA-2024:7374",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-controller-podman-container-rhel9:1.5.5-3"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-09-30T00:00:00Z",
+    "advisory" : "RHSA-2024:7374",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-controller-podman-rhel9:1.5.5-3"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-09-30T00:00:00Z",
+    "advisory" : "RHSA-2024:7374",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-flow-collector-rhel9:1.5.5-3"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-09-30T00:00:00Z",
+    "advisory" : "RHSA-2024:7374",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-operator-bundle:1.5.5-3"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-09-30T00:00:00Z",
+    "advisory" : "RHSA-2024:7374",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-router-rhel9:2.5.3-5"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-09-30T00:00:00Z",
+    "advisory" : "RHSA-2024:7374",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-service-controller-rhel9:1.5.5-3"
+  }, {
+    "product_name" : "Service Interconnect 1 for RHEL 9",
+    "release_date" : "2024-09-30T00:00:00Z",
+    "advisory" : "RHSA-2024:7374",
+    "cpe" : "cpe:/a:redhat:service_interconnect:1::el9",
+    "package" : "service-interconnect/skupper-site-controller-rhel9:1.5.5-3"
+  } ],
+  "package_state" : [ {
+    "product_name" : "Red Hat Enterprise Linux 10",
+    "fix_state" : "Not affected",
+    "package_name" : "python3.12",
+    "cpe" : "cpe:/o:redhat:enterprise_linux:10"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 6",
+    "fix_state" : "Will not fix",
+    "package_name" : "python",
+    "cpe" : "cpe:/o:redhat:enterprise_linux:6"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 7",
+    "fix_state" : "Will not fix",
+    "package_name" : "python",
+    "cpe" : "cpe:/o:redhat:enterprise_linux:7"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 7",
+    "fix_state" : "Will not fix",
+    "package_name" : "python3",
+    "cpe" : "cpe:/o:redhat:enterprise_linux:7"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8",
+    "fix_state" : "Will not fix",
+    "package_name" : "gimp:flatpak/python2",
+    "cpe" : "cpe:/o:redhat:enterprise_linux:8"
+  }, {
+    "product_name" : "Red Hat Enterprise Linux 8",
+    "fix_state" : "Not affected",
+    "package_name" : "python36:3.6/python36",
+    "cpe" : "cpe:/o:redhat:enterprise_linux:8"
+  } ],
+  "references" : [ "https://www.cve.org/CVERecord?id=CVE-2024-6923\nhttps://nvd.nist.gov/vuln/detail/CVE-2024-6923\nhttps://github.com/python/cpython/issues/121650\nhttps://github.com/python/cpython/pull/122233\nhttps://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/" ],
+  "name" : "CVE-2024-6923",
+  "mitigation" : {
+    "value" : "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+    "lang" : "en:us"
+  },
+  "csaw" : false
+}

--- a/pkg/extract/redhat/cve/testdata/golden/data/2024/CVE-2024-6923.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2024/CVE-2024-6923.json
@@ -1,0 +1,71 @@
+{
+	"id": "CVE-2024-6923",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-6923",
+				"title": "cpython: python: email module doesn't properly quotes newlines in email headers, allowing header injection",
+				"description": "There is a MEDIUM severity vulnerability affecting CPython.\nThe \nemail module didn’t properly quote newlines for email headers when \nserializing an email message allowing for header injection when an email\nis serialized.\nA vulnerability was found in the email module that uses Python language. The email module doesn't properly quote new lines in email headers. This flaw allows an attacker to inject email headers that could, among other possibilities, add hidden email destinations or inject content into the email, impacting data confidentiality and integrity.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Moderate"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:N",
+							"base_score": 6.8,
+							"base_severity": "MEDIUM",
+							"temporal_score": 6.8,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.8,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"mitigations": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://github.com/python/cpython/issues/121650"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://github.com/python/cpython/pull/122233"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+					}
+				],
+				"published": "2024-08-01T00:00:00Z"
+			}
+		}
+	],
+	"data_source": {
+		"id": "redhat-cve",
+		"raws": [
+			"fixtures/2024/CVE-2024-6923.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/vex/testdata/golden/data/2023/CVE-2023-6238.json
+++ b/pkg/extract/redhat/vex/testdata/golden/data/2023/CVE-2023-6238.json
@@ -34,6 +34,12 @@
 						]
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -93,6 +99,12 @@
 						"cwe": [
 							"CWE-120"
 						]
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
 					}
 				],
 				"references": [
@@ -156,6 +168,12 @@
 						]
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -215,6 +233,12 @@
 						"cwe": [
 							"CWE-120"
 						]
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
 					}
 				],
 				"references": [

--- a/pkg/extract/redhat/vex/testdata/golden/data/2024/CVE-2024-6923.json
+++ b/pkg/extract/redhat/vex/testdata/golden/data/2024/CVE-2024-6923.json
@@ -344,6 +344,77 @@
 			},
 			"segments": [
 				{
+					"ecosystem": "redhat:8",
+					"tag": "78ca648c-cc65-2eef-a39c-97dec711da64"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2024-6923",
+				"title": "cpython: python: email module doesn't properly quotes newlines in email headers, allowing header injection",
+				"description": "A vulnerability was found in the email module that uses Python language. The email module doesn't properly quote new lines in email headers. This flaw allows an attacker to inject email headers that could, among other possibilities, add hidden email destinations or inject content into the email, impacting data confidentiality and integrity.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Moderate"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:N",
+							"base_score": 6.8,
+							"base_severity": "MEDIUM",
+							"temporal_score": 6.8,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.8,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://github.com/python/cpython/issues/121650"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://github.com/python/cpython/pull/122233"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+					}
+				],
+				"published": "2024-08-01T00:00:00Z",
+				"modified": "2026-03-10T02:42:06Z"
+			},
+			"segments": [
+				{
 					"ecosystem": "redhat:6",
 					"tag": "e16faea0-078d-81fc-8d19-515306c46417"
 				}
@@ -372,6 +443,12 @@
 							"environmental_score": 6.8,
 							"environmental_severity": "MEDIUM"
 						}
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
 					}
 				],
 				"references": [
@@ -439,6 +516,12 @@
 						}
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -502,6 +585,12 @@
 							"environmental_score": 6.8,
 							"environmental_severity": "MEDIUM"
 						}
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
 					}
 				],
 				"references": [
@@ -569,6 +658,12 @@
 						}
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -632,6 +727,12 @@
 							"environmental_score": 6.8,
 							"environmental_severity": "MEDIUM"
 						}
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
 					}
 				],
 				"references": [
@@ -699,69 +800,10 @@
 						}
 					}
 				],
-				"references": [
+				"workarounds": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
-					},
-					{
-						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
-					},
-					{
-						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
-					},
-					{
-						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
-					},
-					{
-						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
-					},
-					{
-						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
-					},
-					{
-						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
-					}
-				],
-				"published": "2024-08-01T00:00:00Z",
-				"modified": "2026-03-10T02:42:06Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "redhat:8",
-					"tag": "78ca648c-cc65-2eef-a39c-97dec711da64"
-				}
-			]
-		},
-		{
-			"content": {
-				"id": "CVE-2024-6923",
-				"title": "cpython: python: email module doesn't properly quotes newlines in email headers, allowing header injection",
-				"description": "A vulnerability was found in the email module that uses Python language. The email module doesn't properly quote new lines in email headers. This flaw allows an attacker to inject email headers that could, among other possibilities, add hidden email destinations or inject content into the email, impacting data confidentiality and integrity.",
-				"severity": [
-					{
-						"type": "vendor",
-						"source": "secalert@redhat.com",
-						"vendor": "Moderate"
-					},
-					{
-						"type": "cvss_v31",
-						"source": "secalert@redhat.com",
-						"cvss_v31": {
-							"vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:N",
-							"base_score": 6.8,
-							"base_severity": "MEDIUM",
-							"temporal_score": 6.8,
-							"temporal_severity": "MEDIUM",
-							"environmental_score": 6.8,
-							"environmental_severity": "MEDIUM"
-						}
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
 					}
 				],
 				"references": [
@@ -829,6 +871,12 @@
 						}
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -892,6 +940,12 @@
 							"environmental_score": 6.8,
 							"environmental_severity": "MEDIUM"
 						}
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
 					}
 				],
 				"references": [
@@ -959,6 +1013,12 @@
 						}
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -1022,6 +1082,12 @@
 							"environmental_score": 6.8,
 							"environmental_severity": "MEDIUM"
 						}
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
 					}
 				],
 				"references": [
@@ -1089,6 +1155,12 @@
 						}
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -1152,6 +1224,12 @@
 							"environmental_score": 6.8,
 							"environmental_severity": "MEDIUM"
 						}
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
 					}
 				],
 				"references": [
@@ -1219,6 +1297,12 @@
 						}
 					}
 				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
+					}
+				],
 				"references": [
 					{
 						"source": "secalert@redhat.com",
@@ -1282,6 +1366,12 @@
 							"environmental_score": 6.8,
 							"environmental_severity": "MEDIUM"
 						}
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability."
 					}
 				],
 				"references": [

--- a/pkg/extract/redhat/vex/vex.go
+++ b/pkg/extract/redhat/vex/vex.go
@@ -33,6 +33,7 @@ import (
 	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
 	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 	cvssV2Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v2"
 	cvssV30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
@@ -206,10 +207,12 @@ type product struct {
 	repositories    []string
 }
 
-type ass struct {
-	advisory advisory
-	severity severity
-	status   status
+type assessment struct {
+	advisory   advisory
+	severity   severity
+	status     status
+	mitigation string
+	workaround string
 }
 
 type advisory struct {
@@ -570,12 +573,12 @@ func walkProductTree(trackingID string, pt vex.ProductTree, c2r map[string][]str
 	return pm, nil
 }
 
-func walkVulnerabilities(vulns []vex.Vulnerability, pids []vex.ProductID) (map[vex.ProductID]ass, vulnerabilityContentTypes.Content, error) {
+func walkVulnerabilities(vulns []vex.Vulnerability, pids []vex.ProductID) (map[vex.ProductID]assessment, vulnerabilityContentTypes.Content, error) {
 	if len(vulns) != 1 {
 		return nil, vulnerabilityContentTypes.Content{}, errors.Errorf("unexpected vulnerabilities length. expected: %d, actual: %d", 1, len(vulns))
 	}
 
-	assm := make(map[vex.ProductID]ass)
+	assm := make(map[vex.ProductID]assessment)
 
 	if err := func() error {
 		if len(vulns[0].ProductStatus.FirstAffected) > 0 || len(vulns[0].ProductStatus.FirstFixed) > 0 || len(vulns[0].ProductStatus.LastAffected) > 0 || len(vulns[0].ProductStatus.Recommended) > 0 {
@@ -623,7 +626,7 @@ func walkVulnerabilities(vulns []vex.Vulnerability, pids []vex.ProductID) (map[v
 				switch base := assm[p]; base.status.product_status {
 				case "unaffected":
 					if base.status.affected_status != "" {
-						return errors.New("already set affected_status")
+						return errors.Errorf("already set affected_status. cve: %s, product_id: %s", vulns[0].CVE, p)
 					}
 					base.status.affected_status = f.Label
 					assm[p] = base
@@ -646,19 +649,31 @@ func walkVulnerabilities(vulns []vex.Vulnerability, pids []vex.ProductID) (map[v
 				return pids
 			}() {
 				switch r.Category {
-				case "mitigation", "workaround":
-					// TODO:
+				case "mitigation":
+					base := assm[p]
+					if base.mitigation != "" {
+						return errors.Errorf("already set mitigation. cve: %s, product_id: %s", vulns[0].CVE, p)
+					}
+					base.mitigation = r.Details
+					assm[p] = base
+				case "workaround":
+					base := assm[p]
+					if base.workaround != "" {
+						return errors.Errorf("already set workaround. cve: %s, product_id: %s", vulns[0].CVE, p)
+					}
+					base.workaround = r.Details
+					assm[p] = base
 				case "no_fix_planned", "none_available":
 					base := assm[p]
 					if base.status.affected_status != "" {
-						return errors.New("already set affected_status")
+						return errors.Errorf("already set affected_status. cve: %s, product_id: %s", vulns[0].CVE, p)
 					}
 					base.status.affected_status = r.Details
 					assm[p] = base
 				case "vendor_fix":
 					base := assm[p]
 					if base.advisory.id != "" {
-						return errors.New("already set advisory id")
+						return errors.Errorf("already set advisory id. cve: %s, product_id: %s", vulns[0].CVE, p)
 					}
 					base.advisory = advisory{
 						id:   strings.TrimPrefix(r.URL, "https://access.redhat.com/errata/"),
@@ -764,18 +779,18 @@ type productsWithMaxPid struct {
 	p2sm   map[string][]product2 // key: product2.cpe
 }
 
-func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityContentTypes.Content, pm map[vex.ProductID][]product, assm map[vex.ProductID]ass) ([]advisoryTypes.Advisory, []vulnerabilityTypes.Vulnerability, []detectionTypes.Detection, error) {
+func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityContentTypes.Content, pm map[vex.ProductID][]product, assm map[vex.ProductID]assessment) ([]advisoryTypes.Advisory, []vulnerabilityTypes.Vulnerability, []detectionTypes.Detection, error) {
 	baseVulnerability.Published = utiltime.Parse([]string{"2006-01-02T15:04:05-07:00"}, doc.Tracking.InitialReleaseDate)
 	baseVulnerability.Modified = utiltime.Parse([]string{"2006-01-02T15:04:05-07:00"}, doc.Tracking.CurrentReleaseDate)
-	for pid, ass := range assm {
-		if ass.severity.impact == "" && doc.AggregateSeverity != nil {
-			ass.severity.impact = doc.AggregateSeverity.Text
-			assm[pid] = ass
+	for pid, assessment := range assm {
+		if assessment.severity.impact == "" && doc.AggregateSeverity != nil {
+			assessment.severity.impact = doc.AggregateSeverity.Text
+			assm[pid] = assessment
 		}
 	}
 
-	// major -> ass -> productWithMaxPid
-	apmm := make(map[string]map[ass]productsWithMaxPid)
+	// major -> assessment -> productWithMaxPid
+	apmm := make(map[string]map[assessment]productsWithMaxPid)
 	for pid, ps := range pm {
 		for _, p := range ps {
 			if p.name == "" {
@@ -785,16 +800,16 @@ func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityConten
 
 			apm, found := apmm[p.major]
 			if !found {
-				apm = map[ass]productsWithMaxPid{}
+				apm = map[assessment]productsWithMaxPid{}
 			}
-			ass, found := assm[pid]
+			assessment, found := assm[pid]
 			if !found {
 				// FIXME: what to do?
 				slog.Warn("advisory/severity/status not found for pid", slog.String("product_id", string(pid)))
 				continue
 			}
 
-			pmax, found := apm[ass]
+			pmax, found := apm[assessment]
 			if !found {
 				pmax = productsWithMaxPid{
 					maxPid: pid,
@@ -829,7 +844,7 @@ func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityConten
 					}
 				}
 			}
-			apm[ass] = pmax
+			apm[assessment] = pmax
 			apmm[p.major] = apm
 		}
 	}
@@ -841,7 +856,7 @@ func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityConten
 	for major, apm := range apmm {
 		var conds []conditionTypes.Condition
 		es := ecosystemTypes.Ecosystem(fmt.Sprintf("%s:%s", ecosystemTypes.EcosystemTypeRedHat, major))
-		for ass, pmax := range apm {
+		for assessment, pmax := range apm {
 			tag := calculateTag(pmax)
 			ss := []segmentTypes.Segment{{
 				Ecosystem: es,
@@ -858,7 +873,7 @@ func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityConten
 				}
 
 				for _, p2 := range p2s {
-					vcs, err := buildVersionCriterion(p2, ass)
+					vcs, err := buildVersionCriterion(p2, assessment)
 					if err != nil {
 						return nil, nil, nil, errors.Wrap(err, "build version criterion")
 					}
@@ -880,7 +895,7 @@ func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityConten
 				})
 			}
 
-			v, err := buildVulnerability(baseVulnerability, ass)
+			v, err := buildVulnerability(baseVulnerability, assessment)
 			if err != nil {
 				return nil, nil, nil, errors.Wrap(err, "build vulnerability")
 			}
@@ -889,7 +904,7 @@ func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityConten
 				Segments: ss,
 			})
 
-			a, err := buildAdvisory(ass)
+			a, err := buildAdvisory(assessment)
 			if err != nil {
 				return nil, nil, nil, errors.Wrap(err, "build advisory")
 			}
@@ -917,8 +932,8 @@ func buildDataComponents(doc vex.Document, baseVulnerability vulnerabilityConten
 	return as, vs, ds, nil
 }
 
-func buildVersionCriterion(p2 product2, ass ass) ([]vcTypes.Criterion, error) {
-	switch ass.status.product_status {
+func buildVersionCriterion(p2 product2, assessment assessment) ([]vcTypes.Criterion, error) {
+	switch assessment.status.product_status {
 	case "fixed":
 		if p2.name == "" && p2.version == "" {
 			return nil, nil
@@ -963,7 +978,7 @@ func buildVersionCriterion(p2 product2, ass ass) ([]vcTypes.Criterion, error) {
 				Vulnerable: true,
 				FixStatus: &fixstatusTypes.FixStatus{
 					Class:  fixstatusTypes.ClassUnfixed,
-					Vendor: ass.status.affected_status,
+					Vendor: assessment.status.affected_status,
 				},
 				Package: vcPackageTypes.Package{
 					Type: vcPackageTypes.PackageTypeBinary,
@@ -990,7 +1005,7 @@ func buildVersionCriterion(p2 product2, ass ass) ([]vcTypes.Criterion, error) {
 				Vulnerable: true,
 				FixStatus: &fixstatusTypes.FixStatus{
 					Class:  fixstatusTypes.ClassUnfixed,
-					Vendor: ass.status.affected_status,
+					Vendor: assessment.status.affected_status,
 				},
 				Package: vcPackageTypes.Package{
 					Type: vcPackageTypes.PackageTypeSource,
@@ -1010,16 +1025,16 @@ func buildVersionCriterion(p2 product2, ass ass) ([]vcTypes.Criterion, error) {
 	case "unaffected":
 		return nil, nil
 	default:
-		return nil, errors.Errorf("unexpected product_status. expected: %q, actual: %q", []string{"fixed", "affected", "unaffected"}, ass.status.product_status)
+		return nil, errors.Errorf("unexpected product_status. expected: %q, actual: %q", []string{"fixed", "affected", "unaffected"}, assessment.status.product_status)
 	}
 
 }
 
-func buildVulnerability(baseVulnerability vulnerabilityContentTypes.Content, ass ass) (vulnerabilityContentTypes.Content, error) {
+func buildVulnerability(baseVulnerability vulnerabilityContentTypes.Content, assessment assessment) (vulnerabilityContentTypes.Content, error) {
 	ss, err := func() ([]severityTypes.Severity, error) {
 		var ss []severityTypes.Severity
-		if ass.severity.cvss2 != "" {
-			v2, err := cvssV2Types.Parse(ass.severity.cvss2)
+		if assessment.severity.cvss2 != "" {
+			v2, err := cvssV2Types.Parse(assessment.severity.cvss2)
 			if err != nil {
 				return nil, errors.Wrapf(err, "parse cvss2")
 			}
@@ -1029,10 +1044,10 @@ func buildVulnerability(baseVulnerability vulnerabilityContentTypes.Content, ass
 				CVSSv2: v2,
 			})
 		}
-		if ass.severity.cvss3 != "" {
+		if assessment.severity.cvss3 != "" {
 			switch {
-			case strings.HasPrefix(ass.severity.cvss3, "CVSS:3.0"):
-				v30, err := cvssV30Types.Parse(ass.severity.cvss3)
+			case strings.HasPrefix(assessment.severity.cvss3, "CVSS:3.0"):
+				v30, err := cvssV30Types.Parse(assessment.severity.cvss3)
 				if err != nil {
 					return nil, errors.Wrap(err, "parse cvss3")
 				}
@@ -1041,8 +1056,8 @@ func buildVulnerability(baseVulnerability vulnerabilityContentTypes.Content, ass
 					Source:  "secalert@redhat.com",
 					CVSSv30: v30,
 				})
-			case strings.HasPrefix(ass.severity.cvss3, "CVSS:3.1"):
-				v31, err := cvssV31Types.Parse(ass.severity.cvss3)
+			case strings.HasPrefix(assessment.severity.cvss3, "CVSS:3.1"):
+				v31, err := cvssV31Types.Parse(assessment.severity.cvss3)
 				if err != nil {
 					return nil, errors.Wrap(err, "parse cvss3")
 				}
@@ -1052,14 +1067,14 @@ func buildVulnerability(baseVulnerability vulnerabilityContentTypes.Content, ass
 					CVSSv31: v31,
 				})
 			default:
-				return nil, errors.Errorf("unexpected CVSSv3 string. expected: %q, actual: %q", "<score>/CVSS:3.[01]/<vector>", ass.severity.cvss3)
+				return nil, errors.Errorf("unexpected CVSSv3 string. expected: %q, actual: %q", "<score>/CVSS:3.[01]/<vector>", assessment.severity.cvss3)
 			}
 		}
-		if ass.severity.impact != "" {
+		if assessment.severity.impact != "" {
 			ss = append(ss, severityTypes.Severity{
 				Type:   severityTypes.SeverityTypeVendor,
 				Source: "secalert@redhat.com",
-				Vendor: &ass.severity.impact,
+				Vendor: &assessment.severity.impact,
 			})
 		}
 		return ss, nil
@@ -1068,20 +1083,32 @@ func buildVulnerability(baseVulnerability vulnerabilityContentTypes.Content, ass
 		return vulnerabilityContentTypes.Content{}, errors.Wrap(err, "walk severity")
 	}
 	baseVulnerability.Severity = ss
+	if assessment.mitigation != "" {
+		baseVulnerability.Mitigations = []remediationTypes.Remediation{{
+			Source:      "secalert@redhat.com",
+			Description: assessment.mitigation,
+		}}
+	}
+	if assessment.workaround != "" {
+		baseVulnerability.Workarounds = []remediationTypes.Remediation{{
+			Source:      "secalert@redhat.com",
+			Description: assessment.workaround,
+		}}
+	}
 	return baseVulnerability, nil
 }
 
-func buildAdvisory(ass ass) (*advisoryContentTypes.Content, error) {
-	if ass.advisory.id == "" {
+func buildAdvisory(assessment assessment) (*advisoryContentTypes.Content, error) {
+	if assessment.advisory.id == "" {
 		return nil, nil
 	}
 	a := advisoryContentTypes.Content{
-		ID: advisoryContentTypes.AdvisoryID(ass.advisory.id),
+		ID: advisoryContentTypes.AdvisoryID(assessment.advisory.id),
 		References: []referenceTypes.Reference{{
 			Source: "secalert@redhat.com",
-			URL:    fmt.Sprintf("https://access.redhat.com/errata/%s", ass.advisory.id),
+			URL:    fmt.Sprintf("https://access.redhat.com/errata/%s", assessment.advisory.id),
 		}},
-		Published: utiltime.Parse([]string{"2006-01-02T15:04:05-07:00"}, ass.advisory.date),
+		Published: utiltime.Parse([]string{"2006-01-02T15:04:05-07:00"}, assessment.advisory.date),
 	}
 	return &a, nil
 }

--- a/pkg/extract/types/data/advisory/content/content.go
+++ b/pkg/extract/types/data/advisory/content/content.go
@@ -9,21 +9,24 @@ import (
 	exploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/exploit"
 	kevTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 )
 
 type Content struct {
-	ID          AdvisoryID                 `json:"id,omitempty"`
-	Title       string                     `json:"title,omitempty"`
-	Description string                     `json:"description,omitempty"`
-	Severity    []severityTypes.Severity   `json:"severity,omitempty"`
-	CWE         []cweTypes.CWE             `json:"cwe,omitempty"`
-	Exploit     []exploitTypes.Exploit     `json:"exploit,omitempty"`
-	KEV         *kevTypes.KEV              `json:"kev,omitempty"`
-	References  []referenceTypes.Reference `json:"references,omitempty"`
-	Published   *time.Time                 `json:"published,omitempty"`
-	Modified    *time.Time                 `json:"modified,omitempty"`
-	Optional    map[string]any             `json:"optional,omitempty"`
+	ID          AdvisoryID                     `json:"id,omitempty"`
+	Title       string                         `json:"title,omitempty"`
+	Description string                         `json:"description,omitempty"`
+	Severity    []severityTypes.Severity       `json:"severity,omitempty"`
+	CWE         []cweTypes.CWE                 `json:"cwe,omitempty"`
+	Mitigations []remediationTypes.Remediation `json:"mitigations,omitempty"`
+	Workarounds []remediationTypes.Remediation `json:"workarounds,omitempty"`
+	Exploit     []exploitTypes.Exploit         `json:"exploit,omitempty"`
+	KEV         *kevTypes.KEV                  `json:"kev,omitempty"`
+	References  []referenceTypes.Reference     `json:"references,omitempty"`
+	Published   *time.Time                     `json:"published,omitempty"`
+	Modified    *time.Time                     `json:"modified,omitempty"`
+	Optional    map[string]any                 `json:"optional,omitempty"`
 }
 
 type AdvisoryID string
@@ -35,6 +38,9 @@ func (c *Content) Sort() {
 		(&c.CWE[i]).Sort()
 	}
 	slices.SortFunc(c.CWE, cweTypes.Compare)
+
+	slices.SortFunc(c.Mitigations, remediationTypes.Compare)
+	slices.SortFunc(c.Workarounds, remediationTypes.Compare)
 
 	for i := range c.Exploit {
 		(&c.Exploit[i]).Sort()
@@ -55,6 +61,8 @@ func Compare(x, y Content) int {
 		cmp.Compare(x.Description, y.Description),
 		slices.CompareFunc(x.Severity, y.Severity, severityTypes.Compare),
 		slices.CompareFunc(x.CWE, y.CWE, cweTypes.Compare),
+		slices.CompareFunc(x.Mitigations, y.Mitigations, remediationTypes.Compare),
+		slices.CompareFunc(x.Workarounds, y.Workarounds, remediationTypes.Compare),
 		slices.CompareFunc(x.Exploit, y.Exploit, exploitTypes.Compare),
 		func() int {
 			switch {

--- a/pkg/extract/types/data/remediation/remediation.go
+++ b/pkg/extract/types/data/remediation/remediation.go
@@ -1,0 +1,15 @@
+package remediation
+
+import "cmp"
+
+type Remediation struct {
+	Source      string `json:"source,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+func Compare(x, y Remediation) int {
+	return cmp.Or(
+		cmp.Compare(x.Source, y.Source),
+		cmp.Compare(x.Description, y.Description),
+	)
+}

--- a/pkg/extract/types/data/remediation/remediation_test.go
+++ b/pkg/extract/types/data/remediation/remediation_test.go
@@ -1,0 +1,69 @@
+package remediation_test
+
+import (
+	"testing"
+
+	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
+)
+
+func TestCompare(t *testing.T) {
+	type args struct {
+		x remediationTypes.Remediation
+		y remediationTypes.Remediation
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "x == y",
+			args: args{
+				x: remediationTypes.Remediation{
+					Source:      "source1",
+					Description: "description1",
+				},
+				y: remediationTypes.Remediation{
+					Source:      "source1",
+					Description: "description1",
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "x:source < y:source",
+			args: args{
+				x: remediationTypes.Remediation{
+					Source:      "source1",
+					Description: "description",
+				},
+				y: remediationTypes.Remediation{
+					Source:      "source2",
+					Description: "description",
+				},
+			},
+			want: -1,
+		},
+		{
+			name: "x:description > y:description",
+			args: args{
+				x: remediationTypes.Remediation{
+					Source:      "source",
+					Description: "description2",
+				},
+				y: remediationTypes.Remediation{
+					Source:      "source",
+					Description: "description1",
+				},
+			},
+			want: +1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := remediationTypes.Compare(tt.args.x, tt.args.y); got != tt.want {
+				t.Errorf("Compare() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/extract/types/data/vulnerability/content/content.go
+++ b/pkg/extract/types/data/vulnerability/content/content.go
@@ -11,25 +11,28 @@ import (
 	kevTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev"
 	metasploitTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/metasploit"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 	snortTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/snort"
 )
 
 type Content struct {
-	ID          VulnerabilityID              `json:"id,omitempty"`
-	Title       string                       `json:"title,omitempty"`
-	Description string                       `json:"description,omitempty"`
-	Severity    []severityTypes.Severity     `json:"severity,omitempty"`
-	CWE         []cweTypes.CWE               `json:"cwe,omitempty"`
-	Exploit     []exploitTypes.Exploit       `json:"exploit,omitempty"`
-	Metasploit  []metasploitTypes.Metasploit `json:"metasploit,omitempty"`
-	EPSS        *epssTypes.EPSS              `json:"epss,omitempty"`
-	Snort       []snortTypes.Snort           `json:"snort,omitempty"`
-	KEV         *kevTypes.KEV                `json:"kev,omitempty"`
-	References  []referenceTypes.Reference   `json:"references,omitempty"`
-	Published   *time.Time                   `json:"published,omitempty"`
-	Modified    *time.Time                   `json:"modified,omitempty"`
-	Optional    map[string]any               `json:"optional,omitempty"`
+	ID          VulnerabilityID                `json:"id,omitempty"`
+	Title       string                         `json:"title,omitempty"`
+	Description string                         `json:"description,omitempty"`
+	Severity    []severityTypes.Severity       `json:"severity,omitempty"`
+	CWE         []cweTypes.CWE                 `json:"cwe,omitempty"`
+	Mitigations []remediationTypes.Remediation `json:"mitigations,omitempty"`
+	Workarounds []remediationTypes.Remediation `json:"workarounds,omitempty"`
+	Exploit     []exploitTypes.Exploit         `json:"exploit,omitempty"`
+	Metasploit  []metasploitTypes.Metasploit   `json:"metasploit,omitempty"`
+	EPSS        *epssTypes.EPSS                `json:"epss,omitempty"`
+	Snort       []snortTypes.Snort             `json:"snort,omitempty"`
+	KEV         *kevTypes.KEV                  `json:"kev,omitempty"`
+	References  []referenceTypes.Reference     `json:"references,omitempty"`
+	Published   *time.Time                     `json:"published,omitempty"`
+	Modified    *time.Time                     `json:"modified,omitempty"`
+	Optional    map[string]any                 `json:"optional,omitempty"`
 }
 
 type VulnerabilityID string
@@ -41,6 +44,9 @@ func (c *Content) Sort() {
 		(&c.CWE[i]).Sort()
 	}
 	slices.SortFunc(c.CWE, cweTypes.Compare)
+
+	slices.SortFunc(c.Mitigations, remediationTypes.Compare)
+	slices.SortFunc(c.Workarounds, remediationTypes.Compare)
 
 	for i := range c.Exploit {
 		(&c.Exploit[i]).Sort()
@@ -68,6 +74,8 @@ func Compare(x, y Content) int {
 		cmp.Compare(x.Description, y.Description),
 		slices.CompareFunc(x.Severity, y.Severity, severityTypes.Compare),
 		slices.CompareFunc(x.CWE, y.CWE, cweTypes.Compare),
+		slices.CompareFunc(x.Mitigations, y.Mitigations, remediationTypes.Compare),
+		slices.CompareFunc(x.Workarounds, y.Workarounds, remediationTypes.Compare),
 		slices.CompareFunc(x.Exploit, y.Exploit, exploitTypes.Compare),
 		slices.CompareFunc(x.Metasploit, y.Metasploit, metasploitTypes.Compare),
 		func() int {

--- a/pkg/extract/ubuntu/tracker/tracker.go
+++ b/pkg/extract/ubuntu/tracker/tracker.go
@@ -25,6 +25,7 @@ import (
 	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
 	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
@@ -294,6 +295,22 @@ func extract(fetched tracker.Advisory, paths []string) (dataTypes.Data, error) {
 	baseVC := vulnerabilityContentTypes.Content{
 		ID:          vulnerabilityContentTypes.VulnerabilityID(fetched.Candidate),
 		Description: fetched.Description,
+		Mitigations: func() []remediationTypes.Remediation {
+			if len(fetched.Mitigation) == 0 {
+				return nil
+			}
+			rs := make([]remediationTypes.Remediation, 0, len(fetched.Mitigation))
+			for _, m := range fetched.Mitigation {
+				if m == "" {
+					continue
+				}
+				rs = append(rs, remediationTypes.Remediation{
+					Source:      "launchpad.net/ubuntu-cve-tracker",
+					Description: m,
+				})
+			}
+			return rs
+		}(),
 		References: func() []referenceTypes.Reference {
 			rs := make([]referenceTypes.Reference, 0, len(fetched.References))
 			for _, r := range fetched.References {


### PR DESCRIPTION
Raw sources carry Mitigation/Workaround data that was previously
dropped during extraction: microsoft/cvrf explicitly discarded the
"Mitigation"/"Workaround" remediation types, redhat/csaf and
redhat/vex left a TODO on the "mitigation"/"workaround" categories,
and redhat/cve, ubuntu/tracker, mitre/v5 had no destination field at
all. Introduce a dedicated remediation package and wire it into both
vulnerability.Content and advisory.Content so this prose guidance
survives extraction.

- Add pkg/extract/types/data/remediation with
  Remediation{Source, Description} and Compare.
- Add Mitigations and Workarounds slices to vulnerability/content and
  advisory/content; extend Sort and Compare.
- Wire extractors:
    - redhat/cve: Mitigation.Value -> Mitigations
    - redhat/csaf: per-product mitigation/workaround categories ->
      Mitigations/Workarounds (assert each product has at most one of
      each, matching the existing vendor_fix / no_fix_planned
      bookkeeping)
    - redhat/vex: same per-product treatment as redhat/csaf
    - ubuntu/tracker: Mitigation []string -> Mitigations (one per item)
    - mitre/v5: CNA and ADP Workarounds -> Workarounds (en only)
    - microsoft/cvrf: Remediation entries with Type "Mitigation" or
      "Workaround" filtered by ProductID per Content (previously
      discarded in buildDetections); empty ProductID falls back to
      v.ProductStatuses.Status.ProductID (apply to all products)
- Regenerate golden fixtures for redhat/csaf RHSA-2023:6939,
  redhat/vex https://github.com/advisories/GHSA-2j83-334m-g9w4 and https://github.com/advisories/GHSA-87qc-q3w7-7m8w, mitre/v5 https://github.com/advisories/GHSA-9xg8-vx2w-7c89,
  and microsoft/cvrf https://github.com/advisories/GHSA-4h7p-4c7p-j56v.

Scope: categories are limited to Mitigation and Workaround (prose
guidance). VendorFix / NoneAvailable / NoFixPlanned are intentionally
not modeled here because they are already expressed through detection
(version and kb criteria, or the absence of a fixed version).