### PR TITLE
chore: apply gofmt to remaining files flagged on #828

### DIFF
--- a/pkg/extract/enisa/kev/kev.go
+++ b/pkg/extract/enisa/kev/kev.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
 	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
 	advisoryContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory/content"
-	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
 	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
 	kevTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev"
 	enisaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/kev/enisa"

--- a/pkg/extract/microsoft/msuc/msuc.go
+++ b/pkg/extract/microsoft/msuc/msuc.go
@@ -411,10 +411,11 @@ var monthlyTrackTitleRE = regexp.MustCompile(`^(\d{4})-(\d{2}) (Security Only Qu
 // Server 2012 R2 / Win 8.1 era KBs. The month appears as an English name
 // BEFORE the year (e.g. "April, 2017 ..."), so the capture order differs from
 // monthlyTrackTitleRE:
-//   m[1] = month name (e.g. "April")     -- vs. m[1] = year ("2017") in modern
-//   m[2] = year       (e.g. "2017")      -- vs. m[2] = month ("04") in modern
-//   m[3] = track                         -- same as modern
-//   m[4] = product                       -- same as modern
+//
+//	m[1] = month name (e.g. "April")     -- vs. m[1] = year ("2017") in modern
+//	m[2] = year       (e.g. "2017")      -- vs. m[2] = month ("04") in modern
+//	m[3] = track                         -- same as modern
+//	m[4] = product                       -- same as modern
 //
 // Whitespace is intentionally strict (a single ASCII space at every
 // boundary). In a snapshot of the production raw MSUC corpus taken

--- a/pkg/extract/types/data/kev/vulncheck/vulncheck.go
+++ b/pkg/extract/types/data/kev/vulncheck/vulncheck.go
@@ -9,7 +9,7 @@ import (
 )
 
 type VulnCheck struct {
-	XDB                  []xdbTypes.XDB                                  `json:"xdb,omitempty"`
+	XDB                  []xdbTypes.XDB                                   `json:"xdb,omitempty"`
 	ReportedExploitation []reportedExploitationTypes.ReportedExploitation `json:"reported_exploitation,omitempty"`
 }
 

--- a/pkg/extract/util/util_test.go
+++ b/pkg/extract/util/util_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 
-	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
 	microsoftkbUpdateTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/update"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
 )

--- a/pkg/fetch/redhat/vex/v2/v2.go
+++ b/pkg/fetch/redhat/vex/v2/v2.go
@@ -190,4 +190,3 @@ func (o options) fetchArchive(client *utilhttp.Client, name string) error {
 
 	return nil
 }
-


### PR DESCRIPTION
## What

Apply ``gofmt -w`` to five files that ``gofmt -l .`` flagged but were out of scope for #828:

- ``pkg/extract/enisa/kev/kev.go``
- ``pkg/extract/microsoft/msuc/msuc.go``
- ``pkg/extract/types/data/kev/vulncheck/vulncheck.go``
- ``pkg/extract/util/util_test.go``
- ``pkg/fetch/redhat/vex/v2/v2.go``

## Why

@shino flagged these in #828 ([comment](https://github.com/MaineK00n/vuls-data-update/pull/828#issuecomment-4598324012)). Keeps ``gofmt -l .`` silent so future PRs don't carry incidental formatting noise.

## How

Just ``gofmt -w <file>`` on each. Diffs are pure formatting — mostly import ordering. No semantic change.

## Test plan

- [x] ``gofmt -l .`` is silent over the affected paths
- [x] ``GOEXPERIMENT=jsonv2 go build ./...``
- [x] ``GOEXPERIMENT=jsonv2 go test ./pkg/extract/enisa/kev/... ./pkg/extract/microsoft/msuc/... ./pkg/extract/types/data/kev/vulncheck/... ./pkg/extract/util/... ./pkg/fetch/redhat/vex/v2/...``

## Relationship to other PRs

Follow-up to #828 (CWE extractor). Independent of #829 (capec) and #830 (attack).