### PR TITLE
refactor(extract): skip .git in WalkDir traversal of dotgit checkouts

### DIFF
--- a/pkg/extract/alma/errata/errata.go
+++ b/pkg/extract/alma/errata/errata.go
@@ -79,7 +79,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "read dir %s", args)
 	}
 	for _, ve := range ventries {
-		if !ve.IsDir() {
+		if !ve.IsDir() || ve.Name() == ".git" {
 			continue
 		}
 

--- a/pkg/extract/alma/osv/osv.go
+++ b/pkg/extract/alma/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/alma/oval/oval.go
+++ b/pkg/extract/alma/oval/oval.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/alpine/osv/osv.go
+++ b/pkg/extract/alpine/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/alpine/secdb/secdb.go
+++ b/pkg/extract/alpine/secdb/secdb.go
@@ -74,6 +74,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/amazon/amazon.go
+++ b/pkg/extract/amazon/amazon.go
@@ -76,6 +76,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/android/osv/osv.go
+++ b/pkg/extract/android/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/arch/arch.go
+++ b/pkg/extract/arch/arch.go
@@ -75,6 +75,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/attack/attack.go
+++ b/pkg/extract/attack/attack.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/bitnami/osv/osv.go
+++ b/pkg/extract/bitnami/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/capec/capec.go
+++ b/pkg/extract/capec/capec.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/cargo/db/db.go
+++ b/pkg/extract/cargo/db/db.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/cargo/ghsa/ghsa.go
+++ b/pkg/extract/cargo/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/cargo/osv/osv.go
+++ b/pkg/extract/cargo/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/chainguard/osv/osv.go
+++ b/pkg/extract/chainguard/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/cisa/kev/kev.go
+++ b/pkg/extract/cisa/kev/kev.go
@@ -61,7 +61,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/composer/db/db.go
+++ b/pkg/extract/composer/db/db.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/composer/ghsa/ghsa.go
+++ b/pkg/extract/composer/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/composer/glsa/glsa.go
+++ b/pkg/extract/composer/glsa/glsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/composer/osv/osv.go
+++ b/pkg/extract/composer/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/conan/glsa/glsa.go
+++ b/pkg/extract/conan/glsa/glsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/cwe/cwe.go
+++ b/pkg/extract/cwe/cwe.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/debian/osv/osv.go
+++ b/pkg/extract/debian/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/debian/oval/oval.go
+++ b/pkg/extract/debian/oval/oval.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/debian/tracker/api/api.go
+++ b/pkg/extract/debian/tracker/api/api.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/enisa/kev/kev.go
+++ b/pkg/extract/enisa/kev/kev.go
@@ -64,7 +64,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/epss/epss.go
+++ b/pkg/extract/epss/epss.go
@@ -64,6 +64,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/erlang/ghsa/ghsa.go
+++ b/pkg/extract/erlang/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/erlang/osv/osv.go
+++ b/pkg/extract/erlang/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/exploit/github/github.go
+++ b/pkg/extract/exploit/github/github.go
@@ -62,7 +62,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/exploit/inthewild/inthewild.go
+++ b/pkg/extract/exploit/inthewild/inthewild.go
@@ -65,7 +65,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/exploit/trickest/trickest.go
+++ b/pkg/extract/exploit/trickest/trickest.go
@@ -64,7 +64,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/fedora/api/api.go
+++ b/pkg/extract/fedora/api/api.go
@@ -78,7 +78,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/fortinet/cvrf/cvrf.go
+++ b/pkg/extract/fortinet/cvrf/cvrf.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/fortinet/handmade/handmade.go
+++ b/pkg/extract/fortinet/handmade/handmade.go
@@ -47,6 +47,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/freebsd/freebsd.go
+++ b/pkg/extract/freebsd/freebsd.go
@@ -75,6 +75,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/gentoo/gentoo.go
+++ b/pkg/extract/gentoo/gentoo.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/ghactions/osv/osv.go
+++ b/pkg/extract/ghactions/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/git/osv/osv.go
+++ b/pkg/extract/git/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/golang/db/db.go
+++ b/pkg/extract/golang/db/db.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/golang/ghsa/ghsa.go
+++ b/pkg/extract/golang/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/golang/glsa/glsa.go
+++ b/pkg/extract/golang/glsa/glsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/golang/osv/osv.go
+++ b/pkg/extract/golang/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/golang/vulndb/vulndb.go
+++ b/pkg/extract/golang/vulndb/vulndb.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/haskell/db/db.go
+++ b/pkg/extract/haskell/db/db.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/haskell/osv/osv.go
+++ b/pkg/extract/haskell/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/jvn/feed/detail/detail.go
+++ b/pkg/extract/jvn/feed/detail/detail.go
@@ -82,6 +82,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/jvn/feed/product/product.go
+++ b/pkg/extract/jvn/feed/product/product.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/jvn/feed/rss/rss.go
+++ b/pkg/extract/jvn/feed/rss/rss.go
@@ -82,6 +82,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/linux/osv/osv.go
+++ b/pkg/extract/linux/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/maven/ghsa/ghsa.go
+++ b/pkg/extract/maven/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/maven/glsa/glsa.go
+++ b/pkg/extract/maven/glsa/glsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/maven/osv/osv.go
+++ b/pkg/extract/maven/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/microsoft/bulletin/bulletin.go
+++ b/pkg/extract/microsoft/bulletin/bulletin.go
@@ -84,7 +84,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -137,7 +137,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -119,6 +119,9 @@ func buildUpdateIDMap(root string) (map[string]string, error) {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 
@@ -172,6 +175,9 @@ func (o options) extract(root string, updateIDMap map[string]string) error {
 			}
 
 			if d.IsDir() {
+				if d.Name() == ".git" {
+					return filepath.SkipDir
+				}
 				return nil
 			}
 

--- a/pkg/extract/mitre/cvrf/cvrf.go
+++ b/pkg/extract/mitre/cvrf/cvrf.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/mitre/v4/v4.go
+++ b/pkg/extract/mitre/v4/v4.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/mitre/v5/v5.go
+++ b/pkg/extract/mitre/v5/v5.go
@@ -67,7 +67,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/msf/msf.go
+++ b/pkg/extract/msf/msf.go
@@ -67,7 +67,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/netbsd/netbsd.go
+++ b/pkg/extract/netbsd/netbsd.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/npm/db/db.go
+++ b/pkg/extract/npm/db/db.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/npm/ghsa/ghsa.go
+++ b/pkg/extract/npm/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/npm/glsa/glsa.go
+++ b/pkg/extract/npm/glsa/glsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/npm/osv/osv.go
+++ b/pkg/extract/npm/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/nuclei/repository/repository.go
+++ b/pkg/extract/nuclei/repository/repository.go
@@ -143,7 +143,14 @@ func extract(args string) (map[string]dataTypes.Data, error) {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/nuget/ghsa/ghsa.go
+++ b/pkg/extract/nuget/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/nuget/glsa/glsa.go
+++ b/pkg/extract/nuget/glsa/glsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/nuget/osv/osv.go
+++ b/pkg/extract/nuget/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/nvd/api/cpe/cpe.go
+++ b/pkg/extract/nvd/api/cpe/cpe.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/nvd/api/cve/cve.go
+++ b/pkg/extract/nvd/api/cve/cve.go
@@ -111,7 +111,14 @@ func Extract(cveDir, cpematchDir string, opts ...Option) error {
 				return err
 			}
 
-			if d.IsDir() || filepath.Ext(path) != ".json" {
+			if d.IsDir() {
+				if d.Name() == ".git" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			if filepath.Ext(path) != ".json" {
 				return nil
 			}
 

--- a/pkg/extract/nvd/feed/cpe/v1/v1.go
+++ b/pkg/extract/nvd/feed/cpe/v1/v1.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/nvd/feed/cpe/v2/v2.go
+++ b/pkg/extract/nvd/feed/cpe/v2/v2.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/nvd/feed/cpematch/v1/v1.go
+++ b/pkg/extract/nvd/feed/cpematch/v1/v1.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/nvd/feed/cpematch/v2/v2.go
+++ b/pkg/extract/nvd/feed/cpematch/v2/v2.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/nvd/feed/cve/v1/v1.go
+++ b/pkg/extract/nvd/feed/cve/v1/v1.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/nvd/feed/cve/v2/v2.go
+++ b/pkg/extract/nvd/feed/cve/v2/v2.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/oss-fuzz/osv/osv.go
+++ b/pkg/extract/oss-fuzz/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/perl/db/db.go
+++ b/pkg/extract/perl/db/db.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/pip/db/db.go
+++ b/pkg/extract/pip/db/db.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/pip/ghsa/ghsa.go
+++ b/pkg/extract/pip/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/pip/glsa/glsa.go
+++ b/pkg/extract/pip/glsa/glsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/pip/osv/osv.go
+++ b/pkg/extract/pip/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/pub/ghsa/ghsa.go
+++ b/pkg/extract/pub/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/pub/osv/osv.go
+++ b/pkg/extract/pub/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/r/db/db.go
+++ b/pkg/extract/r/db/db.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/r/osv/osv.go
+++ b/pkg/extract/r/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/redhat/csaf/csaf.go
+++ b/pkg/extract/redhat/csaf/csaf.go
@@ -106,7 +106,14 @@ func Extract(csafDir, repository2cpeDir string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/redhat/cve/cve.go
+++ b/pkg/extract/redhat/cve/cve.go
@@ -69,7 +69,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/redhat/cvrf/cvrf.go
+++ b/pkg/extract/redhat/cvrf/cvrf.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/redhat/osv/osv.go
+++ b/pkg/extract/redhat/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/redhat/vex/v1/v1.go
+++ b/pkg/extract/redhat/vex/v1/v1.go
@@ -106,7 +106,14 @@ func Extract(vexDir, repository2cpeDir string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/redhat/vex/v2/v2.go
+++ b/pkg/extract/redhat/vex/v2/v2.go
@@ -109,7 +109,14 @@ func Extract(vexDir, repository2cpeDir string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/rocky/errata/errata.go
+++ b/pkg/extract/rocky/errata/errata.go
@@ -82,7 +82,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "read dir %s", args)
 	}
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		if !entry.IsDir() || entry.Name() == ".git" {
 			continue
 		}
 

--- a/pkg/extract/rubygems/db/db.go
+++ b/pkg/extract/rubygems/db/db.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/rubygems/ghsa/ghsa.go
+++ b/pkg/extract/rubygems/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/rubygems/glsa/glsa.go
+++ b/pkg/extract/rubygems/glsa/glsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/rubygems/osv/osv.go
+++ b/pkg/extract/rubygems/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/snort/snort.go
+++ b/pkg/extract/snort/snort.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/suse/csaf/csaf.go
+++ b/pkg/extract/suse/csaf/csaf.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/suse/csaf_vex/csaf_vex.go
+++ b/pkg/extract/suse/csaf_vex/csaf_vex.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/suse/cvrf/cvrf.go
+++ b/pkg/extract/suse/cvrf/cvrf.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/suse/cvrf_cve/cvrf_cve.go
+++ b/pkg/extract/suse/cvrf_cve/cvrf_cve.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/suse/osv/osv.go
+++ b/pkg/extract/suse/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/swift/ghsa/ghsa.go
+++ b/pkg/extract/swift/ghsa/ghsa.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/swift/osv/osv.go
+++ b/pkg/extract/swift/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/ubuntu/osv/osv.go
+++ b/pkg/extract/ubuntu/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/ubuntu/oval/oval.go
+++ b/pkg/extract/ubuntu/oval/oval.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/pkg/extract/vulncheck/kev/kev.go
+++ b/pkg/extract/vulncheck/kev/kev.go
@@ -62,7 +62,14 @@ func Extract(args string, opts ...Option) error {
 			return err
 		}
 
-		if d.IsDir() || filepath.Ext(path) != ".json" {
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
 			return nil
 		}
 

--- a/pkg/extract/wolfi/osv/osv.go
+++ b/pkg/extract/wolfi/osv/osv.go
@@ -48,6 +48,9 @@ func Extract(args string, opts ...Option) error {
 		}
 
 		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 


### PR DESCRIPTION
## What

Stop `pkg/extract` traversals from descending into the `.git` directory of a dotgit checkout. Two mechanisms are covered:

1. **`filepath.WalkDir` callbacks** — add a `.git` `filepath.SkipDir` branch (commit 1).
2. **`os.ReadDir` recursion loops** — add a `.git` skip in the directory-listing guard (commit 2).

## Why

Raw vulnerability feeds in this project are distributed as dotgit checkouts — the working tree carries its own `.git` directory. When an extractor walks the checkout, it descends into `.git` and visits every blob, pack and ref file. The `.json` extension filter discards them from extraction, but the inode reads still happen — wasted I/O that scales with repository age.

NVD CVE / cpematch feeds are the most painful case (hundreds of thousands of objects per `.git`); this PR was prompted by branch review feedback on #827, where the NVD Feed v2 extractor diverged from every sibling by adding `SkipDir`. Rather than ratchet that PR down to match the sibling convention, this PR lifts the sibling convention up so #827 (and any future extractor that walks a dotgit checkout) does not look out of place.

## How

### Commit 1 — WalkDir SkipDir

For each `filepath.WalkDir` call that walks the **root** of a dotgit checkout (the argument the user passes to `Extract`):

- `if d.IsDir() { return nil }` → add a `.git` `SkipDir` branch inside
- `if d.IsDir() || filepath.Ext(path) != ".json" { return nil }` → split into separate `IsDir` and `Ext` checks so the `.git` skip has a home

Walks that target a **subdirectory** of the checkout (e.g. `filepath.Join(root, "definitions")`, `filepath.Join(args, target)`) or an **output directory** (`filepath.Join(o.dir, "microsoftkb")`) are intentionally not touched — `.git` cannot appear there, and adding a dead branch would be noise.

### Commit 2 — os.ReadDir loops (rocky/alma errata)

`rocky/errata` and `alma/errata` don't use `WalkDir` at the top level — they iterate `os.ReadDir` over the dotgit root and recurse into each subdirectory entry, guarded only on `!IsDir()`. Since `.git` is itself a directory, that guard let the loop descend into the whole `.git` tree. Added the `entry.Name() == ".git"` skip already used by the sibling `rocky/osv` `os.ReadDir` loop.

The other `os.ReadDir`-based extractors already skip `.git` at the listing layer and are unchanged: `rocky/osv`, `redhat/oval/v1`, `redhat/oval/v2`, `suse/oval`.

## Scope notes

`filepath.WalkDir` calls left untouched because they walk a subdirectory or the output dir (no `.git` possible there):

- `pkg/extract/rocky/{errata,osv}`, `pkg/extract/alma/errata` — inner walks (errata also fixed at the `os.ReadDir` layer in commit 2)
- `pkg/extract/oracle/linux`, `pkg/extract/ubuntu/tracker` — inner walks over fixed-name subdirs
- `pkg/extract/redhat/oval/{v1,v2}`, `pkg/extract/suse/oval` — inner walks (these read `.git`-skipping `os.ReadDir` outer loops)
- `pkg/extract/microsoft/wsusscn2` — inner / output walks
- `pkg/extract/microsoft/msuc` — the `kbDir` walk is over the output dir and was left as-is; the two `root` walks (the dotgit checkout root, confirmed by `utilgit.GetDataSourceRepository(args)` → `git.PlainOpen(args)`) were touched in commit 1
- `pkg/extract/debian/tracker/salsa` — inner walks
- `pkg/extract/exploit/exploitdb` — inner walks

## Testing

- `GOEXPERIMENT=jsonv2 go build ./...` — clean
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/...` — all pass
- `go vet ./pkg/extract/...` — clean
- No behavior change for inputs without a `.git` directory; goldens unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
