### PR TITLE
chore(ci): scope permissions per job with empty workflow defaults

### DIFF
--- a/.github/workflows/push-log.yml
+++ b/.github/workflows/push-log.yml
@@ -5,12 +5,12 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   log:
     runs-on: ubuntu-slim
+    permissions: {}
     steps:
       - name: Log push event
         run: echo "Push detected."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,7 @@ name: Test
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   GOEXPERIMENT: jsonv2
@@ -13,6 +12,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6


### PR DESCRIPTION
Set workflow-level permissions to {} and grant only the minimum required permissions at each job.