### PR TITLE
fix(extract/microsoft/cvrf): inject Edge Stable for CVE-2023-21796

### DIFF
--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -478,12 +478,20 @@ func buildVulnerabilities(v cvrf.Vulnerability, c cvrf.CVRF, products map[string
 	// but documented elsewhere as affected. Build Content from CVE-level data
 	// only — per-product fields (severity, impact, mitigations, workarounds)
 	// are unknown for the missing product since Microsoft did not publish them.
-	// appendOrMergeSegment handles both cases:
-	//   - same Content as an existing vuln → merges segment into that record
-	//   - different Content (existing vulns carry per-product severity), or
-	//     len(vulns) == 0 → appends a fresh vuln entry
+	// Skip when an existing vuln already carries a segment for the same tag —
+	// that means CVRF now lists the product (e.g. after re-publication) and we
+	// must defer to its data to avoid emitting a duplicate vuln entry.
+	// appendOrMergeSegment otherwise:
+	//   - merges into an existing vuln with matching Content (rare), or
+	//   - appends a fresh vuln entry — including the len(vulns) == 0 case.
 	for _, mp := range missingProductOverrides[v.CVE] {
 		if isCBLMarinerOrAzureLinux(mp.Product) {
+			continue
+		}
+		tag := segmentTypes.DetectionTag(mp.Product)
+		if slices.ContainsFunc(vulns, func(it vulnerabilityTypes.Vulnerability) bool {
+			return slices.ContainsFunc(it.Segments, func(s segmentTypes.Segment) bool { return s.Tag == tag })
+		}) {
 			continue
 		}
 		vc := vulnerabilityContentTypes.Content{
@@ -498,7 +506,7 @@ func buildVulnerabilities(v cvrf.Vulnerability, c cvrf.CVRF, products map[string
 		vulns = appendOrMergeSegment(vulns,
 			vulnerabilityTypes.Vulnerability{
 				Content:  vc,
-				Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft, Tag: segmentTypes.DetectionTag(mp.Product)}},
+				Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft, Tag: tag}},
 			},
 			func(item vulnerabilityTypes.Vulnerability) int {
 				return vulnerabilityContentTypes.Compare(item.Content, vc)
@@ -576,8 +584,16 @@ func buildAdvisories(v cvrf.Vulnerability, c cvrf.CVRF, products map[string]stri
 	// but documented elsewhere as affected. Build Content from CVE-level data
 	// only — per-product fields (severity, impact, mitigations, workarounds)
 	// are unknown for the missing product since Microsoft did not publish them.
+	// Skip when an existing advisory already carries a segment for the same
+	// tag — CVRF now lists the product and we defer to its data.
 	for _, mp := range missingProductOverrides[v.CVE] {
 		if isCBLMarinerOrAzureLinux(mp.Product) {
+			continue
+		}
+		tag := segmentTypes.DetectionTag(mp.Product)
+		if slices.ContainsFunc(advisories, func(it advisoryTypes.Advisory) bool {
+			return slices.ContainsFunc(it.Segments, func(s segmentTypes.Segment) bool { return s.Tag == tag })
+		}) {
 			continue
 		}
 		ac := advisoryContentTypes.Content{
@@ -592,7 +608,7 @@ func buildAdvisories(v cvrf.Vulnerability, c cvrf.CVRF, products map[string]stri
 		advisories = appendOrMergeSegment(advisories,
 			advisoryTypes.Advisory{
 				Content:  ac,
-				Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft, Tag: segmentTypes.DetectionTag(mp.Product)}},
+				Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft, Tag: tag}},
 			},
 			func(item advisoryTypes.Advisory) int {
 				return advisoryContentTypes.Compare(item.Content, ac)
@@ -790,11 +806,16 @@ func buildDetections(v cvrf.Vulnerability, products map[string]string) (map[ecos
 
 	// Apply missing-product overrides: products Microsoft omitted from CVRF
 	// for this advisory but documented elsewhere as affected. Synthesise a
-	// FixedBuild criterion so detection still fires. appendConditions
-	// deduplicates against equal criterions, so this is idempotent if
-	// Microsoft later re-publishes the CVRF with the product included.
+	// FixedBuild criterion so detection still fires. Skip when an existing
+	// condition already targets the same tag — that means CVRF now lists the
+	// product (e.g. after re-publication) and we must defer to its data to
+	// avoid emitting a stale FixedBuild side-by-side with the canonical one.
 	for _, mp := range missingProductOverrides[v.CVE] {
 		tag := segmentTypes.DetectionTag(mp.Product)
+		if slices.ContainsFunc(conditionsByEcosystem[ecosystemTypes.EcosystemTypeMicrosoft],
+			func(c conditionTypes.Condition) bool { return c.Tag == tag }) {
+			continue
+		}
 		criterionProductName := microsoftutil.NormalizeProductName(mp.Product)
 		fixedBuildCriterion, err := buildFixedBuildCriterion(v.CVE, criterionProductName, mp.FixedBuild)
 		if err != nil {

--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -475,25 +475,36 @@ func buildVulnerabilities(v cvrf.Vulnerability, c cvrf.CVRF, products map[string
 	}
 
 	// Apply missing-product overrides: products Microsoft omitted from CVRF
-	// but documented elsewhere as affected. Reuse the content of an existing
-	// vuln (same CVE metadata) so segments accumulate on a single record.
-	if len(vulns) > 0 {
-		for _, mp := range missingProductOverrides[v.CVE] {
-			if isCBLMarinerOrAzureLinux(mp.Product) {
-				continue
-			}
-			vc := vulns[0].Content
-			vulns = appendOrMergeSegment(vulns,
-				vulnerabilityTypes.Vulnerability{
-					Content:  vc,
-					Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft, Tag: segmentTypes.DetectionTag(mp.Product)}},
-				},
-				func(item vulnerabilityTypes.Vulnerability) int {
-					return vulnerabilityContentTypes.Compare(item.Content, vc)
-				},
-				func(item *vulnerabilityTypes.Vulnerability) *[]segmentTypes.Segment { return &item.Segments },
-			)
+	// but documented elsewhere as affected. Build Content from CVE-level data
+	// only — per-product fields (severity, impact, mitigations, workarounds)
+	// are unknown for the missing product since Microsoft did not publish them.
+	// appendOrMergeSegment handles both cases:
+	//   - same Content as an existing vuln → merges segment into that record
+	//   - different Content (existing vulns carry per-product severity), or
+	//     len(vulns) == 0 → appends a fresh vuln entry
+	for _, mp := range missingProductOverrides[v.CVE] {
+		if isCBLMarinerOrAzureLinux(mp.Product) {
+			continue
 		}
+		vc := vulnerabilityContentTypes.Content{
+			ID:          vulnerabilityContentTypes.VulnerabilityID(v.CVE),
+			Title:       v.Title,
+			Description: description,
+			CWE:         cwes,
+			References:  refs,
+			Published:   published,
+			Modified:    modified,
+		}
+		vulns = appendOrMergeSegment(vulns,
+			vulnerabilityTypes.Vulnerability{
+				Content:  vc,
+				Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft, Tag: segmentTypes.DetectionTag(mp.Product)}},
+			},
+			func(item vulnerabilityTypes.Vulnerability) int {
+				return vulnerabilityContentTypes.Compare(item.Content, vc)
+			},
+			func(item *vulnerabilityTypes.Vulnerability) *[]segmentTypes.Segment { return &item.Segments },
+		)
 	}
 
 	// If all products were CBL-Mariner/Azure Linux, emit product-independent metadata.
@@ -562,25 +573,32 @@ func buildAdvisories(v cvrf.Vulnerability, c cvrf.CVRF, products map[string]stri
 	}
 
 	// Apply missing-product overrides: products Microsoft omitted from CVRF
-	// but documented elsewhere as affected. Reuse the content of an existing
-	// advisory (same CVE metadata) so segments accumulate on a single record.
-	if len(advisories) > 0 {
-		for _, mp := range missingProductOverrides[v.CVE] {
-			if isCBLMarinerOrAzureLinux(mp.Product) {
-				continue
-			}
-			ac := advisories[0].Content
-			advisories = appendOrMergeSegment(advisories,
-				advisoryTypes.Advisory{
-					Content:  ac,
-					Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft, Tag: segmentTypes.DetectionTag(mp.Product)}},
-				},
-				func(item advisoryTypes.Advisory) int {
-					return advisoryContentTypes.Compare(item.Content, ac)
-				},
-				func(item *advisoryTypes.Advisory) *[]segmentTypes.Segment { return &item.Segments },
-			)
+	// but documented elsewhere as affected. Build Content from CVE-level data
+	// only — per-product fields (severity, impact, mitigations, workarounds)
+	// are unknown for the missing product since Microsoft did not publish them.
+	for _, mp := range missingProductOverrides[v.CVE] {
+		if isCBLMarinerOrAzureLinux(mp.Product) {
+			continue
 		}
+		ac := advisoryContentTypes.Content{
+			ID:          advisoryContentTypes.AdvisoryID(v.CVE),
+			Title:       v.Title,
+			Description: description,
+			CWE:         cwes,
+			References:  refs,
+			Published:   published,
+			Modified:    modified,
+		}
+		advisories = appendOrMergeSegment(advisories,
+			advisoryTypes.Advisory{
+				Content:  ac,
+				Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft, Tag: segmentTypes.DetectionTag(mp.Product)}},
+			},
+			func(item advisoryTypes.Advisory) int {
+				return advisoryContentTypes.Compare(item.Content, ac)
+			},
+			func(item *advisoryTypes.Advisory) *[]segmentTypes.Segment { return &item.Segments },
+		)
 	}
 
 	// If all products were CBL-Mariner/Azure Linux, emit product-independent metadata.

--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -474,6 +474,28 @@ func buildVulnerabilities(v cvrf.Vulnerability, c cvrf.CVRF, products map[string
 		)
 	}
 
+	// Apply missing-product overrides: products Microsoft omitted from CVRF
+	// but documented elsewhere as affected. Reuse the content of an existing
+	// vuln (same CVE metadata) so segments accumulate on a single record.
+	if len(vulns) > 0 {
+		for _, mp := range missingProductOverrides[v.CVE] {
+			if isCBLMarinerOrAzureLinux(mp.Product) {
+				continue
+			}
+			vc := vulns[0].Content
+			vulns = appendOrMergeSegment(vulns,
+				vulnerabilityTypes.Vulnerability{
+					Content:  vc,
+					Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft, Tag: segmentTypes.DetectionTag(mp.Product)}},
+				},
+				func(item vulnerabilityTypes.Vulnerability) int {
+					return vulnerabilityContentTypes.Compare(item.Content, vc)
+				},
+				func(item *vulnerabilityTypes.Vulnerability) *[]segmentTypes.Segment { return &item.Segments },
+			)
+		}
+	}
+
 	// If all products were CBL-Mariner/Azure Linux, emit product-independent metadata.
 	if len(vulns) == 0 {
 		vulns = append(vulns, vulnerabilityTypes.Vulnerability{
@@ -537,6 +559,28 @@ func buildAdvisories(v cvrf.Vulnerability, c cvrf.CVRF, products map[string]stri
 			},
 			func(item *advisoryTypes.Advisory) *[]segmentTypes.Segment { return &item.Segments },
 		)
+	}
+
+	// Apply missing-product overrides: products Microsoft omitted from CVRF
+	// but documented elsewhere as affected. Reuse the content of an existing
+	// advisory (same CVE metadata) so segments accumulate on a single record.
+	if len(advisories) > 0 {
+		for _, mp := range missingProductOverrides[v.CVE] {
+			if isCBLMarinerOrAzureLinux(mp.Product) {
+				continue
+			}
+			ac := advisories[0].Content
+			advisories = appendOrMergeSegment(advisories,
+				advisoryTypes.Advisory{
+					Content:  ac,
+					Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft, Tag: segmentTypes.DetectionTag(mp.Product)}},
+				},
+				func(item advisoryTypes.Advisory) int {
+					return advisoryContentTypes.Compare(item.Content, ac)
+				},
+				func(item *advisoryTypes.Advisory) *[]segmentTypes.Segment { return &item.Segments },
+			)
+		}
 	}
 
 	// If all products were CBL-Mariner/Azure Linux, emit product-independent metadata.
@@ -724,6 +768,24 @@ func buildDetections(v cvrf.Vulnerability, products map[string]string) (map[ecos
 				},
 			},
 		}})
+	}
+
+	// Apply missing-product overrides: products Microsoft omitted from CVRF
+	// for this advisory but documented elsewhere as affected. Synthesise a
+	// FixedBuild criterion so detection still fires. appendConditions
+	// deduplicates against equal criterions, so this is idempotent if
+	// Microsoft later re-publishes the CVRF with the product included.
+	for _, mp := range missingProductOverrides[v.CVE] {
+		tag := segmentTypes.DetectionTag(mp.Product)
+		criterionProductName := microsoftutil.NormalizeProductName(mp.Product)
+		fixedBuildCriterion, err := buildFixedBuildCriterion(v.CVE, criterionProductName, mp.FixedBuild)
+		if err != nil {
+			return nil, errors.Wrapf(err, "build fixed build criterion for missing product %q", mp.Product)
+		}
+		if fixedBuildCriterion == nil {
+			continue
+		}
+		appendConditions(conditionsByEcosystem, tag, []criterionTypes.Criterion{*fixedBuildCriterion})
 	}
 
 	return conditionsByEcosystem, nil
@@ -2145,6 +2207,38 @@ var fixedBuildOverrides = map[[3]string]string{
 	{"CVE-2026-25172", "Windows 11 Version 25H2 for ARM64-based Systems", "10.0.26100.7982"}: "10.0.26200.7982",
 	{"CVE-2026-25173", "Windows 11 Version 25H2 for ARM64-based Systems", "10.0.26100.7982"}: "10.0.26200.7982",
 	{"CVE-2026-26111", "Windows 11 Version 25H2 for ARM64-based Systems", "10.0.26100.7982"}: "10.0.26200.7982",
+}
+
+// missingProductOverride describes a product that Microsoft omitted from a
+// CVRF advisory's ProductTree / ProductStatuses / Remediations, but which is
+// documented elsewhere (e.g. Microsoft Edge Release Notes) to be affected and
+// fixed in the given build. The override synthesises a FixedBuild criterion
+// for the missing product so that detection still fires.
+type missingProductOverride struct {
+	Product    string
+	FixedBuild string
+}
+
+// missingProductOverrides maps a CVE ID to a list of products Microsoft failed
+// to list in CVRF for that advisory. Each entry produces a synthesised
+// FixedBuild criterion as if the product had been listed under ProductStatuses
+// with the given fixed version.
+//
+// Use this mechanism only when the affected product is documented elsewhere
+// (e.g. Edge Release Notes) but is omitted from CVRF's ProductTree /
+// ProductStatuses / Remediations entirely. When the product IS listed but the
+// FixedBuild value is wrong/empty, prefer fixedBuildOverrides above.
+var missingProductOverrides = map[string][]missingProductOverride{
+	// CVE-2023-21796 — Microsoft Edge (Chromium-based) Elevation of Privilege Vulnerability
+	// CVRF only lists "Microsoft Edge (Chromium-based) Extended Stable" (PID 12142)
+	// and the Vendor Fix Remediation has no ProductID, so neither the Stable
+	// channel nor any FixedBuild is registered. The same fix is shipped in the
+	// Stable channel: Microsoft Edge Stable Release Notes (Jan 12, 2023) credit
+	// CVE-2023-21796 to 109.0.1518.49.
+	// https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnotes-security
+	"CVE-2023-21796": {
+		{Product: "Microsoft Edge (Chromium-based)", FixedBuild: "109.0.1518.49"},
+	},
 }
 
 func buildKBCriterion(product, kbID string) *criterionTypes.Criterion {

--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -2248,11 +2248,11 @@ type missingProductOverride struct {
 // FixedBuild value is wrong/empty, prefer fixedBuildOverrides above.
 var missingProductOverrides = map[string][]missingProductOverride{
 	// CVE-2023-21796 — Microsoft Edge (Chromium-based) Elevation of Privilege Vulnerability
-	// CVRF only lists "Microsoft Edge (Chromium-based) Extended Stable" (PID 12142)
-	// and the Vendor Fix Remediation has no ProductID, so neither the Stable
-	// channel nor any FixedBuild is registered. The same fix is shipped in the
-	// Stable channel: Microsoft Edge Stable Release Notes (Jan 12, 2023) credit
-	// CVE-2023-21796 to 109.0.1518.49.
+	// CVRF lists only "Microsoft Edge (Chromium-based) Extended Stable" (PID 12142,
+	// fixed at 108.0.1462.83); the Stable channel is absent from ProductTree /
+	// ProductStatuses / Remediations entirely, even though the same fix ships in
+	// the Stable channel per Microsoft Edge Stable Release Notes (Jan 12, 2023),
+	// which credit CVE-2023-21796 to 109.0.1518.49.
 	// https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnotes-security
 	"CVE-2023-21796": {
 		{Product: "Microsoft Edge (Chromium-based)", FixedBuild: "109.0.1518.49"},

--- a/pkg/extract/microsoft/cvrf/testdata/fixtures/2023-Jan/2023/CVE-2023-21796.json
+++ b/pkg/extract/microsoft/cvrf/testdata/fixtures/2023-Jan/2023/CVE-2023-21796.json
@@ -1,0 +1,191 @@
+{
+	"document_title": "January 2023 Security Updates",
+	"document_type": "Security Update",
+	"documentpublisher": {
+		"type": "Vendor",
+		"contact_details": "secure@microsoft.com",
+		"issuing_authority": "The Microsoft Security Response Center (MSRC) identifies, monitors, resolves, and responds to security incidents and Microsoft software security vulnerabilities. For more information, see http://www.microsoft.com/security/msrc."
+	},
+	"documenttracking": {
+		"identification": {
+			"id": "CVE-2023-21796",
+			"alias": "CVE-2023-21796"
+		},
+		"status": "Final",
+		"version": "1.0",
+		"revisionhistory": {
+			"revision": {
+				"number": "70",
+				"date": "2026-05-06T14:37:31",
+				"description": "January 2023 Security Updates"
+			}
+		},
+		"initial_release_date": "2023-01-10T08:00:00",
+		"current_release_date": "2026-05-06T14:37:31"
+	},
+	"documentnotes": {
+		"note": [
+			{
+				"text": "<h2 id=\"updates-this-month\">Updates this Month</h2>\n<p>This release consists of security updates for the following products, features and roles.</p>\n<ul>\n<li>.NET Core</li>\n<li>3D Builder</li>\n<li>Azure Service Fabric Container</li>\n<li>Microsoft Bluetooth Driver</li>\n<li>Microsoft Edge (Chromium-based)</li>\n<li>Microsoft Exchange Server</li>\n<li>Microsoft Graphics Component</li>\n<li>Microsoft Local Security Authority Server (lsasrv)</li>\n<li>Microsoft Message Queuing</li>\n<li>Microsoft Office</li>\n<li>Microsoft Office SharePoint</li>\n<li>Microsoft Office Visio</li>\n<li>Microsoft WDAC OLE DB provider for SQL</li>\n<li>Visual Studio Code</li>\n<li>Windows ALPC</li>\n<li>Windows Ancillary Function Driver for WinSock</li>\n<li>Windows Authentication Methods</li>\n<li>Windows Backup Engine</li>\n<li>Windows Bind Filter Driver</li>\n<li>Windows BitLocker</li>\n<li>Windows Boot Manager</li>\n<li>Windows Credential Manager</li>\n<li>Windows Cryptographic Services</li>\n<li>Windows DWM Core Library</li>\n<li>Windows Error Reporting</li>\n<li>Windows Event Tracing</li>\n<li>Windows IKE Extension</li>\n<li>Windows Installer</li>\n<li>Windows Internet Key Exchange (IKE) Protocol</li>\n<li>Windows iSCSI</li>\n<li>Windows Kernel</li>\n<li>Windows Layer 2 Tunneling Protocol</li>\n<li>Windows LDAP - Lightweight Directory Access Protocol</li>\n<li>Windows Local Security Authority (LSA)</li>\n<li>Windows Local Session Manager (LSM)</li>\n<li>Windows Malicious Software Removal Tool</li>\n<li>Windows Management Instrumentation</li>\n<li>Windows MSCryptDImportKey</li>\n<li>Windows NTLM</li>\n<li>Windows ODBC Driver</li>\n<li>Windows Overlay Filter</li>\n<li>Windows Point-to-Point Tunneling Protocol</li>\n<li>Windows Print Spooler Components</li>\n<li>Windows Remote Access Service L2TP Driver</li>\n<li>Windows RPC API</li>\n<li>Windows Secure Socket Tunneling Protocol (SSTP)</li>\n<li>Windows Smart Card</li>\n<li>Windows Task Scheduler</li>\n<li>Windows Virtual Registry Provider</li>\n<li>Windows Workstation Service</li>\n</ul>\n<p>Please note the following information regarding the security updates:</p>\n<h2 id=\"security-update-guide-blog-posts\">Security Update Guide Blog Posts</h2>\n<table>\n<thead>\n<tr>\n<th>Date</th>\n<th>Blog Post</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>January 6, 2023</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2023/01/06/publishing-cbl-mariner-cves-on-the-security-update-guide-cvrf-api/\">Publishing CBL-Mariner CVEs on the Security Update Guide CVRF API</a></td>\n</tr>\n<tr>\n<td>December 29, 2022</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2022/12/29/security-update-guide-improvement-representing-hotpatch-updates/\">Security Update Guide Improvement – Representing Hotpatch Updates</a></td>\n</tr>\n<tr>\n<td>August 9, 2022</td>\n<td><a href=\"https://aka.ms/SUGNotificationProfile2\">Security Update Guide Notification System News: Create your profile now</a></td>\n</tr>\n<tr>\n<td>January 11, 2022</td>\n<td><a href=\"https://aka.ms/SUGNotificationProfile\">Coming Soon: New Security Update Guide Notification System</a></td>\n</tr>\n<tr>\n<td>February 9, 2021</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2021/02/09/continuing-to-listen-good-news-about-the-security-update-guide-api/\">Continuing to Listen: Good News about the Security Update Guide API</a></td>\n</tr>\n<tr>\n<td>January 13, 2021</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2021/01/13/security-update-guide-supports-cves-assigned-by-industry-partners/\">Security Update Guide Supports CVEs Assigned by Industry Partners</a></td>\n</tr>\n<tr>\n<td>December 8, 2020</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2020/12/08/security-update-guide-lets-keep-the-conversation-going/\">Security Update Guide: Let’s keep the conversation going</a></td>\n</tr>\n<tr>\n<td>November 9, 2020</td>\n<td><a href=\"https://msrc-blog.microsoft.com/2020/11/09/vulnerability-descriptions-in-the-new-version-of-the-security-update-guide/\">Vulnerability Descriptions in the New Version of the Security Update Guide</a></td>\n</tr>\n</tbody>\n</table>\n<h2 id=\"relevant-information\">Relevant Information</h2>\n<ul>\n<li>The new Hotpatching feature is now generally available. Please see <a href=\"https://docs.microsoft.com/en-us/azure/automanage/automanage-hotpatch?WT.mc_id=modinfra-18529-thmaure\">Hotpatching feature for Windows Server Azure Edition virtual machines (VMs)</a> for more information.</li>\n<li>Windows 10 updates are cumulative. The monthly security release includes all security fixes for vulnerabilities that affect Windows 10, in addition to non-security updates. The updates are available via the <a href=\"https://www.catalog.update.microsoft.com/Home.aspx\">Microsoft Update Catalog</a>. For information on lifecycle and support dates for Windows 10 operating systems, please see <a href=\"https://docs.microsoft.com/en-us/lifecycle/faq/windows\">Windows Lifecycle Facts Sheet</a>.</li>\n<li>Microsoft is improving Windows Release Notes. For more information, please see <a href=\"https://techcommunity.microsoft.com/t5/windows-it-pro-blog/what-s-next-for-windows-release-notes/ba-p/1754399\">What's next for Windows release notes</a>.</li>\n<li>A list of the latest servicing stack updates for each operating system can be found in <a href=\"https://msrc.microsoft.com/update-guide/en-us/vulnerability/ADV990001\">ADV990001</a>. This list will be updated whenever a new servicing stack update is released. It is important to install the latest servicing stack update.</li>\n<li>In addition to security changes for the vulnerabilities, updates include defense-in-depth updates to help improve security-related features.</li>\n<li>Customers running Windows 7, Windows Server 2008 R2, or Windows Server 2008 need to purchase the Extended Security Update to continue receiving security updates. See <a href=\"https://support.microsoft.com/en-us/topic/procedure-to-continue-receiving-security-updates-after-extended-support-ends-on-january-14-2020-48c59204-fe67-3f42-84fc-c3c3145ff28e\">4522133</a> for more information.</li>\n</ul>\n<h2 id=\"faqs-mitigations-and-workarounds\">FAQs, Mitigations, and Workarounds</h2>\n<p>The following CVEs have FAQs, Mitigations, or Workarounds. You can see these in more detail from the Vulnerabilities tab by selecting <strong>FAQs</strong>, <strong>Mitigations</strong> and <strong>Workarounds</strong> columns in the <strong>Edit Columns</strong> panel.</p>\n<ul>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21524\">CVE-2023-21524</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21525\">CVE-2023-21525</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21531\">CVE-2023-21531</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21532\">CVE-2023-21532</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21535\">CVE-2023-21535</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21536\">CVE-2023-21536</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21537\">CVE-2023-21537</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21539\">CVE-2023-21539</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21540\">CVE-2023-21540</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21541\">CVE-2023-21541</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21542\">CVE-2023-21542</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21543\">CVE-2023-21543</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21546\">CVE-2023-21546</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21548\">CVE-2023-21548</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21549\">CVE-2023-21549</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21550\">CVE-2023-21550</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21551\">CVE-2023-21551</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21552\">CVE-2023-21552</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21555\">CVE-2023-21555</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21556\">CVE-2023-21556</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21557\">CVE-2023-21557</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21558\">CVE-2023-21558</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21559\">CVE-2023-21559</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21560\">CVE-2023-21560</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21561\">CVE-2023-21561</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21563\">CVE-2023-21563</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21674\">CVE-2023-21674</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21675\">CVE-2023-21675</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21676\">CVE-2023-21676</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21678\">CVE-2023-21678</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21679\">CVE-2023-21679</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21680\">CVE-2023-21680</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21681\">CVE-2023-21681</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21682\">CVE-2023-21682</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21724\">CVE-2023-21724</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21725\">CVE-2023-21725</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21726\">CVE-2023-21726</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21730\">CVE-2023-21730</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21732\">CVE-2023-21732</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21733\">CVE-2023-21733</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21734\">CVE-2023-21734</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21735\">CVE-2023-21735</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21736\">CVE-2023-21736</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21737\">CVE-2023-21737</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21738\">CVE-2023-21738</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21739\">CVE-2023-21739</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21741\">CVE-2023-21741</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21742\">CVE-2023-21742</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21743\">CVE-2023-21743</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21744\">CVE-2023-21744</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21745\">CVE-2023-21745</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21746\">CVE-2023-21746</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21747\">CVE-2023-21747</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21748\">CVE-2023-21748</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21749\">CVE-2023-21749</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21750\">CVE-2023-21750</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21752\">CVE-2023-21752</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21753\">CVE-2023-21753</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21754\">CVE-2023-21754</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21755\">CVE-2023-21755</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21759\">CVE-2023-21759</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21760\">CVE-2023-21760</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21761\">CVE-2023-21761</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21762\">CVE-2023-21762</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21763\">CVE-2023-21763</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21764\">CVE-2023-21764</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21765\">CVE-2023-21765</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21766\">CVE-2023-21766</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21767\">CVE-2023-21767</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21768\">CVE-2023-21768</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21771\">CVE-2023-21771</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21772\">CVE-2023-21772</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21773\">CVE-2023-21773</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21774\">CVE-2023-21774</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21776\">CVE-2023-21776</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21779\">CVE-2023-21779</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21780\">CVE-2023-21780</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21781\">CVE-2023-21781</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21782\">CVE-2023-21782</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21783\">CVE-2023-21783</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21784\">CVE-2023-21784</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21785\">CVE-2023-21785</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21786\">CVE-2023-21786</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21787\">CVE-2023-21787</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21788\">CVE-2023-21788</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21789\">CVE-2023-21789</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21790\">CVE-2023-21790</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21791\">CVE-2023-21791</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21792\">CVE-2023-21792</a></li>\n<li><a href=\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2023-21793\">CVE-2023-21793</a></li>\n</ul>\n<h2 id=\"known-issues\">Known Issues</h2>\n<p>You can see these in more detail from the Deployments tab by selecting <strong>Known Issues</strong> column in the <strong>Edit Columns</strong> panel.</p>\n<p>For more information about Windows Known Issues, please see <a href=\"https://docs.microsoft.com/en-us/windows/release-information/windows-message-center\">Windows message center</a> (links to currently-supported versions of Windows are in the left pane).</p>\n<table>\n<thead>\n<tr>\n<th>KB Article</th>\n<th>Applies To</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022143\">5022143</a></td>\n<td>Microsoft Exchange Server 2016</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022193\">5022193</a></td>\n<td>Microsoft Exchange Server 2019</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022286\">5022286</a></td>\n<td>Windows 10, version 1809, Windows Server 2019</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022303\">5022303</a></td>\n<td>Windows 11 version 22H2</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022338\">5022338</a></td>\n<td>Windows 7, Windows Server 2008 R2 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022339\">5022339</a></td>\n<td>Windows 7, Windows Server 2008 R2 (Security-only update)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022340\">5022340</a></td>\n<td>Windows Server 2008 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022343\">5022343</a></td>\n<td>Windows Server 2012 (Security-only update)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022346\">5022346</a></td>\n<td>Windows 8.1, Windows Server 2012 R2 (Security-only update)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022348\">5022348</a></td>\n<td>Windows Server 2012 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022352\">5022352</a></td>\n<td>Windows 8.1, Windows Server 2012 R2 (Monthly Rollup)</td>\n</tr>\n<tr>\n<td><a href=\"https://support.microsoft.com/help/5022353\">5022353</a></td>\n<td>Windows Server 2008 (Security-only update)</td>\n</tr>\n</tbody>\n</table>\n",
+				"title": "Release Notes",
+				"audience": "Public",
+				"type": "Details",
+				"ordinal": "0"
+			},
+			{
+				"text": "The information provided in the Microsoft Knowledge Base is provided \"as is\" without warranty of any kind. Microsoft disclaims all warranties, either express or implied, including the warranties of merchantability and fitness for a particular purpose. In no event shall Microsoft Corporation or its suppliers be liable for any damages whatsoever including direct, indirect, incidental, consequential, loss of business profits or special damages, even if Microsoft Corporation or its suppliers have been advised of the possibility of such damages. Some states do not allow the exclusion or limitation of liability for consequential or incidental damages so the foregoing limitation may not apply.",
+				"title": "Legal Disclaimer",
+				"audience": "Public",
+				"type": "Legal Disclaimer",
+				"ordinal": "1"
+			}
+		]
+	},
+	"producttree": {
+		"branch": {
+			"type": "Vendor",
+			"name": "Microsoft",
+			"branch": [
+				{
+					"type": "Product Family",
+					"name": "Browser",
+					"fullproductname": [
+						{
+							"text": "Microsoft Edge (Chromium-based) Extended Stable",
+							"productid": "12142"
+						}
+					]
+				}
+			]
+		},
+		"fullproductname": [
+			{
+				"text": "Microsoft Edge (Chromium-based) Extended Stable",
+				"productid": "12142"
+			}
+		]
+	},
+	"vulnerability": [
+		{
+			"ordinal": "139",
+			"title": "Microsoft Edge (Chromium-based) Elevation of Privilege Vulnerability",
+			"notes": {
+				"note": [
+					{
+						"title": "Description",
+						"type": "Description",
+						"ordinal": "0"
+					},
+					{
+						"text": "<p><strong>According to the CVSS metric, the attack complexity is high (AC:H). What does that mean for this vulnerability?</strong></p>\n<p>Successful exploitation of this vulnerability requires an attacker to take additional actions prior to exploitation to prepare the target environment.</p>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "<p><strong>According to the CVSS metric, a successful exploitation could lead to a scope change (S:C). What does this mean for this vulnerability?</strong></p>\n<p>This vulnerability could lead to a browser sandbox escape.</p>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "<p><strong>According to the CVSS metric, user interaction is required (UI:R). What interaction would the user have to do?</strong></p>\n<p>The user would have to click on a specially crafted URL to be compromised by the attacker.</p>\n",
+						"title": "FAQ",
+						"type": "FAQ",
+						"ordinal": "10"
+					},
+					{
+						"text": "Microsoft Edge (Chromium-based)",
+						"title": "Microsoft Edge (Chromium-based)",
+						"type": "Tag",
+						"ordinal": "20"
+					},
+					{
+						"text": "Microsoft",
+						"title": "Microsoft",
+						"type": "CNA",
+						"ordinal": "30"
+					},
+					{
+						"text": "Yes",
+						"title": "Customer Action Required",
+						"type": "Other",
+						"ordinal": "40"
+					}
+				]
+			},
+			"cve": "CVE-2023-21796",
+			"productstatuses": {
+				"status": {
+					"type": "Known Affected",
+					"product_id": [
+						"12142"
+					]
+				}
+			},
+			"threats": {
+				"threat": [
+					{
+						"type": "Impact",
+						"description": "Elevation of Privilege",
+						"product_id": "12142"
+					},
+					{
+						"type": "Severity",
+						"description": "Important",
+						"product_id": "12142"
+					},
+					{
+						"type": "Exploit Status",
+						"description": "Publicly Disclosed:No;Exploited:No;Latest Software Release:Exploitation Less Likely;Older Software Release:Exploitation Less Likely;DOS:N/A"
+					}
+				]
+			},
+			"cvssscoresets": {
+				"scoreset": [
+					{
+						"base_score": "8.3",
+						"temporal_score": "7.2",
+						"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H/E:U/RL:O/RC:C",
+						"product_id": "12142"
+					}
+				]
+			},
+			"remediations": {
+				"remediation": [
+					{
+						"type": "Vendor Fix",
+						"description": "Release Notes",
+						"product_id": [
+							"12142"
+						],
+						"restart_required": "No",
+						"sub_type": "Security Update",
+						"fixed_build": "108.0.1462.83"
+					}
+				]
+			},
+			"acknowledgments": {
+				"acknowledgment": [
+					{
+						"name": "K. Edward with PHi"
+					}
+				]
+			},
+			"revisionhistory": {
+				"revision": [
+					{
+						"number": "1.0",
+						"date": "2023-01-12T08:00:00",
+						"description": "<p>Information published.</p>\n"
+					},
+					{
+						"number": "1.1",
+						"date": "2023-01-17T08:00:00",
+						"description": "<p>Added Extended Stable build information. This is an informational change only.</p>\n"
+					}
+				]
+			}
+		}
+	]
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2023/CVE-2023-21796.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2023/CVE-2023-21796.json
@@ -1,0 +1,133 @@
+{
+	"id": "CVE-2023-21796",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-21796",
+				"title": "Microsoft Edge (Chromium-based) Elevation of Privilege Vulnerability",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secure@microsoft.com",
+						"vendor": "Important"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secure@microsoft.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:H/A:H/E:U/RL:O/RC:C",
+							"base_score": 8.3,
+							"base_severity": "HIGH",
+							"temporal_score": 7.2,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.3,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "secure@microsoft.com",
+						"url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-21796"
+					}
+				],
+				"published": "2023-01-10T08:00:00Z",
+				"modified": "2026-05-06T14:37:31Z",
+				"optional": {
+					"impact": "Elevation of Privilege"
+				}
+			},
+			"segments": [
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft Edge (Chromium-based)"
+				},
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft Edge (Chromium-based) Extended Stable"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "microsoft",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Microsoft Edge (Chromium-based)"
+										}
+									},
+									"affected": {
+										"type": "microsoft-edge",
+										"range": [
+											{
+												"lt": "109.0.1518.49"
+											}
+										],
+										"fixed": [
+											"109.0.1518.49"
+										]
+									}
+								}
+							}
+						]
+					},
+					"tag": "Microsoft Edge (Chromium-based)"
+				},
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Microsoft Edge (Chromium-based) Extended Stable"
+										}
+									},
+									"affected": {
+										"type": "microsoft-edge",
+										"range": [
+											{
+												"lt": "108.0.1462.83"
+											}
+										],
+										"fixed": [
+											"108.0.1462.83"
+										]
+									}
+								}
+							}
+						]
+					},
+					"tag": "Microsoft Edge (Chromium-based) Extended Stable"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "microsoft-cvrf",
+		"raws": [
+			"fixtures/2023-Jan/2023/CVE-2023-21796.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2023/CVE-2023-21796.json
+++ b/pkg/extract/microsoft/cvrf/testdata/golden/data/CVE/2023/CVE-2023-21796.json
@@ -5,6 +5,26 @@
 			"content": {
 				"id": "CVE-2023-21796",
 				"title": "Microsoft Edge (Chromium-based) Elevation of Privilege Vulnerability",
+				"references": [
+					{
+						"source": "secure@microsoft.com",
+						"url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-21796"
+					}
+				],
+				"published": "2023-01-10T08:00:00Z",
+				"modified": "2026-05-06T14:37:31Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "microsoft",
+					"tag": "Microsoft Edge (Chromium-based)"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-21796",
+				"title": "Microsoft Edge (Chromium-based) Elevation of Privilege Vulnerability",
 				"severity": [
 					{
 						"type": "vendor",
@@ -38,10 +58,6 @@
 				}
 			},
 			"segments": [
-				{
-					"ecosystem": "microsoft",
-					"tag": "Microsoft Edge (Chromium-based)"
-				},
 				{
 					"ecosystem": "microsoft",
 					"tag": "Microsoft Edge (Chromium-based) Extended Stable"


### PR DESCRIPTION
## Summary

- Microsoft's CVRF for **CVE-2023-21796** lists only `Microsoft Edge (Chromium-based) Extended Stable` (PID 12142) in ProductTree / ProductStatuses / Vendor Fix Remediations. The Stable channel is omitted entirely, even though the same fix ships in Stable per the [Microsoft Edge Stable Release Notes (Jan 12, 2023)](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnotes-security), which credit CVE-2023-21796 to version `109.0.1518.49`.
- Without the Stable channel entry, vuls cannot detect this CVE on hosts running the regular Stable channel — the far more common deployment.

## Approach

Add a new `missingProductOverrides` mechanism that parallels the existing `fixedBuildOverrides`:

- `fixedBuildOverrides` corrects the FixedBuild value when a product **is listed** in CVRF but the version is wrong/empty.
- `missingProductOverrides` synthesises a `FixedBuild` criterion (and a matching segment on the Vulnerability / Advisory record) when a product is **omitted from CVRF entirely**.

The override is applied at the end of `buildDetections`, `buildVulnerabilities`, and `buildAdvisories`. Because `appendConditions` and `appendOrMergeSegment` deduplicate against equal criterions / segments, the override is idempotent if Microsoft later re-publishes the CVRF with the missing product included.

Populated with one entry today:

```go
"CVE-2023-21796": {
    {Product: "Microsoft Edge (Chromium-based)", FixedBuild: "109.0.1518.49"},
},
```

## Output diff for CVE-2023-21796

Before: only the Extended Stable channel is registered.

After:
- `vulnerabilities[0].segments` includes both `Microsoft Edge (Chromium-based)` and `Microsoft Edge (Chromium-based) Extended Stable`.
- `detections[0].conditions` carries a tag for each, with `< 109.0.1518.49` (Stable) and `< 108.0.1462.83` (Extended Stable).

## Test plan

- [x] `go test ./pkg/extract/microsoft/cvrf/...` passes (TestExtract diffs golden).
- [x] `go test ./pkg/extract/microsoft/...` passes.
- [x] `go vet ./...` clean.
- [x] Added regression fixture: `testdata/fixtures/2023-Jan/2023/CVE-2023-21796.json` (raw CVRF as-published).
- [x] Added golden: `testdata/golden/data/CVE/2023/CVE-2023-21796.json` (expected post-extraction shape with both channels).
- [x] Verified existing fixtures (e.g. CVE-2023-29326) still match their goldens — no regressions.