### PR TITLE
fix(extract/microsoft/cvrf): add SQL Server 2025 CU4 and Live Preview

### DIFF
--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -1198,6 +1198,7 @@ func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criter
 			"Microsoft SQL Server 2022 for x64-based Systems (GDR)",
 			"Microsoft SQL Server 2025 for x64-based Systems (CU2)",
 			"Microsoft SQL Server 2025 for x64-based Systems (CU3)",
+			"Microsoft SQL Server 2025 for x64-based Systems (CU4)",
 			"Microsoft SQL Server 2025 for x64-based Systems (GDR)",
 			"SQL Server 2019 for Linux Containers",
 			"SQL Server Integration Services for Visual Studio 2019",
@@ -1440,6 +1441,7 @@ func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criter
 			"Visual Studio Code - GitHub Pull Requests and Issues Extension",
 			"Visual Studio Code - JS Debug Extension",
 			"Visual Studio Code - Kubernetes Tools",
+			"Visual Studio Code - Live Preview extension",
 			"Visual Studio Code Remote - Containers Extension",
 			"Visual Studio Code Remote - SSH Extension",
 			"Visual Studio Code WSL Extension":


### PR DESCRIPTION
## What
Add two new Microsoft product names that started appearing in the May 2026 CVRF feed:

- `Microsoft SQL Server 2025 for x64-based Systems (CU4)` → routed to the SQL Server case, FixedBuild parsed via `sqlserverversion.NewVersion` (same handling as the sibling CU2/CU3/GDR entries).
- `Visual Studio Code - Live Preview extension` → added to the no-FixedBuild-validation group, alongside the other Visual Studio Code extensions.

## Why
The `Extract All` run on vulsio/vuls-data-db failed with:

```
unknown product "Microsoft SQL Server 2025 for x64-based Systems (CU4)" (matches prefix "Microsoft SQL Server 20") not listed in buildFixedBuildCriterion, please add it
unexpected FixedBuild format for CVE-2026-40370 (Microsoft SQL Server 2025 for x64-based Systems (CU4)): "17.0.4040.1"
```

Run: https://github.com/vulsio/vuls-data-db/actions/runs/25781576069

A second run with only the SQL Server CU4 entry added surfaced the same kind of error for `Visual Studio Code - Live Preview extension` (CVE-2026-41612, FixedBuild `0.4.19`), so both are fixed in this PR.

`buildFixedBuildCriterion` intentionally errors when a product matches a known prefix (`Microsoft SQL Server 20`, `Visual Studio Code`) but is not explicitly listed — to force human classification of new products. This change adds those classifications.

## How
- `pkg/extract/microsoft/cvrf/cvrf.go`: extend the SQL Server case list with the CU4 entry, and extend the VS Code extension no-validation list with the Live Preview entry.

## Testing
- `GOEXPERIMENT=jsonv2 go build ./cmd/vuls-data-update`
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/microsoft/cvrf/...` → ok
- `GOEXPERIMENT=jsonv2 vuls-data-update extract microsoft-cvrf --dir <out> <local raw snapshot pulled from ghcr.io/vulsio/vuls-data-db:vuls-data-raw-microsoft-cvrf>` → exit 0, both CVE-2026-40370 and CVE-2026-41612 emit `data/CVE/2026/*.json` containing the expected SQL Server CU4 / Live Preview entries.