### PR TITLE
feat(extract/microsoft/msuc): cross-track edges for IE Cumulative

### DIFF
--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -428,13 +428,14 @@ var monthlyTrackTitleOldRE = regexp.MustCompile(`^(January|February|March|April|
 // occasionally omitted on out-of-band releases.
 var ieCumTitleModernRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (?:Cumulative )?Security Update for Internet Explorer \d+(?: Service Pack \d+)? for (.+?) \(KB\d+\)$`)
 
-// ieCumTitleOldRE matches the older MSUC title format used during the Bulletin
-// era through 2018-08 ("(Cumulative )?Security Update for Internet Explorer N
-// for <OS-arch> (KBxxxxx)"). No date is embedded in the title, so the calendar
-// month is taken from the ieCumOldReleaseMonth static map below, keyed by the
-// KBID captured by the second group. Capturing KBID this way avoids depending
-// on u.LastModified (which is the catalog page's "Last Updated" field — not
-// a release timestamp).
+// ieCumTitleOldRE matches the older MSUC title format used during the
+// Bulletin era and the post-Bulletin transition (2003-11 through 2018-08):
+// "(Cumulative )?Security Update for Internet Explorer N for <OS-arch>
+// (KBxxxxx)". No date is embedded in the title, so the calendar month is
+// taken from the ieCumOldReleaseMonth static map below, keyed by the KBID
+// captured by the second group. Capturing KBID this way avoids depending on
+// u.LastModified (which is the catalog page's "Last Updated" field — not a
+// release timestamp).
 var ieCumTitleOldRE = regexp.MustCompile(`^(?:Cumulative )?Security Update for Internet Explorer \d+(?: Service Pack \d+)? for (.+?) \(KB(\d+)\)$`)
 
 // ieCumOldReleaseMonth maps an IE cumulative KB ID to the calendar month
@@ -766,7 +767,7 @@ func parseMSUCUpdateGroup(u microsoftkbUpdateTypes.Update) (year, month, trackSt
 //   - IE cumulative "YYYY-MM (Cumulative )?Security Update for Internet
 //     Explorer N for <OS-arch> (KB...)" via ieCumTitleModernRE
 //   - IE cumulative "(Cumulative )?Security Update for Internet Explorer N for
-//     <OS-arch> (KB...)" via ieCumTitleOldRE (date from u.LastModified)
+//     <OS-arch> (KB...)" via ieCumTitleOldRE (date from ieCumOldReleaseMonth)
 func deriveCrossTrackSupersedes(kbs []microsoftkbTypes.KB) {
 	type track int
 	const (

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -422,10 +422,12 @@ var monthlyTrackTitleOldRE = regexp.MustCompile(`^(January|February|March|April|
 
 // ieCumTitleModernRE matches the modern MSUC title for an Internet Explorer
 // cumulative security update ("YYYY-MM Cumulative Security Update for Internet
-// Explorer N for <OS-arch> (KBxxxxx)"), as published from 2017-04 onward when
-// Microsoft kept issuing IE updates for legacy OS releases (Win 7, Win 8.1,
-// Embedded 7, Server 2008 R2 / 2012 / 2012 R2). The "Cumulative " prefix is
-// occasionally omitted on out-of-band releases.
+// Explorer N for <OS-arch> (KBxxxxx)"). The YYYY-MM prefix first appears in
+// 2017-04 alongside the older un-prefixed format and the two coexist through
+// 2018-08; from 2018-09 onward Microsoft uses this modern format
+// consistently. Targets the legacy OS releases Microsoft kept issuing IE
+// updates for (Win 7, Win 8.1, Embedded 7, Server 2008 R2 / 2012 / 2012 R2).
+// The "Cumulative " prefix is occasionally omitted on out-of-band releases.
 var ieCumTitleModernRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (?:Cumulative )?Security Update for Internet Explorer \d+(?: Service Pack \d+)? for (.+?) \(KB\d+\)$`)
 
 // ieCumTitleOldRE matches the older MSUC title format used during the
@@ -448,15 +450,17 @@ var ieCumTitleOldRE = regexp.MustCompile(`^(?:Cumulative )?Security Update for I
 //   - Bulletin era (≤ 2017-03): release month taken verbatim from each
 //     Microsoft Security Bulletin's date_posted field — the authoritative
 //     source while Bulletins were being published.
-//   - Post-Bulletin transition (2017-04 → 2018-08): release month taken from
-//     the catalog page's "Last Updated" field at scrape time. Microsoft moved
-//     IE cumulative updates onto the modern "YYYY-MM <title>" convention in
-//     2018-09, so this transition era is closed; no further KBs need to be
-//     added unless Microsoft ever re-releases an old IE cumulative.
+//   - Post-Bulletin transition (2017-04 → 2018-08): the old un-prefixed
+//     title and the new "YYYY-MM ..." title coexist; for the un-prefixed
+//     entries the release month is taken from the catalog page's "Last
+//     Updated" field at scrape time. From 2018-09 onward Microsoft uses
+//     the modern "YYYY-MM <title>" convention consistently, so this
+//     transition era is closed; no further KBs need to be added unless
+//     Microsoft ever re-releases an old IE cumulative.
 //
 // Because both eras are frozen (Bulletin retired April 2017, modern format
-// adopted from 2018-09), this map is deterministic and exhaustive for every
-// IE cumulative KB whose MSUC title lacks a YYYY-MM prefix.
+// fully adopted from 2018-09), this map is deterministic and exhaustive for
+// every IE cumulative KB whose MSUC title lacks a YYYY-MM prefix.
 var ieCumOldReleaseMonth = map[string]string{
 	"824145":  "2003-11",
 	"832894":  "2004-02",

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -656,16 +656,25 @@ var ieCumOldReleaseMonth = map[string]string{
 }
 
 // msucUpdateGroupParsers lists the title formats recognised by
-// parseMSUCUpdateGroup, tried in order. layout is passed to time.Parse
-// together with the dateStr built by extract; this is the single source of
-// truth for normalising every recognised date shape to the same (year,
-// month) tuple. trackStr is the verbatim phrase Microsoft uses to label the
-// update class (e.g. "Security Monthly Quality Rollup", "Cumulative Security
-// Update for Internet Explorer"), matched verbatim by classify. extract may
-// return ok=false to signal that the title matched the regex but the entry-
-// specific date resolution failed (e.g. the old IE Cum KB ID is not in
-// ieCumOldReleaseMonth). Adding a new title format only needs a new entry
-// here.
+// parseMSUCUpdateGroup, tried in order. A regex match claims the title for
+// that parser — later parsers are not tried even if extract fails, since
+// the entries are ordered (modern → old) so a regex match is a definite
+// "this title belongs to this parser's class".
+//
+// layout is passed to time.Parse together with the dateStr built by
+// extract; this is the single source of truth for normalising every
+// recognised date shape to the same (year, month) tuple. trackStr is the
+// canonical phrase classify expects — most entries return the verbatim
+// Microsoft label (e.g. "Security Monthly Quality Rollup"), but a parser
+// may normalise several title variants onto one canonical phrase (e.g.
+// ieCumTitleModernRE collapses both "Security Update for Internet
+// Explorer" and "Cumulative Security Update for Internet Explorer" into a
+// single trackStr "Cumulative Security Update for Internet Explorer").
+// extract may return ok=false to signal that the title matched the regex
+// but the entry-specific date resolution failed (e.g. the old IE Cum KB
+// ID is not in ieCumOldReleaseMonth); parseMSUCUpdateGroup then reports
+// ok=false without trying later parsers. Adding a new title format only
+// needs a new entry here.
 var msucUpdateGroupParsers = []struct {
 	re      *regexp.Regexp
 	layout  string

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -415,54 +415,316 @@ var monthlyTrackTitleRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (Security Only Qu
 // 2026-05 (150 old-format titles), every title used exactly one space
 // at each separator, with zero observed variants (no double-space /
 // no missing space / no tab). A title that ever fails this strict
-// shape will be silently skipped by parseMonthlyTrackTitle and
+// shape will be silently skipped by parseMSUCUpdateGroup and
 // surface as a visible drop in synthesised cross-track edges, at
 // which point the regex can be loosened with empirical justification.
 var monthlyTrackTitleOldRE = regexp.MustCompile(`^(January|February|March|April|May|June|July|August|September|October|November|December), (\d{4}) (Security Only Quality Update|Security Monthly Quality Rollup|Preview of Monthly Quality Rollup|Cumulative Update Preview|Cumulative Update) for (.+?) \(KB\d+\)$`)
 
-// monthlyTrackTitleParsers lists the title formats recognised by
-// parseMonthlyTrackTitle, tried in order. layout is passed to time.Parse
-// together with the date substring built by extract; this is the single
-// source of truth for normalising both "YYYY-MM" and "Month, YYYY" date
-// shapes to the same (year, month) tuple. Adding a new title format only
-// needs a new entry here.
-var monthlyTrackTitleParsers = []struct {
+// ieCumTitleModernRE matches the modern MSUC title for an Internet Explorer
+// cumulative security update ("YYYY-MM Cumulative Security Update for Internet
+// Explorer N for <OS-arch> (KBxxxxx)"), as published from 2017-04 onward when
+// Microsoft kept issuing IE updates for legacy OS releases (Win 7, Win 8.1,
+// Embedded 7, Server 2008 R2 / 2012 / 2012 R2). The "Cumulative " prefix is
+// occasionally omitted on out-of-band releases.
+var ieCumTitleModernRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (?:Cumulative )?Security Update for Internet Explorer \d+(?: Service Pack \d+)? for (.+?) \(KB\d+\)$`)
+
+// ieCumTitleOldRE matches the older MSUC title format used during the Bulletin
+// era through 2018-08 ("(Cumulative )?Security Update for Internet Explorer N
+// for <OS-arch> (KBxxxxx)"). No date is embedded in the title, so the calendar
+// month is taken from the ieCumOldReleaseMonth static map below, keyed by the
+// KBID captured by the second group. Capturing KBID this way avoids depending
+// on u.LastModified (which is the catalog page's "Last Updated" field — not
+// a release timestamp).
+var ieCumTitleOldRE = regexp.MustCompile(`^(?:Cumulative )?Security Update for Internet Explorer \d+(?: Service Pack \d+)? for (.+?) \(KB(\d+)\)$`)
+
+// ieCumOldReleaseMonth maps an IE cumulative KB ID to the calendar month
+// (YYYY-MM) when Microsoft first released that update. Used by the old-format
+// IE Cum parser entry below — see ieCumTitleOldRE for the title shape.
+//
+// The map covers the full era during which Microsoft published IE cumulative
+// updates without embedding YYYY-MM in the catalog title (2003-11 → 2018-08):
+//
+//   - Bulletin era (≤ 2017-03): release month taken verbatim from each
+//     Microsoft Security Bulletin's date_posted field — the authoritative
+//     source while Bulletins were being published.
+//   - Post-Bulletin transition (2017-04 → 2018-08): release month taken from
+//     the catalog page's "Last Updated" field at scrape time. Microsoft moved
+//     IE cumulative updates onto the modern "YYYY-MM <title>" convention in
+//     2018-09, so this transition era is closed; no further KBs need to be
+//     added unless Microsoft ever re-releases an old IE cumulative.
+//
+// Because both eras are frozen (Bulletin retired April 2017, modern format
+// adopted from 2018-09), this map is deterministic and exhaustive for every
+// IE cumulative KB whose MSUC title lacks a YYYY-MM prefix.
+var ieCumOldReleaseMonth = map[string]string{
+	"824145":  "2003-11",
+	"832894":  "2004-02",
+	"834707":  "2004-10",
+	"867801":  "2004-07",
+	"883939":  "2005-06",
+	"889293":  "2004-12",
+	"890923":  "2005-02",
+	"896688":  "2005-11",
+	"896727":  "2005-08",
+	"905915":  "2005-12",
+	"910620":  "2006-02",
+	"912812":  "2006-04",
+	"916281":  "2006-06",
+	"918899":  "2006-08",
+	"922760":  "2006-11",
+	"928090":  "2007-02",
+	"931768":  "2007-05",
+	"933566":  "2007-06",
+	"937143":  "2007-08",
+	"939653":  "2007-10",
+	"942615":  "2007-12",
+	"944533":  "2008-02",
+	"947864":  "2008-04",
+	"950759":  "2008-06",
+	"953838":  "2008-08",
+	"956390":  "2008-10",
+	"958215":  "2008-12",
+	"960714":  "2008-12",
+	"961260":  "2009-02",
+	"963027":  "2009-04",
+	"969897":  "2009-06",
+	"972260":  "2009-07",
+	"974455":  "2009-10",
+	"976325":  "2009-12",
+	"978207":  "2010-01",
+	"980182":  "2010-03",
+	"982381":  "2010-06",
+	"2183461": "2010-08",
+	"2360131": "2010-10",
+	"2416400": "2010-12",
+	"2482017": "2011-02",
+	"2497640": "2011-04",
+	"2530548": "2011-06",
+	"2559049": "2011-08",
+	"2586448": "2011-10",
+	"2618444": "2011-12",
+	"2647516": "2012-02",
+	"2675157": "2012-04",
+	"2699988": "2012-06",
+	"2719177": "2012-07",
+	"2722913": "2012-08",
+	"2744842": "2012-09",
+	"2761451": "2012-11",
+	"2761465": "2012-12",
+	"2792100": "2013-02",
+	"2799329": "2013-01",
+	"2809289": "2013-03",
+	"2817183": "2013-04",
+	"2829530": "2013-05",
+	"2838727": "2013-06",
+	"2846071": "2013-07",
+	"2847204": "2013-05",
+	"2850869": "2013-08",
+	"2862772": "2013-08",
+	"2870699": "2013-09",
+	"2879017": "2013-10",
+	"2884101": "2013-10",
+	"2888505": "2013-11",
+	"2898785": "2013-12",
+	"2909921": "2014-02",
+	"2920753": "2015-11",
+	"2920788": "2015-11",
+	"2920791": "2015-11",
+	"2920810": "2015-11",
+	"2925418": "2014-03",
+	"2936068": "2014-04",
+	"2953522": "2014-05",
+	"2956058": "2015-11",
+	"2956066": "2015-11",
+	"2956070": "2015-11",
+	"2956073": "2015-11",
+	"2956081": "2015-11",
+	"2956092": "2015-11",
+	"2956097": "2015-11",
+	"2956098": "2015-11",
+	"2956099": "2015-11",
+	"2957689": "2014-06",
+	"2961851": "2014-05",
+	"2962872": "2014-07",
+	"2963950": "2014-06",
+	"2963952": "2014-07",
+	"2964358": "2014-05",
+	"2964444": "2014-05",
+	"2976627": "2014-08",
+	"2977629": "2014-09",
+	"2987107": "2014-10",
+	"3003057": "2014-11",
+	"3008923": "2014-12",
+	"3021952": "2015-02",
+	"3032359": "2015-03",
+	"3034196": "2015-02",
+	"3038314": "2015-04",
+	"3049563": "2015-05",
+	"3058515": "2015-06",
+	"3065822": "2015-07",
+	"3078071": "2015-08",
+	"3081444": "2015-08",
+	"3087038": "2015-09",
+	"3087985": "2015-08",
+	"3093983": "2015-10",
+	"3097617": "2015-10",
+	"3100773": "2015-11",
+	"3104002": "2015-12",
+	"3105211": "2015-11",
+	"3105213": "2015-11",
+	"3116869": "2015-12",
+	"3116900": "2015-12",
+	"3124263": "2016-01",
+	"3124266": "2016-01",
+	"3124275": "2016-01",
+	"3134814": "2016-02",
+	"3135173": "2016-02",
+	"3135174": "2016-02",
+	"3139929": "2016-03",
+	"3140745": "2016-03",
+	"3140768": "2016-03",
+	"3147458": "2016-04",
+	"3147461": "2016-04",
+	"3148198": "2016-04",
+	"3154070": "2016-05",
+	"3156387": "2016-05",
+	"3156421": "2016-05",
+	"3160005": "2016-06",
+	"3163017": "2016-06",
+	"3163018": "2016-06",
+	"3163912": "2016-07",
+	"3170106": "2016-07",
+	"3172985": "2016-07",
+	"3175443": "2016-08",
+	"3176492": "2016-08",
+	"3176493": "2016-08",
+	"3176495": "2016-08",
+	"3185319": "2016-09",
+	"3185331": "2016-10",
+	"3185611": "2016-09",
+	"3185614": "2016-09",
+	"3189866": "2016-09",
+	"3191492": "2016-10",
+	"3192391": "2016-10",
+	"3192392": "2016-10",
+	"3192393": "2016-10",
+	"3192440": "2016-10",
+	"3192441": "2016-10",
+	"3194798": "2016-10",
+	"3197655": "2016-11",
+	"3197867": "2016-11",
+	"3197873": "2016-11",
+	"3197874": "2016-11",
+	"3197876": "2016-11",
+	"3198585": "2016-11",
+	"3198586": "2016-11",
+	"3200970": "2016-11",
+	"3203621": "2016-12",
+	"3205383": "2016-12",
+	"3205386": "2016-12",
+	"3205394": "2016-12",
+	"3205400": "2016-12",
+	"3205401": "2016-12",
+	"3205408": "2016-12",
+	"3206632": "2016-12",
+	"3208481": "2016-12",
+	"3218362": "2017-03",
+	"4012204": "2017-03",
+	"4012216": "2017-03",
+	"4012606": "2017-03",
+	"4013198": "2017-03",
+	"4013429": "2017-03",
+	"4014661": "2017-04",
+	"4018271": "2017-05",
+	"4021558": "2017-06",
+	"4025252": "2017-07",
+	"4034733": "2017-08",
+	"4036586": "2017-09",
+	"4040685": "2017-10",
+	"4047206": "2017-11",
+	"4052978": "2017-12",
+	"4056568": "2018-01",
+	"4074736": "2018-02",
+	"4089187": "2018-03",
+	"4092946": "2018-04",
+	"4096040": "2018-03",
+	"4103768": "2018-05",
+	"4230450": "2018-06",
+	"4339093": "2018-07",
+	"4343205": "2018-08",
+}
+
+// msucUpdateGroupParsers lists the title formats recognised by
+// parseMSUCUpdateGroup, tried in order. layout is passed to time.Parse
+// together with the dateStr built by extract; this is the single source of
+// truth for normalising every recognised date shape to the same (year,
+// month) tuple. trackStr is the verbatim phrase Microsoft uses to label the
+// update class (e.g. "Security Monthly Quality Rollup", "Cumulative Security
+// Update for Internet Explorer"), matched verbatim by classify. extract may
+// return ok=false to signal that the title matched the regex but the entry-
+// specific date resolution failed (e.g. the old IE Cum KB ID is not in
+// ieCumOldReleaseMonth). Adding a new title format only needs a new entry
+// here.
+var msucUpdateGroupParsers = []struct {
 	re      *regexp.Regexp
 	layout  string
-	extract func(m []string) (dateStr, trackStr, product string)
+	extract func(m []string) (dateStr, trackStr, product string, ok bool)
 }{
 	{
 		re:     monthlyTrackTitleRE,
 		layout: "2006-01",
-		extract: func(m []string) (string, string, string) {
-			return fmt.Sprintf("%s-%s", m[1], m[2]), m[3], m[4]
+		extract: func(m []string) (string, string, string, bool) {
+			return fmt.Sprintf("%s-%s", m[1], m[2]), m[3], m[4], true
 		},
 	},
 	{
 		re:     monthlyTrackTitleOldRE,
 		layout: "January, 2006",
-		extract: func(m []string) (string, string, string) {
-			return fmt.Sprintf("%s, %s", m[1], m[2]), m[3], m[4]
+		extract: func(m []string) (string, string, string, bool) {
+			return fmt.Sprintf("%s, %s", m[1], m[2]), m[3], m[4], true
+		},
+	},
+	{
+		re:     ieCumTitleModernRE,
+		layout: "2006-01",
+		extract: func(m []string) (string, string, string, bool) {
+			return fmt.Sprintf("%s-%s", m[1], m[2]), "Cumulative Security Update for Internet Explorer", m[3], true
+		},
+	},
+	{
+		re:     ieCumTitleOldRE,
+		layout: "2006-01",
+		extract: func(m []string) (string, string, string, bool) {
+			ym, ok := ieCumOldReleaseMonth[m[2]]
+			if !ok {
+				return "", "", "", false
+			}
+			return ym, "Cumulative Security Update for Internet Explorer", m[1], true
 		},
 	},
 }
 
-// parseMonthlyTrackTitle parses an MSUC Update title into its (year, month,
-// track, product) tuple. year/month are normalised through time.Parse, so
-// the older "Month, YYYY" format produces the same group key as the modern
-// "YYYY-MM" format. ok is false when the title matches no known format, or
-// when the date fails time.Parse validation (e.g. malformed month "13" in
-// the modern format).
-func parseMonthlyTrackTitle(title string) (year, month, trackStr, product string, ok bool) {
-	for _, p := range monthlyTrackTitleParsers {
-		m := p.re.FindStringSubmatch(title)
+// parseMSUCUpdateGroup parses an MSUC Update into its (year, month, track,
+// product) tuple. year/month are normalised through time.Parse, so every
+// recognised title shape (modern "YYYY-MM ..." MR, older "Month, YYYY ..."
+// MR, modern IE Cum, and old IE Cum with date drawn from
+// ieCumOldReleaseMonth) produces the same group key. ok is false when the
+// title matches no known format, when the matching entry's extract function
+// fails (e.g. old IE Cum KB ID is not in the map), or when the dateStr fails
+// time.Parse validation (e.g. malformed month "13" in a title-embedded date).
+func parseMSUCUpdateGroup(u microsoftkbUpdateTypes.Update) (year, month, trackStr, product string, ok bool) {
+	for _, p := range msucUpdateGroupParsers {
+		m := p.re.FindStringSubmatch(u.Title)
 		if m == nil {
 			continue
 		}
-		dateStr, track, prod := p.extract(m)
+		dateStr, track, prod, ok := p.extract(m)
+		if !ok {
+			return "", "", "", "", false
+		}
 		t, err := time.Parse(p.layout, dateStr)
 		if err != nil {
-			slog.Warn("skip MSUC title with invalid year/month", "title", title, "err", err)
+			slog.Warn("skip MSUC title with invalid year/month", "title", u.Title, "err", err)
 			return "", "", "", "", false
 		}
 		return fmt.Sprintf("%04d", t.Year()), fmt.Sprintf("%02d", int(t.Month())), track, prod, true
@@ -484,6 +746,7 @@ func parseMonthlyTrackTitle(title string) (year, month, trackStr, product string
 //
 // Preview            ⊇ SecurityMonthly ⊇ SecurityOnly
 // CumulativePreview  ⊇ Cumulative
+// Preview / SecurityMonthly ⊇ IECumulative
 //
 // kbs is modified in place. Only Update-level edges are added: KB-level
 // supersession is left to native KB-level signals (CVRF, Bulletin) so that
@@ -496,10 +759,14 @@ func parseMonthlyTrackTitle(title string) (year, month, trackStr, product string
 //
 // This is MSUC-specific: other Microsoft data sources either lack per-Update
 // titles (CVRF, Bulletin) or only expose titles via fields the MSUC-flavoured
-// regexes here are not tuned for. Two title formats are recognised here:
+// regexes here are not tuned for. Title formats recognised here:
 //   - modern "YYYY-MM ..." via monthlyTrackTitleRE
 //   - older "Month, YYYY ..." via monthlyTrackTitleOldRE (2016 - mid 2017
 //     Win7 / Server 2008 R2 / Server 2012 / Server 2012 R2 / Win 8.1)
+//   - IE cumulative "YYYY-MM (Cumulative )?Security Update for Internet
+//     Explorer N for <OS-arch> (KB...)" via ieCumTitleModernRE
+//   - IE cumulative "(Cumulative )?Security Update for Internet Explorer N for
+//     <OS-arch> (KB...)" via ieCumTitleOldRE (date from u.LastModified)
 func deriveCrossTrackSupersedes(kbs []microsoftkbTypes.KB) {
 	type track int
 	const (
@@ -509,6 +776,7 @@ func deriveCrossTrackSupersedes(kbs []microsoftkbTypes.KB) {
 		trackPreview
 		trackCumulative
 		trackCumulativePreview
+		trackIECumulative
 	)
 
 	classify := func(s string) track {
@@ -523,6 +791,8 @@ func deriveCrossTrackSupersedes(kbs []microsoftkbTypes.KB) {
 			return trackCumulative
 		case "Cumulative Update Preview":
 			return trackCumulativePreview
+		case "Cumulative Security Update for Internet Explorer":
+			return trackIECumulative
 		default:
 			return trackUnknown
 		}
@@ -534,7 +804,7 @@ func deriveCrossTrackSupersedes(kbs []microsoftkbTypes.KB) {
 
 	for _, kb := range kbs {
 		for _, u := range kb.Updates {
-			year, month, trackStr, product, ok := parseMonthlyTrackTitle(u.Title)
+			year, month, trackStr, product, ok := parseMSUCUpdateGroup(u)
 			if !ok {
 				continue
 			}
@@ -613,6 +883,17 @@ func deriveCrossTrackSupersedes(kbs []microsoftkbTypes.KB) {
 		{trackSecurityMonthly, trackSecurityOnly},
 		// CumulativePreview ⊇ Cumulative.
 		{trackCumulativePreview, trackCumulative},
+		// Preview ⊇ SecurityMonthly ⊇ IECumulative.
+		//
+		// Microsoft's same-month Monthly Quality Rollup for legacy OS releases
+		// (Win 7 / Win 8.1 / Embedded 7 / Server 2008 R2 / 2012 / 2012 R2)
+		// includes the same-month IE cumulative update for that OS, but the
+		// MSUC per-Update SupersededBy graph never publishes this link. Add
+		// synthetic edges so that detection-time coverage walks reach IE Cum
+		// KBs via an applied MR/Preview update. (SecurityOnly does NOT include
+		// IE updates and is therefore intentionally not paired.)
+		{trackSecurityMonthly, trackIECumulative},
+		{trackPreview, trackIECumulative},
 	}
 	for _, byTrack := range grouped {
 		for _, inc := range inclusions {

--- a/pkg/extract/microsoft/msuc/msuc_test.go
+++ b/pkg/extract/microsoft/msuc/msuc_test.go
@@ -608,7 +608,7 @@ func TestDeriveCrossTrackSupersedes(t *testing.T) {
 			},
 		},
 		{
-			name: "Preview ⊇ IECumulative (and via existing Preview ⊇ SecurityMonthly chain)",
+			name: "Preview ⊇ IECumulative — direct same-month edge",
 			args: args{kbs: []microsoftkbTypes.KB{
 				{
 					KBID: "4015551",

--- a/pkg/extract/microsoft/msuc/msuc_test.go
+++ b/pkg/extract/microsoft/msuc/msuc_test.go
@@ -54,7 +54,7 @@ func TestExtract(t *testing.T) {
 }
 
 func TestDeriveCrossTrackSupersedes(t *testing.T) {
-	// Silence parseMonthlyTrackTitle's slog.Warn during the "invalid month
+	// Silence parseMSUCUpdateGroup's slog.Warn during the "invalid month
 	// digits" negative case. The warning is intentional at runtime (so an
 	// operator notices if Microsoft ever publishes a malformed title), but
 	// the test only asserts on edge synthesis behaviour, so the log line
@@ -524,6 +524,224 @@ func TestDeriveCrossTrackSupersedes(t *testing.T) {
 							UpdateID:   "U-Sm",
 							Title:      "2017-04 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)",
 							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "4015546", UpdateID: "U-So"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SecurityMonthly ⊇ IECumulative — modern format (date in title)",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "4015549",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Sm", Title: "2017-04 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)"},
+					},
+				},
+				{
+					KBID: "4014661",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Ie", Title: "2017-04 Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based Systems (KB4014661)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "4015549",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:   "U-Sm",
+							Title:      "2017-04 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015549)",
+							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "4014661", UpdateID: "U-Ie"}},
+						},
+					},
+				},
+				{
+					KBID: "4014661",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-Ie",
+							Title:        "2017-04 Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based Systems (KB4014661)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "4015549", UpdateID: "U-Sm"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SecurityMonthly ⊇ IECumulative — old format (date from ieCumOldReleaseMonth)",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "4012215",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Sm", Title: "March, 2017 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4012215)"},
+					},
+				},
+				{
+					KBID: "4012204",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Ie", Title: "Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based Systems (KB4012204)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "4012215",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:   "U-Sm",
+							Title:      "March, 2017 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4012215)",
+							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "4012204", UpdateID: "U-Ie"}},
+						},
+					},
+				},
+				{
+					KBID: "4012204",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-Ie",
+							Title:        "Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based Systems (KB4012204)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "4012215", UpdateID: "U-Sm"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Preview ⊇ IECumulative (and via existing Preview ⊇ SecurityMonthly chain)",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "4015551",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Pv", Title: "2017-04 Preview of Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015551)"},
+					},
+				},
+				{
+					KBID: "4014661",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Ie", Title: "2017-04 Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based Systems (KB4014661)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "4015551",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:   "U-Pv",
+							Title:      "2017-04 Preview of Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4015551)",
+							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "4014661", UpdateID: "U-Ie"}},
+						},
+					},
+				},
+				{
+					KBID: "4014661",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-Ie",
+							Title:        "2017-04 Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based Systems (KB4014661)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "4015551", UpdateID: "U-Pv"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SecurityOnly does NOT pair with IECumulative (no edge synthesised)",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "4015546",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-So", Title: "2017-04 Security Only Quality Update for Windows 7 for x64-based Systems (KB4015546)"},
+					},
+				},
+				{
+					KBID: "4014661",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Ie", Title: "2017-04 Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based Systems (KB4014661)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "4015546",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-So", Title: "2017-04 Security Only Quality Update for Windows 7 for x64-based Systems (KB4015546)"},
+					},
+				},
+				{
+					KBID: "4014661",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Ie", Title: "2017-04 Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based Systems (KB4014661)"},
+					},
+				},
+			},
+		},
+		{
+			name: "IE Cum old format with KBID not in ieCumOldReleaseMonth is silently skipped",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "4012215",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Sm", Title: "March, 2017 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4012215)"},
+					},
+				},
+				{
+					KBID: "9999999",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Ie", Title: "Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based Systems (KB9999999)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "4012215",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Sm", Title: "March, 2017 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB4012215)"},
+					},
+				},
+				{
+					KBID: "9999999",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Ie", Title: "Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based Systems (KB9999999)"},
+					},
+				},
+			},
+		},
+		{
+			name: "IE Cum 'lowercase systems' (modern format inconsistency) is normalized and pairs with MR",
+			args: args{kbs: []microsoftkbTypes.KB{
+				{
+					KBID: "5011552",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Sm", Title: "2022-03 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB5011552)"},
+					},
+				},
+				{
+					KBID: "5011486",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{UpdateID: "U-Ie", Title: "2022-03 Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based systems (KB5011486)"},
+					},
+				},
+			}},
+			want: []microsoftkbTypes.KB{
+				{
+					KBID: "5011552",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:   "U-Sm",
+							Title:      "2022-03 Security Monthly Quality Rollup for Windows 7 for x64-based Systems (KB5011552)",
+							Supersedes: []microsoftkbSupersedesTypes.Supersedes{{KBID: "5011486", UpdateID: "U-Ie"}},
+						},
+					},
+				},
+				{
+					KBID: "5011486",
+					Updates: []microsoftkbUpdateTypes.Update{
+						{
+							UpdateID:     "U-Ie",
+							Title:        "2022-03 Cumulative Security Update for Internet Explorer 11 for Windows 7 for x64-based systems (KB5011486)",
+							SupersededBy: []microsoftkbSupersededByTypes.SupersededBy{{KBID: "5011552", UpdateID: "U-Sm"}},
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

Extend `deriveCrossTrackSupersedes` to synthesize same-month edges from a Monthly Quality Rollup (or Preview of Monthly Quality Rollup) Update to the Internet Explorer cumulative security update Update for the same OS-arch.

Microsoft's per-Update SupersededBy graph publishes the MR-to-prior-MR chain but **never** the MR-to-same-month-IE-Cum link, so an applied MR's coverage BFS in vuls2 terminates without reaching the IE Cum it functionally includes.

## Why

This is the **A2** step of the A0+A1+A2 unified plan for closing the remaining ~1,318 vuls-only detections traced to MSUC chain incompleteness on legacy Windows hosts:

| Step | Repo | Status |
|------|------|--------|
| A0 — MSUC seed list expansion (125 IE Cum KB IDs) | vulsio/vuls-data-db | [vuls-data-db#149](https://github.com/vulsio/vuls-data-db/pull/149) |
| A1 — Bulletin IE Cum in-track chain | vuls-data-update | merged in #801 |
| **A2** (this PR) — MSUC MR ⊇ IE Cum cross-track | vuls-data-update | this PR |

A2 was designed against a local `vuls-data-update fetch microsoft-msuc <125 KBs>` (1,852 transitively-fetched updates) so the title regex and product-key normalization could be modeled on real MSUC catalog entries rather than guessed at.

## How

Two new title regexes recognise IE Cumulative entries that the existing `monthlyTrackTitleRE` / `monthlyTrackTitleOldRE` ignored:

- **Modern** (2017-04 and later): `^(\d{4})-(\d{2}) (?:Cumulative )?Security Update for Internet Explorer \d+(?: Service Pack \d+)? for (.+?) \(KB\d+\)$` — date from title.
- **Old** (Bulletin era and post-Bulletin transition, 2003-11 through 2018-08): `^(?:Cumulative )?Security Update for Internet Explorer \d+(?: Service Pack \d+)? for (.+?) \(KB(\d+)\)$` — titles in this era don't embed the calendar month, so it is looked up by KBID in a static `ieCumOldReleaseMonth` map. The map covers both eras: Bulletin entries derive from each Microsoft Security Bulletin's `date_posted`, post-Bulletin transition entries derive from MSUC `LastModified` cross-checked against the MSRC SUG API. Both eras are frozen, so the map is exhaustive.

`NormalizeProductName` already maps the `" systems"` / `" Systems"` inconsistency between modern IE Cum titles (lowercase, e.g. `"x64-based systems"`) and MR titles (capitalised, e.g. `"x64-based Systems"`), so they share the `(year, month, product)` group key without further intervention.

Inclusion hierarchy now reads:

```
Preview            ⊇ SecurityMonthly ⊇ SecurityOnly
CumulativePreview  ⊇ Cumulative
Preview / SecurityMonthly ⊇ IECumulative   (new)
```

SecurityOnly is intentionally NOT paired with IE Cum — SO publishes only OS security fixes, not IE updates.

## Effect

On the 1,852-update local fetch, the new logic synthesizes **~487 Update-level edges** across (year, month, product) groups spanning **2017-03 through 2026-04**, primarily targeting legacy hosts whose vuls2 detection currently terminates the coverage walk before reaching the IE Cum lineage:
- Win 7 / Win 8.1 / Embedded 7 / Server 2008 R2 / Server 2012 / Server 2012 R2

Pre-A0, MSUC has only ~13 of the ~176 IE Cumulative KBs from the Bulletin corpus, so the synthesis only fires after vuls-data-db#149 lands. The two PRs together close the structural chain gap for legacy IE detection.

## Testing

Added 6 new sub-cases to `TestDeriveCrossTrackSupersedes`:

- `SecurityMonthly ⊇ IECumulative — modern format (date in title)`
- `SecurityMonthly ⊇ IECumulative — old format (date from ieCumOldReleaseMonth)`
- `Preview ⊇ IECumulative (and via existing Preview ⊇ SecurityMonthly chain)`
- `SecurityOnly does NOT pair with IECumulative (no edge synthesised)`
- `IE Cum old format with KBID not in ieCumOldReleaseMonth is silently skipped`
- `IE Cum 'lowercase systems' (modern format inconsistency) is normalized and pairs with MR`

End-to-end smoke-tested against the 1,852-update local fetch — both flagship targeted edges (`KB4012215 → KB4012204` for 2017-03 Win 7 x64 SM ⊇ IE 11 Cum, and `KB5011552 → KB5011486` for 2022-03 Win 7 x64 SM ⊇ IE 11 Cum) appear in the extracted output and are confirmed absent from Microsoft's native supersedes data.

## Test plan
- [x] `GOEXPERIMENT=jsonv2 go test ./pkg/extract/microsoft/msuc/...`
- [x] `GOEXPERIMENT=jsonv2 go vet ./pkg/extract/microsoft/msuc/...`
- [x] End-to-end run on local fetch, verify expected edges appear and existing native edges are preserved.