### PR TITLE
feat(extract/microsoft/msuc): cross-track Supersedes for monthly KBs

### DIFF
--- a/pkg/extract/microsoft/msuc/export_test.go
+++ b/pkg/extract/microsoft/msuc/export_test.go
@@ -1,0 +1,3 @@
+package msuc
+
+var DeriveCrossTrackSupersedes = deriveCrossTrackSupersedes

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -8,7 +8,9 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -20,6 +22,7 @@ import (
 	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
 	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
 	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
 	microsoftkbUpdateTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/update"
 	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
@@ -285,6 +288,7 @@ func (o options) extract(root string, updateIDMap map[string]string) error {
 	}
 
 	microsoftutil.DeriveSupersedes(kbs)
+	deriveCrossTrackSupersedes(kbs)
 
 	for _, kb := range kbs {
 		if err := util.Write(filepath.Join(o.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)), kb, true); err != nil {
@@ -383,4 +387,165 @@ func normalizeNA(s string) string {
 		return ""
 	}
 	return s
+}
+
+// monthlyTrackTitleRE matches the title of a monthly Quality Update / Rollup,
+// capturing year, month, track, and product name.
+//
+// Microsoft releases parallel-track updates per product per month:
+//   - "Security Only Quality Update"        (narrowest)
+//   - "Security Monthly Quality Rollup"     (includes Security Only + non-security fixes)
+//   - "Preview of Monthly Quality Rollup"   (includes Security Monthly + next-month previews)
+//   - "Cumulative Update"                   (Win10/11/Server 2016+)
+//   - "Cumulative Update Preview"           (Win10/11/Server 2016+ preview track)
+var monthlyTrackTitleRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (Security Only Quality Update|Security Monthly Quality Rollup|Preview of Monthly Quality Rollup|Cumulative Update Preview|Cumulative Update) for (.+?) \(KB\d+\)$`)
+
+// deriveCrossTrackSupersedes augments Update-level Supersedes / SupersededBy
+// with cross-track equivalence for monthly Quality Rollups within the same
+// product+year+month.
+//
+// Microsoft does NOT consistently record cross-track supersession in MSUC's
+// per-Update SupersededBy graph: across the production raw corpus the SO/SM,
+// SO/PV and SM/PV pairings are 0% covered while CU/CP is ~92% covered.
+// However the broader-track update is functionally a superset of the narrower
+// one, so for detection-time coverage we add synthetic edges (both
+// Supersedes on the broader-track Update and the reverse SupersededBy on the
+// narrower-track Update):
+//
+// Preview            ⊇ SecurityMonthly ⊇ SecurityOnly
+// CumulativePreview  ⊇ Cumulative
+//
+// kbs is modified in place. Only Update-level edges are added: KB-level
+// supersession is left to native KB-level signals (CVRF, Bulletin) so that
+// cross-arch / partial supersession is not lossy-aggregated to KB level.
+// Detection still discovers cross-track equivalence via the Update-level
+// edges. Architecture pairing across tracks is 1:1 within a group because
+// monthlyTrackTitleRE captures the architecture suffix (e.g. "for x64-based
+// Systems") as part of the product key, so each (year, month,
+// product+architecture, track) tuple has at most one Update.
+//
+// This is MSUC-specific: other Microsoft data sources either lack per-Update
+// titles (CVRF, Bulletin) or do not expose modern monthly-track titles in the
+// `YYYY-MM ...` form expected by monthlyTrackTitleRE (WSUSSCN2 uses the older
+// "Month, YYYY" format for the relevant EOL products and omits Cumulative
+// Update Preview entries entirely).
+func deriveCrossTrackSupersedes(kbs []microsoftkbTypes.KB) {
+	type track int
+	const (
+		trackUnknown track = iota
+		trackSecurityOnly
+		trackSecurityMonthly
+		trackPreview
+		trackCumulative
+		trackCumulativePreview
+	)
+
+	classify := func(s string) track {
+		switch s {
+		case "Security Only Quality Update":
+			return trackSecurityOnly
+		case "Security Monthly Quality Rollup":
+			return trackSecurityMonthly
+		case "Preview of Monthly Quality Rollup":
+			return trackPreview
+		case "Cumulative Update":
+			return trackCumulative
+		case "Cumulative Update Preview":
+			return trackCumulativePreview
+		default:
+			return trackUnknown
+		}
+	}
+
+	type member struct{ kbID, updateID string }
+	type group struct{ year, month, product string }
+	grouped := make(map[group]map[track][]member)
+
+	for _, kb := range kbs {
+		for _, u := range kb.Updates {
+			m := monthlyTrackTitleRE.FindStringSubmatch(u.Title)
+			if m == nil {
+				continue
+			}
+			tr := classify(m[3])
+			if tr == trackUnknown {
+				continue
+			}
+			g := group{year: m[1], month: m[2], product: microsoftutil.NormalizeProductName(m[4])}
+			if grouped[g] == nil {
+				grouped[g] = make(map[track][]member)
+			}
+			grouped[g][tr] = append(grouped[g][tr], member{kbID: kb.KBID, updateID: u.UpdateID})
+		}
+	}
+
+	kbIdx := make(map[string]*microsoftkbTypes.KB, len(kbs))
+	for i := range kbs {
+		kbIdx[kbs[i].KBID] = &kbs[i]
+	}
+	updateIdx := func(kbID, updateID string) *microsoftkbUpdateTypes.Update {
+		kb, ok := kbIdx[kbID]
+		if !ok {
+			return nil
+		}
+		if i := slices.IndexFunc(kb.Updates, func(u microsoftkbUpdateTypes.Update) bool {
+			return u.UpdateID == updateID
+		}); i >= 0 {
+			return &kb.Updates[i]
+		}
+		return nil
+	}
+
+	addEdge := func(super, sub member) {
+		if super.kbID == "" || sub.kbID == "" || super.kbID == sub.kbID {
+			return
+		}
+		// Mirror DeriveSupersedes's Update-level guard: synthesize an edge
+		// only when both endpoints have an UpdateID. updateIdx requires a
+		// non-empty UpdateID to match deterministically.
+		if super.updateID == "" || sub.updateID == "" {
+			return
+		}
+
+		// Update-level edges only. Architecture pairing across tracks is 1:1
+		// within the same (year, month, product+architecture) group because
+		// the product capture in monthlyTrackTitleRE includes the architecture
+		// suffix (e.g. "for x64-based Systems").
+		if superU := updateIdx(super.kbID, super.updateID); superU != nil {
+			if !slices.ContainsFunc(superU.Supersedes, func(s microsoftkbSupersedesTypes.Supersedes) bool {
+				return s.KBID == sub.kbID && s.UpdateID == sub.updateID
+			}) {
+				superU.Supersedes = append(superU.Supersedes, microsoftkbSupersedesTypes.Supersedes{KBID: sub.kbID, UpdateID: sub.updateID})
+			}
+		}
+		if subU := updateIdx(sub.kbID, sub.updateID); subU != nil {
+			if !slices.ContainsFunc(subU.SupersededBy, func(s microsoftkbSupersededByTypes.SupersededBy) bool {
+				return s.KBID == super.kbID && s.UpdateID == super.updateID
+			}) {
+				subU.SupersededBy = append(subU.SupersededBy, microsoftkbSupersededByTypes.SupersededBy{KBID: super.kbID, UpdateID: super.updateID})
+			}
+		}
+	}
+
+	addBetween := func(supers, subs []member) {
+		for _, sup := range supers {
+			for _, sub := range subs {
+				addEdge(sup, sub)
+			}
+		}
+	}
+
+	inclusions := []struct{ super, sub track }{
+		// Preview ⊇ SecurityMonthly ⊇ SecurityOnly.
+		{trackPreview, trackSecurityMonthly},
+		{trackPreview, trackSecurityOnly},
+		{trackSecurityMonthly, trackSecurityOnly},
+		// CumulativePreview ⊇ Cumulative.
+		{trackCumulativePreview, trackCumulative},
+	}
+	for _, byTrack := range grouped {
+		for _, inc := range inclusions {
+			addBetween(byTrack[inc.super], byTrack[inc.sub])
+		}
+	}
 }

--- a/pkg/extract/microsoft/msuc/msuc_test.go
+++ b/pkg/extract/microsoft/msuc/msuc_test.go
@@ -4,7 +4,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/msuc"
+	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
+	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
+	microsoftkbUpdateTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/update"
 	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
 )
 
@@ -40,6 +47,336 @@ func TestExtract(t *testing.T) {
 					t.Error("unexpected error:", err)
 				}
 				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}
+
+func TestDeriveCrossTrackSupersedes(t *testing.T) {
+	type args struct {
+		kbs []microsoftkbTypes.KB
+	}
+	tests := []struct {
+		name string
+		args args
+		want []microsoftkbTypes.KB
+	}{
+		{
+			name: "Preview ⊇ SecurityMonthly ⊇ SecurityOnly (Server 2008 R2 2018-02)",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "4074598",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-So", Title: "2018-02 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB4074598)"},
+					},
+				},
+				{
+					KBID: "4074594",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Sm", Title: "2018-02 Security Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB4074594)"},
+					},
+				},
+				{
+					KBID: "4075211",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Pv", Title: "2018-02 Preview of Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB4075211)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "4074594",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-Sm",
+							Title:        "2018-02 Security Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB4074594)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "4075211", UpdateID: "U-Pv"}},
+							Supersedes:   []microsoftkbSupersedesTypes.Supersedes{{KBID: "4074598", UpdateID: "U-So"}},
+						},
+					},
+				},
+				{
+					KBID: "4074598",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-So",
+							Title:        "2018-02 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB4074598)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "4074594", UpdateID: "U-Sm"}, {KBID: "4075211", UpdateID: "U-Pv"}},
+						},
+					},
+				},
+				{
+					KBID: "4075211",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:   "U-Pv",
+							Title:      "2018-02 Preview of Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB4075211)",
+							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "4074594", UpdateID: "U-Sm"}, {KBID: "4074598", UpdateID: "U-So"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "CumulativePreview ⊇ Cumulative (Win10 1607 2019-02)",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "4480973",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-C", Title: "2019-02 Cumulative Update for Windows 10 Version 1607 for x64-based Systems (KB4480973)"},
+					},
+				},
+				{
+					KBID: "4485447",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Cp", Title: "2019-02 Cumulative Update Preview for Windows 10 Version 1607 for x64-based Systems (KB4485447)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "4480973",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-C",
+							Title:        "2019-02 Cumulative Update for Windows 10 Version 1607 for x64-based Systems (KB4480973)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "4485447", UpdateID: "U-Cp"}},
+						},
+					},
+				},
+				{
+					KBID: "4485447",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:   "U-Cp",
+							Title:      "2019-02 Cumulative Update Preview for Windows 10 Version 1607 for x64-based Systems (KB4485447)",
+							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "4480973", UpdateID: "U-C"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "different month: no cross-track edges added",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-A", Title: "2018-02 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2018-03 Preview of Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB1002)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-A", Title: "2018-02 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2018-03 Preview of Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB1002)"},
+					},
+				},
+			},
+		},
+		{
+			name: "different product: no cross-track edges added",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-A", Title: "2018-02 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2018-02 Preview of Monthly Quality Rollup for Windows 7 for x64-based Systems (KB1002)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-A", Title: "2018-02 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2018-02 Preview of Monthly Quality Rollup for Windows 7 for x64-based Systems (KB1002)"},
+					},
+				},
+			},
+		},
+		{
+			name: "product name normalization (\" version \" → \" Version \") groups together",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-A", Title: "2019-02 Cumulative Update for Windows 10 version 1607 for x64-based Systems (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2019-02 Cumulative Update Preview for Windows 10 Version 1607 for x64-based Systems (KB1002)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-A",
+							Title:        "2019-02 Cumulative Update for Windows 10 version 1607 for x64-based Systems (KB1001)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "B", UpdateID: "U-B"}},
+						},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:   "U-B",
+							Title:      "2019-02 Cumulative Update Preview for Windows 10 Version 1607 for x64-based Systems (KB1002)",
+							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "A", UpdateID: "U-A"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "non-monthly title (e.g. .NET Framework) ignored",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-A", Title: "Security and Quality Rollup for .NET Framework 3.5.1 on Windows 7 SP1 (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2018-02 Preview of Monthly Quality Rollup for Windows 7 for x64-based Systems (KB1002)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-A", Title: "Security and Quality Rollup for .NET Framework 3.5.1 on Windows 7 SP1 (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2018-02 Preview of Monthly Quality Rollup for Windows 7 for x64-based Systems (KB1002)"},
+					},
+				},
+			},
+		},
+		{
+			name: "preexisting Supersedes/SupersededBy preserved (no duplicate added)",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID:       "B",
+					Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "A"}},
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2018-02 Security Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB1002)"},
+					},
+				},
+				{
+					KBID:         "A",
+					SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "B"}},
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-A", Title: "2018-02 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB1001)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID:         "A",
+					SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "B"}},
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-A",
+							Title:        "2018-02 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB1001)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "B", UpdateID: "U-B"}},
+						},
+					},
+				},
+				{
+					KBID:       "B",
+					Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "A"}},
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:   "U-B",
+							Title:      "2018-02 Security Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB1002)",
+							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "A", UpdateID: "U-A"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty UpdateID skipped (no malformed edges synthesized)",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "", Title: "2018-02 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2018-02 Security Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB1002)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "", Title: "2018-02 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2018-02 Security Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB1002)"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msuc.DeriveCrossTrackSupersedes(tt.args.kbs)
+			if diff := cmp.Diff(tt.want, tt.args.kbs,
+				cmpopts.SortSlices(func(x, y microsoftkbTypes.KB) bool { return microsoftkbTypes.Compare(x, y) < 0 }),
+				cmpopts.SortSlices(func(x, y microsoftkbUpdateTypes.Update) bool { return microsoftkbUpdateTypes.Compare(x, y) < 0 }),
+				cmpopts.SortSlices(func(x, y microsoftkbSupersededByTypes.SupersededBy) bool {
+					return microsoftkbSupersededByTypes.Compare(x, y) < 0
+				}),
+				cmpopts.SortSlices(func(x, y microsoftkbSupersedesTypes.Supersedes) bool {
+					return microsoftkbSupersedesTypes.Compare(x, y) < 0
+				}),
+			); diff != "" {
+				t.Errorf("msuc.DeriveCrossTrackSupersedes() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/extract/microsoft/msuc/testdata/fixtures/happy/651e95ab-6e7c-4ea6-9cd2-3cbabd9b76f0.json
+++ b/pkg/extract/microsoft/msuc/testdata/fixtures/happy/651e95ab-6e7c-4ea6-9cd2-3cbabd9b76f0.json
@@ -1,0 +1,22 @@
+{
+	"update_id": "651e95ab-6e7c-4ea6-9cd2-3cbabd9b76f0",
+	"title": "2018-02 Security Monthly Quality Rollup for Windows 7 for x86-based Systems (KB4074598)",
+	"description": "A security issue has been identified in a Microsoft software product that could affect your system. You can help protect your system by installing this update from Microsoft. For a complete listing of the issues that are included in this update, see the associated Microsoft Knowledge Base article. After you install this update, you may have to restart your system.",
+	"architecture": "X86",
+	"classification": "SecurityUpdates",
+	"supported_products": "Windows7",
+	"supported_languages": "all",
+	"security_bulliten": "n/a",
+	"msrc_severity": "Critical",
+	"kb_article": "4074598",
+	"more_info": "https://support.microsoft.com/help/4074598",
+	"support_url": "https://support.microsoft.com/help/4074598",
+	"supersededby": [],
+	"supersedes": [],
+	"reboot_behavior": "Can request restart",
+	"user_input": "No",
+	"connectivity": "No",
+	"uninstall_notes": "ThissoftwareupdatecanberemovedbyselectingViewinstalledupdatesintheProgramsandFeaturesControlPanel.",
+	"uninstall_steps": "n/a",
+	"last_modified": "2/13/2018"
+}

--- a/pkg/extract/microsoft/msuc/testdata/fixtures/happy/9da71c39-5043-4f64-b9d6-71d569d0544d.json
+++ b/pkg/extract/microsoft/msuc/testdata/fixtures/happy/9da71c39-5043-4f64-b9d6-71d569d0544d.json
@@ -1,0 +1,22 @@
+{
+	"update_id": "9da71c39-5043-4f64-b9d6-71d569d0544d",
+	"title": "2018-02 Preview of Monthly Quality Rollup for Windows 7 for x86-based Systems (KB4075211)",
+	"description": "Install this update to resolve issues in Windows. For a complete listing of the issues that are included in this update, see the associated Microsoft Knowledge Base article for more information. After you install this item, you may have to restart your computer.",
+	"architecture": "X86",
+	"classification": "Updates",
+	"supported_products": "Windows7",
+	"supported_languages": "all",
+	"security_bulliten": "n/a",
+	"msrc_severity": "n/a",
+	"kb_article": "4075211",
+	"more_info": "https://support.microsoft.com/help/4075211",
+	"support_url": "https://support.microsoft.com/help/4075211",
+	"supersededby": [],
+	"supersedes": [],
+	"reboot_behavior": "Can request restart",
+	"user_input": "No",
+	"connectivity": "No",
+	"uninstall_notes": "ThissoftwareupdatecanberemovedbyselectingViewinstalledupdatesintheProgramsandFeaturesControlPanel.",
+	"uninstall_steps": "n/a",
+	"last_modified": "2/22/2018"
+}

--- a/pkg/extract/microsoft/msuc/testdata/fixtures/happy/ae42a70d-ccc6-4ef7-9590-db44662ef5c0.json
+++ b/pkg/extract/microsoft/msuc/testdata/fixtures/happy/ae42a70d-ccc6-4ef7-9590-db44662ef5c0.json
@@ -1,0 +1,22 @@
+{
+	"update_id": "ae42a70d-ccc6-4ef7-9590-db44662ef5c0",
+	"title": "2018-02 Security Only Quality Update for Windows 7 for x86-based Systems (KB4074587)",
+	"description": "A security issue has been identified in a Microsoft software product that could affect your system. You can help protect your system by installing this update from Microsoft. For a complete listing of the issues that are included in this update, see the associated Microsoft Knowledge Base article. After you install this update, you may have to restart your system.",
+	"architecture": "X86",
+	"classification": "SecurityUpdates",
+	"supported_products": "Windows7",
+	"supported_languages": "all",
+	"security_bulliten": "n/a",
+	"msrc_severity": "Critical",
+	"kb_article": "4074587",
+	"more_info": "https://support.microsoft.com/help/4074587",
+	"support_url": "https://support.microsoft.com/help/4074587",
+	"reboot_behavior": "Can request restart",
+	"user_input": "No",
+	"connectivity": "No",
+	"uninstall_notes": "ThissoftwareupdatecanberemovedbyselectingViewinstalledupdatesintheProgramsandFeaturesControlPanel.",
+	"uninstall_steps": "n/a",
+	"last_modified": "2/13/2018",
+	"supersededby": [],
+	"supersedes": []
+}

--- a/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/4074xxx/4074587.json
+++ b/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/4074xxx/4074587.json
@@ -1,0 +1,44 @@
+{
+	"kb_id": "4074587",
+	"url": "https://support.microsoft.com/help/4074587",
+	"updates": [
+		{
+			"update_id": "ae42a70d-ccc6-4ef7-9590-db44662ef5c0",
+			"title": "2018-02 Security Only Quality Update for Windows 7 for x86-based Systems (KB4074587)",
+			"description": "A security issue has been identified in a Microsoft software product that could affect your system. You can help protect your system by installing this update from Microsoft. For a complete listing of the issues that are included in this update, see the associated Microsoft Knowledge Base article. After you install this update, you may have to restart your system.",
+			"msrc_severity": "Critical",
+			"architecture": "X86",
+			"classification": "SecurityUpdates",
+			"products": [
+				"Windows7"
+			],
+			"languages": [
+				"all"
+			],
+			"more_info_url": "https://support.microsoft.com/help/4074587",
+			"support_url": "https://support.microsoft.com/help/4074587",
+			"superseded_by": [
+				{
+					"kb_id": "4074598",
+					"update_id": "651e95ab-6e7c-4ea6-9cd2-3cbabd9b76f0"
+				},
+				{
+					"kb_id": "4075211",
+					"update_id": "9da71c39-5043-4f64-b9d6-71d569d0544d"
+				}
+			],
+			"reboot_behavior": "Can request restart",
+			"user_input": "No",
+			"connectivity": "No",
+			"uninstall_notes": "ThissoftwareupdatecanberemovedbyselectingViewinstalledupdatesintheProgramsandFeaturesControlPanel.",
+			"last_modified": "2018-02-13T00:00:00Z",
+			"catalog_url": "https://www.catalog.update.microsoft.com/ScopedViewInline.aspx?updateid=ae42a70d-ccc6-4ef7-9590-db44662ef5c0"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-msuc",
+		"raws": [
+			"happy/ae42a70d-ccc6-4ef7-9590-db44662ef5c0.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/4074xxx/4074598.json
+++ b/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/4074xxx/4074598.json
@@ -1,0 +1,46 @@
+{
+	"kb_id": "4074598",
+	"url": "https://support.microsoft.com/help/4074598",
+	"updates": [
+		{
+			"update_id": "651e95ab-6e7c-4ea6-9cd2-3cbabd9b76f0",
+			"title": "2018-02 Security Monthly Quality Rollup for Windows 7 for x86-based Systems (KB4074598)",
+			"description": "A security issue has been identified in a Microsoft software product that could affect your system. You can help protect your system by installing this update from Microsoft. For a complete listing of the issues that are included in this update, see the associated Microsoft Knowledge Base article. After you install this update, you may have to restart your system.",
+			"msrc_severity": "Critical",
+			"architecture": "X86",
+			"classification": "SecurityUpdates",
+			"products": [
+				"Windows7"
+			],
+			"languages": [
+				"all"
+			],
+			"more_info_url": "https://support.microsoft.com/help/4074598",
+			"support_url": "https://support.microsoft.com/help/4074598",
+			"superseded_by": [
+				{
+					"kb_id": "4075211",
+					"update_id": "9da71c39-5043-4f64-b9d6-71d569d0544d"
+				}
+			],
+			"supersedes": [
+				{
+					"kb_id": "4074587",
+					"update_id": "ae42a70d-ccc6-4ef7-9590-db44662ef5c0"
+				}
+			],
+			"reboot_behavior": "Can request restart",
+			"user_input": "No",
+			"connectivity": "No",
+			"uninstall_notes": "ThissoftwareupdatecanberemovedbyselectingViewinstalledupdatesintheProgramsandFeaturesControlPanel.",
+			"last_modified": "2018-02-13T00:00:00Z",
+			"catalog_url": "https://www.catalog.update.microsoft.com/ScopedViewInline.aspx?updateid=651e95ab-6e7c-4ea6-9cd2-3cbabd9b76f0"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-msuc",
+		"raws": [
+			"happy/651e95ab-6e7c-4ea6-9cd2-3cbabd9b76f0.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/4075xxx/4075211.json
+++ b/pkg/extract/microsoft/msuc/testdata/golden/microsoftkb/4075xxx/4075211.json
@@ -1,0 +1,43 @@
+{
+	"kb_id": "4075211",
+	"url": "https://support.microsoft.com/help/4075211",
+	"updates": [
+		{
+			"update_id": "9da71c39-5043-4f64-b9d6-71d569d0544d",
+			"title": "2018-02 Preview of Monthly Quality Rollup for Windows 7 for x86-based Systems (KB4075211)",
+			"description": "Install this update to resolve issues in Windows. For a complete listing of the issues that are included in this update, see the associated Microsoft Knowledge Base article for more information. After you install this item, you may have to restart your computer.",
+			"architecture": "X86",
+			"classification": "Updates",
+			"products": [
+				"Windows7"
+			],
+			"languages": [
+				"all"
+			],
+			"more_info_url": "https://support.microsoft.com/help/4075211",
+			"support_url": "https://support.microsoft.com/help/4075211",
+			"supersedes": [
+				{
+					"kb_id": "4074587",
+					"update_id": "ae42a70d-ccc6-4ef7-9590-db44662ef5c0"
+				},
+				{
+					"kb_id": "4074598",
+					"update_id": "651e95ab-6e7c-4ea6-9cd2-3cbabd9b76f0"
+				}
+			],
+			"reboot_behavior": "Can request restart",
+			"user_input": "No",
+			"connectivity": "No",
+			"uninstall_notes": "ThissoftwareupdatecanberemovedbyselectingViewinstalledupdatesintheProgramsandFeaturesControlPanel.",
+			"last_modified": "2018-02-22T00:00:00Z",
+			"catalog_url": "https://www.catalog.update.microsoft.com/ScopedViewInline.aspx?updateid=9da71c39-5043-4f64-b9d6-71d569d0544d"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-msuc",
+		"raws": [
+			"happy/9da71c39-5043-4f64-b9d6-71d569d0544d.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/util/util_test.go
+++ b/pkg/extract/microsoft/util/util_test.go
@@ -1,10 +1,10 @@
 package util
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
 	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
@@ -217,17 +217,20 @@ func TestNormalizeProductName(t *testing.T) {
 }
 
 func TestDeriveSupersedes(t *testing.T) {
+	type args struct {
+		kbs []microsoftkbTypes.KB
+	}
 	tests := []struct {
 		name string
-		kbs  []microsoftkbTypes.KB
+		args args
 		want []microsoftkbTypes.KB
 	}{
 		{
 			name: "basic KB-level: B superseded by A → A supersedes B",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
 				{KBID: "1"},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{KBID: "1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2"}}},
 				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
@@ -235,11 +238,11 @@ func TestDeriveSupersedes(t *testing.T) {
 		},
 		{
 			name: "chain: C→B→A → B.Supersedes=[C], A.Supersedes=[B]",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{KBID: "3", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "2"}}},
 				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
 				{KBID: "1"},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{KBID: "1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2"}}},
 				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}, Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "3"}}},
@@ -248,11 +251,11 @@ func TestDeriveSupersedes(t *testing.T) {
 		},
 		{
 			name: "fan-in: B→A and C→A → A.Supersedes=[B,C]",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
 				{KBID: "3", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
 				{KBID: "1"},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{KBID: "1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2"}, {KBID: "3"}}},
 				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
@@ -261,37 +264,37 @@ func TestDeriveSupersedes(t *testing.T) {
 		},
 		{
 			name: "superseding KB absent: no Supersedes added, no panic",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "99"}}},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "99"}}},
 			},
 		},
 		{
 			name: "self-supersession ignored",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{KBID: "1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{KBID: "1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}}},
 			},
 		},
 		{
 			name: "empty SupersededBy KBID ignored",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{KBID: "1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: ""}}},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{KBID: "1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: ""}}},
 			},
 		},
 		{
 			name: "KB-level deduplication: duplicate SupersededBy entry adds Supersedes only once",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}, {KBID: "1"}}},
 				{KBID: "1"},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{KBID: "1", Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "2"}}},
 				{KBID: "2", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1"}, {KBID: "1"}}},
@@ -299,7 +302,7 @@ func TestDeriveSupersedes(t *testing.T) {
 		},
 		{
 			name: "basic update-level: KB2/U2 superseded by KB1/U1 → KB1/U1.Supersedes=[KB2/U2]",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{
 					KBID: "2",
 					Updates: []microsoftkbUpdateTypes.Update{
@@ -310,7 +313,7 @@ func TestDeriveSupersedes(t *testing.T) {
 					KBID:    "1",
 					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
 				},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{
 					KBID: "1",
@@ -328,14 +331,14 @@ func TestDeriveSupersedes(t *testing.T) {
 		},
 		{
 			name: "update self-supersession ignored",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{
 					KBID: "1",
 					Updates: []microsoftkbUpdateTypes.Update{
 						{UpdateID: "U1", SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "1", UpdateID: "U2"}}},
 					},
 				},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{
 					KBID: "1",
@@ -347,7 +350,7 @@ func TestDeriveSupersedes(t *testing.T) {
 		},
 		{
 			name: "empty UpdateID in SupersededBy skips update-level",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{
 					KBID: "2",
 					Updates: []microsoftkbUpdateTypes.Update{
@@ -358,7 +361,7 @@ func TestDeriveSupersedes(t *testing.T) {
 					KBID:    "1",
 					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
 				},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{
 					KBID:    "1",
@@ -374,7 +377,7 @@ func TestDeriveSupersedes(t *testing.T) {
 		},
 		{
 			name: "update-level deduplication: duplicate SupersededBy entry adds Supersedes only once",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{
 					KBID: "2",
 					Updates: []microsoftkbUpdateTypes.Update{
@@ -388,7 +391,7 @@ func TestDeriveSupersedes(t *testing.T) {
 					KBID:    "1",
 					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
 				},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{
 					KBID: "1",
@@ -409,7 +412,7 @@ func TestDeriveSupersedes(t *testing.T) {
 		},
 		{
 			name: "update-level cross-KB: same UpdateID in two KBs only the matching KBID gets Supersedes",
-			kbs: []microsoftkbTypes.KB{
+			args: args{kbs: []microsoftkbTypes.KB{
 				{
 					KBID: "2",
 					Updates: []microsoftkbUpdateTypes.Update{
@@ -426,7 +429,7 @@ func TestDeriveSupersedes(t *testing.T) {
 					KBID:    "3",
 					Updates: []microsoftkbUpdateTypes.Update{{UpdateID: "U1"}},
 				},
-			},
+			}},
 			want: []microsoftkbTypes.KB{
 				{
 					KBID: "1",
@@ -450,16 +453,17 @@ func TestDeriveSupersedes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			DeriveSupersedes(tt.kbs)
-			for i := range tt.kbs {
-				tt.kbs[i].Sort()
-			}
-			slices.SortFunc(tt.kbs, microsoftkbTypes.Compare)
-			for i := range tt.want {
-				tt.want[i].Sort()
-			}
-			slices.SortFunc(tt.want, microsoftkbTypes.Compare)
-			if diff := cmp.Diff(tt.want, tt.kbs); diff != "" {
+			DeriveSupersedes(tt.args.kbs)
+			if diff := cmp.Diff(tt.want, tt.args.kbs,
+				cmpopts.SortSlices(func(x, y microsoftkbTypes.KB) bool { return microsoftkbTypes.Compare(x, y) < 0 }),
+				cmpopts.SortSlices(func(x, y microsoftkbUpdateTypes.Update) bool { return microsoftkbUpdateTypes.Compare(x, y) < 0 }),
+				cmpopts.SortSlices(func(x, y microsoftkbSupersededByTypes.SupersededBy) bool {
+					return microsoftkbSupersededByTypes.Compare(x, y) < 0
+				}),
+				cmpopts.SortSlices(func(x, y microsoftkbSupersedesTypes.Supersedes) bool {
+					return microsoftkbSupersedesTypes.Compare(x, y) < 0
+				}),
+			); diff != "" {
 				t.Errorf("DeriveSupersedes() mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Microsoft releases parallel-track Windows updates per product per month
(Security Only Quality Update / Security Monthly Quality Rollup / Preview
of Monthly Quality Rollup; Cumulative Update / Cumulative Update Preview).
The broader-track update is functionally a superset of the narrower one,
but Microsoft's per-Update SupersededBy graph in MSUC does NOT consistently
record this cross-track equivalence. Across 5,539 raw MSUC entries:

  Security Only          → Security Monthly        : 0 / 1001  (0.0%)
  Security Only          → Preview of Monthly      : 0 /  298  (0.0%)
  Security Monthly       → Preview of Monthly      : 0 /  306  (0.0%)
  Cumulative Update      → Cumulative Update Preview: 387 / 422 (91.7%)

The Win7 / Server 2008 R2 / Server 2012 SO/SM/PV trio is essentially
unrecorded, leaving 1,605 cross-track edges missing. As a result, when a
host has applied e.g. the Preview of Monthly Quality Rollup, walking the
SupersededBy/Supersedes graph never reaches the corresponding Security
Only KBs, leaving them flagged as missing fixes.

Add deriveCrossTrackSupersedes in the MSUC extractor and invoke it after
DeriveSupersedes. The function parses each Update.Title with a regex
capturing year, month, track, and product name (including architecture
suffix), groups by (year, month, normalized product), and adds
Update-level Supersedes / SupersededBy edges for the inclusion
relationships:

  Preview ⊇ SecurityMonthly ⊇ SecurityOnly
  CumulativePreview ⊇ Cumulative

Only Update-level edges are added; KB-level supersession is left to native
KB-level signals (CVRF, Bulletin) so cross-arch / partial supersession is
not lossy-aggregated to the KB level. Detection still discovers
cross-track equivalence by walking the Update-level edges. Within a single
(year, month, product + architecture, track) tuple there is at most one
Update, so cross-track Update IDs map 1:1.

This is MSUC-specific: CVRF and Bulletin produce KBs without per-Update
Title fields, and WSUSSCN2's relevant Server 2008 R2 / Win7 / Server 2012
entries use the older 'Month, YYYY' title format which the modern
'YYYY-MM …' regex does not match.

This is dynamic — every newly extracted month's KBs are automatically
covered without requiring a static lookup table or periodic regeneration.

The MSUC extractor's golden fixture is extended with the 2018-02 Win7 x86
SO/SM/PV trio (KB4074587 / KB4074598 / KB4075211) where Microsoft records
zero cross-track supersession natively, so the resulting Update-level
edges in the golden are entirely supplied by deriveCrossTrackSupersedes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

