### PR TITLE
fix(extract/types/cpecriterion): reject substring over-match in concrete CPE attributes

### DIFF
--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -128,21 +128,6 @@ type Query struct {
 	CPE string
 }
 
-// cpeAttrs enumerates every CPE 2.3 WFN attribute checked by concretelyDisjoint.
-var cpeAttrs = []string{
-	common.AttributePart,
-	common.AttributeVendor,
-	common.AttributeProduct,
-	common.AttributeVersion,
-	common.AttributeUpdate,
-	common.AttributeEdition,
-	common.AttributeLanguage,
-	common.AttributeSwEdition,
-	common.AttributeTargetSw,
-	common.AttributeTargetHw,
-	common.AttributeOther,
-}
-
 // concretelyDisjoint reports whether two WFNs disagree byte-wise on any
 // concrete (non-ANY/NA) attribute. It exists to work around an upstream
 // go-cpe matching bug: matching.IsDisjoint returns false (and
@@ -163,7 +148,19 @@ var cpeAttrs = []string{
 // against future go-cpe regressions; wildcard / ANY / NA values fall
 // through unchanged so legitimate broad-criterion matches still hit.
 func concretelyDisjoint(qWFN, cWFN common.WellFormedName) bool {
-	for _, a := range cpeAttrs {
+	for _, a := range []string{
+		common.AttributePart,
+		common.AttributeVendor,
+		common.AttributeProduct,
+		common.AttributeVersion,
+		common.AttributeUpdate,
+		common.AttributeEdition,
+		common.AttributeLanguage,
+		common.AttributeSwEdition,
+		common.AttributeTargetSw,
+		common.AttributeTargetHw,
+		common.AttributeOther,
+	} {
 		qv := qWFN.GetString(a)
 		cv := cWFN.GetString(a)
 		if qv == "ANY" || qv == "NA" || cv == "ANY" || cv == "NA" {

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -128,6 +128,54 @@ type Query struct {
 	CPE string
 }
 
+// cpeAttrs enumerates every CPE 2.3 WFN attribute checked by concretelyDisjoint.
+var cpeAttrs = []string{
+	common.AttributePart,
+	common.AttributeVendor,
+	common.AttributeProduct,
+	common.AttributeVersion,
+	common.AttributeUpdate,
+	common.AttributeEdition,
+	common.AttributeLanguage,
+	common.AttributeSwEdition,
+	common.AttributeTargetSw,
+	common.AttributeTargetHw,
+	common.AttributeOther,
+}
+
+// concretelyDisjoint reports whether two WFNs disagree byte-wise on any
+// concrete (non-ANY/NA) attribute. It exists to work around an upstream
+// go-cpe matching bug: matching.IsDisjoint returns false (and
+// matching.IsSuperset returns true) for two concrete values where the
+// trailing numeric segment of one is a numeric prefix of the other —
+// e.g. version "5.15.10" is reported as a "superset" of "5.15.103",
+// or "5.15" of "5.150". Alphabetic substrings ("linux_kernel" vs
+// "linux_kernel_extra") and dot-boundary segment additions ("5.15" vs
+// "5.15.10") are NOT affected. The bug let exact-match criteria fire
+// on unrelated concrete versions and produced false positives during
+// vuls-compare runs against linux_kernel.
+//
+// Tracked upstream as knqyf263/go-cpe#3 (issue) with a fix proposed in
+// knqyf263/go-cpe#9; this spot-check can be dropped once that fix lands
+// and we bump the dependency.
+//
+// The check runs on every attribute (not just version) for robustness
+// against future go-cpe regressions; wildcard / ANY / NA values fall
+// through unchanged so legitimate broad-criterion matches still hit.
+func concretelyDisjoint(qWFN, cWFN common.WellFormedName) bool {
+	for _, a := range cpeAttrs {
+		qv := qWFN.GetString(a)
+		cv := cWFN.GetString(a)
+		if qv == "ANY" || qv == "NA" || cv == "ANY" || cv == "NA" {
+			continue
+		}
+		if qv != cv {
+			return true
+		}
+	}
+	return false
+}
+
 func (c Criterion) Accept(query Query) (bool, error) {
 	qWFN, err := naming.UnbindFS(query.CPE)
 	if err != nil {
@@ -139,7 +187,7 @@ func (c Criterion) Accept(query Query) (bool, error) {
 		return false, errors.Wrapf(err, "unbind %q to WFN", string(c.CPE))
 	}
 
-	if !matching.IsDisjoint(qWFN, cWFN) {
+	if !matching.IsDisjoint(qWFN, cWFN) && !concretelyDisjoint(qWFN, cWFN) {
 		// c.version="NA" short-circuits: NA makes any subsequent version
 		// narrowing semantically meaningless.
 		if cWFN.GetString(common.AttributeVersion) == "NA" {
@@ -177,7 +225,7 @@ func (c Criterion) Accept(query Query) (bool, error) {
 		if err != nil {
 			return false, errors.Wrapf(err, "unbind %q to WFN", string(m))
 		}
-		if !matching.IsDisjoint(qWFN, mWFN) {
+		if !matching.IsDisjoint(qWFN, mWFN) && !concretelyDisjoint(qWFN, mWFN) {
 			return true, nil
 		}
 	}

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
@@ -228,6 +228,32 @@ func TestCriterion_Accept(t *testing.T) {
 			want: true,
 		},
 		{
+			// go-cpe matching mis-classifies pairs of concrete values where one
+			// trailing numeric segment is a numeric prefix of the other — e.g.
+			// IsDisjoint("5.15.10", "5.15.103") returns false. The
+			// concretelyDisjoint spot-check rescues the byte-wise truth so
+			// the main CPE path does not falsely match.
+			name: "go-cpe over-match guard: main CPE concrete-vs-concrete substring → false",
+			fields: fields{
+				Vulnerable: true,
+				CPE:        "cpe:2.3:o:linux:linux_kernel:5.15.10:*:*:*:*:*:*:*",
+			},
+			args: args{query: ccTypes.Query{CPE: "cpe:2.3:o:linux:linux_kernel:5.15.103:*:*:*:*:*:*:*"}},
+			want: false,
+		},
+		{
+			// Same over-match guard applied along the CPEMatches loop — a
+			// cpematch entry "5.15.10" must NOT swallow a "5.15.103" query.
+			name: "go-cpe over-match guard: CPEMatches concrete-vs-concrete substring → false",
+			fields: fields{
+				Vulnerable: true,
+				CPE:        "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+				CPEMatches: []ccTypes.CPE{"cpe:2.3:o:linux:linux_kernel:5.15.10:*:*:*:*:*:*:*"},
+			},
+			args: args{query: ccTypes.Query{CPE: "cpe:2.3:o:linux:linux_kernel:5.15.103:*:*:*:*:*:*:*"}},
+			want: false,
+		},
+		{
 			name: "unparseable query version with range yields false",
 			fields: fields{
 				Vulnerable: true,


### PR DESCRIPTION
## What

Add a per-attribute spot-check to `cpecriterion.Criterion.Accept` that rejects matches where two concrete (non-ANY/NA) CPE attribute values differ byte-wise, working around a go-cpe matching bug that lets an exact-match criterion fire on an unrelated concrete version.

## Why

go-cpe's `matching.IsDisjoint` returns false (and `IsSuperset` returns true) for two concrete values where the trailing numeric segment of one is a numeric prefix of the other — e.g. version `"5.15.10"` is reported as a "superset" of `"5.15.103"`, or `"5.15"` of `"5.150"`. Alphabetic substrings (`linux_kernel` vs `linux_kernel_extra`) and dot-boundary segment additions (`5.15` vs `5.15.10`) are NOT affected.

Without the guard, an exact-match CPE criterion fires on unrelated concrete versions and produces false positives in detection — originally surfaced as spurious CVE-2023-53118 / CVE-2023-53626 hits for `linux_kernel:5.15.10` while diffing the go-cve-dictionary path against the vuls2 path with vuls-compare.

Tracked upstream as knqyf263/go-cpe#3 (issue) with a fix proposed in knqyf263/go-cpe#9; this guard can be dropped once that fix lands and the dependency is bumped.

## How

`concretelyDisjoint(qWFN, cWFN)` walks all 11 CPE 2.3 WFN attributes; if both sides carry concrete (non-ANY/NA) values that don't match byte-wise, the pair is treated as disjoint regardless of what go-cpe claims. The check runs after `!matching.IsDisjoint` on both `Accept` paths (the main CPE branch and the CPEMatches fallback loop). Wildcard / ANY / NA values fall through unchanged, so legitimate broad-criterion matches still hit.

The check runs on every attribute (not just version) for robustness against future go-cpe regressions.

## Testing

- Two new table cases in `cpecriterion_test.go`: a main-CPE concrete-vs-concrete substring pair (`5.15.10` criterion vs `5.15.103` query → false) and the same shape routed through the CPEMatches loop.
- `GOEXPERIMENT=jsonv2 go test ./...` — full suite green.
