### PR TITLE
feat(extract/mitre/cwe): add definition-page reference and rankings

### DIFF
--- a/pkg/extract/mitre/cwe/cwe.go
+++ b/pkg/extract/mitre/cwe/cwe.go
@@ -6,6 +6,9 @@ import (
 	"log/slog"
 	"path/filepath"
 	"slices"
+	"strconv"
+	"strings"
+	"unicode"
 
 	"github.com/pkg/errors"
 
@@ -27,6 +30,7 @@ import (
 	detectionmethodTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/detectionmethod"
 	modeofintroductionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/modeofintroduction"
 	potentialmitigationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/potentialmitigation"
+	rankingTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/ranking"
 	relatedweaknessTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/relatedweakness"
 	weaknessordinalityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/weaknessordinality"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
@@ -71,6 +75,14 @@ func Extract(args string, opts ...Option) error {
 	}
 
 	slog.Info("Extract MITRE CWE")
+	// Derive ranking placements (CWE Top 25 / OWASP Top Ten / CWE/SANS Top 25)
+	// up front, keyed by ranked weakness CWE ID, so each weakness can carry its
+	// placements as it is extracted below.
+	rankings, err := buildRankings(args)
+	if err != nil {
+		return errors.Wrapf(err, "build rankings from %s", args)
+	}
+
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -88,7 +100,7 @@ func Extract(args string, opts ...Option) error {
 		kind := filepath.Base(filepath.Dir(path))
 		switch kind {
 		case "weakness":
-			return extractWeakness(path, args, options.dir)
+			return extractWeakness(path, args, options.dir, rankings)
 		case "category":
 			return extractCategory(path, args, options.dir)
 		case "view":
@@ -123,15 +135,135 @@ func Extract(args string, opts ...Option) error {
 	return nil
 }
 
-func extractWeakness(path, args, outDir string) error {
+// owaspCategoryRank returns the rank of an OWASP Top Ten "A0N" category from its
+// name (e.g. 3 from "OWASP Top Ten 2021 Category A03:2021 - Injection"). OWASP
+// views only ever contain "A0N" tier categories, so a name not in that form is
+// reported as an error rather than skipped. Both the modern "A03:YYYY" and older
+// "A6 - ..." spellings are handled.
+func owaspCategoryRank(name string) (int, error) {
+	before, after, found := strings.Cut(name, " Category A")
+	if !found || !strings.HasPrefix(before, "OWASP Top Ten ") {
+		return 0, errors.Errorf("unexpected OWASP category name. expected: %q, actual: %q", "OWASP Top Ten <year> Category A<N> ...", name)
+	}
+	// after begins with the tier number ("03:2021 - ..." / "6 - ..."); its
+	// leading run of digits, up to the first non-digit, is the rank.
+	end := strings.IndexFunc(after, func(r rune) bool { return !unicode.IsDigit(r) })
+	if end < 0 {
+		end = len(after)
+	}
+	rank, err := strconv.Atoi(after[:end])
+	if err != nil {
+		return 0, errors.Wrapf(err, "parse rank from OWASP category name %q", name)
+	}
+	return rank, nil
+}
+
+// rankingIndex holds, keyed by ranked weakness CWE ID (e.g. "CWE-79"), the
+// placements to attach to each weakness and the ranking-list raw files those
+// placements derive from.
+type rankingIndex struct {
+	placements map[string][]rankingTypes.Ranking
+	rawPaths   map[string][]string
+}
+
+// buildRankings scans the ranking lists and returns a rankingIndex. Two list
+// shapes are recognized:
+//   - the "CWE Top 25" and "CWE/SANS Top 25" views, whose flat rank and
+//     (HTML-only) score come from the supplemental data; the catalog view
+//     supplies only the list name;
+//   - the OWASP Top Ten views, whose member "A0N" categories carry the rank and
+//     whose member weaknesses inherit it.
+//
+// The raw path of every view/category actually read is recorded against each
+// ranked weakness so the placement's provenance lands in the weakness's Raws.
+func buildRankings(args string) (rankingIndex, error) {
+	idx := rankingIndex{
+		placements: make(map[string][]rankingTypes.Ranking),
+		rawPaths:   make(map[string][]string),
+	}
+	add := func(cweID string, r rankingTypes.Ranking, raws ...string) {
+		idx.placements[cweID] = append(idx.placements[cweID], r)
+		idx.rawPaths[cweID] = append(idx.rawPaths[cweID], raws...)
+	}
+	if err := filepath.WalkDir(filepath.Join(args, "view"), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		vr := utiljson.NewJSONReader()
+		var v cwe.View
+		if err := vr.Read(path, args, &v); err != nil {
+			return errors.Wrapf(err, "read json %s", path)
+		}
+		viewID := fmt.Sprintf("CWE-%s", v.ID)
+		viewRaw := vr.Paths()[0]
+		switch {
+		case strings.Contains(v.Name, "CWE Top 25 Most Dangerous Software"),
+			strings.Contains(v.Name, "CWE/SANS Top 25"):
+			// The flat rank and the (HTML-only) score come from the supplemental
+			// data, in rank order; the catalog view supplies only the list name.
+			// A matched view with no supplemental data is an error, not a
+			// silently empty ranking.
+			entries, ok := supplementalRankings[viewID]
+			if !ok {
+				return errors.Errorf("no supplemental ranking data for %q (%s)", v.Name, viewID)
+			}
+			for i, e := range entries {
+				add(e.cwe, rankingTypes.Ranking{
+					ViewID:   viewID,
+					ViewName: v.Name,
+					Rank:     i + 1,
+					Score:    e.score,
+				}, viewRaw)
+			}
+		case strings.Contains(v.Name, "OWASP Top Ten"):
+			// Members are the "A0N" tier categories; read each on demand for its
+			// rank (the A number) and the weaknesses that inherit it.
+			for _, m := range v.Members {
+				categoryPath := filepath.Join(args, "category", fmt.Sprintf("%s.json", m.CWEID))
+				cr := utiljson.NewJSONReader()
+				var c cwe.Category
+				if err := cr.Read(categoryPath, args, &c); err != nil {
+					return errors.Wrapf(err, "read json %s", categoryPath)
+				}
+				rank, err := owaspCategoryRank(c.Name)
+				if err != nil {
+					return errors.Wrapf(err, "rank %s", categoryPath)
+				}
+				categoryID := fmt.Sprintf("CWE-%s", c.ID)
+				catRaw := cr.Paths()[0]
+				for _, wm := range c.Relationships {
+					add(fmt.Sprintf("CWE-%s", wm.CWEID), rankingTypes.Ranking{
+						ViewID:       viewID,
+						ViewName:     v.Name,
+						CategoryID:   categoryID,
+						CategoryName: c.Name,
+						Rank:         rank,
+					}, viewRaw, catRaw)
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return rankingIndex{}, errors.Wrapf(err, "walk %s", filepath.Join(args, "view"))
+	}
+	return idx, nil
+}
+
+func extractWeakness(path, args, outDir string, rankings rankingIndex) error {
 	r := utiljson.NewJSONReader()
 	var w cwe.Weakness
 	if err := r.Read(path, args, &w); err != nil {
 		return errors.Wrapf(err, "read json %s", path)
 	}
 
+	cweID := fmt.Sprintf("CWE-%s", w.ID)
+
 	extracted := cweTypes.CWE{
-		ID:          fmt.Sprintf("CWE-%s", w.ID),
+		ID:          cweID,
 		Kind:        "weakness",
 		Name:        w.Name,
 		Status:      w.Status,
@@ -281,11 +413,12 @@ func extractWeakness(path, args, outDir string) error {
 			}(),
 			Notes:        collectNotes(w.Notes),
 			MappingNotes: convertMappingNotes(w.MappingNotes),
+			Rankings:     slices.Clone(rankings.placements[cweID]),
 		},
-		References: extractReferences(w.References),
+		References: extractReferences(w.ID, w.References),
 		DataSource: sourceTypes.Source{
 			ID:   sourceTypes.MitreCWE,
-			Raws: r.Paths(),
+			Raws: util.Unique(slices.Concat(r.Paths(), rankings.rawPaths[cweID])),
 		},
 	}
 
@@ -334,7 +467,7 @@ func extractCategory(path, args, outDir string) error {
 			Notes:        collectNotes(c.Notes),
 			MappingNotes: convertMappingNotes(c.MappingNotes),
 		},
-		References: extractReferences(c.References),
+		References: extractReferences(c.ID, c.References),
 		DataSource: sourceTypes.Source{
 			ID:   sourceTypes.MitreCWE,
 			Raws: r.Paths(),
@@ -385,7 +518,7 @@ func extractView(path, args, outDir string) error {
 			Notes:        collectNotes(v.Notes),
 			MappingNotes: convertMappingNotes(v.MappingNotes),
 		},
-		References: extractReferences(v.References),
+		References: extractReferences(v.ID, v.References),
 		DataSource: sourceTypes.Source{
 			ID:   sourceTypes.MitreCWE,
 			Raws: r.Paths(),
@@ -398,8 +531,17 @@ func extractView(path, args, outDir string) error {
 	return nil
 }
 
-func extractReferences(refs []cwe.Reference) []referenceTypes.Reference {
-	out := make([]referenceTypes.Reference, 0, len(refs))
+// extractReferences returns the CWE entry's own definition-page URL together
+// with its External_References. id is the bare numeric CWE ID (e.g. "1007").
+// The definition-page URL is always included so every entry self-references its
+// canonical page, mirroring how the NVD extractor adds the vuln/detail link.
+// The returned order is not significant; util.Write sorts references on output.
+func extractReferences(id string, refs []cwe.Reference) []referenceTypes.Reference {
+	out := make([]referenceTypes.Reference, 0, len(refs)+1)
+	out = append(out, referenceTypes.Reference{
+		Source: "cwe.mitre.org",
+		URL:    fmt.Sprintf("https://cwe.mitre.org/data/definitions/%s.html", id),
+	})
 	for _, r := range refs {
 		if r.URL == "" {
 			continue

--- a/pkg/extract/mitre/cwe/rankingdata.go
+++ b/pkg/extract/mitre/cwe/rankingdata.go
@@ -1,0 +1,106 @@
+package cwe
+
+// rankingEntry is a CWE's placement (rank == slice index + 1) in a ranking
+// list, with its published score (0 when the source published none).
+type rankingEntry struct {
+	cwe   string
+	score float64
+}
+
+// supplementalRankings carries ranking data published only as HTML tables on
+// the MITRE archive pages, absent from the fetched CWE catalog: the per-CWE
+// score for each yearly "CWE Top 25" list, and the rank+score for the
+// discontinued "CWE/SANS Top 25" lists (whose flat ranking the catalog does
+// not encode). Keyed by the list's view CWE ID; entries are in published rank
+// order. Transcribed from the pages below and cross-checked against their
+// tables; extend and re-verify when MITRE publishes a new CWE Top 25.
+//
+//	CWE-750  https://cwe.mitre.org/top25/archive/2009/2009_cwe_sans_top25.html
+//	CWE-800  https://cwe.mitre.org/top25/archive/2010/2010_cwe_sans_top25.html
+//	CWE-900  https://cwe.mitre.org/top25/archive/2011/2011_cwe_sans_top25.html
+//	CWE-1337 https://cwe.mitre.org/top25/archive/2021/2021_cwe_top25.html
+//	CWE-1350 https://cwe.mitre.org/top25/archive/2020/2020_cwe_top25.html
+//	CWE-1387 https://cwe.mitre.org/top25/archive/2022/2022_cwe_top25.html
+//	CWE-1425 https://cwe.mitre.org/top25/archive/2023/2023_cwe_top25.html
+//	CWE-1430 https://cwe.mitre.org/top25/archive/2024/2024_cwe_top25.html
+//	CWE-1435 https://cwe.mitre.org/top25/archive/2025/2025_cwe_top25.html
+var supplementalRankings = map[string][]rankingEntry{
+	"CWE-750": { // 2009 CWE/SANS Top 25 Most Dangerous Programming Errors (no published scores)
+		{"CWE-20", 0}, {"CWE-116", 0}, {"CWE-89", 0}, {"CWE-79", 0}, {"CWE-78", 0},
+		{"CWE-319", 0}, {"CWE-352", 0}, {"CWE-362", 0}, {"CWE-209", 0}, {"CWE-119", 0},
+		{"CWE-642", 0}, {"CWE-73", 0}, {"CWE-426", 0}, {"CWE-94", 0}, {"CWE-494", 0},
+		{"CWE-404", 0}, {"CWE-665", 0}, {"CWE-682", 0}, {"CWE-285", 0}, {"CWE-327", 0},
+		{"CWE-259", 0}, {"CWE-732", 0}, {"CWE-330", 0}, {"CWE-250", 0}, {"CWE-602", 0},
+	},
+	"CWE-800": { // 2010 CWE/SANS Top 25 Most Dangerous Programming Errors
+		{"CWE-79", 346}, {"CWE-89", 330}, {"CWE-120", 273}, {"CWE-352", 261}, {"CWE-285", 219},
+		{"CWE-807", 202}, {"CWE-22", 197}, {"CWE-434", 194}, {"CWE-78", 188}, {"CWE-311", 188},
+		{"CWE-798", 176}, {"CWE-805", 158}, {"CWE-98", 157}, {"CWE-129", 156},
+		{"CWE-754", 155}, {"CWE-209", 154}, {"CWE-190", 154}, {"CWE-131", 153},
+		{"CWE-306", 147}, {"CWE-494", 146}, {"CWE-732", 145}, {"CWE-770", 145},
+		{"CWE-601", 142}, {"CWE-327", 141}, {"CWE-362", 138},
+	},
+	"CWE-900": { // 2011 CWE/SANS Top 25 Most Dangerous Software Errors
+		{"CWE-89", 93.8}, {"CWE-78", 83.3}, {"CWE-120", 79.0}, {"CWE-79", 77.7},
+		{"CWE-306", 76.9}, {"CWE-862", 76.8}, {"CWE-798", 75.0}, {"CWE-311", 75.0},
+		{"CWE-434", 74.0}, {"CWE-807", 73.8}, {"CWE-250", 73.1}, {"CWE-352", 70.1},
+		{"CWE-22", 69.3}, {"CWE-494", 68.5}, {"CWE-863", 67.8}, {"CWE-829", 66.0},
+		{"CWE-732", 65.5}, {"CWE-676", 64.6}, {"CWE-327", 64.1}, {"CWE-131", 62.4},
+		{"CWE-307", 61.5}, {"CWE-601", 61.1}, {"CWE-134", 61.0}, {"CWE-190", 60.3},
+		{"CWE-759", 59.9},
+	},
+	"CWE-1337": { // 2021 CWE Top 25 Most Dangerous Software Weaknesses
+		{"CWE-787", 65.93}, {"CWE-79", 46.84}, {"CWE-125", 24.9}, {"CWE-20", 20.47},
+		{"CWE-78", 19.55}, {"CWE-89", 19.54}, {"CWE-416", 16.83}, {"CWE-22", 14.69},
+		{"CWE-352", 14.46}, {"CWE-434", 8.45}, {"CWE-306", 7.93}, {"CWE-190", 7.12},
+		{"CWE-502", 6.71}, {"CWE-287", 6.58}, {"CWE-476", 6.54}, {"CWE-798", 6.27},
+		{"CWE-119", 5.84}, {"CWE-862", 5.47}, {"CWE-276", 5.09}, {"CWE-200", 4.74},
+		{"CWE-522", 4.21}, {"CWE-732", 4.2}, {"CWE-611", 4.02}, {"CWE-918", 3.78},
+		{"CWE-77", 3.58},
+	},
+	"CWE-1350": { // 2020 CWE Top 25 Most Dangerous Software Weaknesses
+		{"CWE-79", 46.82}, {"CWE-787", 46.17}, {"CWE-20", 33.47}, {"CWE-125", 26.50},
+		{"CWE-119", 23.73}, {"CWE-89", 20.69}, {"CWE-200", 19.16}, {"CWE-416", 18.87},
+		{"CWE-352", 17.29}, {"CWE-78", 16.44}, {"CWE-190", 15.81}, {"CWE-22", 13.67},
+		{"CWE-476", 8.35}, {"CWE-287", 8.17}, {"CWE-434", 7.38}, {"CWE-732", 6.95},
+		{"CWE-94", 6.53}, {"CWE-522", 5.49}, {"CWE-611", 5.33}, {"CWE-798", 5.19},
+		{"CWE-502", 4.93}, {"CWE-269", 4.87}, {"CWE-400", 4.14}, {"CWE-306", 3.85},
+		{"CWE-862", 3.77},
+	},
+	"CWE-1387": { // 2022 CWE Top 25 Most Dangerous Software Weaknesses
+		{"CWE-787", 64.20}, {"CWE-79", 45.97}, {"CWE-89", 22.11}, {"CWE-20", 20.63},
+		{"CWE-125", 17.67}, {"CWE-78", 17.53}, {"CWE-416", 15.50}, {"CWE-22", 14.08},
+		{"CWE-352", 11.53}, {"CWE-434", 9.56}, {"CWE-476", 7.15}, {"CWE-502", 6.68},
+		{"CWE-190", 6.53}, {"CWE-287", 6.35}, {"CWE-798", 5.66}, {"CWE-862", 5.53},
+		{"CWE-77", 5.42}, {"CWE-306", 5.15}, {"CWE-119", 4.85}, {"CWE-276", 4.84},
+		{"CWE-918", 4.27}, {"CWE-362", 3.57}, {"CWE-400", 3.56}, {"CWE-611", 3.38},
+		{"CWE-94", 3.32},
+	},
+	"CWE-1425": { // 2023 CWE Top 25 Most Dangerous Software Weaknesses
+		{"CWE-787", 63.72}, {"CWE-79", 45.54}, {"CWE-89", 34.27}, {"CWE-416", 16.71},
+		{"CWE-78", 15.65}, {"CWE-20", 15.50}, {"CWE-125", 14.60}, {"CWE-22", 14.11},
+		{"CWE-352", 11.73}, {"CWE-434", 10.41}, {"CWE-862", 6.90}, {"CWE-476", 6.59},
+		{"CWE-287", 6.39}, {"CWE-190", 5.89}, {"CWE-502", 5.56}, {"CWE-77", 4.95},
+		{"CWE-119", 4.75}, {"CWE-798", 4.57}, {"CWE-918", 4.56}, {"CWE-306", 3.78},
+		{"CWE-362", 3.53}, {"CWE-269", 3.31}, {"CWE-94", 3.30}, {"CWE-863", 3.16},
+		{"CWE-276", 3.16},
+	},
+	"CWE-1430": { // 2024 CWE Top 25 Most Dangerous Software Weaknesses
+		{"CWE-79", 56.92}, {"CWE-787", 45.20}, {"CWE-89", 35.88}, {"CWE-352", 19.57},
+		{"CWE-22", 12.74}, {"CWE-125", 11.42}, {"CWE-78", 11.30}, {"CWE-416", 10.19},
+		{"CWE-862", 10.11}, {"CWE-434", 10.03}, {"CWE-94", 7.13}, {"CWE-20", 6.78},
+		{"CWE-77", 6.74}, {"CWE-287", 5.94}, {"CWE-269", 5.22}, {"CWE-502", 5.07},
+		{"CWE-200", 5.07}, {"CWE-863", 4.05}, {"CWE-918", 4.05}, {"CWE-119", 3.69},
+		{"CWE-476", 3.58}, {"CWE-798", 3.46}, {"CWE-190", 3.37}, {"CWE-400", 3.23},
+		{"CWE-306", 2.73},
+	},
+	"CWE-1435": { // 2025 CWE Top 25 Most Dangerous Software Weaknesses
+		{"CWE-79", 60.38}, {"CWE-89", 28.72}, {"CWE-352", 13.64}, {"CWE-862", 13.28},
+		{"CWE-787", 12.68}, {"CWE-22", 8.99}, {"CWE-416", 8.47}, {"CWE-125", 7.88},
+		{"CWE-78", 7.85}, {"CWE-94", 7.57}, {"CWE-120", 6.96}, {"CWE-434", 6.87},
+		{"CWE-476", 6.41}, {"CWE-121", 5.75}, {"CWE-502", 5.23}, {"CWE-122", 5.21},
+		{"CWE-863", 4.14}, {"CWE-20", 4.09}, {"CWE-284", 4.07}, {"CWE-200", 4.01},
+		{"CWE-306", 3.47}, {"CWE-918", 3.36}, {"CWE-77", 3.15}, {"CWE-639", 2.62},
+		{"CWE-770", 2.54},
+	},
+}

--- a/pkg/extract/mitre/cwe/testdata/fixtures/category/1347.json
+++ b/pkg/extract/mitre/cwe/testdata/fixtures/category/1347.json
@@ -1,0 +1,12 @@
+{
+	"id": "1347",
+	"name": "OWASP Top Ten 2021 Category A03:2021 - Injection",
+	"status": "Incomplete",
+	"summary": "Weaknesses in this category are related to the A03 category in the OWASP Top Ten 2021.",
+	"relationships": [
+		{
+			"cweid": "79",
+			"view_id": "1344"
+		}
+	]
+}

--- a/pkg/extract/mitre/cwe/testdata/fixtures/category/1440.json
+++ b/pkg/extract/mitre/cwe/testdata/fixtures/category/1440.json
@@ -1,0 +1,12 @@
+{
+	"id": "1440",
+	"name": "OWASP Top Ten 2025 Category A05:2025 - Injection",
+	"status": "Incomplete",
+	"summary": "Weaknesses in this category are related to the A05 category in the OWASP Top Ten 2025.",
+	"relationships": [
+		{
+			"cweid": "79",
+			"view_id": "1450"
+		}
+	]
+}

--- a/pkg/extract/mitre/cwe/testdata/fixtures/view/1344.json
+++ b/pkg/extract/mitre/cwe/testdata/fixtures/view/1344.json
@@ -1,0 +1,13 @@
+{
+	"id": "1344",
+	"name": "Weaknesses in OWASP Top Ten (2021)",
+	"type": "Graph",
+	"status": "Incomplete",
+	"objective": "CWE entries in this view (graph) are associated with the OWASP Top Ten, as released in 2021.",
+	"members": [
+		{
+			"cweid": "1347",
+			"view_id": "1344"
+		}
+	]
+}

--- a/pkg/extract/mitre/cwe/testdata/fixtures/view/1430.json
+++ b/pkg/extract/mitre/cwe/testdata/fixtures/view/1430.json
@@ -1,0 +1,29 @@
+{
+	"id": "1430",
+	"name": "Weaknesses in the 2024 CWE Top 25 Most Dangerous Software Weaknesses",
+	"type": "Graph",
+	"status": "Draft",
+	"objective": "CWE entries in this view are listed in the 2024 CWE Top 25 Most Dangerous Software Weaknesses.",
+	"members": [
+		{
+			"cweid": "79",
+			"view_id": "1430"
+		},
+		{
+			"cweid": "787",
+			"view_id": "1430"
+		},
+		{
+			"cweid": "89",
+			"view_id": "1430"
+		},
+		{
+			"cweid": "352",
+			"view_id": "1430"
+		},
+		{
+			"cweid": "22",
+			"view_id": "1430"
+		}
+	]
+}

--- a/pkg/extract/mitre/cwe/testdata/fixtures/view/1435.json
+++ b/pkg/extract/mitre/cwe/testdata/fixtures/view/1435.json
@@ -1,0 +1,29 @@
+{
+	"id": "1435",
+	"name": "Weaknesses in the 2025 CWE Top 25 Most Dangerous Software Weaknesses",
+	"type": "Graph",
+	"status": "Draft",
+	"objective": "CWE entries in this view are listed in the 2025 CWE Top 25 Most Dangerous Software Weaknesses.",
+	"members": [
+		{
+			"cweid": "79",
+			"view_id": "1435"
+		},
+		{
+			"cweid": "89",
+			"view_id": "1435"
+		},
+		{
+			"cweid": "352",
+			"view_id": "1435"
+		},
+		{
+			"cweid": "862",
+			"view_id": "1435"
+		},
+		{
+			"cweid": "787",
+			"view_id": "1435"
+		}
+	]
+}

--- a/pkg/extract/mitre/cwe/testdata/fixtures/view/1450.json
+++ b/pkg/extract/mitre/cwe/testdata/fixtures/view/1450.json
@@ -1,0 +1,13 @@
+{
+	"id": "1450",
+	"name": "Weaknesses in OWASP Top Ten RC1 (2025)",
+	"type": "Graph",
+	"status": "Incomplete",
+	"objective": "CWE entries in this view (graph) are associated with the first release candidate (RC1) of the OWASP Top Ten, as released in 2025.",
+	"members": [
+		{
+			"cweid": "1440",
+			"view_id": "1450"
+		}
+	]
+}

--- a/pkg/extract/mitre/cwe/testdata/fixtures/view/900.json
+++ b/pkg/extract/mitre/cwe/testdata/fixtures/view/900.json
@@ -1,0 +1,25 @@
+{
+	"id": "900",
+	"name": "Weaknesses in the 2011 CWE/SANS Top 25 Most Dangerous Software Errors",
+	"type": "Graph",
+	"status": "Obsolete",
+	"objective": "CWE entries in this view are listed in the 2011 CWE/SANS Top 25 Most Dangerous Software Errors.",
+	"members": [
+		{
+			"cweid": "864",
+			"view_id": "900"
+		},
+		{
+			"cweid": "865",
+			"view_id": "900"
+		},
+		{
+			"cweid": "866",
+			"view_id": "900"
+		},
+		{
+			"cweid": "867",
+			"view_id": "900"
+		}
+	]
+}

--- a/pkg/extract/mitre/cwe/testdata/fixtures/weakness/79.json
+++ b/pkg/extract/mitre/cwe/testdata/fixtures/weakness/79.json
@@ -1,0 +1,9 @@
+{
+	"id": "79",
+	"name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+	"abstraction": "Base",
+	"structure": "Simple",
+	"status": "Stable",
+	"diagram": "/data/images/CWE-79-Diagram.png",
+	"description": "The product does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
+}

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1007.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1007.json
@@ -115,6 +115,10 @@
 		},
 		{
 			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/1007.html"
+		},
+		{
+			"source": "cwe.mitre.org",
 			"url": "https://www.microsoftpressstore.com/store/writing-secure-code-9780735617223"
 		}
 	],

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1344.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1344.json
@@ -1,0 +1,28 @@
+{
+	"id": "CWE-1344",
+	"kind": "view",
+	"name": "Weaknesses in OWASP Top Ten (2021)",
+	"status": "Incomplete",
+	"description": "CWE entries in this view (graph) are associated with the OWASP Top Ten, as released in 2021.",
+	"view": {
+		"type": "Graph",
+		"members": [
+			{
+				"cweid": "CWE-1347",
+				"view_id": "CWE-1344"
+			}
+		]
+	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/1344.html"
+		}
+	],
+	"data_source": {
+		"id": "mitre-cwe",
+		"raws": [
+			"fixtures/view/1344.json"
+		]
+	}
+}

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1347.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1347.json
@@ -1,0 +1,27 @@
+{
+	"id": "CWE-1347",
+	"kind": "category",
+	"name": "OWASP Top Ten 2021 Category A03:2021 - Injection",
+	"status": "Incomplete",
+	"description": "Weaknesses in this category are related to the A03 category in the OWASP Top Ten 2021.",
+	"category": {
+		"members": [
+			{
+				"cweid": "CWE-79",
+				"view_id": "CWE-1344"
+			}
+		]
+	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/1347.html"
+		}
+	],
+	"data_source": {
+		"id": "mitre-cwe",
+		"raws": [
+			"fixtures/category/1347.json"
+		]
+	}
+}

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1430.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1430.json
@@ -1,0 +1,44 @@
+{
+	"id": "CWE-1430",
+	"kind": "view",
+	"name": "Weaknesses in the 2024 CWE Top 25 Most Dangerous Software Weaknesses",
+	"status": "Draft",
+	"description": "CWE entries in this view are listed in the 2024 CWE Top 25 Most Dangerous Software Weaknesses.",
+	"view": {
+		"type": "Graph",
+		"members": [
+			{
+				"cweid": "CWE-22",
+				"view_id": "CWE-1430"
+			},
+			{
+				"cweid": "CWE-352",
+				"view_id": "CWE-1430"
+			},
+			{
+				"cweid": "CWE-787",
+				"view_id": "CWE-1430"
+			},
+			{
+				"cweid": "CWE-79",
+				"view_id": "CWE-1430"
+			},
+			{
+				"cweid": "CWE-89",
+				"view_id": "CWE-1430"
+			}
+		]
+	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/1430.html"
+		}
+	],
+	"data_source": {
+		"id": "mitre-cwe",
+		"raws": [
+			"fixtures/view/1430.json"
+		]
+	}
+}

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1435.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1435.json
@@ -1,0 +1,44 @@
+{
+	"id": "CWE-1435",
+	"kind": "view",
+	"name": "Weaknesses in the 2025 CWE Top 25 Most Dangerous Software Weaknesses",
+	"status": "Draft",
+	"description": "CWE entries in this view are listed in the 2025 CWE Top 25 Most Dangerous Software Weaknesses.",
+	"view": {
+		"type": "Graph",
+		"members": [
+			{
+				"cweid": "CWE-352",
+				"view_id": "CWE-1435"
+			},
+			{
+				"cweid": "CWE-787",
+				"view_id": "CWE-1435"
+			},
+			{
+				"cweid": "CWE-79",
+				"view_id": "CWE-1435"
+			},
+			{
+				"cweid": "CWE-862",
+				"view_id": "CWE-1435"
+			},
+			{
+				"cweid": "CWE-89",
+				"view_id": "CWE-1435"
+			}
+		]
+	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/1435.html"
+		}
+	],
+	"data_source": {
+		"id": "mitre-cwe",
+		"raws": [
+			"fixtures/view/1435.json"
+		]
+	}
+}

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1440.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1440.json
@@ -1,0 +1,27 @@
+{
+	"id": "CWE-1440",
+	"kind": "category",
+	"name": "OWASP Top Ten 2025 Category A05:2025 - Injection",
+	"status": "Incomplete",
+	"description": "Weaknesses in this category are related to the A05 category in the OWASP Top Ten 2025.",
+	"category": {
+		"members": [
+			{
+				"cweid": "CWE-79",
+				"view_id": "CWE-1450"
+			}
+		]
+	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/1440.html"
+		}
+	],
+	"data_source": {
+		"id": "mitre-cwe",
+		"raws": [
+			"fixtures/category/1440.json"
+		]
+	}
+}

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1450.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1450.json
@@ -1,0 +1,28 @@
+{
+	"id": "CWE-1450",
+	"kind": "view",
+	"name": "Weaknesses in OWASP Top Ten RC1 (2025)",
+	"status": "Incomplete",
+	"description": "CWE entries in this view (graph) are associated with the first release candidate (RC1) of the OWASP Top Ten, as released in 2025.",
+	"view": {
+		"type": "Graph",
+		"members": [
+			{
+				"cweid": "CWE-1440",
+				"view_id": "CWE-1450"
+			}
+		]
+	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/1450.html"
+		}
+	],
+	"data_source": {
+		"id": "mitre-cwe",
+		"raws": [
+			"fixtures/view/1450.json"
+		]
+	}
+}

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-355.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-355.json
@@ -76,6 +76,12 @@
 			]
 		}
 	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/355.html"
+		}
+	],
 	"data_source": {
 		"id": "mitre-cwe",
 		"raws": [

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-699.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-699.json
@@ -199,6 +199,12 @@
 			]
 		}
 	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/699.html"
+		}
+	],
 	"data_source": {
 		"id": "mitre-cwe",
 		"raws": [

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-79.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-79.json
@@ -1,0 +1,65 @@
+{
+	"id": "CWE-79",
+	"kind": "weakness",
+	"name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+	"status": "Stable",
+	"description": "The product does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users.",
+	"weakness": {
+		"abstraction": "Base",
+		"structure": "Simple",
+		"diagram": "/data/images/CWE-79-Diagram.png",
+		"rankings": [
+			{
+				"view_id": "CWE-1344",
+				"view_name": "Weaknesses in OWASP Top Ten (2021)",
+				"category_id": "CWE-1347",
+				"category_name": "OWASP Top Ten 2021 Category A03:2021 - Injection",
+				"rank": 3
+			},
+			{
+				"view_id": "CWE-1430",
+				"view_name": "Weaknesses in the 2024 CWE Top 25 Most Dangerous Software Weaknesses",
+				"rank": 1,
+				"score": 56.92
+			},
+			{
+				"view_id": "CWE-1435",
+				"view_name": "Weaknesses in the 2025 CWE Top 25 Most Dangerous Software Weaknesses",
+				"rank": 1,
+				"score": 60.38
+			},
+			{
+				"view_id": "CWE-1450",
+				"view_name": "Weaknesses in OWASP Top Ten RC1 (2025)",
+				"category_id": "CWE-1440",
+				"category_name": "OWASP Top Ten 2025 Category A05:2025 - Injection",
+				"rank": 5
+			},
+			{
+				"view_id": "CWE-900",
+				"view_name": "Weaknesses in the 2011 CWE/SANS Top 25 Most Dangerous Software Errors",
+				"rank": 4,
+				"score": 77.7
+			}
+		]
+	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/79.html"
+		}
+	],
+	"data_source": {
+		"id": "mitre-cwe",
+		"raws": [
+			"fixtures/category/1347.json",
+			"fixtures/category/1440.json",
+			"fixtures/view/1344.json",
+			"fixtures/view/1430.json",
+			"fixtures/view/1435.json",
+			"fixtures/view/1450.json",
+			"fixtures/view/900.json",
+			"fixtures/weakness/79.json"
+		]
+	}
+}

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-900.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-900.json
@@ -1,0 +1,40 @@
+{
+	"id": "CWE-900",
+	"kind": "view",
+	"name": "Weaknesses in the 2011 CWE/SANS Top 25 Most Dangerous Software Errors",
+	"status": "Obsolete",
+	"description": "CWE entries in this view are listed in the 2011 CWE/SANS Top 25 Most Dangerous Software Errors.",
+	"view": {
+		"type": "Graph",
+		"members": [
+			{
+				"cweid": "CWE-864",
+				"view_id": "CWE-900"
+			},
+			{
+				"cweid": "CWE-865",
+				"view_id": "CWE-900"
+			},
+			{
+				"cweid": "CWE-866",
+				"view_id": "CWE-900"
+			},
+			{
+				"cweid": "CWE-867",
+				"view_id": "CWE-900"
+			}
+		]
+	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/900.html"
+		}
+	],
+	"data_source": {
+		"id": "mitre-cwe",
+		"raws": [
+			"fixtures/view/900.json"
+		]
+	}
+}

--- a/pkg/extract/types/cwe/weakness/ranking/ranking.go
+++ b/pkg/extract/types/cwe/weakness/ranking/ranking.go
@@ -1,0 +1,31 @@
+package ranking
+
+import "cmp"
+
+// Ranking records that a weakness appears in a CWE ranking list at a given
+// position, attached to each ranked weakness so the rank is visible from the
+// weakness entry itself. It is derived from two list shapes, which differ in
+// the fields they populate:
+//   - "CWE Top 25" and "CWE/SANS Top 25" views: ViewID, ViewName, Rank and
+//     Score, all from supplemental data; no Category.
+//   - OWASP Top Ten views: ViewID, ViewName, the A-tier CategoryID/CategoryName,
+//     and Rank (the "A0N" number shared by the category's weaknesses); no Score.
+type Ranking struct {
+	ViewID       string  `json:"view_id,omitempty"`       // ranking list view, e.g. "CWE-1430" / "CWE-1344"
+	ViewName     string  `json:"view_name,omitempty"`     // e.g. "Weaknesses in OWASP Top Ten (2021)"
+	CategoryID   string  `json:"category_id,omitempty"`   // OWASP only: the A-tier category, e.g. "CWE-1347"
+	CategoryName string  `json:"category_name,omitempty"` // OWASP only: e.g. "OWASP Top Ten 2021 Category A03:2021 - Injection"
+	Rank         int     `json:"rank,omitzero"`           // 1-based position in the list
+	Score        float64 `json:"score,omitzero"`          // published score where one exists (CWE Top 25, CWE/SANS)
+}
+
+func Compare(x, y Ranking) int {
+	return cmp.Or(
+		cmp.Compare(x.ViewID, y.ViewID),
+		cmp.Compare(x.ViewName, y.ViewName),
+		cmp.Compare(x.CategoryID, y.CategoryID),
+		cmp.Compare(x.CategoryName, y.CategoryName),
+		cmp.Compare(x.Rank, y.Rank),
+		cmp.Compare(x.Score, y.Score),
+	)
+}

--- a/pkg/extract/types/cwe/weakness/weakness.go
+++ b/pkg/extract/types/cwe/weakness/weakness.go
@@ -14,6 +14,7 @@ import (
 	detectionmethodTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/detectionmethod"
 	modeofintroductionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/modeofintroduction"
 	potentialmitigationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/potentialmitigation"
+	rankingTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/ranking"
 	relatedweaknessTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/relatedweakness"
 	weaknessordinalityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe/weakness/weaknessordinality"
 )
@@ -39,6 +40,7 @@ type Weakness struct {
 	DetectionMethods      []detectionmethodTypes.DetectionMethod           `json:"detection_methods,omitempty"`
 	TaxonomyMappings      []taxonomymappingTypes.TaxonomyMapping           `json:"taxonomy_mappings,omitempty"`
 	Notes                 []noteTypes.Note                                 `json:"notes,omitempty"`
+	Rankings              []rankingTypes.Ranking                           `json:"rankings,omitempty"` // CWE Top 25 / OWASP / CWE-SANS placements, derived from ranking lists
 	MappingNotes          mappingnotesTypes.MappingNotes                   `json:"mapping_notes,omitzero"`
 }
 
@@ -67,6 +69,7 @@ func (w *Weakness) Sort() {
 	slices.SortFunc(w.DetectionMethods, detectionmethodTypes.Compare)
 	slices.SortFunc(w.TaxonomyMappings, taxonomymappingTypes.Compare)
 	slices.SortFunc(w.Notes, noteTypes.Compare)
+	slices.SortFunc(w.Rankings, rankingTypes.Compare)
 	w.MappingNotes.Sort()
 }
 
@@ -92,6 +95,7 @@ func Compare(x, y Weakness) int {
 		slices.CompareFunc(x.DetectionMethods, y.DetectionMethods, detectionmethodTypes.Compare),
 		slices.CompareFunc(x.TaxonomyMappings, y.TaxonomyMappings, taxonomymappingTypes.Compare),
 		slices.CompareFunc(x.Notes, y.Notes, noteTypes.Compare),
+		slices.CompareFunc(x.Rankings, y.Rankings, rankingTypes.Compare),
 		mappingnotesTypes.Compare(x.MappingNotes, y.MappingNotes),
 	)
 }


### PR DESCRIPTION
## What

Enriches the MITRE CWE extractor with two additions:

1. **Self-reference** — every weakness/category/view now carries its canonical definition-page URL (`https://cwe.mitre.org/data/definitions/<ID>.html`).
2. **Rankings** — each weakness lists the ranking lists it appears in, with rank and (where published) score.

`CWE-79` example:

```jsonc
"rankings": [
    { "view_id": "CWE-1344", "view_name": "Weaknesses in OWASP Top Ten (2021)",
      "category_id": "CWE-1347", "category_name": "OWASP Top Ten 2021 Category A03:2021 - Injection", "rank": 3 },
    { "view_id": "CWE-1430", "view_name": "Weaknesses in the 2024 CWE Top 25 ...", "rank": 1, "score": 56.92 },
    { "view_id": "CWE-900",  "view_name": "Weaknesses in the 2011 CWE/SANS Top 25 ...", "rank": 4, "score": 77.7 }
]
```

## Why

- The CWE entry's own definition-page URL was missing from `references` (NVD and other extractors already self-reference their canonical page).
- CWE Top 25 / OWASP Top Ten / CWE-SANS Top 25 placements are useful for prioritization but were not surfaced on the weakness entries.

## How

- **References**: prepend the definition-page URL in `extractReferences`.
- **Rankings** (single `view/` pass, `buildRankings`):
  - **CWE Top 25 / CWE/SANS Top 25** — rank and score both from the supplemental data (`rankingdata.go`); the catalog view supplies only the list name. (Scores are HTML-only, and for CWE/SANS the catalog also lacks a flat rank, so the catalog member order is not used.)
  - **OWASP Top Ten** — rank from the `A0N` member categories (read on demand); view and category both recorded.
- **`rankingdata.go`** — 225 supplemental score/rank entries that exist only as HTML on the MITRE archive pages. Transcribed and cross-checked against the source tables; source URLs documented in the file, extended when a new CWE Top 25 is published.
- New type `types/cwe/weakness/ranking` (`view_id, view_name, category_id, category_name, rank, score`) + `Weakness.Rankings`.

## Testing

- Golden tests extended with fixtures for a Top 25 weakness (CWE-79), CWE Top 25 views (1430/1435), OWASP view+category pairs (1344/1347, 1450/1440), and a CWE/SANS view (900); goldens regenerated.
- `GOEXPERIMENT=jsonv2 go test ./...` passes; `gofmt` / `go vet` clean.
- All 225 supplemental values validated against the raw archive HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

