### PR TITLE
feat(extract/microsoft/bulletin): synthesize per-component rows

### DIFF
--- a/pkg/extract/microsoft/bulletin/bulletin.go
+++ b/pkg/extract/microsoft/bulletin/bulletin.go
@@ -443,9 +443,9 @@ func normalizeArchiveComponentKey(bulletinID, affectedProduct, affectedComponent
 	// therefore can't disagree with each other). The generator emits
 	// product-keyed entries only for the safe pairs and silently drops
 	// any pair whose markdown cells truly span tables with conflicting
-	// NA state. The lone such pair across the corpus — MS15-128 /
-	// KB3116869 / CVE-2015-6108 — is the only known remaining FP
-	// trade-off.
+	// NA state. The one such pair across the corpus (MS15-128 /
+	// KB3116869 / CVE-2015-6108) is recovered by bulletinArchiveComponentReattribution
+	// — see that map's doc comment.
 	case "MS12-054", "MS12-074",
 		"MS13-046", "MS13-081",
 		"MS15-097", "MS15-128",
@@ -517,6 +517,157 @@ func isOSPlatform(s string) bool {
 	}
 }
 
+// componentReattribution describes a synthetic per-component row that should be
+// emitted alongside an OS-only xlsx row. See bulletinArchiveComponentReattribution.
+type componentReattribution struct {
+	Component string   // affected_component value to set on the synthesized row
+	CVEs      []string // CVEs to move from the OS row to the synthesized row
+}
+
+// bulletinArchiveComponentReattribution captures per-component CVE attributions that
+// Microsoft documents in component matrix tables but BulletinSearch.xlsx
+// collapses into the OS-only row (because Microsoft did not emit a
+// distinct xlsx row for the OS + component configuration). At extract
+// time, the listed CVEs are moved from the OS row's cves to a
+// synthesized row carrying the listed affected_component, preserving
+// the markdown's per-configuration precision and producing a separate
+// detection segment for the (OS + component) configuration.
+//
+// Map shape: bulletinID → component_kb → []componentReattribution
+//
+// Each entry encodes a specific markdown row from a component matrix
+// table whose configuration is reachable in production (i.e. customers
+// could have that OS + component combination installed) but absent
+// from xlsx as a standalone row. Without the split, a scanner would
+// either flag the OS row for CVEs it isn't actually exposed to (FP) or
+// silently miss the configuration entirely.
+//
+// Example: MS15-128 / KB3116869 — the bulletin's .NET Framework 3.5
+// component matrix table marks Win 10 / KB3116869 as Critical RCE for
+// CVE-2015-6108, but xlsx only carries the OS-only Win 10 row
+// (cves=CVE-2015-6106,CVE-2015-6107,CVE-2015-6108, affected_component
+// absent). Splitting the .NET 3.5 attribution off produces two
+// detection rows: the OS-only row covering CVE-2015-6107, and a
+// synthesized "Windows 10 + .NET Framework 3.5" row covering
+// CVE-2015-6108 (CVE-2015-6106 is dropped earlier by
+// bulletinArchiveKBNotApplicable as truly NA for Win 10).
+//
+// MS15-128 / KB3116869 / CVE-2015-6108 is the ONLY such case in the
+// MSRC bulletin archive corpus. A corpus-wide audit (per-(KB, CVE)
+// cross-table cell scan + xlsx component-row presence check) surfaced
+// no other bulletins where (a) the markdown documents a component
+// configuration with a CVE that the OS-only context marks NA AND (b)
+// xlsx is missing the (OS + component, KB) row. Additional candidates
+// the audit surfaced (e.g. MS08-040, MS09-004, MS09-024, MS09-062,
+// MS12-027) turned out to share applicability between OS-only and
+// OS+component contexts, so the xlsx OS row already attributes the
+// CVEs correctly — no reattribution needed. The map is therefore
+// expected to stay at one entry unless Microsoft re-publishes the
+// archive in a structurally different way.
+var bulletinArchiveComponentReattribution = map[string]map[string][]componentReattribution{
+	"MS15-128": {
+		"3116869": {
+			{Component: "Microsoft .NET Framework 3.5", CVEs: []string{"CVE-2015-6108"}},
+		},
+	},
+}
+
+// applyComponentReattributions returns a copy of rows expanded by
+// bulletinArchiveComponentReattribution. For each row whose
+// (bulletin_id, component_kb) matches an entry, the matching CVEs are
+// removed from the original row's cves string and one synthesized row
+// per reattribution entry is appended carrying the listed
+// affected_component and only the CVEs that were actually present on
+// the source row.
+//
+// Three invariants guard against accidental data corruption:
+//
+//   - Only OS-only rows (affected_component empty) are eligible. Rows
+//     that already carry an affected_component value are real
+//     component rows and are passed through unchanged, even if their
+//     (bulletin_id, component_kb) collides with a map entry — rewriting
+//     them would silently corrupt Microsoft's own component attribution.
+//   - CVE token comparison goes through parseCVEs so historical xlsx
+//     format anomalies ("CVE-CVE-...", concatenated CVEs, whitespace,
+//     case) are normalized the same way the main extract path does. A
+//     row whose cves cell fails parseCVEs is passed through unchanged;
+//     the main extract loop surfaces the parse error with full context.
+//   - Only the intersection of (map entry's CVEs) ∩ (row's actual CVEs)
+//     is moved. If a map entry lists a CVE that isn't on the source
+//     row, that CVE is skipped (not synthesized). If none of an entry's
+//     CVEs are present, the entire synth row is dropped. This makes
+//     accidental map mistypes manifest as "no change" rather than as
+//     silent over-attribution.
+func applyComponentReattributions(rows []bulletin.Bulletin) []bulletin.Bulletin {
+	out := make([]bulletin.Bulletin, 0, len(rows))
+	for _, row := range rows {
+		// Pass through rows that already carry a real affected_component
+		// value — they are not the OS-only rows the map targets.
+		if row.AffectedComponent != "" {
+			out = append(out, row)
+			continue
+		}
+
+		reattributions, ok := bulletinArchiveComponentReattribution[strings.ToUpper(row.BulletinID)][row.ComponentKB]
+		if !ok {
+			out = append(out, row)
+			continue
+		}
+
+		parsed, err := parseCVEs(row.CVEs)
+		if err != nil {
+			// Best-effort: defer the error to the main extract loop, which
+			// will surface it with full context. Pass the row through
+			// unchanged so we don't silently mutate a malformed row.
+			out = append(out, row)
+			continue
+		}
+		present := make(map[string]struct{}, len(parsed))
+		for _, c := range parsed {
+			present[c] = struct{}{}
+		}
+
+		// Build the synthesized rows from the intersection of each entry's
+		// CVEs and the row's actual CVEs. Empty intersections are dropped.
+		movedAll := make(map[string]struct{})
+		synths := make([]componentReattribution, 0, len(reattributions))
+		for _, r := range reattributions {
+			actual := make([]string, 0, len(r.CVEs))
+			for _, c := range r.CVEs {
+				if _, ok := present[c]; ok {
+					actual = append(actual, c)
+					movedAll[c] = struct{}{}
+				}
+			}
+			if len(actual) == 0 {
+				continue
+			}
+			synths = append(synths, componentReattribution{Component: r.Component, CVEs: actual})
+		}
+
+		// Rebuild row.CVEs from the parsed list excluding moved CVEs. This
+		// also re-canonicalises any anomalies parseCVEs handled, so the
+		// downstream loop sees the normalized form.
+		kept := make([]string, 0, len(parsed))
+		for _, c := range parsed {
+			if _, drop := movedAll[c]; drop {
+				continue
+			}
+			kept = append(kept, c)
+		}
+		row.CVEs = strings.Join(kept, ",")
+		out = append(out, row)
+
+		for _, r := range synths {
+			synth := row
+			synth.AffectedComponent = r.Component
+			synth.CVEs = strings.Join(r.CVEs, ",")
+			out = append(out, synth)
+		}
+	}
+	return out
+}
+
 func (e extractor) extract(rows []bulletin.Bulletin) ([]dataTypes.Data, []microsoftkbTypes.KB, error) {
 	type dataGroup struct {
 		advisories []advisoryTypes.Advisory
@@ -528,7 +679,7 @@ func (e extractor) extract(rows []bulletin.Bulletin) ([]dataTypes.Data, []micros
 	kbProducts := make(map[string]map[string]struct{})
 	kbSupersededBy := make(map[string]map[string]struct{}) // old KBID → set of new KBIDs
 
-	for _, row := range rows {
+	for _, row := range applyComponentReattributions(rows) {
 		if row.AffectedProduct == "" {
 			switch strings.ToUpper(row.BulletinID) {
 			case "MS01-002", "MS01-050":

--- a/pkg/extract/microsoft/bulletin/bulletin_test.go
+++ b/pkg/extract/microsoft/bulletin/bulletin_test.go
@@ -5,8 +5,11 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/bulletin"
 	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+	fetch "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/bulletin"
 )
 
 func TestExtract(t *testing.T) {
@@ -644,12 +647,14 @@ func TestBulletinArchiveNotApplicable(t *testing.T) {
 				innerKey:   "Windows Server 2016 for x64-based Systems (Server Core installation)",
 				cve:        "CVE-2017-0024",
 			},
-			// The one (KB, CVE) pair that genuinely cannot be filtered: MS15-128 /
-			// KB3116869 / CVE-2015-6108 is "Not applicable" in the OS-level table
-			// but "Critical Remote Code Execution" in the same bulletin's
-			// component-level table, with the same xlsx affected_product label
-			// for both. Cross-table-mixed at the (KB, CVE) grain — no static map
-			// shape can disambiguate. Documented as a known FP.
+			// MS15-128 / KB3116869 / CVE-2015-6108 is "Not applicable" in the
+			// OS-level table but "Critical Remote Code Execution" in the same
+			// bulletin's component-level table, with the same xlsx
+			// affected_product label for both. A static (bulletin, component)
+			// NA map cannot disambiguate at this grain. This case is now
+			// handled by bulletinArchiveComponentReattribution, which splits
+			// the OS-only xlsx row into an OS-only row + a synthesized
+			// "OS + .NET Framework 3.5" row carrying CVE-2015-6108.
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -738,6 +743,89 @@ func TestBulletinArchiveCVECorrections(t *testing.T) {
 			}
 			if fix != tt.wantFix {
 				t.Errorf("bulletinArchiveCVECorrections[%q][%q] = %q, want %q", tt.bulletinID, tt.token, fix, tt.wantFix)
+			}
+		})
+	}
+}
+
+func TestApplyComponentReattributions(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []fetch.Bulletin
+		want []fetch.Bulletin
+	}{
+		{
+			name: "row without a split entry is passed through unchanged",
+			in: []fetch.Bulletin{
+				{BulletinID: "MS15-097", AffectedProduct: "Windows 7 for 32-bit Systems Service Pack 1", ComponentKB: "3087039", CVEs: "CVE-2015-2506,CVE-2015-2507"},
+			},
+			want: []fetch.Bulletin{
+				{BulletinID: "MS15-097", AffectedProduct: "Windows 7 for 32-bit Systems Service Pack 1", ComponentKB: "3087039", CVEs: "CVE-2015-2506,CVE-2015-2507"},
+			},
+		},
+		{
+			name: "MS15-128 KB3116869 Win 10 32-bit row is split into OS-only + .NET 3.5 rows",
+			in: []fetch.Bulletin{
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 10 for 32-bit Systems", ComponentKB: "3116869", CVEs: "CVE-2015-6106,CVE-2015-6107,CVE-2015-6108"},
+			},
+			want: []fetch.Bulletin{
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 10 for 32-bit Systems", ComponentKB: "3116869", CVEs: "CVE-2015-6106,CVE-2015-6107"},
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 10 for 32-bit Systems", AffectedComponent: "Microsoft .NET Framework 3.5", ComponentKB: "3116869", CVEs: "CVE-2015-6108"},
+			},
+		},
+		{
+			name: "lowercase bulletin_id matches the dispatch case-insensitively",
+			in: []fetch.Bulletin{
+				{BulletinID: "ms15-128", AffectedProduct: "Windows 10 for x64-based Systems", ComponentKB: "3116869", CVEs: "CVE-2015-6106,CVE-2015-6108"},
+			},
+			want: []fetch.Bulletin{
+				{BulletinID: "ms15-128", AffectedProduct: "Windows 10 for x64-based Systems", ComponentKB: "3116869", CVEs: "CVE-2015-6106"},
+				{BulletinID: "ms15-128", AffectedProduct: "Windows 10 for x64-based Systems", AffectedComponent: "Microsoft .NET Framework 3.5", ComponentKB: "3116869", CVEs: "CVE-2015-6108"},
+			},
+		},
+		{
+			name: "row whose KB does not match an entry is passed through unchanged",
+			in: []fetch.Bulletin{
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 7 for 32-bit Systems Service Pack 1", ComponentKB: "3109094", CVEs: "CVE-2015-6106"},
+			},
+			want: []fetch.Bulletin{
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 7 for 32-bit Systems Service Pack 1", ComponentKB: "3109094", CVEs: "CVE-2015-6106"},
+			},
+		},
+		{
+			name: "row that already has affected_component is passed through unchanged even if it matches the dispatch",
+			in: []fetch.Bulletin{
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 10 for 32-bit Systems", AffectedComponent: "Microsoft .NET Framework 3.5", ComponentKB: "3116869", CVEs: "CVE-2015-6106,CVE-2015-6107,CVE-2015-6108"},
+			},
+			want: []fetch.Bulletin{
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 10 for 32-bit Systems", AffectedComponent: "Microsoft .NET Framework 3.5", ComponentKB: "3116869", CVEs: "CVE-2015-6106,CVE-2015-6107,CVE-2015-6108"},
+			},
+		},
+		{
+			name: "synth row is skipped when none of the entry's CVEs are present on the source row",
+			in: []fetch.Bulletin{
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 10 for 32-bit Systems", ComponentKB: "3116869", CVEs: "CVE-2015-6106,CVE-2015-6107"},
+			},
+			want: []fetch.Bulletin{
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 10 for 32-bit Systems", ComponentKB: "3116869", CVEs: "CVE-2015-6106,CVE-2015-6107"},
+			},
+		},
+		{
+			name: "parseCVEs normalizes \"CVE-CVE-\" prefix duplication before comparison",
+			in: []fetch.Bulletin{
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 10 for 32-bit Systems", ComponentKB: "3116869", CVEs: "CVE-CVE-2015-6106,CVE-2015-6107,CVE-CVE-2015-6108"},
+			},
+			want: []fetch.Bulletin{
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 10 for 32-bit Systems", ComponentKB: "3116869", CVEs: "CVE-2015-6106,CVE-2015-6107"},
+				{BulletinID: "MS15-128", AffectedProduct: "Windows 10 for 32-bit Systems", AffectedComponent: "Microsoft .NET Framework 3.5", ComponentKB: "3116869", CVEs: "CVE-2015-6108"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bulletin.ApplyComponentReattributions(tt.in)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ApplyComponentReattributions() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/extract/microsoft/bulletin/export_test.go
+++ b/pkg/extract/microsoft/bulletin/export_test.go
@@ -9,4 +9,6 @@ var (
 	BulletinArchiveKBNotApplicable        = bulletinArchiveKBNotApplicable
 	BulletinArchiveComponentNotApplicable = bulletinArchiveComponentNotApplicable
 	BulletinArchiveCVECorrections         = bulletinArchiveCVECorrections
+	BulletinArchiveComponentReattribution = bulletinArchiveComponentReattribution
+	ApplyComponentReattributions          = applyComponentReattributions
 )


### PR DESCRIPTION
## Summary

Stacked on #815. Adds a row-splitting preprocessor to the bulletin
extractor that synthesizes per-component rows for configurations
documented in the markdown's component matrix tables but missing
from BulletinSearch.xlsx as standalone rows.

## Why

Some bulletins' component matrix tables (e.g. MS15-128's `.NET
Framework 3.5`) document CVE applicability for (OS + component)
configurations that xlsx does not carry as a distinct row.
xlsx collapses these into the OS-only row's `cves` cell, which
aggregates per-CVE applicability across all configurations the
bulletin covers. The result:

- **Without filtering**: scanner over-attributes — flags the OS row
  for CVEs that only apply when the component is installed (FP).
- **With KB-keyed NA filtering**: scanner misses the configurations
  where the CVE IS applicable (FN). This is why the previous version
  of #815 documented `MS15-128 / KB3116869 / CVE-2015-6108` as the
  lone unfilterable trade-off.

## How

A new map `bulletinArchiveComponentReattribution: bulletinID → component_kb →
[]componentReattribution` describes per-component CVE attributions that
should be moved off the OS row into synthesized rows. At extract
time:

1. For each xlsx row, check `bulletinArchiveComponentReattribution` for matching
   `(bulletin_id, component_kb)`.
2. If matched: remove the listed CVEs from the original row's `cves`
   cell, then append one synthesized row per split entry carrying
   the listed `affected_component` and only the listed CVEs.

Detection downstream then sees two rows: one matching the OS itself
with the CVEs that apply standalone, and one matching the
(OS + component) configuration with the CVEs that apply only when
the component is present. No FP on no-component systems; no FN on
with-component systems.

## Initial entry

The first entry recovers `MS15-128 / KB3116869 / CVE-2015-6108`:

| Configuration | CVE-2015-6108 attribution |
|---|---|
| Win 10 (any) (no .NET 3.5) — OS row in xlsx | Filtered out (correctly) |
| Win 10 + .NET 3.5 — synthesized row | Critical RCE (correctly) |

## Testing

- New unit test `TestApplyComponentReattributions` covers:
  - Pass-through for rows without a split entry
  - The MS15-128 / KB3116869 Win 10 32-bit and x64 splits (CVE-2015-6108
    moved off the OS row into a `.NET Framework 3.5`-tagged
    synthesized row)
  - Case-insensitive bulletin_id matching
  - Non-matching `component_kb` pass-through
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/microsoft/bulletin/...` — passes
- `GOEXPERIMENT=jsonv2 go test ./...` — passes

## Test plan

- [ ] Build with `GOEXPERIMENT=jsonv2 go build ./...`
- [ ] Test with `GOEXPERIMENT=jsonv2 go test ./...`
- [ ] Extract a real BulletinSearch.xlsx and confirm MS15-128 has a
      separate `Microsoft .NET Framework 3.5 on Windows 10 ...` row
      with `CVE-2015-6108` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
