### PR TITLE
fix(extract/microsoft/cvrf): support Visual Studio 2026 Version 18.5

### DIFF
--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -1168,7 +1168,8 @@ func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criter
 			"Microsoft Visual Studio 2022 Version 17.8",
 			"Microsoft Visual Studio 2022 Version 17.9",
 			"Microsoft Visual Studio 2026 Version 18.3",
-			"Microsoft Visual Studio 2026 Version 18.4":
+			"Microsoft Visual Studio 2026 Version 18.4",
+			"Microsoft Visual Studio 2026 Version 18.5":
 			if _, err := visualstudioversion.NewVersion(fixedBuild); err != nil {
 				return rangeTypes.RangeTypeUnknown, errors.Wrap(err, "visualstudioversion.NewVersion")
 			}


### PR DESCRIPTION
## Summary

Nightly extract for `microsoft-cvrf` is failing with:
```
unexpected FixedBuild format for CVE-2026-40372 (Microsoft Visual Studio 2026 Version 18.5): "18.5.2"
```
(see https://github.com/vulsio/vuls-data-db/actions/runs/25138438890/job/73683894143)

Microsoft published CVE-2026-40372 in the 2026-Apr CVRF channel covering `Microsoft Visual Studio 2026 Version 18.5` with FixedBuild `18.5.2`. This product name was not listed in the Visual Studio case of `buildFixedBuildCriterion`, so the prefix-detection fallback triggered the 'unknown product' guard.

## Fix

Add `Microsoft Visual Studio 2026 Version 18.5` to the Visual Studio case alongside 18.3 and 18.4. The 3-segment value `18.5.2` is already parsed correctly by `visualstudioversion.NewVersion` (Modern format).

## Verification

- `go build ./...` passes
- `go test ./pkg/extract/microsoft/cvrf/...` passes