### PR TITLE
fix(extract/redhat/vex/v1): allow pkg:pypi/ purl prefix

### DIFF
--- a/pkg/extract/redhat/vex/v1/v1.go
+++ b/pkg/extract/redhat/vex/v1/v1.go
@@ -402,7 +402,7 @@ func walkProductTree(pt v1.ProductTree, c2r map[string][]string) (map[v1.Product
 						// processed or just added to this skip list — silent
 						// data loss is worse than a loud failure.
 						for _, s := range []string{
-							"pkg:generic/", "pkg:maven/", "pkg:npm/", "pkg:oci/",
+							"pkg:generic/", "pkg:maven/", "pkg:npm/", "pkg:oci/", "pkg:pypi/",
 						} {
 							if strings.HasPrefix(fpn.ProductIdentificationHelper.PURL, s) {
 								return nil, nil


### PR DESCRIPTION
## What
Add `pkg:pypi/` to the non-RPM PURL skip list in `pkg/extract/redhat/vex/v1/v1.go`.

## Why
CVE-2026-44432 introduced a new `pkg:pypi/urllib3` PURL in the VEX v1 product tree. The extractor explicitly rejects unknown PURL prefixes with `unexpected purl prefix` (intentional fail-loud behaviour — see the comment block above the skip list), aborting the entire extract job.

Failing CI runs on vuls-data-db:
- https://github.com/vulsio/vuls-data-db/actions/runs/26254814990/job/77274837362
- https://github.com/vulsio/vuls-data-db/actions/runs/26254814990/job/77276928743

PyPI artifacts are not RHEL RPMs and have no detection mapping in this feed, so they belong with the other non-RPM types (`generic`/`maven`/`npm`/`oci`) that are silently skipped.

## How
Single-line change: extended the skip-list slice to include `pkg:pypi/`.

## Testing
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/redhat/vex/v1/...` → PASS
- `GOEXPERIMENT=jsonv2 go build ./cmd/vuls-data-update` → builds clean
- Ran `extract redhat-vex-v1` against the full `ghcr.io/vulsio/vuls-data-db/vuls-data-raw-redhat-vex-v1` (318,105 CVE files including CVE-2026-44432) → exit 0, all files extracted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)