### PR TITLE
feat(extract/microsoft/msuc): match older Month, YYYY monthly titles

### DIFF
--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -402,8 +402,13 @@ var monthlyTrackTitleRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (Security Only Qu
 
 // monthlyTrackTitleOldRE matches the older title format used by 2016 - mid 2017
 // monthly updates ("Month, YYYY ...") for Win7 / Server 2008 R2 / Server 2012 /
-// Server 2012 R2 / Win 8.1 era KBs. Same capture groups as monthlyTrackTitleRE
-// but month is given as a name and appears after the year.
+// Server 2012 R2 / Win 8.1 era KBs. The month appears as an English name
+// BEFORE the year (e.g. "April, 2017 ..."), so the capture order differs from
+// monthlyTrackTitleRE:
+//   m[1] = month name (e.g. "April")     -- vs. m[1] = year ("2017") in modern
+//   m[2] = year       (e.g. "2017")      -- vs. m[2] = month ("04") in modern
+//   m[3] = track                         -- same as modern
+//   m[4] = product                       -- same as modern
 var monthlyTrackTitleOldRE = regexp.MustCompile(`^(January|February|March|April|May|June|July|August|September|October|November|December), (\d{4}) (Security Only Quality Update|Security Monthly Quality Rollup|Preview of Monthly Quality Rollup|Cumulative Update Preview|Cumulative Update) for (.+?) \(KB\d+\)$`)
 
 // monthlyTrackTitleParsers lists the title formats recognised by

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -389,8 +389,8 @@ func normalizeNA(s string) string {
 	return s
 }
 
-// monthlyTrackTitleRE matches the title of a monthly Quality Update / Rollup,
-// capturing year, month, track, and product name.
+// monthlyTrackTitleRE matches the modern title of a monthly Quality Update /
+// Rollup ("YYYY-MM ..."), capturing year, month, track, and product name.
 //
 // Microsoft releases parallel-track updates per product per month:
 //   - "Security Only Quality Update"        (narrowest)
@@ -399,6 +399,21 @@ func normalizeNA(s string) string {
 //   - "Cumulative Update"                   (Win10/11/Server 2016+)
 //   - "Cumulative Update Preview"           (Win10/11/Server 2016+ preview track)
 var monthlyTrackTitleRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (Security Only Quality Update|Security Monthly Quality Rollup|Preview of Monthly Quality Rollup|Cumulative Update Preview|Cumulative Update) for (.+?) \(KB\d+\)$`)
+
+// monthlyTrackTitleOldRE matches the older title format used by 2016 - mid 2017
+// monthly updates ("Month, YYYY ...") for Win7 / Server 2008 R2 / Server 2012 /
+// Server 2012 R2 / Win 8.1 era KBs. Same capture groups as monthlyTrackTitleRE
+// but month is given as a name and appears after the year.
+var monthlyTrackTitleOldRE = regexp.MustCompile(`^(January|February|March|April|May|June|July|August|September|October|November|December), (\d{4}) (Security Only Quality Update|Security Monthly Quality Rollup|Preview of Monthly Quality Rollup|Cumulative Update Preview|Cumulative Update) for (.+?) \(KB\d+\)$`)
+
+// oldMonthNumbers maps month names used by monthlyTrackTitleOldRE to the
+// two-digit numeric form used by monthlyTrackTitleRE so both regex variants
+// produce comparable (year, month) group keys.
+var oldMonthNumbers = map[string]string{
+	"January": "01", "February": "02", "March": "03", "April": "04",
+	"May": "05", "June": "06", "July": "07", "August": "08",
+	"September": "09", "October": "10", "November": "11", "December": "12",
+}
 
 // deriveCrossTrackSupersedes augments Update-level Supersedes / SupersededBy
 // with cross-track equivalence for monthly Quality Rollups within the same
@@ -425,10 +440,11 @@ var monthlyTrackTitleRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (Security Only Qu
 // product+architecture, track) tuple has at most one Update.
 //
 // This is MSUC-specific: other Microsoft data sources either lack per-Update
-// titles (CVRF, Bulletin) or do not expose modern monthly-track titles in the
-// `YYYY-MM ...` form expected by monthlyTrackTitleRE (WSUSSCN2 uses the older
-// "Month, YYYY" format for the relevant EOL products and omits Cumulative
-// Update Preview entries entirely).
+// titles (CVRF, Bulletin) or only expose titles via fields the MSUC-flavoured
+// regexes here are not tuned for. Two title formats are recognised here:
+//   - modern "YYYY-MM ..." via monthlyTrackTitleRE
+//   - older "Month, YYYY ..." via monthlyTrackTitleOldRE (2016 - mid 2017
+//     Win7 / Server 2008 R2 / Server 2012 / Server 2012 R2 / Win 8.1)
 func deriveCrossTrackSupersedes(kbs []microsoftkbTypes.KB) {
 	type track int
 	const (
@@ -463,15 +479,19 @@ func deriveCrossTrackSupersedes(kbs []microsoftkbTypes.KB) {
 
 	for _, kb := range kbs {
 		for _, u := range kb.Updates {
-			m := monthlyTrackTitleRE.FindStringSubmatch(u.Title)
-			if m == nil {
+			var year, month, trackStr, product string
+			if m := monthlyTrackTitleRE.FindStringSubmatch(u.Title); m != nil {
+				year, month, trackStr, product = m[1], m[2], m[3], m[4]
+			} else if m := monthlyTrackTitleOldRE.FindStringSubmatch(u.Title); m != nil {
+				year, month, trackStr, product = m[2], oldMonthNumbers[m[1]], m[3], m[4]
+			} else {
 				continue
 			}
-			tr := classify(m[3])
+			tr := classify(trackStr)
 			if tr == trackUnknown {
 				continue
 			}
-			g := group{year: m[1], month: m[2], product: microsoftutil.NormalizeProductName(m[4])}
+			g := group{year: year, month: month, product: microsoftutil.NormalizeProductName(product)}
 			if grouped[g] == nil {
 				grouped[g] = make(map[track][]member)
 			}

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -412,7 +412,7 @@ var monthlyTrackTitleRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (Security Only Qu
 //
 // Whitespace is intentionally strict (a single ASCII space at every
 // boundary). In a snapshot of the production raw MSUC corpus taken
-// 2026-05 (282 old-format titles), every title used exactly one space
+// 2026-05 (150 old-format titles), every title used exactly one space
 // at each separator, with zero observed variants (no double-space /
 // no missing space / no tab). A title that ever fails this strict
 // shape will be silently skipped by parseMonthlyTrackTitle and

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -411,11 +411,12 @@ var monthlyTrackTitleRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (Security Only Qu
 //   m[4] = product                       -- same as modern
 //
 // Whitespace is intentionally strict (a single ASCII space at every
-// boundary). All 282 old-format titles in the production raw MSUC corpus
-// use exactly one space at each separator, with zero observed variants
-// (no double-space / no missing space / no tab). A title that ever fails
-// this strict shape will be silently skipped by parseMonthlyTrackTitle
-// and surface as a visible drop in synthesised cross-track edges, at
+// boundary). In a snapshot of the production raw MSUC corpus taken
+// 2026-05 (282 old-format titles), every title used exactly one space
+// at each separator, with zero observed variants (no double-space /
+// no missing space / no tab). A title that ever fails this strict
+// shape will be silently skipped by parseMonthlyTrackTitle and
+// surface as a visible drop in synthesised cross-track edges, at
 // which point the regex can be loosened with empirical justification.
 var monthlyTrackTitleOldRE = regexp.MustCompile(`^(January|February|March|April|May|June|July|August|September|October|November|December), (\d{4}) (Security Only Quality Update|Security Monthly Quality Rollup|Preview of Monthly Quality Rollup|Cumulative Update Preview|Cumulative Update) for (.+?) \(KB\d+\)$`)
 

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -409,6 +409,14 @@ var monthlyTrackTitleRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (Security Only Qu
 //   m[2] = year       (e.g. "2017")      -- vs. m[2] = month ("04") in modern
 //   m[3] = track                         -- same as modern
 //   m[4] = product                       -- same as modern
+//
+// Whitespace is intentionally strict (a single ASCII space at every
+// boundary). All 282 old-format titles in the production raw MSUC corpus
+// use exactly one space at each separator, with zero observed variants
+// (no double-space / no missing space / no tab). A title that ever fails
+// this strict shape will be silently skipped by parseMonthlyTrackTitle
+// and surface as a visible drop in synthesised cross-track edges, at
+// which point the regex can be loosened with empirical justification.
 var monthlyTrackTitleOldRE = regexp.MustCompile(`^(January|February|March|April|May|June|July|August|September|October|November|December), (\d{4}) (Security Only Quality Update|Security Monthly Quality Rollup|Preview of Monthly Quality Rollup|Cumulative Update Preview|Cumulative Update) for (.+?) \(KB\d+\)$`)
 
 // monthlyTrackTitleParsers lists the title formats recognised by

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -459,13 +459,13 @@ func parseMonthlyTrackTitle(title string) (year, month, trackStr, product string
 		if m == nil {
 			continue
 		}
-		dateStr, trackStr, product := p.extract(m)
+		dateStr, track, prod := p.extract(m)
 		t, err := time.Parse(p.layout, dateStr)
 		if err != nil {
 			slog.Warn("skip MSUC title with invalid year/month", "title", title, "err", err)
 			return "", "", "", "", false
 		}
-		return fmt.Sprintf("%04d", t.Year()), fmt.Sprintf("%02d", int(t.Month())), trackStr, product, true
+		return fmt.Sprintf("%04d", t.Year()), fmt.Sprintf("%02d", int(t.Month())), track, prod, true
 	}
 	return "", "", "", "", false
 }

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -406,13 +406,54 @@ var monthlyTrackTitleRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (Security Only Qu
 // but month is given as a name and appears after the year.
 var monthlyTrackTitleOldRE = regexp.MustCompile(`^(January|February|March|April|May|June|July|August|September|October|November|December), (\d{4}) (Security Only Quality Update|Security Monthly Quality Rollup|Preview of Monthly Quality Rollup|Cumulative Update Preview|Cumulative Update) for (.+?) \(KB\d+\)$`)
 
-// oldMonthNumbers maps month names used by monthlyTrackTitleOldRE to the
-// two-digit numeric form used by monthlyTrackTitleRE so both regex variants
-// produce comparable (year, month) group keys.
-var oldMonthNumbers = map[string]string{
-	"January": "01", "February": "02", "March": "03", "April": "04",
-	"May": "05", "June": "06", "July": "07", "August": "08",
-	"September": "09", "October": "10", "November": "11", "December": "12",
+// monthlyTrackTitleParsers lists the title formats recognised by
+// parseMonthlyTrackTitle, tried in order. layout is passed to time.Parse
+// together with the date substring built by extract; this is the single
+// source of truth for normalising both "YYYY-MM" and "Month, YYYY" date
+// shapes to the same (year, month) tuple. Adding a new title format only
+// needs a new entry here.
+var monthlyTrackTitleParsers = []struct {
+	re      *regexp.Regexp
+	layout  string
+	extract func(m []string) (dateStr, trackStr, product string)
+}{
+	{
+		re:     monthlyTrackTitleRE,
+		layout: "2006-01",
+		extract: func(m []string) (string, string, string) {
+			return fmt.Sprintf("%s-%s", m[1], m[2]), m[3], m[4]
+		},
+	},
+	{
+		re:     monthlyTrackTitleOldRE,
+		layout: "January, 2006",
+		extract: func(m []string) (string, string, string) {
+			return fmt.Sprintf("%s, %s", m[1], m[2]), m[3], m[4]
+		},
+	},
+}
+
+// parseMonthlyTrackTitle parses an MSUC Update title into its (year, month,
+// track, product) tuple. year/month are normalised through time.Parse, so
+// the older "Month, YYYY" format produces the same group key as the modern
+// "YYYY-MM" format. ok is false when the title matches no known format, or
+// when the date fails time.Parse validation (e.g. malformed month "13" in
+// the modern format).
+func parseMonthlyTrackTitle(title string) (year, month, trackStr, product string, ok bool) {
+	for _, p := range monthlyTrackTitleParsers {
+		m := p.re.FindStringSubmatch(title)
+		if m == nil {
+			continue
+		}
+		dateStr, trackStr, product := p.extract(m)
+		t, err := time.Parse(p.layout, dateStr)
+		if err != nil {
+			slog.Warn("skip MSUC title with invalid year/month", "title", title, "err", err)
+			return "", "", "", "", false
+		}
+		return fmt.Sprintf("%04d", t.Year()), fmt.Sprintf("%02d", int(t.Month())), trackStr, product, true
+	}
+	return "", "", "", "", false
 }
 
 // deriveCrossTrackSupersedes augments Update-level Supersedes / SupersededBy
@@ -479,12 +520,8 @@ func deriveCrossTrackSupersedes(kbs []microsoftkbTypes.KB) {
 
 	for _, kb := range kbs {
 		for _, u := range kb.Updates {
-			var year, month, trackStr, product string
-			if m := monthlyTrackTitleRE.FindStringSubmatch(u.Title); m != nil {
-				year, month, trackStr, product = m[1], m[2], m[3], m[4]
-			} else if m := monthlyTrackTitleOldRE.FindStringSubmatch(u.Title); m != nil {
-				year, month, trackStr, product = m[2], oldMonthNumbers[m[1]], m[3], m[4]
-			} else {
+			year, month, trackStr, product, ok := parseMonthlyTrackTitle(u.Title)
+			if !ok {
 				continue
 			}
 			tr := classify(trackStr)

--- a/pkg/extract/microsoft/msuc/msuc_test.go
+++ b/pkg/extract/microsoft/msuc/msuc_test.go
@@ -450,6 +450,37 @@ func TestDeriveCrossTrackSupersedes(t *testing.T) {
 			},
 		},
 		{
+			name: "old Month, YYYY with non-standard whitespace: skipped, no cross-track edges (regex is strict by design — see msuc.go)",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "4015546",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-So", Title: "April,  2017 Security Only Quality Update for Windows 7 for x64-based Systems (KB4015546)"},
+					},
+				},
+				{
+					KBID: "4015549",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Sm", Title: "April,   2017 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "4015546",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-So", Title: "April,  2017 Security Only Quality Update for Windows 7 for x64-based Systems (KB4015546)"},
+					},
+				},
+				{
+					KBID: "4015549",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Sm", Title: "April,   2017 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)"},
+					},
+				},
+			},
+		},
+		{
 			name: "old and modern titles share (year, month, product) group across formats",
 			args: args{kbs: []microsoftkbTypes.KB{
 				{

--- a/pkg/extract/microsoft/msuc/msuc_test.go
+++ b/pkg/extract/microsoft/msuc/msuc_test.go
@@ -362,6 +362,101 @@ func TestDeriveCrossTrackSupersedes(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "old Month, YYYY title: Preview ⊇ SecurityMonthly ⊇ SecurityOnly (Win 7 April 2017)",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "4015546",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-So", Title: "April, 2017 Security Only Quality Update for Windows 7 for x64-based Systems (KB4015546)"},
+					},
+				},
+				{
+					KBID: "4015549",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Sm", Title: "April, 2017 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)"},
+					},
+				},
+				{
+					KBID: "4015552",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Pv", Title: "April, 2017 Preview of Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015552)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "4015546",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-So",
+							Title:        "April, 2017 Security Only Quality Update for Windows 7 for x64-based Systems (KB4015546)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "4015549", UpdateID: "U-Sm"}, {KBID: "4015552", UpdateID: "U-Pv"}},
+						},
+					},
+				},
+				{
+					KBID: "4015549",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-Sm",
+							Title:        "April, 2017 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "4015552", UpdateID: "U-Pv"}},
+							Supersedes:   []microsoftkbSupersedesTypes.Supersedes{{KBID: "4015546", UpdateID: "U-So"}},
+						},
+					},
+				},
+				{
+					KBID: "4015552",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:   "U-Pv",
+							Title:      "April, 2017 Preview of Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015552)",
+							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "4015549", UpdateID: "U-Sm"}, {KBID: "4015546", UpdateID: "U-So"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "old and modern titles share (year, month, product) group across formats",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "4015546",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-So", Title: "April, 2017 Security Only Quality Update for Windows 7 for x64-based Systems (KB4015546)"},
+					},
+				},
+				{
+					KBID: "4015549",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Sm", Title: "2017-04 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "4015546",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-So",
+							Title:        "April, 2017 Security Only Quality Update for Windows 7 for x64-based Systems (KB4015546)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "4015549", UpdateID: "U-Sm"}},
+						},
+					},
+				},
+				{
+					KBID: "4015549",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:   "U-Sm",
+							Title:      "2017-04 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)",
+							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "4015546", UpdateID: "U-So"}},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/extract/microsoft/msuc/msuc_test.go
+++ b/pkg/extract/microsoft/msuc/msuc_test.go
@@ -419,6 +419,37 @@ func TestDeriveCrossTrackSupersedes(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid month digits (e.g. \"2025-13\"): skipped, no cross-track edges added",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-A", Title: "2025-13 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2025-13 Security Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB1002)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "A",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-A", Title: "2025-13 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB1001)"},
+					},
+				},
+				{
+					KBID: "B",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-B", Title: "2025-13 Security Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB1002)"},
+					},
+				},
+			},
+		},
+		{
 			name: "old and modern titles share (year, month, product) group across formats",
 			args: args{kbs: []microsoftkbTypes.KB{
 				{

--- a/pkg/extract/microsoft/msuc/msuc_test.go
+++ b/pkg/extract/microsoft/msuc/msuc_test.go
@@ -1,6 +1,7 @@
 package msuc_test
 
 import (
+	"log/slog"
 	"path/filepath"
 	"testing"
 
@@ -53,6 +54,15 @@ func TestExtract(t *testing.T) {
 }
 
 func TestDeriveCrossTrackSupersedes(t *testing.T) {
+	// Silence parseMonthlyTrackTitle's slog.Warn during the "invalid month
+	// digits" negative case. The warning is intentional at runtime (so an
+	// operator notices if Microsoft ever publishes a malformed title), but
+	// the test only asserts on edge synthesis behaviour, so the log line
+	// is pure noise here.
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.DiscardHandler))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
 	type args struct {
 		kbs []microsoftkbTypes.KB
 	}


### PR DESCRIPTION
## What

`deriveCrossTrackSupersedes` (added in #789) parses MSUC `Update.Title` strings
to discover the (year, month, product, track) tuple and synthesises cross-track
Update-level `Supersedes` / `SupersededBy` edges within each tuple. Its regex
matches only the modern \`YYYY-MM …\` shape.

This PR extends the matcher to also recognise the older \`Month, YYYY …\` shape
that Microsoft used for 2016 – mid 2017 monthly Quality Updates / Rollups (Win
7 / Server 2008 R2 / Server 2012 / Server 2012 R2 / Win 8.1 era).

## Why

In the production raw MSUC corpus the older shape accounts for ~150 titles,
which include the exact legacy Security Only KBs that have no native
`SupersededBy` edges in Microsoft's MSUC graph:

```
KB3212642  January, 2017 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems
KB4015546  April,   2017 Security Only Quality Update for Windows 7 for x64-based Systems
KB3192403  October, 2016 Preview of Monthly Quality Rollup for Windows 7
…
```

Without a cross-track edge these KBs stay outside `coveredKBs` even when the
host applied a later Monthly Rollup, so they re-surface as \"unfixed\" on
legacy server hosts during vuls2 detection (= the Y3/Y4 over-report cluster
on Server 2008 R2 / Server 2012 etc. in our internal vuls-compare bench).

## How

- Add `monthlyTrackTitleOldRE` for `Month, YYYY` form.
- Add `oldMonthNumbers` map (`\"January\"` → `\"01\"`, …) so the older format
  produces the same `(year, month)` key as the modern format.
- The match loop now tries the modern regex first and falls back to the older
  one. The remainder of the function (classify / grouping / edge synthesis /
  inclusions) is reused unchanged, so all five tracks (Security Only / Security
  Monthly / Preview / Cumulative / Cumulative Preview) are covered for both
  formats.

## Coverage check on real raw data (vuls-data-raw-microsoft-msuc/)

| | titles |
|---|---:|
| modern regex match | 4,771 |
| **older regex match (new)** | **150** |
| neither (non-monthly / out of scope) | 623 |

## Test plan

- [x] `go test ./pkg/extract/microsoft/msuc/...` — existing 7 cases plus 2 new ones pass:
  - \`old Month, YYYY title: Preview ⊇ SecurityMonthly ⊇ SecurityOnly (Win 7 April 2017)\`
  - \`old and modern titles share (year, month, product) group across formats\`
- [x] `go test ./pkg/extract/microsoft/...` — all microsoft packages pass
- [x] `go vet ./...` — clean

## Out of scope

- WSUSSCN2 also uses older title shapes for the EOL products; this PR only
  touches the MSUC extractor, mirroring #789's scope.
- Product-name normalisation for older-format quirks such as `Windows Server
  2008 R2 x64 Edition` (Preview track) vs `Windows Server 2008 R2 for
  x64-based Systems` (SO/SM track) — these would still be in separate groups
  and therefore not paired. Adding `microsoftutil.canonicalProductNames`
  entries for those aliases can be a follow-up if bench results show it
  matters.
