### PR TITLE
fix(extract/redhat/vex/v1): tolerate rpmmod truncated to module:stream on versioned purls

### DIFF
--- a/pkg/extract/redhat/vex/v1/testdata/fixtures/vex/2026/CVE-2026-11611.json
+++ b/pkg/extract/redhat/vex/v1/testdata/fixtures/vex/2026/CVE-2026-11611.json
@@ -1,0 +1,915 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Moderate"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright © Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://security.access.redhat.com/data/csaf/v2/vex/2026/cve-2026-11611.json"
+      }
+    ],
+    "title": "389-ds-base: 389-ds-base: Content Sync plugin unbounded queue growth and race conditions",
+    "tracking": {
+      "current_release_date": "2026-06-08T16:17:58+00:00",
+      "generator": {
+        "date": "2026-06-08T16:17:58+00:00",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "4.8.2"
+        }
+      },
+      "id": "CVE-2026-11611",
+      "initial_release_date": "2026-04-16T00:00:00+00:00",
+      "revision_history": [
+        {
+          "date": "2026-04-16T00:00:00+00:00",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2026-06-08T16:16:30+00:00",
+          "number": "2",
+          "summary": "Current version"
+        },
+        {
+          "date": "2026-06-08T16:17:58+00:00",
+          "number": "3",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "3"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Directory Server 11",
+                "product": {
+                  "name": "Red Hat Directory Server 11",
+                  "product_id": "red_hat_directory_server_11",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:directory_server:11"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Directory Server 11"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Directory Server 12",
+                "product": {
+                  "name": "Red Hat Directory Server 12",
+                  "product_id": "red_hat_directory_server_12",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:directory_server:12"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Directory Server 12"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Directory Server 13",
+                "product": {
+                  "name": "Red Hat Directory Server 13",
+                  "product_id": "red_hat_directory_server_13",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:directory_server:13"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Directory Server 13"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 10",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 10",
+                  "product_id": "red_hat_enterprise_linux_10",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:10"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 10"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 6",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 6",
+                  "product_id": "red_hat_enterprise_linux_6",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:6"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 6"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 7",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 7",
+                  "product_id": "red_hat_enterprise_linux_7",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 7"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 8",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 8",
+                  "product_id": "red_hat_enterprise_linux_8",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:8"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 8"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 9",
+                "product": {
+                  "name": "Red Hat Enterprise Linux 9",
+                  "product_id": "red_hat_enterprise_linux_9",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:9"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux 9"
+          },
+          {
+            "category": "product_version",
+            "name": "redhat-ds:11/389-ds-base.src",
+            "product": {
+              "name": "redhat-ds:11/389-ds-base.src",
+              "product_id": "redhat-ds:11/389-ds-base.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/389-ds-base@1.4.3.39-21.module%2Bel8dsrv%2B24083%2Bd25fcbb4?arch=src&rpmmod=redhat-ds:11"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "redhat-ds:12/389-ds-base.src",
+            "product": {
+              "name": "redhat-ds:12/389-ds-base.src",
+              "product_id": "redhat-ds:12/389-ds-base.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/389-ds-base@2.8.0-6.module%2Bel9dsrv%2B24230%2B6f167244?arch=src&rpmmod=redhat-ds:12"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "389-ds-base.src",
+            "product": {
+              "name": "389-ds-base.src",
+              "product_id": "389-ds-base.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/389-ds-base@3.2.0-5.el10dsrv?arch=src"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "python3-lib389",
+            "product": {
+              "name": "python3-lib389",
+              "product_id": "python3-lib389",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/python3-lib389"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "389-ds-base-bdb",
+            "product": {
+              "name": "389-ds-base-bdb",
+              "product_id": "389-ds-base-bdb",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/389-ds-base-bdb"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "389-ds-base-devel",
+            "product": {
+              "name": "389-ds-base-devel",
+              "product_id": "389-ds-base-devel",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/389-ds-base-devel"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "389-ds-base-snmp",
+            "product": {
+              "name": "389-ds-base-snmp",
+              "product_id": "389-ds-base-snmp",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/389-ds-base-snmp"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "389-ds-base-libs",
+            "product": {
+              "name": "389-ds-base-libs",
+              "product_id": "389-ds-base-libs",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/389-ds-base-libs"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "389-ds-base",
+            "product": {
+              "name": "389-ds-base",
+              "product_id": "389-ds-base",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/389-ds-base"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "389-ds-base-legacy-tools",
+            "product": {
+              "name": "389-ds-base-legacy-tools",
+              "product_id": "389-ds-base-legacy-tools",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/389-ds-base-legacy-tools"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "cockpit-389-ds",
+            "product": {
+              "name": "cockpit-389-ds",
+              "product_id": "cockpit-389-ds",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/cockpit-389-ds"
+              }
+            }
+          }
+        ],
+        "category": "vendor",
+        "name": "Red Hat"
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "redhat-ds:11/389-ds-base.src as a component of Red Hat Directory Server 11",
+          "product_id": "red_hat_directory_server_11:redhat-ds:11/389-ds-base.src"
+        },
+        "product_reference": "redhat-ds:11/389-ds-base.src",
+        "relates_to_product_reference": "red_hat_directory_server_11"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "redhat-ds:12/389-ds-base.src as a component of Red Hat Directory Server 12",
+          "product_id": "red_hat_directory_server_12:redhat-ds:12/389-ds-base.src"
+        },
+        "product_reference": "redhat-ds:12/389-ds-base.src",
+        "relates_to_product_reference": "red_hat_directory_server_12"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base.src as a component of Red Hat Directory Server 13",
+          "product_id": "red_hat_directory_server_13:389-ds-base.src"
+        },
+        "product_reference": "389-ds-base.src",
+        "relates_to_product_reference": "red_hat_directory_server_13"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:389-ds-base"
+        },
+        "product_reference": "389-ds-base",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-bdb as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:389-ds-base-bdb"
+        },
+        "product_reference": "389-ds-base-bdb",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-devel as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:389-ds-base-devel"
+        },
+        "product_reference": "389-ds-base-devel",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-libs as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:389-ds-base-libs"
+        },
+        "product_reference": "389-ds-base-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-snmp as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:389-ds-base-snmp"
+        },
+        "product_reference": "389-ds-base-snmp",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base.src as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:389-ds-base.src"
+        },
+        "product_reference": "389-ds-base.src",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-lib389 as a component of Red Hat Enterprise Linux 10",
+          "product_id": "red_hat_enterprise_linux_10:python3-lib389"
+        },
+        "product_reference": "python3-lib389",
+        "relates_to_product_reference": "red_hat_enterprise_linux_10"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base as a component of Red Hat Enterprise Linux 6",
+          "product_id": "red_hat_enterprise_linux_6:389-ds-base"
+        },
+        "product_reference": "389-ds-base",
+        "relates_to_product_reference": "red_hat_enterprise_linux_6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-devel as a component of Red Hat Enterprise Linux 6",
+          "product_id": "red_hat_enterprise_linux_6:389-ds-base-devel"
+        },
+        "product_reference": "389-ds-base-devel",
+        "relates_to_product_reference": "red_hat_enterprise_linux_6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-libs as a component of Red Hat Enterprise Linux 6",
+          "product_id": "red_hat_enterprise_linux_6:389-ds-base-libs"
+        },
+        "product_reference": "389-ds-base-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base.src as a component of Red Hat Enterprise Linux 6",
+          "product_id": "red_hat_enterprise_linux_6:389-ds-base.src"
+        },
+        "product_reference": "389-ds-base.src",
+        "relates_to_product_reference": "red_hat_enterprise_linux_6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:389-ds-base"
+        },
+        "product_reference": "389-ds-base",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-devel as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:389-ds-base-devel"
+        },
+        "product_reference": "389-ds-base-devel",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-libs as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:389-ds-base-libs"
+        },
+        "product_reference": "389-ds-base-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-snmp as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:389-ds-base-snmp"
+        },
+        "product_reference": "389-ds-base-snmp",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base.src as a component of Red Hat Enterprise Linux 7",
+          "product_id": "red_hat_enterprise_linux_7:389-ds-base.src"
+        },
+        "product_reference": "389-ds-base.src",
+        "relates_to_product_reference": "red_hat_enterprise_linux_7"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:389-ds-base"
+        },
+        "product_reference": "389-ds-base",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-devel as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:389-ds-base-devel"
+        },
+        "product_reference": "389-ds-base-devel",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-legacy-tools as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:389-ds-base-legacy-tools"
+        },
+        "product_reference": "389-ds-base-legacy-tools",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-libs as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:389-ds-base-libs"
+        },
+        "product_reference": "389-ds-base-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-snmp as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:389-ds-base-snmp"
+        },
+        "product_reference": "389-ds-base-snmp",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base.src as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:389-ds-base.src"
+        },
+        "product_reference": "389-ds-base.src",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "cockpit-389-ds as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:cockpit-389-ds"
+        },
+        "product_reference": "cockpit-389-ds",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-lib389 as a component of Red Hat Enterprise Linux 8",
+          "product_id": "red_hat_enterprise_linux_8:python3-lib389"
+        },
+        "product_reference": "python3-lib389",
+        "relates_to_product_reference": "red_hat_enterprise_linux_8"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:389-ds-base"
+        },
+        "product_reference": "389-ds-base",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-devel as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:389-ds-base-devel"
+        },
+        "product_reference": "389-ds-base-devel",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-libs as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:389-ds-base-libs"
+        },
+        "product_reference": "389-ds-base-libs",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base-snmp as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:389-ds-base-snmp"
+        },
+        "product_reference": "389-ds-base-snmp",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "389-ds-base.src as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:389-ds-base.src"
+        },
+        "product_reference": "389-ds-base.src",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3-lib389 as a component of Red Hat Enterprise Linux 9",
+          "product_id": "red_hat_enterprise_linux_9:python3-lib389"
+        },
+        "product_reference": "python3-lib389",
+        "relates_to_product_reference": "red_hat_enterprise_linux_9"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2026-11611",
+      "cwe": {
+        "id": "CWE-400",
+        "name": "Uncontrolled Resource Consumption"
+      },
+      "discovery_date": "2026-04-16T00:00:00+00:00",
+      "flags": [
+        {
+          "label": "vulnerable_code_not_present",
+          "product_ids": [
+            "red_hat_enterprise_linux_6:389-ds-base",
+            "red_hat_enterprise_linux_6:389-ds-base-devel",
+            "red_hat_enterprise_linux_6:389-ds-base-libs",
+            "red_hat_enterprise_linux_6:389-ds-base.src"
+          ]
+        }
+      ],
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla ID",
+          "text": "2485424"
+        }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in 389 Directory Server. The Content Synchronization persistent search plugin allows unbounded memory growth when an authenticated client stops reading sync responses, enabling denial of service. Additional race conditions in plugin thread lifecycle can cause crashes during connection teardown or shutdown.",
+          "title": "Vulnerability description"
+        },
+        {
+          "category": "summary",
+          "text": "389-ds-base: 389-ds-base: Content Sync plugin unbounded queue growth and race conditions",
+          "title": "Vulnerability summary"
+        },
+        {
+          "category": "general",
+          "text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+          "title": "CVSS score applicability"
+        }
+      ],
+      "product_status": {
+        "known_affected": [
+          "red_hat_directory_server_11:redhat-ds:11/389-ds-base.src",
+          "red_hat_directory_server_12:redhat-ds:12/389-ds-base.src",
+          "red_hat_directory_server_13:389-ds-base.src",
+          "red_hat_enterprise_linux_10:389-ds-base",
+          "red_hat_enterprise_linux_10:389-ds-base-bdb",
+          "red_hat_enterprise_linux_10:389-ds-base-devel",
+          "red_hat_enterprise_linux_10:389-ds-base-libs",
+          "red_hat_enterprise_linux_10:389-ds-base-snmp",
+          "red_hat_enterprise_linux_10:389-ds-base.src",
+          "red_hat_enterprise_linux_10:python3-lib389",
+          "red_hat_enterprise_linux_7:389-ds-base",
+          "red_hat_enterprise_linux_7:389-ds-base-devel",
+          "red_hat_enterprise_linux_7:389-ds-base-libs",
+          "red_hat_enterprise_linux_7:389-ds-base-snmp",
+          "red_hat_enterprise_linux_7:389-ds-base.src",
+          "red_hat_enterprise_linux_8:389-ds-base",
+          "red_hat_enterprise_linux_8:389-ds-base-devel",
+          "red_hat_enterprise_linux_8:389-ds-base-legacy-tools",
+          "red_hat_enterprise_linux_8:389-ds-base-libs",
+          "red_hat_enterprise_linux_8:389-ds-base-snmp",
+          "red_hat_enterprise_linux_8:389-ds-base.src",
+          "red_hat_enterprise_linux_8:cockpit-389-ds",
+          "red_hat_enterprise_linux_8:python3-lib389",
+          "red_hat_enterprise_linux_9:389-ds-base",
+          "red_hat_enterprise_linux_9:389-ds-base-devel",
+          "red_hat_enterprise_linux_9:389-ds-base-libs",
+          "red_hat_enterprise_linux_9:389-ds-base-snmp",
+          "red_hat_enterprise_linux_9:389-ds-base.src",
+          "red_hat_enterprise_linux_9:python3-lib389"
+        ],
+        "known_not_affected": [
+          "red_hat_enterprise_linux_6:389-ds-base",
+          "red_hat_enterprise_linux_6:389-ds-base-devel",
+          "red_hat_enterprise_linux_6:389-ds-base-libs",
+          "red_hat_enterprise_linux_6:389-ds-base.src"
+        ]
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+        },
+        {
+          "category": "external",
+          "summary": "RHBZ#2485424",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.cve.org/CVERecord?id=CVE-2026-11611",
+          "url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+        },
+        {
+          "category": "external",
+          "summary": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+        },
+        {
+          "category": "external",
+          "summary": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600",
+          "url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+        }
+      ],
+      "release_date": "2026-04-16T00:00:00+00:00",
+      "remediations": [
+        {
+          "category": "workaround",
+          "details": "Bug 1 (Queue DoS): Reduce SYNC_MAX_CONCURRENT from the default of 10 to minimize the number of clients that can accumulate queues. Apply network-level rate limiting on persistent sync search requests. Monitor client connections and terminate stalled sync clients that stop reading for an extended period. Set system-level memory limits (e.g., LimitAS= in the systemd unit file or cgroup memory limits) to prevent unbounded memory growth. Bugs 2 and 3: No workaround available — these are code-level race conditions that require source fixes.",
+          "product_ids": [
+            "red_hat_directory_server_11:redhat-ds:11/389-ds-base.src",
+            "red_hat_directory_server_12:redhat-ds:12/389-ds-base.src",
+            "red_hat_directory_server_13:389-ds-base.src",
+            "red_hat_enterprise_linux_10:389-ds-base",
+            "red_hat_enterprise_linux_10:389-ds-base-bdb",
+            "red_hat_enterprise_linux_10:389-ds-base-devel",
+            "red_hat_enterprise_linux_10:389-ds-base-libs",
+            "red_hat_enterprise_linux_10:389-ds-base-snmp",
+            "red_hat_enterprise_linux_10:389-ds-base.src",
+            "red_hat_enterprise_linux_10:python3-lib389",
+            "red_hat_enterprise_linux_7:389-ds-base",
+            "red_hat_enterprise_linux_7:389-ds-base-devel",
+            "red_hat_enterprise_linux_7:389-ds-base-libs",
+            "red_hat_enterprise_linux_7:389-ds-base-snmp",
+            "red_hat_enterprise_linux_7:389-ds-base.src",
+            "red_hat_enterprise_linux_8:389-ds-base",
+            "red_hat_enterprise_linux_8:389-ds-base-devel",
+            "red_hat_enterprise_linux_8:389-ds-base-legacy-tools",
+            "red_hat_enterprise_linux_8:389-ds-base-libs",
+            "red_hat_enterprise_linux_8:389-ds-base-snmp",
+            "red_hat_enterprise_linux_8:389-ds-base.src",
+            "red_hat_enterprise_linux_8:cockpit-389-ds",
+            "red_hat_enterprise_linux_8:python3-lib389",
+            "red_hat_enterprise_linux_9:389-ds-base",
+            "red_hat_enterprise_linux_9:389-ds-base-devel",
+            "red_hat_enterprise_linux_9:389-ds-base-libs",
+            "red_hat_enterprise_linux_9:389-ds-base-snmp",
+            "red_hat_enterprise_linux_9:389-ds-base.src",
+            "red_hat_enterprise_linux_9:python3-lib389"
+          ]
+        },
+        {
+          "category": "none_available",
+          "details": "Fix deferred",
+          "product_ids": [
+            "red_hat_directory_server_11:redhat-ds:11/389-ds-base.src",
+            "red_hat_directory_server_12:redhat-ds:12/389-ds-base.src",
+            "red_hat_directory_server_13:389-ds-base.src",
+            "red_hat_enterprise_linux_10:389-ds-base",
+            "red_hat_enterprise_linux_10:389-ds-base-bdb",
+            "red_hat_enterprise_linux_10:389-ds-base-devel",
+            "red_hat_enterprise_linux_10:389-ds-base-libs",
+            "red_hat_enterprise_linux_10:389-ds-base-snmp",
+            "red_hat_enterprise_linux_10:389-ds-base.src",
+            "red_hat_enterprise_linux_10:python3-lib389",
+            "red_hat_enterprise_linux_7:389-ds-base",
+            "red_hat_enterprise_linux_7:389-ds-base-devel",
+            "red_hat_enterprise_linux_7:389-ds-base-libs",
+            "red_hat_enterprise_linux_7:389-ds-base-snmp",
+            "red_hat_enterprise_linux_7:389-ds-base.src",
+            "red_hat_enterprise_linux_8:389-ds-base",
+            "red_hat_enterprise_linux_8:389-ds-base-devel",
+            "red_hat_enterprise_linux_8:389-ds-base-legacy-tools",
+            "red_hat_enterprise_linux_8:389-ds-base-libs",
+            "red_hat_enterprise_linux_8:389-ds-base-snmp",
+            "red_hat_enterprise_linux_8:389-ds-base.src",
+            "red_hat_enterprise_linux_8:cockpit-389-ds",
+            "red_hat_enterprise_linux_8:python3-lib389",
+            "red_hat_enterprise_linux_9:389-ds-base",
+            "red_hat_enterprise_linux_9:389-ds-base-devel",
+            "red_hat_enterprise_linux_9:389-ds-base-libs",
+            "red_hat_enterprise_linux_9:389-ds-base-snmp",
+            "red_hat_enterprise_linux_9:389-ds-base.src",
+            "red_hat_enterprise_linux_9:python3-lib389"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "red_hat_directory_server_11:redhat-ds:11/389-ds-base.src",
+            "red_hat_directory_server_12:redhat-ds:12/389-ds-base.src",
+            "red_hat_directory_server_13:389-ds-base.src",
+            "red_hat_enterprise_linux_10:389-ds-base",
+            "red_hat_enterprise_linux_10:389-ds-base-bdb",
+            "red_hat_enterprise_linux_10:389-ds-base-devel",
+            "red_hat_enterprise_linux_10:389-ds-base-libs",
+            "red_hat_enterprise_linux_10:389-ds-base-snmp",
+            "red_hat_enterprise_linux_10:389-ds-base.src",
+            "red_hat_enterprise_linux_10:python3-lib389",
+            "red_hat_enterprise_linux_6:389-ds-base",
+            "red_hat_enterprise_linux_6:389-ds-base-devel",
+            "red_hat_enterprise_linux_6:389-ds-base-libs",
+            "red_hat_enterprise_linux_6:389-ds-base.src",
+            "red_hat_enterprise_linux_7:389-ds-base",
+            "red_hat_enterprise_linux_7:389-ds-base-devel",
+            "red_hat_enterprise_linux_7:389-ds-base-libs",
+            "red_hat_enterprise_linux_7:389-ds-base-snmp",
+            "red_hat_enterprise_linux_7:389-ds-base.src",
+            "red_hat_enterprise_linux_8:389-ds-base",
+            "red_hat_enterprise_linux_8:389-ds-base-devel",
+            "red_hat_enterprise_linux_8:389-ds-base-legacy-tools",
+            "red_hat_enterprise_linux_8:389-ds-base-libs",
+            "red_hat_enterprise_linux_8:389-ds-base-snmp",
+            "red_hat_enterprise_linux_8:389-ds-base.src",
+            "red_hat_enterprise_linux_8:cockpit-389-ds",
+            "red_hat_enterprise_linux_8:python3-lib389",
+            "red_hat_enterprise_linux_9:389-ds-base",
+            "red_hat_enterprise_linux_9:389-ds-base-devel",
+            "red_hat_enterprise_linux_9:389-ds-base-libs",
+            "red_hat_enterprise_linux_9:389-ds-base-snmp",
+            "red_hat_enterprise_linux_9:389-ds-base.src",
+            "red_hat_enterprise_linux_9:python3-lib389"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "red_hat_directory_server_11:redhat-ds:11/389-ds-base.src",
+            "red_hat_directory_server_12:redhat-ds:12/389-ds-base.src",
+            "red_hat_directory_server_13:389-ds-base.src",
+            "red_hat_enterprise_linux_10:389-ds-base",
+            "red_hat_enterprise_linux_10:389-ds-base-bdb",
+            "red_hat_enterprise_linux_10:389-ds-base-devel",
+            "red_hat_enterprise_linux_10:389-ds-base-libs",
+            "red_hat_enterprise_linux_10:389-ds-base-snmp",
+            "red_hat_enterprise_linux_10:389-ds-base.src",
+            "red_hat_enterprise_linux_10:python3-lib389",
+            "red_hat_enterprise_linux_6:389-ds-base",
+            "red_hat_enterprise_linux_6:389-ds-base-devel",
+            "red_hat_enterprise_linux_6:389-ds-base-libs",
+            "red_hat_enterprise_linux_6:389-ds-base.src",
+            "red_hat_enterprise_linux_7:389-ds-base",
+            "red_hat_enterprise_linux_7:389-ds-base-devel",
+            "red_hat_enterprise_linux_7:389-ds-base-libs",
+            "red_hat_enterprise_linux_7:389-ds-base-snmp",
+            "red_hat_enterprise_linux_7:389-ds-base.src",
+            "red_hat_enterprise_linux_8:389-ds-base",
+            "red_hat_enterprise_linux_8:389-ds-base-devel",
+            "red_hat_enterprise_linux_8:389-ds-base-legacy-tools",
+            "red_hat_enterprise_linux_8:389-ds-base-libs",
+            "red_hat_enterprise_linux_8:389-ds-base-snmp",
+            "red_hat_enterprise_linux_8:389-ds-base.src",
+            "red_hat_enterprise_linux_8:cockpit-389-ds",
+            "red_hat_enterprise_linux_8:python3-lib389",
+            "red_hat_enterprise_linux_9:389-ds-base",
+            "red_hat_enterprise_linux_9:389-ds-base-devel",
+            "red_hat_enterprise_linux_9:389-ds-base-libs",
+            "red_hat_enterprise_linux_9:389-ds-base-snmp",
+            "red_hat_enterprise_linux_9:389-ds-base.src",
+            "red_hat_enterprise_linux_9:python3-lib389"
+          ]
+        }
+      ],
+      "title": "389-ds-base: 389-ds-base: Content Sync plugin unbounded queue growth and race conditions"
+    }
+  ]
+}

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2026/CVE-2026-11611.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2026/CVE-2026-11611.json
@@ -1,0 +1,914 @@
+{
+	"id": "CVE-2026-11611",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-11611",
+				"title": "389-ds-base: 389-ds-base: Content Sync plugin unbounded queue growth and race conditions",
+				"description": "A flaw was found in 389 Directory Server. The Content Synchronization persistent search plugin allows unbounded memory growth when an authenticated client stops reading sync responses, enabling denial of service. Additional race conditions in plugin thread lifecycle can cause crashes during connection teardown or shutdown.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Moderate"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+							"base_score": 6.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 6.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-400"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+					}
+				],
+				"published": "2026-04-16T00:00:00Z",
+				"modified": "2026-06-08T16:17:58Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "redhat:6",
+					"tag": "96a5fd7e-5f9a-7d10-ff7b-bb3daf68a9e6"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2026-11611",
+				"title": "389-ds-base: 389-ds-base: Content Sync plugin unbounded queue growth and race conditions",
+				"description": "A flaw was found in 389 Directory Server. The Content Synchronization persistent search plugin allows unbounded memory growth when an authenticated client stops reading sync responses, enabling denial of service. Additional race conditions in plugin thread lifecycle can cause crashes during connection teardown or shutdown.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Moderate"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+							"base_score": 6.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 6.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-400"
+						]
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Bug 1 (Queue DoS): Reduce SYNC_MAX_CONCURRENT from the default of 10 to minimize the number of clients that can accumulate queues. Apply network-level rate limiting on persistent sync search requests. Monitor client connections and terminate stalled sync clients that stop reading for an extended period. Set system-level memory limits (e.g., LimitAS= in the systemd unit file or cgroup memory limits) to prevent unbounded memory growth. Bugs 2 and 3: No workaround available — these are code-level race conditions that require source fixes."
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+					}
+				],
+				"published": "2026-04-16T00:00:00Z",
+				"modified": "2026-06-08T16:17:58Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "redhat:10",
+					"tag": "9f61df13-1394-798b-ceb2-e0355fae8760"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2026-11611",
+				"title": "389-ds-base: 389-ds-base: Content Sync plugin unbounded queue growth and race conditions",
+				"description": "A flaw was found in 389 Directory Server. The Content Synchronization persistent search plugin allows unbounded memory growth when an authenticated client stops reading sync responses, enabling denial of service. Additional race conditions in plugin thread lifecycle can cause crashes during connection teardown or shutdown.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Moderate"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+							"base_score": 6.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 6.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-400"
+						]
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Bug 1 (Queue DoS): Reduce SYNC_MAX_CONCURRENT from the default of 10 to minimize the number of clients that can accumulate queues. Apply network-level rate limiting on persistent sync search requests. Monitor client connections and terminate stalled sync clients that stop reading for an extended period. Set system-level memory limits (e.g., LimitAS= in the systemd unit file or cgroup memory limits) to prevent unbounded memory growth. Bugs 2 and 3: No workaround available — these are code-level race conditions that require source fixes."
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+					}
+				],
+				"published": "2026-04-16T00:00:00Z",
+				"modified": "2026-06-08T16:17:58Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "redhat:7",
+					"tag": "5a46d898-987a-167d-9636-a3757af101db"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2026-11611",
+				"title": "389-ds-base: 389-ds-base: Content Sync plugin unbounded queue growth and race conditions",
+				"description": "A flaw was found in 389 Directory Server. The Content Synchronization persistent search plugin allows unbounded memory growth when an authenticated client stops reading sync responses, enabling denial of service. Additional race conditions in plugin thread lifecycle can cause crashes during connection teardown or shutdown.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Moderate"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+							"base_score": 6.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 6.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-400"
+						]
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Bug 1 (Queue DoS): Reduce SYNC_MAX_CONCURRENT from the default of 10 to minimize the number of clients that can accumulate queues. Apply network-level rate limiting on persistent sync search requests. Monitor client connections and terminate stalled sync clients that stop reading for an extended period. Set system-level memory limits (e.g., LimitAS= in the systemd unit file or cgroup memory limits) to prevent unbounded memory growth. Bugs 2 and 3: No workaround available — these are code-level race conditions that require source fixes."
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+					}
+				],
+				"published": "2026-04-16T00:00:00Z",
+				"modified": "2026-06-08T16:17:58Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "redhat:8",
+					"tag": "07dd0d67-af30-f686-9d55-02a054f51e5d"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2026-11611",
+				"title": "389-ds-base: 389-ds-base: Content Sync plugin unbounded queue growth and race conditions",
+				"description": "A flaw was found in 389 Directory Server. The Content Synchronization persistent search plugin allows unbounded memory growth when an authenticated client stops reading sync responses, enabling denial of service. Additional race conditions in plugin thread lifecycle can cause crashes during connection teardown or shutdown.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Moderate"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+							"base_score": 6.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 6.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-400"
+						]
+					}
+				],
+				"workarounds": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Bug 1 (Queue DoS): Reduce SYNC_MAX_CONCURRENT from the default of 10 to minimize the number of clients that can accumulate queues. Apply network-level rate limiting on persistent sync search requests. Monitor client connections and terminate stalled sync clients that stop reading for an extended period. Set system-level memory limits (e.g., LimitAS= in the systemd unit file or cgroup memory limits) to prevent unbounded memory growth. Bugs 2 and 3: No workaround available — these are code-level race conditions that require source fixes."
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+					}
+				],
+				"published": "2026-04-16T00:00:00Z",
+				"modified": "2026-06-08T16:17:58Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "redhat:9",
+					"tag": "b11b6029-9771-3b11-62f8-656799f9551a"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "redhat:10",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-bdb"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-devel"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-libs"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-snmp"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "python3-lib389"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "source",
+												"source": {
+													"name": "389-ds-base"
+												}
+											}
+										}
+									}
+								]
+							},
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "source",
+												"source": {
+													"name": "389-ds-base"
+												}
+											}
+										}
+									}
+								]
+							}
+						]
+					},
+					"tag": "9f61df13-1394-798b-ceb2-e0355fae8760"
+				}
+			]
+		},
+		{
+			"ecosystem": "redhat:7",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-devel"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-libs"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-snmp"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "source",
+												"source": {
+													"name": "389-ds-base"
+												}
+											}
+										}
+									}
+								]
+							}
+						]
+					},
+					"tag": "5a46d898-987a-167d-9636-a3757af101db"
+				}
+			]
+		},
+		{
+			"ecosystem": "redhat:8",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-devel"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-legacy-tools"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-libs"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-snmp"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "cockpit-389-ds"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "python3-lib389"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "source",
+												"source": {
+													"name": "389-ds-base"
+												}
+											}
+										}
+									}
+								]
+							},
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "source",
+												"source": {
+													"name": "redhat-ds:11::389-ds-base"
+												}
+											}
+										}
+									}
+								]
+							}
+						]
+					},
+					"tag": "07dd0d67-af30-f686-9d55-02a054f51e5d"
+				}
+			]
+		},
+		{
+			"ecosystem": "redhat:9",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-devel"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-libs"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "389-ds-base-snmp"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "python3-lib389"
+												}
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "source",
+												"source": {
+													"name": "389-ds-base"
+												}
+											}
+										}
+									}
+								]
+							},
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Fix deferred"
+											},
+											"package": {
+												"type": "source",
+												"source": {
+													"name": "redhat-ds:12::389-ds-base"
+												}
+											}
+										}
+									}
+								]
+							}
+						]
+					},
+					"tag": "b11b6029-9771-3b11-62f8-656799f9551a"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "redhat-vex",
+		"raws": [
+			"repository2cpe/repository-to-cpe.json",
+			"vex/2026/CVE-2026-11611.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/vex/v1/v1.go
+++ b/pkg/extract/redhat/vex/v1/v1.go
@@ -393,6 +393,7 @@ func walkProductTree(pt v1.ProductTree, c2r map[string][]string) (map[v1.Product
 								// extracted output is identical either way —
 								// warn so the upstream truncation stays visible
 								// without aborting the whole extract.
+								// Reported upstream: https://redhat.atlassian.net/browse/SECDATA-1295
 								if len(ss) < 4 {
 									slog.Warn("rpmmod is missing the version:context suffix", slog.String("purl", fpn.ProductIdentificationHelper.PURL))
 								}

--- a/pkg/extract/redhat/vex/v1/v1.go
+++ b/pkg/extract/redhat/vex/v1/v1.go
@@ -380,8 +380,21 @@ func walkProductTree(pt v1.ProductTree, c2r map[string][]string) (map[v1.Product
 								p.arch = m["arch"]
 							default:
 								ss := strings.Split(rpmmod, ":")
-								if len(ss) < 4 {
+								if len(ss) < 2 {
 									return nil, errors.Errorf("unexpected purl format. expected: %q, actual: %q", "pkg:rpm/redhat/<name>@<version>?arch=<arch>(&epoch=<epoch>)&rpmmod=<<module>:<stream>:<version>:<context>(:<arch>)>", fpn.ProductIdentificationHelper.PURL)
+								}
+								// Some RedHat CSAF entries (e.g. the redhat-ds
+								// module in CVE-2026-11611) carry a versioned
+								// package whose rpmmod is truncated to
+								// "<module>:<stream>", dropping the
+								// ":<version>:<context>" NSVCA suffix that the
+								// same module normally includes. Only
+								// module:stream feeds modularitylabel, so the
+								// extracted output is identical either way —
+								// warn so the upstream truncation stays visible
+								// without aborting the whole extract.
+								if len(ss) < 4 {
+									slog.Warn("rpmmod is missing the version:context suffix", slog.String("purl", fpn.ProductIdentificationHelper.PURL))
 								}
 								p.modularitylabel = fmt.Sprintf("%s:%s", ss[0], ss[1])
 								p.name = instance.Name


### PR DESCRIPTION
## What

Stop the RedHat VEX v1 extractor from aborting on a versioned modular purl whose
`rpmmod` qualifier is truncated to `<module>:<stream>` (missing the
`:<version>:<context>` NSVCA suffix).

## Why

The full `extract redhat-vex-v1` run halted on `CVE-2026-11611.json`:

```
unexpected purl format. expected: "...rpmmod=<<module>:<stream>:<version>:<context>(:<arch>)>",
actual: "pkg:rpm/redhat/389-ds-base@2.8.0-6.module%2Bel9dsrv%2B24230%2B6f167244?arch=src&rpmmod=redhat-ds:12"
```

The `redhat-ds:11` / `redhat-ds:12` purls in that advisory have a package
version (`@…`) but an `rpmmod` of only 2 colon-separated parts, where the same
module is published with the full 4-part NSVCA everywhere else. The strict
`len(ss) < 4` guard turned this single malformed file into a hard failure that
aborted the entire `filepath.WalkDir`.

This was confirmed to be an upstream (RedHat) data defect, reported as
[SECDATA-1295](https://redhat.atlassian.net/browse/SECDATA-1295).

### Audit (exhaustive)

Scanned the complete current corpus — the `csaf_vex_2026-06-06` archive plus
every file changed since (via `changes.csv`, through 2026-06-09):

- Archive: 325,602 files / 6,933,423 `pkg:rpm` purls; **641,393** versioned
  purls carry `rpmmod` and **all** have the full 4-part NSVCA — **0 truncated**
  (cross-validated by a JSON-parse walk and an independent regex pass).
- Post-archive delta (989 changed files): **only `CVE-2026-11611`** is affected
  (2 truncated purls).

So this is a one-off upstream regression, not a format change.

## How

Only `module:stream` (`ss[0]:ss[1]`) feeds `modularitylabel`; `ss[2]`/`ss[3]`
are parsed-and-discarded, so the extracted output is identical whether the
NSVCA suffix is present or not. Therefore:

- Relax the guard from `len(ss) < 4` to `len(ss) < 2`, matching the already-lenient
  `vex/v2` parser.
- `slog.Warn` when the suffix is missing, so the upstream truncation stays
  visible (and any future recurrence shows up in logs) without halting extraction.

## Testing

- `GOEXPERIMENT=jsonv2 go build ./...`, `go vet ./pkg/extract/redhat/vex/v1/` — clean.
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/redhat/...` — pass.
- Added a regression golden test using the real `CVE-2026-11611.json` fixture;
  output yields `modularitylabel=redhat-ds:11`/`redhat-ds:12` with the correct
  version, no abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)