### PR TITLE
feat(extract/enisa/euvd/list): add EUVD list extractor

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -32,6 +32,7 @@ import (
 	debianOVAL "github.com/MaineK00n/vuls-data-update/pkg/extract/debian/oval"
 	debianSecurityTrackerAPI "github.com/MaineK00n/vuls-data-update/pkg/extract/debian/tracker/api"
 	debianSecurityTrackerSalsa "github.com/MaineK00n/vuls-data-update/pkg/extract/debian/tracker/salsa"
+	enisaEUVDList "github.com/MaineK00n/vuls-data-update/pkg/extract/enisa/euvd/list"
 	enisaKEV "github.com/MaineK00n/vuls-data-update/pkg/extract/enisa/kev"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/eol"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/epss"
@@ -158,6 +159,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdConanGLSA(),
 		newCmdDebianOVAL(), newCmdDebianSecurityTrackerAPI(), newCmdDebianSecurityTrackerSalsa(), newCmdDebianOSV(),
 		newCmdEOL(),
+		newCmdENISAEUVDList(),
 		newCmdENISAKEV(),
 		newCmdEPSS(),
 		newCmdErlangGHSA(), newCmdErlangOSV(),
@@ -823,6 +825,31 @@ func newCmdEOL() *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := eol.Extract(eol.WithDir(options.dir)); err != nil {
 				return errors.Wrap(err, "failed to extract eol")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdENISAEUVDList() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "enisa", "euvd", "list"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "enisa-euvd-list <Raw ENISA EUVD List Repository PATH>",
+		Short: "Extract ENISA EUVD List data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract enisa-euvd-list vuls-data-raw-enisa-euvd-list
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := enisaEUVDList.Extract(args[0], enisaEUVDList.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract enisa euvd list")
 			}
 			return nil
 		},

--- a/pkg/extract/enisa/euvd/list/list.go
+++ b/pkg/extract/enisa/euvd/list/list.go
@@ -100,7 +100,7 @@ func Extract(args string, opts ...Option) error {
 		if _, err := time.Parse("2006", splitted[1]); err != nil {
 			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
 		}
-		if splitted[2] == "" || strings.Trim(splitted[2], "0123456789") != "" {
+		if len(splitted[2]) < 4 || strings.Trim(splitted[2], "0123456789") != "" {
 			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
 		}
 		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", extracted.ID)), extracted, true); err != nil {
@@ -198,6 +198,7 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 				References: func() []referenceTypes.Reference {
 					var rs []referenceTypes.Reference
 					for r := range strings.SplitSeq(fetched.References, "\n") {
+						r = strings.TrimSpace(r)
 						if r == "" {
 							continue
 						}
@@ -215,6 +216,7 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 		Vulnerabilities: func() []vulnerabilityTypes.Vulnerability {
 			var vs []vulnerabilityTypes.Vulnerability
 			for a := range strings.SplitSeq(fetched.Aliases, "\n") {
+				a = strings.TrimSpace(a)
 				if !strings.HasPrefix(a, "CVE-") {
 					continue
 				}

--- a/pkg/extract/enisa/euvd/list/list.go
+++ b/pkg/extract/enisa/euvd/list/list.go
@@ -62,7 +62,7 @@ func Extract(args string, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	slog.Info("Extract European Union Vulnerability Database(EUVD) List")
+	slog.Info("Extract European Union Vulnerability Database (EUVD) List")
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -94,7 +94,13 @@ func Extract(args string, opts ...Option) error {
 		if err != nil {
 			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
 		}
+		if splitted[0] != "EUVD" {
+			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
+		}
 		if _, err := time.Parse("2006", splitted[1]); err != nil {
+			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
+		}
+		if splitted[2] == "" || strings.Trim(splitted[2], "0123456789") != "" {
 			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
 		}
 		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", extracted.ID)), extracted, true); err != nil {
@@ -108,7 +114,7 @@ func Extract(args string, opts ...Option) error {
 
 	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
 		ID:   sourceTypes.ENISAEUVDList,
-		Name: new("European Union Vulnerability Database(EUVD) List"),
+		Name: new("European Union Vulnerability Database (EUVD) List"),
 		Raw: func() []repositoryTypes.Repository {
 			r, _ := utilgit.GetDataSourceRepository(args)
 			if r == nil {

--- a/pkg/extract/enisa/euvd/list/list.go
+++ b/pkg/extract/enisa/euvd/list/list.go
@@ -188,6 +188,30 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 		return dataTypes.Data{}, errors.Wrap(err, "parse severity")
 	}
 
+	vulnerabilities, err := func() ([]vulnerabilityTypes.Vulnerability, error) {
+		var vs []vulnerabilityTypes.Vulnerability
+		for a := range strings.SplitSeq(fetched.Aliases, "\n") {
+			a = strings.TrimSpace(a)
+			if a == "" {
+				continue
+			}
+			switch {
+			case strings.HasPrefix(a, "CVE-"), strings.HasPrefix(a, "GHSA-"), strings.HasPrefix(a, "PYSEC-"), strings.HasPrefix(a, "MAL-"):
+				vs = append(vs, vulnerabilityTypes.Vulnerability{
+					Content: vulnerabilityContentTypes.Content{
+						ID: vulnerabilityContentTypes.VulnerabilityID(a),
+					},
+				})
+			default:
+				return nil, errors.Errorf("unexpected alias format. expected: %q, actual: %q", "(CVE|GHSA|PYSEC|MAL)-...", a)
+			}
+		}
+		return vs, nil
+	}()
+	if err != nil {
+		return dataTypes.Data{}, errors.Wrap(err, "parse aliases")
+	}
+
 	return dataTypes.Data{
 		ID: dataTypes.RootID(fetched.ID),
 		Advisories: []advisoryTypes.Advisory{{
@@ -213,21 +237,7 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 				Modified:  utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DateUpdated),
 			},
 		}},
-		Vulnerabilities: func() []vulnerabilityTypes.Vulnerability {
-			var vs []vulnerabilityTypes.Vulnerability
-			for a := range strings.SplitSeq(fetched.Aliases, "\n") {
-				a = strings.TrimSpace(a)
-				if !strings.HasPrefix(a, "CVE-") {
-					continue
-				}
-				vs = append(vs, vulnerabilityTypes.Vulnerability{
-					Content: vulnerabilityContentTypes.Content{
-						ID: vulnerabilityContentTypes.VulnerabilityID(a),
-					},
-				})
-			}
-			return vs
-		}(),
+		Vulnerabilities: vulnerabilities,
 		DataSource: sourceTypes.Source{
 			ID:   sourceTypes.ENISAEUVDList,
 			Raws: raws,

--- a/pkg/extract/enisa/euvd/list/list.go
+++ b/pkg/extract/enisa/euvd/list/list.go
@@ -182,26 +182,6 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 		return dataTypes.Data{}, errors.Wrap(err, "parse severity")
 	}
 
-	parseTime := func(value string) (*time.Time, error) {
-		if value == "" {
-			return nil, nil
-		}
-		t := utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, value)
-		if t == nil {
-			return nil, errors.Errorf("unexpected date format. expected: %q, actual: %q", "Jan 2, 2006, 3:04:05 PM", value)
-		}
-		return t, nil
-	}
-
-	published, err := parseTime(fetched.DatePublished)
-	if err != nil {
-		return dataTypes.Data{}, errors.Wrap(err, "parse datePublished")
-	}
-	modified, err := parseTime(fetched.DateUpdated)
-	if err != nil {
-		return dataTypes.Data{}, errors.Wrap(err, "parse dateUpdated")
-	}
-
 	return dataTypes.Data{
 		ID: dataTypes.RootID(fetched.ID),
 		Advisories: []advisoryTypes.Advisory{{
@@ -222,8 +202,8 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 					}
 					return rs
 				}(),
-				Published: published,
-				Modified:  modified,
+				Published: utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DatePublished),
+				Modified:  utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DateUpdated),
 			},
 		}},
 		Vulnerabilities: func() []vulnerabilityTypes.Vulnerability {

--- a/pkg/extract/enisa/euvd/list/list.go
+++ b/pkg/extract/enisa/euvd/list/list.go
@@ -92,13 +92,13 @@ func Extract(args string, opts ...Option) error {
 
 		splitted, err := util.Split(fetched.ID, "-", "-")
 		if err != nil {
-			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
+			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-...", fetched.ID)
 		}
 		if splitted[0] != "EUVD" {
-			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
+			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-...", fetched.ID)
 		}
 		if _, err := time.Parse("2006", splitted[1]); err != nil {
-			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
+			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-...", fetched.ID)
 		}
 		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", extracted.ID)), extracted, true); err != nil {
 			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", extracted.ID)))

--- a/pkg/extract/enisa/euvd/list/list.go
+++ b/pkg/extract/enisa/euvd/list/list.go
@@ -85,7 +85,10 @@ func Extract(args string, opts ...Option) error {
 			return errors.Wrapf(err, "read json %s", path)
 		}
 
-		extracted := extract(fetched, r.Paths())
+		extracted, err := extract(fetched, r.Paths())
+		if err != nil {
+			return errors.Wrapf(err, "extract %s", path)
+		}
 
 		splitted, err := util.Split(fetched.ID, "-", "-")
 		if err != nil {
@@ -128,63 +131,84 @@ func Extract(args string, opts ...Option) error {
 	return nil
 }
 
-func extract(fetched list.Item, raws []string) dataTypes.Data {
+func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
+	severity, err := func() ([]severityTypes.Severity, error) {
+		switch {
+		case fetched.BaseScoreVector == "":
+			return nil, nil
+		case strings.HasPrefix(fetched.BaseScoreVector, "CVSS:3.0/"):
+			v30, err := v30Types.Parse(fetched.BaseScoreVector)
+			if err != nil {
+				return nil, errors.Wrapf(err, "parse cvss v3.0 vector %s", fetched.BaseScoreVector)
+			}
+			return []severityTypes.Severity{{
+				Type:    severityTypes.SeverityTypeCVSSv30,
+				Source:  "euvd.enisa.europa.eu",
+				CVSSv30: v30,
+			}}, nil
+		case strings.HasPrefix(fetched.BaseScoreVector, "CVSS:3.1/"):
+			v31, err := v31Types.Parse(fetched.BaseScoreVector)
+			if err != nil {
+				return nil, errors.Wrapf(err, "parse cvss v3.1 vector %s", fetched.BaseScoreVector)
+			}
+			return []severityTypes.Severity{{
+				Type:    severityTypes.SeverityTypeCVSSv31,
+				Source:  "euvd.enisa.europa.eu",
+				CVSSv31: v31,
+			}}, nil
+		case strings.HasPrefix(fetched.BaseScoreVector, "CVSS:4.0/"):
+			v40, err := v40Types.Parse(fetched.BaseScoreVector)
+			if err != nil {
+				return nil, errors.Wrapf(err, "parse cvss v4.0 vector %s", fetched.BaseScoreVector)
+			}
+			return []severityTypes.Severity{{
+				Type:    severityTypes.SeverityTypeCVSSv40,
+				Source:  "euvd.enisa.europa.eu",
+				CVSSv40: v40,
+			}}, nil
+		default:
+			v2, err := v2Types.Parse(fetched.BaseScoreVector)
+			if err != nil {
+				return nil, errors.Wrapf(err, "parse cvss v2 vector %s", fetched.BaseScoreVector)
+			}
+			return []severityTypes.Severity{{
+				Type:   severityTypes.SeverityTypeCVSSv2,
+				Source: "euvd.enisa.europa.eu",
+				CVSSv2: v2,
+			}}, nil
+		}
+	}()
+	if err != nil {
+		return dataTypes.Data{}, errors.Wrap(err, "parse severity")
+	}
+
+	parseTime := func(value string) (*time.Time, error) {
+		if value == "" {
+			return nil, nil
+		}
+		t := utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, value)
+		if t == nil {
+			return nil, errors.Errorf("unexpected date format. expected: %q, actual: %q", "Jan 2, 2006, 3:04:05 PM", value)
+		}
+		return t, nil
+	}
+
+	published, err := parseTime(fetched.DatePublished)
+	if err != nil {
+		return dataTypes.Data{}, errors.Wrap(err, "parse datePublished")
+	}
+	modified, err := parseTime(fetched.DateUpdated)
+	if err != nil {
+		return dataTypes.Data{}, errors.Wrap(err, "parse dateUpdated")
+	}
+
 	return dataTypes.Data{
 		ID: dataTypes.RootID(fetched.ID),
 		Advisories: []advisoryTypes.Advisory{{
 			Content: advisoryContentTypes.Content{
 				ID:          advisoryContentTypes.AdvisoryID(fetched.ID),
 				Description: fetched.Description,
-				Severity: func() []severityTypes.Severity {
-					switch {
-					case fetched.BaseScoreVector == "":
-						return nil
-					case strings.HasPrefix(fetched.BaseScoreVector, "CVSS:3.0/"):
-						v30, err := v30Types.Parse(fetched.BaseScoreVector)
-						if err != nil {
-							slog.Warn("unexpected CVSS v3.0 vector", slog.String("id", fetched.ID), slog.String("vector", fetched.BaseScoreVector))
-							return nil
-						}
-						return []severityTypes.Severity{{
-							Type:    severityTypes.SeverityTypeCVSSv30,
-							Source:  "euvd.enisa.europa.eu",
-							CVSSv30: v30,
-						}}
-					case strings.HasPrefix(fetched.BaseScoreVector, "CVSS:3.1/"):
-						v31, err := v31Types.Parse(fetched.BaseScoreVector)
-						if err != nil {
-							slog.Warn("unexpected CVSS v3.1 vector", slog.String("id", fetched.ID), slog.String("vector", fetched.BaseScoreVector))
-							return nil
-						}
-						return []severityTypes.Severity{{
-							Type:    severityTypes.SeverityTypeCVSSv31,
-							Source:  "euvd.enisa.europa.eu",
-							CVSSv31: v31,
-						}}
-					case strings.HasPrefix(fetched.BaseScoreVector, "CVSS:4.0/"):
-						v40, err := v40Types.Parse(fetched.BaseScoreVector)
-						if err != nil {
-							slog.Warn("unexpected CVSS v4.0 vector", slog.String("id", fetched.ID), slog.String("vector", fetched.BaseScoreVector))
-							return nil
-						}
-						return []severityTypes.Severity{{
-							Type:    severityTypes.SeverityTypeCVSSv40,
-							Source:  "euvd.enisa.europa.eu",
-							CVSSv40: v40,
-						}}
-					default:
-						v2, err := v2Types.Parse(fetched.BaseScoreVector)
-						if err != nil {
-							slog.Warn("unexpected CVSS vector", slog.String("id", fetched.ID), slog.String("vector", fetched.BaseScoreVector))
-							return nil
-						}
-						return []severityTypes.Severity{{
-							Type:   severityTypes.SeverityTypeCVSSv2,
-							Source: "euvd.enisa.europa.eu",
-							CVSSv2: v2,
-						}}
-					}
-				}(),
+				Severity:    severity,
 				References: func() []referenceTypes.Reference {
 					var rs []referenceTypes.Reference
 					for r := range strings.SplitSeq(fetched.References, "\n") {
@@ -198,18 +222,8 @@ func extract(fetched list.Item, raws []string) dataTypes.Data {
 					}
 					return rs
 				}(),
-				Published: func() *time.Time {
-					if fetched.DatePublished == "" {
-						return nil
-					}
-					return utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DatePublished)
-				}(),
-				Modified: func() *time.Time {
-					if fetched.DateUpdated == "" {
-						return nil
-					}
-					return utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DateUpdated)
-				}(),
+				Published: published,
+				Modified:  modified,
 			},
 		}},
 		Vulnerabilities: func() []vulnerabilityTypes.Vulnerability {
@@ -230,5 +244,5 @@ func extract(fetched list.Item, raws []string) dataTypes.Data {
 			ID:   sourceTypes.ENISAEUVDList,
 			Raws: raws,
 		},
-	}
+	}, nil
 }

--- a/pkg/extract/enisa/euvd/list/list.go
+++ b/pkg/extract/enisa/euvd/list/list.go
@@ -1,0 +1,234 @@
+package list
+
+import (
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
+	advisoryContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory/content"
+	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	v2Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v2"
+	v30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
+	v31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
+	v40Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v40"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	utiltime "github.com/MaineK00n/vuls-data-update/pkg/extract/util/time"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/enisa/euvd/list"
+)
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "enisa", "euvd", "list"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract European Union Vulnerability Database(EUVD) List")
+	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		r := utiljson.NewJSONReader()
+		var fetched list.Item
+		if err := r.Read(path, args, &fetched); err != nil {
+			return errors.Wrapf(err, "read json %s", path)
+		}
+
+		extracted := extract(fetched, r.Paths())
+
+		splitted, err := util.Split(fetched.ID, "-", "-")
+		if err != nil {
+			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
+		}
+		if _, err := time.Parse("2006", splitted[1]); err != nil {
+			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
+		}
+		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", extracted.ID)), extracted, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", extracted.ID)))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", args)
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.ENISAEUVDList,
+		Name: new("European Union Vulnerability Database(EUVD) List"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+func extract(fetched list.Item, raws []string) dataTypes.Data {
+	return dataTypes.Data{
+		ID: dataTypes.RootID(fetched.ID),
+		Advisories: []advisoryTypes.Advisory{{
+			Content: advisoryContentTypes.Content{
+				ID:          advisoryContentTypes.AdvisoryID(fetched.ID),
+				Description: fetched.Description,
+				Severity: func() []severityTypes.Severity {
+					switch {
+					case fetched.BaseScoreVector == "":
+						return nil
+					case strings.HasPrefix(fetched.BaseScoreVector, "CVSS:3.0/"):
+						v30, err := v30Types.Parse(fetched.BaseScoreVector)
+						if err != nil {
+							slog.Warn("unexpected CVSS v3.0 vector", slog.String("id", fetched.ID), slog.String("vector", fetched.BaseScoreVector))
+							return nil
+						}
+						return []severityTypes.Severity{{
+							Type:    severityTypes.SeverityTypeCVSSv30,
+							Source:  "euvd.enisa.europa.eu",
+							CVSSv30: v30,
+						}}
+					case strings.HasPrefix(fetched.BaseScoreVector, "CVSS:3.1/"):
+						v31, err := v31Types.Parse(fetched.BaseScoreVector)
+						if err != nil {
+							slog.Warn("unexpected CVSS v3.1 vector", slog.String("id", fetched.ID), slog.String("vector", fetched.BaseScoreVector))
+							return nil
+						}
+						return []severityTypes.Severity{{
+							Type:    severityTypes.SeverityTypeCVSSv31,
+							Source:  "euvd.enisa.europa.eu",
+							CVSSv31: v31,
+						}}
+					case strings.HasPrefix(fetched.BaseScoreVector, "CVSS:4.0/"):
+						v40, err := v40Types.Parse(fetched.BaseScoreVector)
+						if err != nil {
+							slog.Warn("unexpected CVSS v4.0 vector", slog.String("id", fetched.ID), slog.String("vector", fetched.BaseScoreVector))
+							return nil
+						}
+						return []severityTypes.Severity{{
+							Type:    severityTypes.SeverityTypeCVSSv40,
+							Source:  "euvd.enisa.europa.eu",
+							CVSSv40: v40,
+						}}
+					default:
+						v2, err := v2Types.Parse(fetched.BaseScoreVector)
+						if err != nil {
+							slog.Warn("unexpected CVSS vector", slog.String("id", fetched.ID), slog.String("vector", fetched.BaseScoreVector))
+							return nil
+						}
+						return []severityTypes.Severity{{
+							Type:   severityTypes.SeverityTypeCVSSv2,
+							Source: "euvd.enisa.europa.eu",
+							CVSSv2: v2,
+						}}
+					}
+				}(),
+				References: func() []referenceTypes.Reference {
+					var rs []referenceTypes.Reference
+					for r := range strings.SplitSeq(fetched.References, "\n") {
+						if r == "" {
+							continue
+						}
+						rs = append(rs, referenceTypes.Reference{
+							Source: "euvd.enisa.europa.eu",
+							URL:    r,
+						})
+					}
+					return rs
+				}(),
+				Published: func() *time.Time {
+					if fetched.DatePublished == "" {
+						return nil
+					}
+					return utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DatePublished)
+				}(),
+				Modified: func() *time.Time {
+					if fetched.DateUpdated == "" {
+						return nil
+					}
+					return utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DateUpdated)
+				}(),
+			},
+		}},
+		Vulnerabilities: func() []vulnerabilityTypes.Vulnerability {
+			var vs []vulnerabilityTypes.Vulnerability
+			for a := range strings.SplitSeq(fetched.Aliases, "\n") {
+				if !strings.HasPrefix(a, "CVE-") {
+					continue
+				}
+				vs = append(vs, vulnerabilityTypes.Vulnerability{
+					Content: vulnerabilityContentTypes.Content{
+						ID: vulnerabilityContentTypes.VulnerabilityID(a),
+					},
+				})
+			}
+			return vs
+		}(),
+		DataSource: sourceTypes.Source{
+			ID:   sourceTypes.ENISAEUVDList,
+			Raws: raws,
+		},
+	}
+}

--- a/pkg/extract/enisa/euvd/list/list.go
+++ b/pkg/extract/enisa/euvd/list/list.go
@@ -185,7 +185,7 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 		return dataTypes.Data{}, errors.Wrap(err, "parse severity")
 	}
 
-	aliasAdvisories, vulnerabilities, err := func() ([]advisoryTypes.Advisory, []vulnerabilityTypes.Vulnerability, error) {
+	advisories, vulnerabilities, err := func() ([]advisoryTypes.Advisory, []vulnerabilityTypes.Vulnerability, error) {
 		var as []advisoryTypes.Advisory
 		var vs []vulnerabilityTypes.Vulnerability
 		for a := range strings.SplitSeq(fetched.Aliases, "\n") {
@@ -240,7 +240,7 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 				Published: utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DatePublished),
 				Modified:  utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DateUpdated),
 			},
-		}}, aliasAdvisories...),
+		}}, advisories...),
 		Vulnerabilities: vulnerabilities,
 		DataSource: sourceTypes.Source{
 			ID:   sourceTypes.ENISAEUVDList,

--- a/pkg/extract/enisa/euvd/list/list.go
+++ b/pkg/extract/enisa/euvd/list/list.go
@@ -100,9 +100,6 @@ func Extract(args string, opts ...Option) error {
 		if _, err := time.Parse("2006", splitted[1]); err != nil {
 			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
 		}
-		if len(splitted[2]) < 4 || strings.Trim(splitted[2], "0123456789") != "" {
-			return errors.Errorf("unexpected EUVD ID format. expected: %q, actual: %q", "EUVD-yyyy-\\d{4,}", fetched.ID)
-		}
 		if err := util.Write(filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", extracted.ID)), extracted, true); err != nil {
 			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", extracted.ID)))
 		}
@@ -188,7 +185,8 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 		return dataTypes.Data{}, errors.Wrap(err, "parse severity")
 	}
 
-	vulnerabilities, err := func() ([]vulnerabilityTypes.Vulnerability, error) {
+	aliasAdvisories, vulnerabilities, err := func() ([]advisoryTypes.Advisory, []vulnerabilityTypes.Vulnerability, error) {
+		var as []advisoryTypes.Advisory
 		var vs []vulnerabilityTypes.Vulnerability
 		for a := range strings.SplitSeq(fetched.Aliases, "\n") {
 			a = strings.TrimSpace(a)
@@ -196,17 +194,23 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 				continue
 			}
 			switch {
-			case strings.HasPrefix(a, "CVE-"), strings.HasPrefix(a, "GHSA-"), strings.HasPrefix(a, "PYSEC-"), strings.HasPrefix(a, "MAL-"):
+			case strings.HasPrefix(a, "CVE-"):
 				vs = append(vs, vulnerabilityTypes.Vulnerability{
 					Content: vulnerabilityContentTypes.Content{
 						ID: vulnerabilityContentTypes.VulnerabilityID(a),
 					},
 				})
+			case strings.HasPrefix(a, "GHSA-"), strings.HasPrefix(a, "PYSEC-"), strings.HasPrefix(a, "MAL-"):
+				as = append(as, advisoryTypes.Advisory{
+					Content: advisoryContentTypes.Content{
+						ID: advisoryContentTypes.AdvisoryID(a),
+					},
+				})
 			default:
-				return nil, errors.Errorf("unexpected alias format. expected: %q, actual: %q", "(CVE|GHSA|PYSEC|MAL)-...", a)
+				return nil, nil, errors.Errorf("unexpected alias format. expected: %q, actual: %q", "(CVE|GHSA|PYSEC|MAL)-...", a)
 			}
 		}
-		return vs, nil
+		return as, vs, nil
 	}()
 	if err != nil {
 		return dataTypes.Data{}, errors.Wrap(err, "parse aliases")
@@ -214,7 +218,7 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 
 	return dataTypes.Data{
 		ID: dataTypes.RootID(fetched.ID),
-		Advisories: []advisoryTypes.Advisory{{
+		Advisories: append([]advisoryTypes.Advisory{{
 			Content: advisoryContentTypes.Content{
 				ID:          advisoryContentTypes.AdvisoryID(fetched.ID),
 				Description: fetched.Description,
@@ -236,7 +240,7 @@ func extract(fetched list.Item, raws []string) (dataTypes.Data, error) {
 				Published: utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DatePublished),
 				Modified:  utiltime.Parse([]string{"Jan 2, 2006, 3:04:05 PM"}, fetched.DateUpdated),
 			},
-		}},
+		}}, aliasAdvisories...),
 		Vulnerabilities: vulnerabilities,
 		DataSource: sourceTypes.Source{
 			ID:   sourceTypes.ENISAEUVDList,

--- a/pkg/extract/enisa/euvd/list/list_test.go
+++ b/pkg/extract/enisa/euvd/list/list_test.go
@@ -1,0 +1,47 @@
+package list_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/enisa/euvd/list"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := list.Extract(tt.args, list.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				// error was expected and occurred, test passed
+				return
+			default:
+				ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				gp, err := filepath.Abs(dir)
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/fixtures/1999/EUVD-1999-0530.json
+++ b/pkg/extract/enisa/euvd/list/testdata/fixtures/1999/EUVD-1999-0530.json
@@ -1,0 +1,31 @@
+{
+	"id": "EUVD-1999-0530",
+	"enisaUuid": "dc3a7a8a-6089-3533-aa0f-ccedf7995e53",
+	"description": "A DNS server allows zone transfers.",
+	"datePublished": "Feb 4, 2000, 5:00:00 AM",
+	"dateUpdated": "Mar 17, 2025, 3:03:26 PM",
+	"baseScore": 0,
+	"baseScoreVersion": "",
+	"baseScoreVector": "AV:N/AC:L/Au:N/C:N/I:N/A:N",
+	"references": "https://www.cve.org/CVERecord?id=CVE-1999-0532\n",
+	"aliases": "GHSA-926f-mjrv-g5m6\nCVE-1999-0532\n",
+	"assigner": "mitre",
+	"epss": 72.95,
+	"enisaIdProduct": [
+		{
+			"id": "7821e150-8223-3e56-8847-acfe40851a97",
+			"product": {
+				"name": "n/a"
+			},
+			"product_version": "n/a"
+		}
+	],
+	"enisaIdVendor": [
+		{
+			"id": "6bfa95a4-409b-3d17-b8d8-398e47ca9d0d",
+			"vendor": {
+				"name": "n/a"
+			}
+		}
+	]
+}

--- a/pkg/extract/enisa/euvd/list/testdata/fixtures/2015/EUVD-2015-6577.json
+++ b/pkg/extract/enisa/euvd/list/testdata/fixtures/2015/EUVD-2015-6577.json
@@ -1,0 +1,31 @@
+{
+	"id": "EUVD-2015-6577",
+	"enisaUuid": "e58fb40c-5eb1-39c2-ba1a-2b290b6256d1",
+	"description": "The Widevine QSEE TrustZone application in Android 5.x before 5.1.1 LMY49F and 6.0 before 2016-01-01 allows attackers to gain privileges via a crafted application that leverages QSEECOM access, aka internal bug 24446875.",
+	"datePublished": "Jan 6, 2016, 12:00:00 AM",
+	"dateUpdated": "Feb 13, 2025, 4:27:12 PM",
+	"baseScore": 0,
+	"baseScoreVersion": "",
+	"baseScoreVector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+	"references": "https://www.exploit-db.com/exploits/39757/\nhttp://www.securitytracker.com/id/1034592\nhttp://source.android.com/security/bulletin/2016-01-01.html\nhttp://seclists.org/fulldisclosure/2023/May/26\nhttp://packetstormsecurity.com/files/172637/Widevine-Trustlet-5.x-6.x-7.x-PRDiagVerifyProvisioning-Buffer-Overflow.html\n",
+	"aliases": "GHSA-gj2v-r3v2-9q7q\nCVE-2015-6639\n",
+	"assigner": "google_android",
+	"epss": 4.99,
+	"enisaIdProduct": [
+		{
+			"id": "b3d93cd1-1e0d-3ad0-8344-cf2bddfc4152",
+			"product": {
+				"name": "n/a"
+			},
+			"product_version": "n/a"
+		}
+	],
+	"enisaIdVendor": [
+		{
+			"id": "4fc85881-179b-36f1-a258-5a3dec061722",
+			"vendor": {
+				"name": "n/a"
+			}
+		}
+	]
+}

--- a/pkg/extract/enisa/euvd/list/testdata/fixtures/2024/EUVD-2024-43417.json
+++ b/pkg/extract/enisa/euvd/list/testdata/fixtures/2024/EUVD-2024-43417.json
@@ -1,0 +1,31 @@
+{
+	"id": "EUVD-2024-43417",
+	"enisaUuid": "fc570127-1308-320e-8a2d-782a3941f729",
+	"description": "Local privilege escalation due to DLL hijacking vulnerability. The following products are affected: Acronis Cyber Files (Windows) before build 9.0.0x24.",
+	"datePublished": "Oct 17, 2024, 9:49:16 AM",
+	"dateUpdated": "Oct 17, 2024, 2:37:50 PM",
+	"baseScore": 7.3,
+	"baseScoreVersion": "3.0",
+	"baseScoreVector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H",
+	"references": "https://security-advisory.acronis.com/advisories/SEC-5845\n",
+	"aliases": "GHSA-88q9-p7rf-93g4\nCVE-2024-49390\n",
+	"assigner": "Acronis",
+	"epss": 0.09,
+	"enisaIdProduct": [
+		{
+			"id": "e8576e81-d9f0-3b00-b425-75ca7b8941cc",
+			"product": {
+				"name": "Acronis Cyber Files"
+			},
+			"product_version": "unspecified <9.0.0x24"
+		}
+	],
+	"enisaIdVendor": [
+		{
+			"id": "74304245-be77-30ac-b48d-bfae21096c16",
+			"vendor": {
+				"name": "Acronis"
+			}
+		}
+	]
+}

--- a/pkg/extract/enisa/euvd/list/testdata/fixtures/2024/EUVD-2024-48678.json
+++ b/pkg/extract/enisa/euvd/list/testdata/fixtures/2024/EUVD-2024-48678.json
@@ -1,0 +1,31 @@
+{
+	"id": "EUVD-2024-48678",
+	"enisaUuid": "c55ba90c-6e03-3c5f-ba3d-6b8591d7f20a",
+	"description": "Improper Check for Unusual or Exceptional Conditions vulnerability in Webroot SecureAnywhere - Web Shield on Windows, ARM, 64 bit, 32 bit (wrURL.Dll modules) allows Functionality Misuse.This issue affects SecureAnywhere - Web Shield: before 2.1.2.3.",
+	"datePublished": "Oct 3, 2024, 5:05:33 PM",
+	"dateUpdated": "Oct 3, 2024, 5:46:18 PM",
+	"baseScore": 6.2,
+	"baseScoreVersion": "2.0",
+	"baseScoreVector": "AV:L/AC:L/Au:S/C:C/I:N/A:C",
+	"references": "https://answers.webroot.com/Webroot/ukp.aspx?pid=12&app=vw&vw=1&login=1&json=1&solutionid=4275\n",
+	"aliases": "GHSA-g5vx-c2fq-6jm8\nCVE-2024-7826\n",
+	"assigner": "OpenText",
+	"epss": 0.3,
+	"enisaIdProduct": [
+		{
+			"id": "311723f8-2f19-3d0b-86c6-acd7469373fb",
+			"product": {
+				"name": "SecureAnywhere - Web Shield"
+			},
+			"product_version": "0 <2.1.2.3"
+		}
+	],
+	"enisaIdVendor": [
+		{
+			"id": "9cd2ae5c-3688-3d8d-93bf-61985feb8929",
+			"vendor": {
+				"name": "Webroot"
+			}
+		}
+	]
+}

--- a/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-0001.json
+++ b/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-0001.json
@@ -1,0 +1,45 @@
+{
+	"id": "EUVD-2025-0001",
+	"enisaUuid": "1476bba1-5e2b-312f-b5fc-18d18c42c467",
+	"description": "An issue was discovered in Django 5.1 before 5.1.5, 5.0 before 5.0.11, and 4.2 before 4.2.18. Lack of upper-bound limit enforcement in strings passed when performing IPv6 validation could lead to a potential denial-of-service attack. The undocumented and private functions clean_ipv6_address and is_valid_ipv6_address are vulnerable, as is the django.forms.GenericIPAddressField form field. (The django.db.models.GenericIPAddressField model field is not affected.)",
+	"datePublished": "Jan 14, 2025, 12:00:00 AM",
+	"dateUpdated": "Feb 12, 2025, 8:31:20 PM",
+	"baseScore": 5.8,
+	"baseScoreVersion": "3.1",
+	"baseScoreVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:L",
+	"references": "https://docs.djangoproject.com/en/dev/releases/security/\nhttps://groups.google.com/g/django-announce\nhttps://www.djangoproject.com/weblog/2025/jan/14/security-releases/\n",
+	"aliases": "CVE-2024-56374\nGHSA-qcgg-j2x8-h9g8\nPYSEC-2025-1\n",
+	"assigner": "mitre",
+	"epss": 0.08,
+	"enisaIdProduct": [
+		{
+			"id": "b43dc513-bfde-3923-b42a-51e4d0741724",
+			"product": {
+				"name": "Django"
+			},
+			"product_version": "5.1 <5.1.5"
+		},
+		{
+			"id": "dc259867-0528-368b-8786-e0708be8360f",
+			"product": {
+				"name": "Django"
+			},
+			"product_version": "4.2 <4.2.18"
+		},
+		{
+			"id": "e4c41bcf-92a0-3432-a30c-e6281f1aa956",
+			"product": {
+				"name": "Django"
+			},
+			"product_version": "5.0 <5.0.11"
+		}
+	],
+	"enisaIdVendor": [
+		{
+			"id": "0a160edd-acac-30a6-b7e9-5d924fe04066",
+			"vendor": {
+				"name": "djangoproject"
+			}
+		}
+	]
+}

--- a/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-10346.json
+++ b/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-10346.json
@@ -1,0 +1,122 @@
+{
+	"id": "EUVD-2025-10346",
+	"enisaUuid": "b40a71a7-145f-3847-8aca-ec3b011882e8",
+	"description": "In the Linux kernel, the following vulnerability has been resolved:\n\nmm/migrate: fix shmem xarray update during migration\n\nA shmem folio can be either in page cache or in swap cache, but not at the\nsame time.  Namely, once it is in swap cache, folio->mapping should be\nNULL, and the folio is no longer in a shmem mapping.\n\nIn __folio_migrate_mapping(), to determine the number of xarray entries to\nupdate, folio_test_swapbacked() is used, but that conflates shmem in page\ncache case and shmem in swap cache case.  It leads to xarray multi-index\nentry corruption, since it turns a sibling entry to a normal entry during\nxas_store() (see [1] for a userspace reproduction).  Fix it by only using\nfolio_test_swapcache() to determine whether xarray is storing swap cache\nentries or not to choose the right number of xarray entries to update.\n\n[1] https://lore.kernel.org/linux-mm/Z8idPCkaJW1IChjT@casper.infradead.org/\n\nNote:\nIn __split_huge_page(), folio_test_anon() && folio_test_swapcache() is\nused to get swap_cache address space, but that ignores the shmem folio in\nswap cache case.  It could lead to NULL pointer dereferencing when a\nin-swap-cache shmem folio is split at __xa_store(), since\n!folio_test_anon() is true and folio->mapping is NULL.  But fortunately,\nits caller split_huge_page_to_list_to_order() bails out early with EBUSY\nwhen folio->mapping is NULL.  So no need to take care of it here.",
+	"datePublished": "Apr 8, 2025, 8:18:05 AM",
+	"dateUpdated": "May 23, 2026, 3:57:36 PM",
+	"baseScore": 0,
+	"baseScoreVersion": "",
+	"baseScoreVector": "",
+	"references": "https://git.kernel.org/stable/c/49100c0b070e900f87c8fac3be9b9ef8a30fa673\nhttps://git.kernel.org/stable/c/29124ae980e2860f0eec7355949d3d3292ee81da\nhttps://git.kernel.org/stable/c/c057ee03f751d6cecf7ee64f52f6545d94082aaa\nhttps://git.kernel.org/stable/c/75cfb92eb63298d717b6b0118f91ba12c4fcfeb5\nhttps://git.kernel.org/stable/c/60cf233b585cdf1f3c5e52d1225606b86acd08b0\n",
+	"aliases": "GHSA-2pcw-fg2m-836w\nCVE-2025-22015\n",
+	"assigner": "Linux",
+	"epss": 0.03,
+	"enisaIdProduct": [
+		{
+			"id": "08ea44be-161d-3703-893b-0a1f13ceef7d",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "patch: 6.6.85"
+		},
+		{
+			"id": "5474234d-564d-3090-ab68-4d4734a5ab9d",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "fc346d0a70a13d52fe1c4bc49516d83a42cd7c4c <60cf233b585cdf1f3c5e52d1225606b86acd08b0"
+		},
+		{
+			"id": "6e67e472-3395-351b-879d-eb003a0c1081",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "patch: 6.12.21"
+		},
+		{
+			"id": "74efddc2-ff3f-3286-829d-382cabbb9119",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "6.7"
+		},
+		{
+			"id": "7dcf85bf-c57b-3432-a6fd-2231168c676f",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "fc346d0a70a13d52fe1c4bc49516d83a42cd7c4c <75cfb92eb63298d717b6b0118f91ba12c4fcfeb5"
+		},
+		{
+			"id": "82f88ec4-3d18-34cc-bf85-cabb5cb45c86",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "patch: 6.13.9"
+		},
+		{
+			"id": "8e84af47-19d8-3285-88fe-a05fabc7f3b8",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "patch: 6.1.132"
+		},
+		{
+			"id": "90ddd1db-f824-3fed-b069-16dd4355c87d",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "patch: 0"
+		},
+		{
+			"id": "9d8e5a6a-f1cb-33cc-8f54-41d427217e7a",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "patch: 6.14"
+		},
+		{
+			"id": "b2343fb3-9127-3e37-bcc0-40d70451b98a",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "07550b1461d4d0499165e7d6f7718cfd0e440427 <29124ae980e2860f0eec7355949d3d3292ee81da"
+		},
+		{
+			"id": "bf03ac25-c3d8-3361-8dd0-287056a98cc3",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "fc346d0a70a13d52fe1c4bc49516d83a42cd7c4c <c057ee03f751d6cecf7ee64f52f6545d94082aaa"
+		},
+		{
+			"id": "c1c4411a-ce15-3a28-b6be-826f58b37fa2",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "be72d197b2281e2ee3f28017fc9be1ab17e26d16 <49100c0b070e900f87c8fac3be9b9ef8a30fa673"
+		},
+		{
+			"id": "c7e89af0-d668-3ec3-9680-47a5a28f4ad1",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "6.1.71 <6.1.132"
+		},
+		{
+			"id": "d5ea1311-af96-3c6d-bb5f-83932580e906",
+			"product": {
+				"name": "Linux"
+			},
+			"product_version": "6.6.10 <6.6.85"
+		}
+	],
+	"enisaIdVendor": [
+		{
+			"id": "f8ffd334-b3c1-3747-bfc3-56bb1ea8ac96",
+			"vendor": {
+				"name": "Linux"
+			}
+		}
+	]
+}

--- a/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-24043.json
+++ b/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-24043.json
@@ -1,0 +1,16 @@
+{
+	"id": "EUVD-2025-24043",
+	"enisaUuid": "12ee47df-1c56-3c46-ac36-edd4eccd27ad",
+	"description": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: This affects a legitimate feature. The cause of the issue is an insecure database configuration established by the user.",
+	"datePublished": "",
+	"dateUpdated": "Aug 9, 2025, 4:52:57 AM",
+	"baseScore": 0,
+	"baseScoreVersion": "",
+	"baseScoreVector": "",
+	"references": "",
+	"aliases": "CVE-2025-8771\n",
+	"assigner": "VulDB",
+	"epss": 0,
+	"enisaIdProduct": [],
+	"enisaIdVendor": []
+}

--- a/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-29028.json
+++ b/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-29028.json
@@ -1,0 +1,32 @@
+{
+	"id": "EUVD-2025-29028",
+	"enisaUuid": "db7dd7ef-2aaf-3969-9156-fa8ebdc6fa15",
+	"description": "Out-of-bounds write in libimagecodec.quram.so prior to SMR Sep-2025 Release 1 allows remote attackers to execute arbitrary code.",
+	"datePublished": "Sep 12, 2025, 7:21:51 AM",
+	"dateUpdated": "Feb 26, 2026, 5:48:39 PM",
+	"baseScore": 8.8,
+	"baseScoreVersion": "3.1",
+	"baseScoreVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+	"references": "https://security.samsungmobile.com/securityUpdate.smsb?year=2025&month=09\n",
+	"aliases": "CVE-2025-21043\nGHSA-h4h8-5cww-x7j2\n",
+	"assigner": "SamsungMobile",
+	"epss": 4.91,
+	"exploitedSince": "Oct 2, 2025, 12:00:00 AM",
+	"enisaIdProduct": [
+		{
+			"id": "5ab99705-ba7b-3104-a163-fc23234145c4",
+			"product": {
+				"name": "Samsung Mobile Devices"
+			},
+			"product_version": "patch: SMR Sep-2025 Release in Android 13, 14, 15, 16"
+		}
+	],
+	"enisaIdVendor": [
+		{
+			"id": "ab0587d6-fbac-34a3-b293-734fd0a9aed5",
+			"vendor": {
+				"name": "Samsung Mobile"
+			}
+		}
+	]
+}

--- a/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-29473.json
+++ b/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-29473.json
@@ -1,0 +1,23 @@
+{
+	"id": "EUVD-2025-29473",
+	"enisaUuid": "f5a7ab76-4c40-386a-84b8-8b20c9a5af15",
+	"description": "Malicious code was inserted into the Nx (build system) package and several related plugins. The tampered package was published to the npm software registry, via a supply-chain attack. Affected versions contain code that scans the file system, collects credentials, and posts them to GitHub as a repo under user's accounts.",
+	"datePublished": "Sep 24, 2025, 9:20:31 PM",
+	"dateUpdated": "Nov 20, 2025, 7:26:10 AM",
+	"baseScore": 9.6,
+	"baseScoreVersion": "3.1",
+	"baseScoreVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+	"references": "https://access.redhat.com/security/cve/CVE-2025-10894\nhttps://access.redhat.com/security/supply-chain-attacks-NPM-packages\nhttps://bugzilla.redhat.com/show_bug.cgi?id=2396282\nhttps://github.com/nrwl/nx/security/advisories/GHSA-cxm3-wv7p-598c\nhttps://www.stepsecurity.io/blog/supply-chain-security-alert-popular-nx-build-system-package-compromised-with-data-stealing-malware\nhttps://www.wiz.io/blog/s1ngularity-supply-chain-attack\n",
+	"aliases": "MAL-2025-41441\nMAL-2025-41443\nGHSA-cxm3-wv7p-598c\nMAL-2025-41438\nMAL-2025-41440\nMAL-2025-41437\nMAL-2025-41439\nMAL-2025-41436\nCVE-2025-10894\nMAL-2025-41442\n",
+	"assigner": "redhat",
+	"epss": 0.31,
+	"enisaIdProduct": [],
+	"enisaIdVendor": [
+		{
+			"id": "42c5d189-b413-32f0-9a3c-a23845354e53",
+			"vendor": {
+				"name": "Red Hat"
+			}
+		}
+	]
+}

--- a/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-29826.json
+++ b/pkg/extract/enisa/euvd/list/testdata/fixtures/2025/EUVD-2025-29826.json
@@ -1,0 +1,31 @@
+{
+	"id": "EUVD-2025-29826",
+	"enisaUuid": "afae623e-d752-3698-b3b6-f9e50ca3528d",
+	"description": "A security flaw has been discovered in PHPGurukul User Management System 1.0. This affects an unknown function of the file /login.php. Performing manipulation of the argument emailid results in sql injection. The attack can be initiated remotely. The exploit has been released to the public and may be exploited.",
+	"datePublished": "Sep 17, 2025, 10:32:11 PM",
+	"dateUpdated": "Sep 18, 2025, 1:28:47 PM",
+	"baseScore": 6.9,
+	"baseScoreVersion": "4.0",
+	"baseScoreVector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N/E:P",
+	"references": "https://vuldb.com/?id.324652\nhttps://vuldb.com/?ctiid.324652\nhttps://vuldb.com/?submit.650222\nhttps://github.com/CSentinel/CVE/issues/3\nhttps://phpgurukul.com/\n",
+	"aliases": "CVE-2025-10624\nGHSA-rf8g-3x8q-7xvc\n",
+	"assigner": "VulDB",
+	"epss": 0.06,
+	"enisaIdProduct": [
+		{
+			"id": "80d70784-6450-3045-b6e1-5fe041ea9b2c",
+			"product": {
+				"name": "User Management System"
+			},
+			"product_version": "1.0"
+		}
+	],
+	"enisaIdVendor": [
+		{
+			"id": "4377e0b3-c854-3c93-a862-80eee1b6c1bb",
+			"vendor": {
+				"name": "PHPGurukul"
+			}
+		}
+	]
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/1999/EUVD-1999-0530.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/1999/EUVD-1999-0530.json
@@ -1,0 +1,47 @@
+{
+	"id": "EUVD-1999-0530",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-1999-0530",
+				"description": "A DNS server allows zone transfers.",
+				"severity": [
+					{
+						"type": "cvss_v2",
+						"source": "euvd.enisa.europa.eu",
+						"cvss_v2": {
+							"vector": "AV:N/AC:L/Au:N/C:N/I:N/A:N",
+							"base_score": 0,
+							"nvd_base_severity": "LOW",
+							"temporal_score": 0,
+							"nvd_temporal_severity": "LOW",
+							"environmental_score": 0,
+							"nvd_environmental_severity": "LOW"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://www.cve.org/CVERecord?id=CVE-1999-0532"
+					}
+				],
+				"published": "2000-02-04T05:00:00Z",
+				"modified": "2025-03-17T15:03:26Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-1999-0532"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-euvd-list",
+		"raws": [
+			"fixtures/1999/EUVD-1999-0530.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/1999/EUVD-1999-0530.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/1999/EUVD-1999-0530.json
@@ -36,6 +36,11 @@
 			"content": {
 				"id": "CVE-1999-0532"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-926f-mjrv-g5m6"
+			}
 		}
 	],
 	"data_source": {

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/1999/EUVD-1999-0530.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/1999/EUVD-1999-0530.json
@@ -29,17 +29,17 @@
 				"published": "2000-02-04T05:00:00Z",
 				"modified": "2025-03-17T15:03:26Z"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-926f-mjrv-g5m6"
+			}
 		}
 	],
 	"vulnerabilities": [
 		{
 			"content": {
 				"id": "CVE-1999-0532"
-			}
-		},
-		{
-			"content": {
-				"id": "GHSA-926f-mjrv-g5m6"
 			}
 		}
 	],

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2015/EUVD-2015-6577.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2015/EUVD-2015-6577.json
@@ -45,17 +45,17 @@
 				"published": "2016-01-06T00:00:00Z",
 				"modified": "2025-02-13T16:27:12Z"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-gj2v-r3v2-9q7q"
+			}
 		}
 	],
 	"vulnerabilities": [
 		{
 			"content": {
 				"id": "CVE-2015-6639"
-			}
-		},
-		{
-			"content": {
-				"id": "GHSA-gj2v-r3v2-9q7q"
 			}
 		}
 	],

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2015/EUVD-2015-6577.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2015/EUVD-2015-6577.json
@@ -52,6 +52,11 @@
 			"content": {
 				"id": "CVE-2015-6639"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-gj2v-r3v2-9q7q"
+			}
 		}
 	],
 	"data_source": {

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2015/EUVD-2015-6577.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2015/EUVD-2015-6577.json
@@ -1,0 +1,63 @@
+{
+	"id": "EUVD-2015-6577",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-2015-6577",
+				"description": "The Widevine QSEE TrustZone application in Android 5.x before 5.1.1 LMY49F and 6.0 before 2016-01-01 allows attackers to gain privileges via a crafted application that leverages QSEECOM access, aka internal bug 24446875.",
+				"severity": [
+					{
+						"type": "cvss_v30",
+						"source": "euvd.enisa.europa.eu",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+							"base_score": 7.8,
+							"base_severity": "HIGH",
+							"temporal_score": 7.8,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.8,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "http://packetstormsecurity.com/files/172637/Widevine-Trustlet-5.x-6.x-7.x-PRDiagVerifyProvisioning-Buffer-Overflow.html"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "http://seclists.org/fulldisclosure/2023/May/26"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "http://source.android.com/security/bulletin/2016-01-01.html"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "http://www.securitytracker.com/id/1034592"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://www.exploit-db.com/exploits/39757/"
+					}
+				],
+				"published": "2016-01-06T00:00:00Z",
+				"modified": "2025-02-13T16:27:12Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2015-6639"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-euvd-list",
+		"raws": [
+			"fixtures/2015/EUVD-2015-6577.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-43417.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-43417.json
@@ -1,0 +1,47 @@
+{
+	"id": "EUVD-2024-43417",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-2024-43417",
+				"description": "Local privilege escalation due to DLL hijacking vulnerability. The following products are affected: Acronis Cyber Files (Windows) before build 9.0.0x24.",
+				"severity": [
+					{
+						"type": "cvss_v30",
+						"source": "euvd.enisa.europa.eu",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H",
+							"base_score": 7.3,
+							"base_severity": "HIGH",
+							"temporal_score": 7.3,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.3,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://security-advisory.acronis.com/advisories/SEC-5845"
+					}
+				],
+				"published": "2024-10-17T09:49:16Z",
+				"modified": "2024-10-17T14:37:50Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-49390"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-euvd-list",
+		"raws": [
+			"fixtures/2024/EUVD-2024-43417.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-43417.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-43417.json
@@ -36,6 +36,11 @@
 			"content": {
 				"id": "CVE-2024-49390"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-88q9-p7rf-93g4"
+			}
 		}
 	],
 	"data_source": {

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-43417.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-43417.json
@@ -29,17 +29,17 @@
 				"published": "2024-10-17T09:49:16Z",
 				"modified": "2024-10-17T14:37:50Z"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-88q9-p7rf-93g4"
+			}
 		}
 	],
 	"vulnerabilities": [
 		{
 			"content": {
 				"id": "CVE-2024-49390"
-			}
-		},
-		{
-			"content": {
-				"id": "GHSA-88q9-p7rf-93g4"
 			}
 		}
 	],

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-48678.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-48678.json
@@ -1,0 +1,47 @@
+{
+	"id": "EUVD-2024-48678",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-2024-48678",
+				"description": "Improper Check for Unusual or Exceptional Conditions vulnerability in Webroot SecureAnywhere - Web Shield on Windows, ARM, 64 bit, 32 bit (wrURL.Dll modules) allows Functionality Misuse.This issue affects SecureAnywhere - Web Shield: before 2.1.2.3.",
+				"severity": [
+					{
+						"type": "cvss_v2",
+						"source": "euvd.enisa.europa.eu",
+						"cvss_v2": {
+							"vector": "AV:L/AC:L/Au:S/C:C/I:N/A:C",
+							"base_score": 6.2,
+							"nvd_base_severity": "MEDIUM",
+							"temporal_score": 6.2,
+							"nvd_temporal_severity": "MEDIUM",
+							"environmental_score": 6.2,
+							"nvd_environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://answers.webroot.com/Webroot/ukp.aspx?pid=12&app=vw&vw=1&login=1&json=1&solutionid=4275"
+					}
+				],
+				"published": "2024-10-03T17:05:33Z",
+				"modified": "2024-10-03T17:46:18Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-7826"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-euvd-list",
+		"raws": [
+			"fixtures/2024/EUVD-2024-48678.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-48678.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-48678.json
@@ -36,6 +36,11 @@
 			"content": {
 				"id": "CVE-2024-7826"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-g5vx-c2fq-6jm8"
+			}
 		}
 	],
 	"data_source": {

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-48678.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2024/EUVD-2024-48678.json
@@ -29,17 +29,17 @@
 				"published": "2024-10-03T17:05:33Z",
 				"modified": "2024-10-03T17:46:18Z"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-g5vx-c2fq-6jm8"
+			}
 		}
 	],
 	"vulnerabilities": [
 		{
 			"content": {
 				"id": "CVE-2024-7826"
-			}
-		},
-		{
-			"content": {
-				"id": "GHSA-g5vx-c2fq-6jm8"
 			}
 		}
 	],

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-0001.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-0001.json
@@ -1,0 +1,55 @@
+{
+	"id": "EUVD-2025-0001",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-2025-0001",
+				"description": "An issue was discovered in Django 5.1 before 5.1.5, 5.0 before 5.0.11, and 4.2 before 4.2.18. Lack of upper-bound limit enforcement in strings passed when performing IPv6 validation could lead to a potential denial-of-service attack. The undocumented and private functions clean_ipv6_address and is_valid_ipv6_address are vulnerable, as is the django.forms.GenericIPAddressField form field. (The django.db.models.GenericIPAddressField model field is not affected.)",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "euvd.enisa.europa.eu",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:L",
+							"base_score": 5.8,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.8,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.8,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://docs.djangoproject.com/en/dev/releases/security/"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://groups.google.com/g/django-announce"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://www.djangoproject.com/weblog/2025/jan/14/security-releases/"
+					}
+				],
+				"published": "2025-01-14T00:00:00Z",
+				"modified": "2025-02-12T20:31:20Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-56374"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-euvd-list",
+		"raws": [
+			"fixtures/2025/EUVD-2025-0001.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-0001.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-0001.json
@@ -44,6 +44,16 @@
 			"content": {
 				"id": "CVE-2024-56374"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-qcgg-j2x8-h9g8"
+			}
+		},
+		{
+			"content": {
+				"id": "PYSEC-2025-1"
+			}
 		}
 	],
 	"data_source": {

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-0001.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-0001.json
@@ -37,13 +37,6 @@
 				"published": "2025-01-14T00:00:00Z",
 				"modified": "2025-02-12T20:31:20Z"
 			}
-		}
-	],
-	"vulnerabilities": [
-		{
-			"content": {
-				"id": "CVE-2024-56374"
-			}
 		},
 		{
 			"content": {
@@ -53,6 +46,13 @@
 		{
 			"content": {
 				"id": "PYSEC-2025-1"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-56374"
 			}
 		}
 	],

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-10346.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-10346.json
@@ -1,0 +1,48 @@
+{
+	"id": "EUVD-2025-10346",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-2025-10346",
+				"description": "In the Linux kernel, the following vulnerability has been resolved:\n\nmm/migrate: fix shmem xarray update during migration\n\nA shmem folio can be either in page cache or in swap cache, but not at the\nsame time.  Namely, once it is in swap cache, folio->mapping should be\nNULL, and the folio is no longer in a shmem mapping.\n\nIn __folio_migrate_mapping(), to determine the number of xarray entries to\nupdate, folio_test_swapbacked() is used, but that conflates shmem in page\ncache case and shmem in swap cache case.  It leads to xarray multi-index\nentry corruption, since it turns a sibling entry to a normal entry during\nxas_store() (see [1] for a userspace reproduction).  Fix it by only using\nfolio_test_swapcache() to determine whether xarray is storing swap cache\nentries or not to choose the right number of xarray entries to update.\n\n[1] https://lore.kernel.org/linux-mm/Z8idPCkaJW1IChjT@casper.infradead.org/\n\nNote:\nIn __split_huge_page(), folio_test_anon() && folio_test_swapcache() is\nused to get swap_cache address space, but that ignores the shmem folio in\nswap cache case.  It could lead to NULL pointer dereferencing when a\nin-swap-cache shmem folio is split at __xa_store(), since\n!folio_test_anon() is true and folio->mapping is NULL.  But fortunately,\nits caller split_huge_page_to_list_to_order() bails out early with EBUSY\nwhen folio->mapping is NULL.  So no need to take care of it here.",
+				"references": [
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://git.kernel.org/stable/c/29124ae980e2860f0eec7355949d3d3292ee81da"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://git.kernel.org/stable/c/49100c0b070e900f87c8fac3be9b9ef8a30fa673"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://git.kernel.org/stable/c/60cf233b585cdf1f3c5e52d1225606b86acd08b0"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://git.kernel.org/stable/c/75cfb92eb63298d717b6b0118f91ba12c4fcfeb5"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://git.kernel.org/stable/c/c057ee03f751d6cecf7ee64f52f6545d94082aaa"
+					}
+				],
+				"published": "2025-04-08T08:18:05Z",
+				"modified": "2026-05-23T15:57:36Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2025-22015"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-euvd-list",
+		"raws": [
+			"fixtures/2025/EUVD-2025-10346.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-10346.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-10346.json
@@ -37,6 +37,11 @@
 			"content": {
 				"id": "CVE-2025-22015"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-2pcw-fg2m-836w"
+			}
 		}
 	],
 	"data_source": {

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-10346.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-10346.json
@@ -30,17 +30,17 @@
 				"published": "2025-04-08T08:18:05Z",
 				"modified": "2026-05-23T15:57:36Z"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-2pcw-fg2m-836w"
+			}
 		}
 	],
 	"vulnerabilities": [
 		{
 			"content": {
 				"id": "CVE-2025-22015"
-			}
-		},
-		{
-			"content": {
-				"id": "GHSA-2pcw-fg2m-836w"
 			}
 		}
 	],

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-24043.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-24043.json
@@ -1,0 +1,25 @@
+{
+	"id": "EUVD-2025-24043",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-2025-24043",
+				"description": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: This affects a legitimate feature. The cause of the issue is an insecure database configuration established by the user.",
+				"modified": "2025-08-09T04:52:57Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2025-8771"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-euvd-list",
+		"raws": [
+			"fixtures/2025/EUVD-2025-24043.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29028.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29028.json
@@ -36,6 +36,11 @@
 			"content": {
 				"id": "CVE-2025-21043"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-h4h8-5cww-x7j2"
+			}
 		}
 	],
 	"data_source": {

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29028.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29028.json
@@ -29,17 +29,17 @@
 				"published": "2025-09-12T07:21:51Z",
 				"modified": "2026-02-26T17:48:39Z"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-h4h8-5cww-x7j2"
+			}
 		}
 	],
 	"vulnerabilities": [
 		{
 			"content": {
 				"id": "CVE-2025-21043"
-			}
-		},
-		{
-			"content": {
-				"id": "GHSA-h4h8-5cww-x7j2"
 			}
 		}
 	],

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29028.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29028.json
@@ -1,0 +1,47 @@
+{
+	"id": "EUVD-2025-29028",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-2025-29028",
+				"description": "Out-of-bounds write in libimagecodec.quram.so prior to SMR Sep-2025 Release 1 allows remote attackers to execute arbitrary code.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "euvd.enisa.europa.eu",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+							"base_score": 8.8,
+							"base_severity": "HIGH",
+							"temporal_score": 8.8,
+							"temporal_severity": "HIGH",
+							"environmental_score": 8.8,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://security.samsungmobile.com/securityUpdate.smsb?year=2025&month=09"
+					}
+				],
+				"published": "2025-09-12T07:21:51Z",
+				"modified": "2026-02-26T17:48:39Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2025-21043"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-euvd-list",
+		"raws": [
+			"fixtures/2025/EUVD-2025-29028.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29473.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29473.json
@@ -49,13 +49,6 @@
 				"published": "2025-09-24T21:20:31Z",
 				"modified": "2025-11-20T07:26:10Z"
 			}
-		}
-	],
-	"vulnerabilities": [
-		{
-			"content": {
-				"id": "CVE-2025-10894"
-			}
 		},
 		{
 			"content": {
@@ -100,6 +93,13 @@
 		{
 			"content": {
 				"id": "MAL-2025-41443"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2025-10894"
 			}
 		}
 	],

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29473.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29473.json
@@ -1,0 +1,112 @@
+{
+	"id": "EUVD-2025-29473",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-2025-29473",
+				"description": "Malicious code was inserted into the Nx (build system) package and several related plugins. The tampered package was published to the npm software registry, via a supply-chain attack. Affected versions contain code that scans the file system, collects credentials, and posts them to GitHub as a repo under user's accounts.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "euvd.enisa.europa.eu",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+							"base_score": 9.6,
+							"base_severity": "CRITICAL",
+							"temporal_score": 9.6,
+							"temporal_severity": "CRITICAL",
+							"environmental_score": 9.7,
+							"environmental_severity": "CRITICAL"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://access.redhat.com/security/cve/CVE-2025-10894"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://access.redhat.com/security/supply-chain-attacks-NPM-packages"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2396282"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://github.com/nrwl/nx/security/advisories/GHSA-cxm3-wv7p-598c"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://www.stepsecurity.io/blog/supply-chain-security-alert-popular-nx-build-system-package-compromised-with-data-stealing-malware"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://www.wiz.io/blog/s1ngularity-supply-chain-attack"
+					}
+				],
+				"published": "2025-09-24T21:20:31Z",
+				"modified": "2025-11-20T07:26:10Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2025-10894"
+			}
+		},
+		{
+			"content": {
+				"id": "GHSA-cxm3-wv7p-598c"
+			}
+		},
+		{
+			"content": {
+				"id": "MAL-2025-41436"
+			}
+		},
+		{
+			"content": {
+				"id": "MAL-2025-41437"
+			}
+		},
+		{
+			"content": {
+				"id": "MAL-2025-41438"
+			}
+		},
+		{
+			"content": {
+				"id": "MAL-2025-41439"
+			}
+		},
+		{
+			"content": {
+				"id": "MAL-2025-41440"
+			}
+		},
+		{
+			"content": {
+				"id": "MAL-2025-41441"
+			}
+		},
+		{
+			"content": {
+				"id": "MAL-2025-41442"
+			}
+		},
+		{
+			"content": {
+				"id": "MAL-2025-41443"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-euvd-list",
+		"raws": [
+			"fixtures/2025/EUVD-2025-29473.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29826.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29826.json
@@ -1,0 +1,59 @@
+{
+	"id": "EUVD-2025-29826",
+	"advisories": [
+		{
+			"content": {
+				"id": "EUVD-2025-29826",
+				"description": "A security flaw has been discovered in PHPGurukul User Management System 1.0. This affects an unknown function of the file /login.php. Performing manipulation of the argument emailid results in sql injection. The attack can be initiated remotely. The exploit has been released to the public and may be exploited.",
+				"severity": [
+					{
+						"type": "cvss_v40",
+						"source": "euvd.enisa.europa.eu",
+						"cvss_v40": {
+							"vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N/E:P",
+							"score": 5.5,
+							"severity": "MEDIUM"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://github.com/CSentinel/CVE/issues/3"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://phpgurukul.com/"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://vuldb.com/?ctiid.324652"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://vuldb.com/?id.324652"
+					},
+					{
+						"source": "euvd.enisa.europa.eu",
+						"url": "https://vuldb.com/?submit.650222"
+					}
+				],
+				"published": "2025-09-17T22:32:11Z",
+				"modified": "2025-09-18T13:28:47Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2025-10624"
+			}
+		}
+	],
+	"data_source": {
+		"id": "enisa-euvd-list",
+		"raws": [
+			"fixtures/2025/EUVD-2025-29826.json"
+		]
+	}
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29826.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29826.json
@@ -48,6 +48,11 @@
 			"content": {
 				"id": "CVE-2025-10624"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-rf8g-3x8q-7xvc"
+			}
 		}
 	],
 	"data_source": {

--- a/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29826.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/data/2025/EUVD-2025-29826.json
@@ -41,17 +41,17 @@
 				"published": "2025-09-17T22:32:11Z",
 				"modified": "2025-09-18T13:28:47Z"
 			}
+		},
+		{
+			"content": {
+				"id": "GHSA-rf8g-3x8q-7xvc"
+			}
 		}
 	],
 	"vulnerabilities": [
 		{
 			"content": {
 				"id": "CVE-2025-10624"
-			}
-		},
-		{
-			"content": {
-				"id": "GHSA-rf8g-3x8q-7xvc"
 			}
 		}
 	],

--- a/pkg/extract/enisa/euvd/list/testdata/golden/datasource.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "enisa-euvd-list",
+	"name": "European Union Vulnerability Database(EUVD) List"
+}

--- a/pkg/extract/enisa/euvd/list/testdata/golden/datasource.json
+++ b/pkg/extract/enisa/euvd/list/testdata/golden/datasource.json
@@ -1,4 +1,4 @@
 {
 	"id": "enisa-euvd-list",
-	"name": "European Union Vulnerability Database(EUVD) List"
+	"name": "European Union Vulnerability Database (EUVD) List"
 }

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -48,6 +48,7 @@ const (
 	EndoflifeDateAPI           SourceID = "endoflife-date-api"
 	EndoflifeDateProducts      SourceID = "endoflife-date-products"
 	EOL                        SourceID = "eol"
+	ENISAEUVDList              SourceID = "enisa-euvd-list"
 	ENISAKEV                   SourceID = "enisa-kev"
 	EPSS                       SourceID = "epss"
 	ErlangGHSA                 SourceID = "erlang-ghsa"

--- a/pkg/fetch/enisa/euvd/detail/detail.go
+++ b/pkg/fetch/enisa/euvd/detail/detail.go
@@ -100,7 +100,7 @@ func Fetch(r io.Reader, opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	slog.Info("Fetch European Union Vulnerability Database(EUVD) Detail")
+	slog.Info("Fetch European Union Vulnerability Database (EUVD) Detail")
 	if err := options.fetch(r); err != nil {
 		return errors.Wrap(err, "fetch")
 	}

--- a/pkg/fetch/enisa/euvd/list/list.go
+++ b/pkg/fetch/enisa/euvd/list/list.go
@@ -101,7 +101,7 @@ func Fetch(opts ...Option) error {
 		return errors.Wrapf(err, "remove %s", options.dir)
 	}
 
-	slog.Info("Fetch European Union Vulnerability Database(EUVD) List")
+	slog.Info("Fetch European Union Vulnerability Database (EUVD) List")
 	if err := options.fetch(); err != nil {
 		return errors.Wrap(err, "fetch")
 	}


### PR DESCRIPTION
## What

Add an extractor for the ENISA European Union Vulnerability Database (EUVD) list dataset (`vuls-data-raw-enisa-euvd-list`), available as `vuls-data-update extract enisa-euvd-list <Raw ENISA EUVD List Repository PATH>` with the new source ID `enisa-euvd-list`.

## Why

The fetcher (`fetch enisa-euvd-list`) already exists and the raw dotgit is published, but there was no extractor to convert it into the canonical extracted schema.

## How

Follows the `extract/enisa/kev` pattern. Per EUVD entry (`data/<year>/<EUVD-ID>.json`):

- **Advisories**: the EUVD entry itself (EUVD ID, description, references, published/modified, CVSS severity), plus one advisory per non-CVE alias — `GHSA-` / `PYSEC-` / `MAL-` are advisory-database record IDs (GitHub Advisory DB / PyPA Advisory DB / OSSF Malicious Packages), modeled the same way rocky/osv models OSV record IDs
- **Vulnerabilities**: one entry per `CVE-` alias (every entry in the current dataset has exactly one)
- Aliases are validated against the allowlist above; an unknown prefix aborts extraction with an error so new alias types are noticed
- **CVSS version is determined by the vector prefix** (`CVSS:3.0/`, `CVSS:3.1/`, `CVSS:4.0/`, otherwise v2), not by `baseScoreVersion` — the raw data has 1,426 entries where `baseScoreVersion` is empty or inconsistent while the vector itself is valid. **Unparseable vectors abort extraction with an error** (matching `extract/nvd/api/cve`), so upstream format drift is caught loudly
- **Date parsing follows the repo-wide `utiltime.Parse` idiom**: unparseable or empty dates yield an omitted field (nil), consistent with all other extractors. This also handles zero-value upstream timestamps (e.g. `Jan 1, 1, 2:00:00 AM`, cf. vulsio/go-cve-dictionary#500) as "no date" without fabricating a year
- EUVD IDs are validated (`EUVD-` prefix + 4-digit year, same as enisa/kev) before being used to build output paths
- Dropped by design (agreed beforehand): `epss` (percent-scaled snapshot without model/date), `enisaIdProduct`/`enisaIdVendor` (free-text versions, not usable as detection criteria), `exploitedSince` (covered by enisa-kev), `assigner`, `enisaUuid`

## Testing

- Golden test with 10 fixtures covering CVSS v2 (incl. score 0) / v3.0 / v3.1 / v4.0, version/vector mismatch, empty `datePublished`, no vector, `exploitedSince`, and CVE/GHSA/PYSEC/MAL aliases
- `GOEXPERIMENT=jsonv2 go build ./...` / `go test ./...` pass
- Full run over the entire raw dataset (356,053 files): 356,053 extracted, zero errors, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)