### PR TITLE
feat(extract/microsoft/util): alias "Server 2008 R2 x64 Edition" product

### DIFF
--- a/pkg/extract/microsoft/util/util.go
+++ b/pkg/extract/microsoft/util/util.go
@@ -35,6 +35,13 @@ var canonicalProductNames = map[string]string{
 	"Microsoft Windows 2000 Server":                               "Windows 2000 Server",
 	"Microsoft SQL Server 2000 Service Pack 4":                    "SQL Server 2000 Service Pack 4",
 	"Microsoft SQL Server 2000 Reporting Services Service Pack 2": "SQL Server 2000 Reporting Services Service Pack 2",
+
+	// MSUC title product name variants. Microsoft used "<OS> x64 Edition" for
+	// the Preview Rollup track in a small number of legacy months (Oct 2016,
+	// Mar 2017, Apr 2017) but "<OS> for x64-based Systems" elsewhere; this
+	// alias lets deriveCrossTrackSupersedes pair PV ↔ SO/SM updates that
+	// would otherwise land in separate (year, month, product) groups.
+	"Windows Server 2008 R2 x64 Edition": "Windows Server 2008 R2 for x64-based Systems",
 }
 
 var productNameReplacer = strings.NewReplacer(

--- a/pkg/extract/microsoft/util/util_test.go
+++ b/pkg/extract/microsoft/util/util_test.go
@@ -147,6 +147,11 @@ func TestNormalizeProductName(t *testing.T) {
 			want: "SQL Server 2000 Reporting Services Service Pack 2",
 		},
 		{
+			name: "MSUC: Windows Server 2008 R2 x64 Edition canonicalized",
+			args: args{s: "Windows Server 2008 R2 x64 Edition"},
+			want: "Windows Server 2008 R2 for x64-based Systems",
+		},
+		{
 			name: "Outlook for iOS canonicalized",
 			args: args{s: "Outlook for iOS"},
 			want: "Microsoft Outlook for iOS",


### PR DESCRIPTION
## What

Add a single alias entry to `microsoftutil.canonicalProductNames`:

```go
"Windows Server 2008 R2 x64 Edition": "Windows Server 2008 R2 for x64-based Systems",
```

## Why

Microsoft used the older `<OS> x64 Edition` form for the Preview Monthly Rollup track in **three legacy months** (Oct 2016, Mar 2017, Apr 2017) while the corresponding Security Only / Security Monthly rows in the same month used the modern `<OS> for x64-based Systems` form.

Without an alias the two variants land in **separate `(year, month, product)` groups** in `deriveCrossTrackSupersedes` (`pkg/extract/microsoft/msuc/msuc.go`), so the PV ↔ SO and PV ↔ SM cross-track edges are not synthesised for those three months.

Concretely the gap looks like this (from the production raw MSUC corpus):

```
April, 2017 Preview of Monthly Quality Rollup for Windows Server 2008 R2 x64 Edition (KB4015552)
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

April, 2017 Security Only Quality Update for Windows Server 2008 R2 for x64-based Systems (KB4015546)
April, 2017 Security Monthly Quality Rollup for Windows Server 2008 R2 for x64-based Systems (KB4015549)
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## How

`canonicalProductNames` is the existing post-`productNameReplacer` map keyed by the post-normalised string. Adding the single entry above is the smallest change that lets `deriveCrossTrackSupersedes` group the PV row with its SO/SM siblings.

## Coverage check on real raw data

Verified against `vuls-data-raw-microsoft-msuc/` (5,544 raw JSON files):

| | titles |
|---|---:|
| `<OS> for x64-based Systems` form | 232 |
| **`<OS> x64 Edition` form (alias target)** | **3** |

The three `x64 Edition` titles are the Preview Monthly Rollup KBs **KB3192403** (Oct 2016), **KB4012218** (Mar 2017), **KB4015552** (Apr 2017). All three were paired with their SM siblings via native MSUC `supersedes` already; the gap is the cross-track edges that `deriveCrossTrackSupersedes` would synthesise within the same month.

## Measured impact

After this change, an extract run on the same raw corpus produces **6 new cross-track Supersedes pairs** (3 × `PV→SM`, 3 × `PV→SO`):

```
KB3192403 (Oct 2016 PV) → KB3185330 (Oct 2016 SM)
KB3192403 (Oct 2016 PV) → KB3192391 (Oct 2016 SO)
KB4012218 (Mar 2017 PV) → KB4012215 (Mar 2017 SM)
KB4012218 (Mar 2017 PV) → KB4012212 (Mar 2017 SO)
KB4015552 (Apr 2017 PV) → KB4015549 (Apr 2017 SM)
KB4015552 (Apr 2017 PV) → KB4015546 (Apr 2017 SO)
```

Each pair has a reciprocal `SupersededBy` on the other side, so 12 new directed edges total.

## Note on dependency

The cross-track edge synthesis itself depends on `monthlyTrackTitleOldRE` from #798 (not yet merged) for the old `Month, YYYY` titles. Once #798 lands, the alias from this PR will be picked up by `deriveCrossTrackSupersedes` for the three affected months. The alias change in this PR is benign on its own.

## Test plan

- [x] `go test ./pkg/extract/microsoft/util/...` — existing `TestNormalizeProductName` plus one new case
  - `MSUC: Windows Server 2008 R2 x64 Edition canonicalized`
- [x] `go test ./pkg/extract/microsoft/...` — all microsoft packages pass
- [x] `go vet ./...` — clean
- [x] Re-ran `extract microsoft-msuc` against `vuls-data-raw-microsoft-msuc/` and confirmed the 6 new cross-track Supersedes pairs above (file-level diff on KB3185330 / KB3192391 / KB3192403 / KB4012212 / KB4012215 / KB4012218 / KB4015546 / KB4015549 / KB4015552).

## Out of scope

- `monthlyTrackTitleOldRE` itself (handled in #798).
- Other product-name aliases. A scan of the production corpus surfaced this as the only systematic `<OS> Edition` vs `<OS> for X-based Systems` inconsistency in monthly Quality Update titles.