### PR TITLE
feat!(extract/types/criterion): classify CPE match quality

### DIFF
--- a/pkg/extract/types/data/detection/condition/criteria/criteria_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criteria_test.go
@@ -7,6 +7,7 @@ import (
 
 	criteriaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria"
 	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
+	ccTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion"
 	necTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/noneexistcriterion"
 	necBinaryPackageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/noneexistcriterion/binary"
 	necSourcePackageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/noneexistcriterion/source"
@@ -15,7 +16,6 @@ import (
 	affectedrangeTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range"
 	vcPackageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/package"
 	vcBinaryPackageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/package/binary"
-	ccTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion"
 	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
 )
 
@@ -733,7 +733,7 @@ func TestCriteria_Accept(t *testing.T) {
 								CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 							},
 						},
-						Accepts: criterionTypes.AcceptQueries{CPE: []int{0}},
+						Accepts: criterionTypes.AcceptQueries{CPE: criterionTypes.CPEAccepts{Exact: []int{0}}},
 					},
 				},
 			},
@@ -2112,7 +2112,7 @@ func TestFilteredCriteria_Affected(t *testing.T) {
 								CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 							},
 						},
-						Accepts: criterionTypes.AcceptQueries{CPE: []int{0}},
+						Accepts: criterionTypes.AcceptQueries{CPE: criterionTypes.CPEAccepts{Exact: []int{0}}},
 					},
 				},
 			},
@@ -2145,7 +2145,7 @@ func TestFilteredCriteria_Affected(t *testing.T) {
 								CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 							},
 						},
-						Accepts: criterionTypes.AcceptQueries{CPE: []int{0}},
+						Accepts: criterionTypes.AcceptQueries{CPE: criterionTypes.CPEAccepts{Exact: []int{0}}},
 					},
 				},
 			},

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -191,8 +191,10 @@ type MatchQuality int
 
 const (
 	// MatchQualityUnknown is the zero value: a quality that was never set.
-	// Accept never returns it — its appearance signals an uninitialised value
-	// or an enum case this code does not handle, which callers treat as a bug.
+	// Accept only ever returns it together with a non-nil error; on the
+	// err == nil path it never appears. So an Unknown with no error signals an
+	// uninitialised value or an enum case this code does not handle, which
+	// callers treat as a bug.
 	MatchQualityUnknown MatchQuality = iota
 	// MatchQualityNone means the criterion was evaluated and does NOT accept
 	// the query (disjoint attributes, out of range, enumeration miss).

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -2,6 +2,7 @@ package cpecriterion
 
 import (
 	"cmp"
+	"maps"
 	"slices"
 	"strings"
 
@@ -173,41 +174,117 @@ func concretelyDisjoint(qWFN, cWFN common.WellFormedName) bool {
 	return false
 }
 
-func (c Criterion) Accept(query Query) (bool, error) {
+// MatchQuality describes how strongly a Criterion matched a Query. It is a
+// source-agnostic property of the CPE relationship alone; how each quality is
+// projected onto a consumer's confidence model (e.g. vuls0's exact vs
+// vendor:product tiers, or JVN's version-less semantics) is the consumer's
+// concern, not this matcher's.
+type MatchQuality int
+
+const (
+	// MatchQualityNone means the criterion does not accept the query.
+	MatchQualityNone MatchQuality = iota
+	// MatchQualityExact means the criterion accepts the query with sufficient
+	// version evidence: a concrete query version confirmed by equality, range,
+	// or enumeration, OR a version=* criterion with no range/cpematches (every
+	// version of the product is affected).
+	MatchQualityExact
+	// MatchQualityVersionUnconfirmed means the criterion accepts the query on
+	// attribute equality but the query's concrete version cannot be confirmed
+	// affected: the criterion version is NA, or the query itself carries no
+	// concrete version (ANY/NA) against a version-bearing criterion.
+	MatchQualityVersionUnconfirmed
+)
+
+func (q MatchQuality) String() string {
+	switch q {
+	case MatchQualityExact:
+		return "Exact"
+	case MatchQualityVersionUnconfirmed:
+		return "VersionUnconfirmed"
+	default:
+		return "None"
+	}
+}
+
+// Match reports how strongly the criterion matches the query (see
+// MatchQuality). The branch structure mirrors the affected-set semantics
+// documented on Criterion: attribute match, then NA short-circuit, then
+// narrowing (range / cpematches), with the CPEMatches enumeration tried both
+// as an out-of-range fallback and (defensively) when the main CPE is disjoint.
+func (c Criterion) Match(query Query) (MatchQuality, error) {
 	qWFN, err := naming.UnbindFS(query.CPE)
 	if err != nil {
-		return false, errors.Wrapf(err, "unbind %q to WFN", query.CPE)
+		return MatchQualityNone, errors.Wrapf(err, "unbind %q to WFN", query.CPE)
 	}
 
 	cWFN, err := naming.UnbindFS(string(c.CPE))
 	if err != nil {
-		return false, errors.Wrapf(err, "unbind %q to WFN", string(c.CPE))
+		return MatchQualityNone, errors.Wrapf(err, "unbind %q to WFN", string(c.CPE))
 	}
 
-	if !matching.IsDisjoint(qWFN, cWFN) && !concretelyDisjoint(qWFN, cWFN) {
-		// c.version="NA" short-circuits: NA makes any subsequent version
-		// narrowing semantically meaningless.
-		if cWFN.GetString(common.AttributeVersion) == "NA" {
-			return true, nil
-		}
-		// No narrowing → accept on attribute match alone.
-		if c.Range == nil && len(c.CPEMatches) == 0 {
-			return true, nil
-		}
-		// ANY / NA on the query side has no concrete version to compare;
-		// match (consistent with legacy versioncriterion CPE handling).
+	queryVersionless := func() bool {
 		switch qWFN.GetString(common.AttributeVersion) {
 		case "ANY", "NA":
-			return true, nil
+			return true
+		default:
+			return false
+		}
+	}
+
+	cv := cWFN.GetString(common.AttributeVersion)
+
+	if cv == "NA" {
+		// A version=NA criterion fixes the product but not the version: it
+		// matches any scan whose non-version attributes are compatible, at
+		// version-unconfirmed quality. This mirrors go-cve-dictionary's
+		// VendorProductMatch for "-" entries, where NA often means "all
+		// versions" (e.g. linux_kernel:- on a classic all-versions CVE). The
+		// criterion version is neutralised to ANY because go-cpe's IsDisjoint
+		// would otherwise reject a concrete scan version against NA; other
+		// concrete attributes (target_sw, edition, ...) must still agree.
+		cAnyVer := maps.Clone(cWFN)
+		anyVal, err := common.NewLogicalValue("ANY")
+		if err != nil {
+			return MatchQualityNone, errors.Wrap(err, "build ANY logical value")
+		}
+		if err := cAnyVer.Set(common.AttributeVersion, anyVal); err != nil {
+			return MatchQualityNone, errors.Wrap(err, "neutralise criterion version")
+		}
+		if !matching.IsDisjoint(qWFN, cAnyVer) && !concretelyDisjoint(qWFN, cAnyVer) {
+			return MatchQualityVersionUnconfirmed, nil
+		}
+		// Non-version attributes disagree; fall through to CPEMatches.
+	} else if !matching.IsDisjoint(qWFN, cWFN) && !concretelyDisjoint(qWFN, cWFN) {
+		// No narrowing → accept on attribute match alone.
+		if c.Range == nil && len(c.CPEMatches) == 0 {
+			switch {
+			case cv == "ANY":
+				// version=* with no range/cpematches: every version of the
+				// product is affected. This "all versions" reading takes
+				// precedence over a version-less query.
+				return MatchQualityExact, nil
+			case queryVersionless():
+				return MatchQualityVersionUnconfirmed, nil
+			default:
+				// Concrete query equal to the concrete criterion version (a
+				// differing one would have been concretelyDisjoint).
+				return MatchQualityExact, nil
+			}
+		}
+		// Has narrowing: a version-less query has no concrete version to
+		// confirm against the range / enumeration.
+		if queryVersionless() {
+			return MatchQualityVersionUnconfirmed, nil
 		}
 		if c.Range != nil {
 			qVersion := strings.ReplaceAll(qWFN.GetString(common.AttributeVersion), "\\.", ".")
 			isAccepted, err := c.Range.Accept(qVersion)
 			if err != nil {
-				return false, errors.Wrap(err, "range accept")
+				return MatchQualityNone, errors.Wrap(err, "range accept")
 			}
 			if isAccepted {
-				return true, nil
+				return MatchQualityExact, nil
 			}
 		}
 		// Fall through to CPEMatches: out-of-range (or non-semver) exceptions
@@ -220,12 +297,25 @@ func (c Criterion) Accept(query Query) (bool, error) {
 	for _, m := range c.CPEMatches {
 		mWFN, err := naming.UnbindFS(string(m))
 		if err != nil {
-			return false, errors.Wrapf(err, "unbind %q to WFN", string(m))
+			return MatchQualityNone, errors.Wrapf(err, "unbind %q to WFN", string(m))
 		}
 		if !matching.IsDisjoint(qWFN, mWFN) && !concretelyDisjoint(qWFN, mWFN) {
-			return true, nil
+			// Reached with a version-less query only via the main-CPE-disjoint
+			// path (the matched path returns above); it has no version to
+			// confirm against the enumerated concrete CPE.
+			if queryVersionless() {
+				return MatchQualityVersionUnconfirmed, nil
+			}
+			return MatchQualityExact, nil
 		}
 	}
 
-	return false, nil
+	return MatchQualityNone, nil
+}
+
+// Accept reports whether the criterion accepts the query, collapsing
+// Match's quality to a bool. Retained for callers that only need acceptance.
+func (c Criterion) Accept(query Query) (bool, error) {
+	q, err := c.Match(query)
+	return q != MatchQualityNone, err
 }

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -182,9 +182,13 @@ func concretelyDisjoint(qWFN, cWFN common.WellFormedName) bool {
 type MatchQuality int
 
 const (
-	// MatchQualityUnknown is the iota-zero default: the criterion does not
-	// accept the query (also the safe value when a quality was never set).
+	// MatchQualityUnknown is the zero value: a quality that was never set.
+	// Accept never returns it — its appearance signals an uninitialised value
+	// or an enum case this code does not handle, which callers treat as a bug.
 	MatchQualityUnknown MatchQuality = iota
+	// MatchQualityNone means the criterion was evaluated and does NOT accept
+	// the query (disjoint attributes, out of range, enumeration miss).
+	MatchQualityNone
 	// MatchQualityExact means the criterion accepts the query with sufficient
 	// version evidence: a concrete query version confirmed by equality, range,
 	// or enumeration, OR a version=* criterion with no range/cpematches (every
@@ -199,6 +203,8 @@ const (
 
 func (q MatchQuality) String() string {
 	switch q {
+	case MatchQualityNone:
+		return "None"
 	case MatchQualityExact:
 		return "Exact"
 	case MatchQualityVersionUnconfirmed:
@@ -208,12 +214,15 @@ func (q MatchQuality) String() string {
 	}
 }
 
-// Match reports how strongly the criterion matches the query (see
-// MatchQuality). The branch structure mirrors the affected-set semantics
-// documented on Criterion: attribute match, then NA short-circuit, then
-// narrowing (range / cpematches), with the CPEMatches enumeration tried both
-// as an out-of-range fallback and (defensively) when the main CPE is disjoint.
-func (c Criterion) Match(query Query) (MatchQuality, error) {
+// Accept reports how strongly the criterion matches the query as a
+// MatchQuality (None vs Exact vs VersionUnconfirmed) — the CPE analogue of the
+// other criterion kinds' Accept (e.g. kbcriterion returns two bools); a richer
+// return under the same vocabulary. The branch structure mirrors the
+// affected-set semantics documented on Criterion: attribute match, then NA
+// short-circuit, then narrowing (range / cpematches), with the CPEMatches
+// enumeration tried both as an out-of-range fallback and (defensively) when the
+// main CPE is disjoint.
+func (c Criterion) Accept(query Query) (MatchQuality, error) {
 	qWFN, err := naming.UnbindFS(query.CPE)
 	if err != nil {
 		return MatchQualityUnknown, errors.Wrapf(err, "unbind %q to WFN", query.CPE)
@@ -306,12 +315,5 @@ func (c Criterion) Match(query Query) (MatchQuality, error) {
 		}
 	}
 
-	return MatchQualityUnknown, nil
-}
-
-// Accept reports whether the criterion accepts the query, collapsing
-// Match's quality to a bool. Retained for callers that only need acceptance.
-func (c Criterion) Accept(query Query) (bool, error) {
-	q, err := c.Match(query)
-	return q != MatchQualityUnknown, err
+	return MatchQualityNone, nil
 }

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -174,6 +174,14 @@ func concretelyDisjoint(qWFN, cWFN common.WellFormedName) bool {
 	return false
 }
 
+// overlaps reports whether two WFNs are non-disjoint — their attribute sets
+// intersect, so the CPEs can refer to the same thing. It is matching.IsDisjoint
+// negated and corrected with the concretelyDisjoint bug-guard: the basic
+// "these two CPEs match on attributes" test used throughout Accept.
+func overlaps(a, b common.WellFormedName) bool {
+	return !matching.IsDisjoint(a, b) && !concretelyDisjoint(a, b)
+}
+
 // MatchQuality describes how strongly a Criterion matched a Query. It is a
 // source-agnostic property of the CPE relationship alone; how each quality is
 // projected onto a consumer's confidence model (e.g. vuls0's exact vs
@@ -256,11 +264,11 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 		if err := cAnyVer.Set(common.AttributeVersion, anyVal); err != nil {
 			return MatchQualityUnknown, errors.Wrap(err, "neutralise criterion version")
 		}
-		if !matching.IsDisjoint(qWFN, cAnyVer) && !concretelyDisjoint(qWFN, cAnyVer) {
+		if overlaps(qWFN, cAnyVer) {
 			return MatchQualityVersionUnconfirmed, nil
 		}
 		// Non-version attributes disagree; fall through to CPEMatches.
-	} else if !matching.IsDisjoint(qWFN, cWFN) && !concretelyDisjoint(qWFN, cWFN) {
+	} else if overlaps(qWFN, cWFN) {
 		// No narrowing → accept on attribute match alone.
 		if c.Range == nil && len(c.CPEMatches) == 0 {
 			switch {
@@ -304,7 +312,7 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 		if err != nil {
 			return MatchQualityUnknown, errors.Wrapf(err, "unbind %q to WFN", string(m))
 		}
-		if !matching.IsDisjoint(qWFN, mWFN) && !concretelyDisjoint(qWFN, mWFN) {
+		if overlaps(qWFN, mWFN) {
 			// Reached with a version-less query only via the main-CPE-disjoint
 			// path (the matched path returns above); it has no version to
 			// confirm against the enumerated concrete CPE.

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -281,7 +281,7 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 				return MatchQualityVersionUnconfirmed, nil
 			default:
 				// Concrete query equal to the concrete criterion version (a
-				// differing one would have been concretelyDisjoint).
+				// differing one would have failed the overlaps check above).
 				return MatchQualityExact, nil
 			}
 		}

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -247,7 +247,8 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 	// version is a single determined value, not a per-branch computation.
 	queryVersionless := qv == "ANY" || qv == "NA"
 
-	if cv == "NA" {
+	switch {
+	case cv == "NA":
 		// A version=NA criterion fixes the product but not the version: it
 		// matches any scan whose non-version attributes are compatible, at
 		// version-unconfirmed quality. This mirrors go-cve-dictionary's
@@ -268,7 +269,7 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 			return MatchQualityVersionUnconfirmed, nil
 		}
 		// Non-version attributes disagree; fall through to CPEMatches.
-	} else if overlaps(qWFN, cWFN) {
+	case overlaps(qWFN, cWFN):
 		// No narrowing → accept on attribute match alone.
 		if c.Range == nil && len(c.CPEMatches) == 0 {
 			switch {
@@ -302,6 +303,8 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 		}
 		// Fall through to CPEMatches: out-of-range (or non-semver) exceptions
 		// the Range alone could not capture.
+	default:
+		// Main CPE disjoint from the query; only CPEMatches can still match.
 	}
 
 	// CPEMatches: tried when (a) main CPE matched but neither NA short-circuit

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -182,8 +182,9 @@ func concretelyDisjoint(qWFN, cWFN common.WellFormedName) bool {
 type MatchQuality int
 
 const (
-	// MatchQualityNone means the criterion does not accept the query.
-	MatchQualityNone MatchQuality = iota
+	// MatchQualityUnknown is the iota-zero default: the criterion does not
+	// accept the query (also the safe value when a quality was never set).
+	MatchQualityUnknown MatchQuality = iota
 	// MatchQualityExact means the criterion accepts the query with sufficient
 	// version evidence: a concrete query version confirmed by equality, range,
 	// or enumeration, OR a version=* criterion with no range/cpematches (every
@@ -203,7 +204,7 @@ func (q MatchQuality) String() string {
 	case MatchQualityVersionUnconfirmed:
 		return "VersionUnconfirmed"
 	default:
-		return "None"
+		return "Unknown"
 	}
 }
 
@@ -215,24 +216,19 @@ func (q MatchQuality) String() string {
 func (c Criterion) Match(query Query) (MatchQuality, error) {
 	qWFN, err := naming.UnbindFS(query.CPE)
 	if err != nil {
-		return MatchQualityNone, errors.Wrapf(err, "unbind %q to WFN", query.CPE)
+		return MatchQualityUnknown, errors.Wrapf(err, "unbind %q to WFN", query.CPE)
 	}
 
 	cWFN, err := naming.UnbindFS(string(c.CPE))
 	if err != nil {
-		return MatchQualityNone, errors.Wrapf(err, "unbind %q to WFN", string(c.CPE))
-	}
-
-	queryVersionless := func() bool {
-		switch qWFN.GetString(common.AttributeVersion) {
-		case "ANY", "NA":
-			return true
-		default:
-			return false
-		}
+		return MatchQualityUnknown, errors.Wrapf(err, "unbind %q to WFN", string(c.CPE))
 	}
 
 	cv := cWFN.GetString(common.AttributeVersion)
+	qv := qWFN.GetString(common.AttributeVersion)
+	// qWFN is fixed for this call, so whether the query carries a concrete
+	// version is a single determined value, not a per-branch computation.
+	queryVersionless := qv == "ANY" || qv == "NA"
 
 	if cv == "NA" {
 		// A version=NA criterion fixes the product but not the version: it
@@ -246,10 +242,10 @@ func (c Criterion) Match(query Query) (MatchQuality, error) {
 		cAnyVer := maps.Clone(cWFN)
 		anyVal, err := common.NewLogicalValue("ANY")
 		if err != nil {
-			return MatchQualityNone, errors.Wrap(err, "build ANY logical value")
+			return MatchQualityUnknown, errors.Wrap(err, "build ANY logical value")
 		}
 		if err := cAnyVer.Set(common.AttributeVersion, anyVal); err != nil {
-			return MatchQualityNone, errors.Wrap(err, "neutralise criterion version")
+			return MatchQualityUnknown, errors.Wrap(err, "neutralise criterion version")
 		}
 		if !matching.IsDisjoint(qWFN, cAnyVer) && !concretelyDisjoint(qWFN, cAnyVer) {
 			return MatchQualityVersionUnconfirmed, nil
@@ -264,7 +260,7 @@ func (c Criterion) Match(query Query) (MatchQuality, error) {
 				// product is affected. This "all versions" reading takes
 				// precedence over a version-less query.
 				return MatchQualityExact, nil
-			case queryVersionless():
+			case queryVersionless:
 				return MatchQualityVersionUnconfirmed, nil
 			default:
 				// Concrete query equal to the concrete criterion version (a
@@ -274,14 +270,14 @@ func (c Criterion) Match(query Query) (MatchQuality, error) {
 		}
 		// Has narrowing: a version-less query has no concrete version to
 		// confirm against the range / enumeration.
-		if queryVersionless() {
+		if queryVersionless {
 			return MatchQualityVersionUnconfirmed, nil
 		}
 		if c.Range != nil {
-			qVersion := strings.ReplaceAll(qWFN.GetString(common.AttributeVersion), "\\.", ".")
+			qVersion := strings.ReplaceAll(qv, "\\.", ".")
 			isAccepted, err := c.Range.Accept(qVersion)
 			if err != nil {
-				return MatchQualityNone, errors.Wrap(err, "range accept")
+				return MatchQualityUnknown, errors.Wrap(err, "range accept")
 			}
 			if isAccepted {
 				return MatchQualityExact, nil
@@ -297,25 +293,25 @@ func (c Criterion) Match(query Query) (MatchQuality, error) {
 	for _, m := range c.CPEMatches {
 		mWFN, err := naming.UnbindFS(string(m))
 		if err != nil {
-			return MatchQualityNone, errors.Wrapf(err, "unbind %q to WFN", string(m))
+			return MatchQualityUnknown, errors.Wrapf(err, "unbind %q to WFN", string(m))
 		}
 		if !matching.IsDisjoint(qWFN, mWFN) && !concretelyDisjoint(qWFN, mWFN) {
 			// Reached with a version-less query only via the main-CPE-disjoint
 			// path (the matched path returns above); it has no version to
 			// confirm against the enumerated concrete CPE.
-			if queryVersionless() {
+			if queryVersionless {
 				return MatchQualityVersionUnconfirmed, nil
 			}
 			return MatchQualityExact, nil
 		}
 	}
 
-	return MatchQualityNone, nil
+	return MatchQualityUnknown, nil
 }
 
 // Accept reports whether the criterion accepts the query, collapsing
 // Match's quality to a bool. Retained for callers that only need acceptance.
 func (c Criterion) Accept(query Query) (bool, error) {
 	q, err := c.Match(query)
-	return q != MatchQualityNone, err
+	return q != MatchQualityUnknown, err
 }

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -270,8 +270,9 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 		}
 		// Non-version attributes disagree; fall through to CPEMatches.
 	case overlaps(qWFN, cWFN):
-		// No narrowing → accept on attribute match alone.
-		if c.Range == nil && len(c.CPEMatches) == 0 {
+		switch {
+		case c.Range == nil && len(c.CPEMatches) == 0:
+			// No narrowing → accept on attribute match alone.
 			switch {
 			case cv == "ANY":
 				// version=* with no range/cpematches: every version of the
@@ -285,13 +286,13 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 				// differing one would have failed the overlaps check above).
 				return MatchQualityExact, nil
 			}
-		}
-		// Has narrowing: a version-less query has no concrete version to
-		// confirm against the range / enumeration.
-		if queryVersionless {
+		case queryVersionless:
+			// Narrowed criterion, but the query has no concrete version to
+			// confirm against the range / enumeration.
 			return MatchQualityVersionUnconfirmed, nil
-		}
-		if c.Range != nil {
+		case c.Range != nil:
+			// Concrete query against a range: accept only if in range,
+			// otherwise fall through to CPEMatches.
 			qVersion := strings.ReplaceAll(qv, "\\.", ".")
 			isAccepted, err := c.Range.Accept(qVersion)
 			if err != nil {
@@ -300,9 +301,9 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 			if isAccepted {
 				return MatchQualityExact, nil
 			}
+		default:
+			// CPEMatches-only narrowing; fall through to CPEMatches.
 		}
-		// Fall through to CPEMatches: out-of-range (or non-semver) exceptions
-		// the Range alone could not capture.
 	default:
 		// Main CPE disjoint from the query; only CPEMatches can still match.
 	}

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -201,13 +201,16 @@ const (
 	MatchQualityNone
 	// MatchQualityExact means the criterion accepts the query with sufficient
 	// version evidence: a concrete query version confirmed by equality, range,
-	// or enumeration, OR a version=* criterion with no range/cpematches (every
-	// version of the product is affected).
+	// or enumeration; a version=* criterion with no range/cpematches (every
+	// version of the product is affected); OR a query whose version is ANY —
+	// the scan asks for all versions of the product, so any match is reported
+	// with full confidence (respecting the intent of whoever wrote the query).
 	MatchQualityExact
 	// MatchQualityVersionUnconfirmed means the criterion accepts the query on
 	// attribute equality but the query's concrete version cannot be confirmed
-	// affected: the criterion version is NA, or the query itself carries no
-	// concrete version (ANY/NA) against a version-bearing criterion.
+	// affected: the query version is NA against a version-bearing criterion, or
+	// the criterion version is NA matched against a concrete/NA query. (A query
+	// version of ANY is Exact instead — see MatchQualityExact.)
 	MatchQualityVersionUnconfirmed
 )
 
@@ -245,9 +248,13 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 
 	cv := cWFN.GetString(common.AttributeVersion)
 	qv := qWFN.GetString(common.AttributeVersion)
-	// qWFN is fixed for this call, so whether the query carries a concrete
-	// version is a single determined value, not a per-branch computation.
-	queryVersionless := qv == "ANY" || qv == "NA"
+	// qWFN is fixed for this call, so the query's version disposition is a
+	// single determined value. ANY and NA are split: query version ANY is the
+	// scan asking for "all versions of this product" (a confident, Exact match
+	// — respecting the query author's intent); query version NA carries no
+	// version to confirm.
+	queryANY := qv == "ANY"
+	queryNA := qv == "NA"
 
 	switch {
 	case cv == "NA":
@@ -268,29 +275,40 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 			return MatchQualityUnknown, errors.Wrap(err, "neutralise criterion version")
 		}
 		if overlaps(qWFN, cAnyVer) {
+			// query=ANY asks for all versions → Exact; otherwise there is no
+			// concrete version to confirm against a no-version criterion.
+			if queryANY {
+				return MatchQualityExact, nil
+			}
 			return MatchQualityVersionUnconfirmed, nil
 		}
 		// Non-version attributes disagree; fall through to CPEMatches.
 	case overlaps(qWFN, cWFN):
 		switch {
+		case queryANY:
+			// The scan asks for all versions of this product (version=*), so
+			// any accepted criterion is a confident match regardless of how it
+			// narrows versions — respecting the query author's intent.
+			// (Deliberately stronger than go-cve-dictionary, which reports a
+			// version-less query at vendor:product.)
+			return MatchQualityExact, nil
 		case c.Range == nil && len(c.CPEMatches) == 0:
 			// No narrowing → accept on attribute match alone.
 			switch {
 			case cv == "ANY":
 				// version=* with no range/cpematches: every version of the
-				// product is affected. This "all versions" reading takes
-				// precedence over a version-less query.
+				// product is affected.
 				return MatchQualityExact, nil
-			case queryVersionless:
+			case queryNA:
 				return MatchQualityVersionUnconfirmed, nil
 			default:
 				// Concrete query equal to the concrete criterion version (a
 				// differing one would have failed the overlaps check above).
 				return MatchQualityExact, nil
 			}
-		case queryVersionless:
-			// Narrowed criterion, but the query has no concrete version to
-			// confirm against the range / enumeration.
+		case queryNA:
+			// Narrowed criterion, but the query has no version to confirm
+			// against the range / enumeration.
 			return MatchQualityVersionUnconfirmed, nil
 		case c.Range != nil:
 			// Concrete query against a range: accept only if in range,
@@ -320,9 +338,10 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 		}
 		if overlaps(qWFN, mWFN) {
 			// Reached with a version-less query only via the main-CPE-disjoint
-			// path (the matched path returns above); it has no version to
-			// confirm against the enumerated concrete CPE.
-			if queryVersionless {
+			// path (the matched path returns above). query=ANY (all versions)
+			// and a confirmed concrete query are Exact; query=NA has no version
+			// to confirm against the enumerated concrete CPE.
+			if queryNA {
 				return MatchQualityVersionUnconfirmed, nil
 			}
 			return MatchQualityExact, nil

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion.go
@@ -248,13 +248,6 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 
 	cv := cWFN.GetString(common.AttributeVersion)
 	qv := qWFN.GetString(common.AttributeVersion)
-	// qWFN is fixed for this call, so the query's version disposition is a
-	// single determined value. ANY and NA are split: query version ANY is the
-	// scan asking for "all versions of this product" (a confident, Exact match
-	// — respecting the query author's intent); query version NA carries no
-	// version to confirm.
-	queryANY := qv == "ANY"
-	queryNA := qv == "NA"
 
 	switch {
 	case cv == "NA":
@@ -277,7 +270,7 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 		if overlaps(qWFN, cAnyVer) {
 			// query=ANY asks for all versions → Exact; otherwise there is no
 			// concrete version to confirm against a no-version criterion.
-			if queryANY {
+			if qv == "ANY" {
 				return MatchQualityExact, nil
 			}
 			return MatchQualityVersionUnconfirmed, nil
@@ -285,7 +278,7 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 		// Non-version attributes disagree; fall through to CPEMatches.
 	case overlaps(qWFN, cWFN):
 		switch {
-		case queryANY:
+		case qv == "ANY":
 			// The scan asks for all versions of this product (version=*), so
 			// any accepted criterion is a confident match regardless of how it
 			// narrows versions — respecting the query author's intent.
@@ -299,14 +292,14 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 				// version=* with no range/cpematches: every version of the
 				// product is affected.
 				return MatchQualityExact, nil
-			case queryNA:
+			case qv == "NA":
 				return MatchQualityVersionUnconfirmed, nil
 			default:
 				// Concrete query equal to the concrete criterion version (a
 				// differing one would have failed the overlaps check above).
 				return MatchQualityExact, nil
 			}
-		case queryNA:
+		case qv == "NA":
 			// Narrowed criterion, but the query has no version to confirm
 			// against the range / enumeration.
 			return MatchQualityVersionUnconfirmed, nil
@@ -341,7 +334,7 @@ func (c Criterion) Accept(query Query) (MatchQuality, error) {
 			// path (the matched path returns above). query=ANY (all versions)
 			// and a confirmed concrete query are Exact; query=NA has no version
 			// to confirm against the enumerated concrete CPE.
-			if queryNA {
+			if qv == "NA" {
 				return MatchQualityVersionUnconfirmed, nil
 			}
 			return MatchQualityExact, nil

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
@@ -399,4 +399,128 @@ func TestCriterion_Accept(t *testing.T) {
 	}
 }
 
-
+func TestCriterion_Match(t *testing.T) {
+	type fields struct {
+		CPE        ccTypes.CPE
+		Range      *ccRangeTypes.Range
+		CPEMatches []ccTypes.CPE
+	}
+	type args struct {
+		query ccTypes.Query
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    ccTypes.MatchQuality
+		wantErr bool
+	}{
+		{
+			name:   "concrete version equality, no narrowing -> Exact",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityExact,
+		},
+		{
+			name:   "range accepts concrete version -> Exact",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"}},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityExact,
+		},
+		{
+			name:   "cpematches accepts concrete version -> Exact",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "1.0.0"}, CPEMatches: []ccTypes.CPE{"cpe:2.3:a:vendor:product:15.4\\(2\\)t1:*:*:*:*:*:*:*"}},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:15.4\\(2\\)t1:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityExact,
+		},
+		{
+			name:   "version=* no range/cpematches, concrete query -> Exact (all versions)",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityExact,
+		},
+		{
+			name:   "version=* no range/cpematches, version-less query -> Exact (all-versions precedence)",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityExact,
+		},
+		{
+			name:   "criterion version NA, version-less query -> VersionUnconfirmed",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*"},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityVersionUnconfirmed,
+		},
+		{
+			// version=NA fixes the product but not the version, so a concrete
+			// scan version still matches at version-unconfirmed quality (e.g.
+			// linux_kernel:- meaning "all versions" — go-cve-dictionary parity).
+			name:   "criterion version NA, concrete query -> VersionUnconfirmed",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*"},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:9.9.9:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityVersionUnconfirmed,
+		},
+		{
+			// A version=NA criterion still gates on non-version attributes:
+			// a disjoint target_sw is not a match.
+			name:   "criterion version NA, disjoint target_sw -> None",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:-:*:*:*:*:windows:*:*"},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:9.9.9:*:*:*:*:linux:*:*"}},
+			want:   ccTypes.MatchQualityNone,
+		},
+		{
+			name:   "concrete criterion, query version ANY -> VersionUnconfirmed",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityVersionUnconfirmed,
+		},
+		{
+			name:   "ranged criterion, query version ANY -> VersionUnconfirmed",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"}},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityVersionUnconfirmed,
+		},
+		{
+			name:   "concrete version mismatch -> None",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:2.0:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityNone,
+		},
+		{
+			name:   "range out of bounds -> None",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "1.0.0"}},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:2.0.0:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityNone,
+		},
+		{
+			name:   "non-semver query against semver range (compare error) -> None (no RPM fallback)",
+			fields: fields{CPE: "cpe:2.3:o:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "22.2"}},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:o:vendor:product:21.4r3:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityNone,
+		},
+		{
+			name:   "part disjoint -> None",
+			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"},
+			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:o:vendor:product:1.0:*:*:*:*:*:*:*"}},
+			want:   ccTypes.MatchQualityNone,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := ccTypes.Criterion{
+				Vulnerable: true,
+				CPE:        tt.fields.CPE,
+				Range:      tt.fields.Range,
+				CPEMatches: tt.fields.CPEMatches,
+			}
+			got, err := c.Match(tt.args.query)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Match() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
@@ -466,7 +466,7 @@ func TestCriterion_Match(t *testing.T) {
 			name:   "criterion version NA, disjoint target_sw -> None",
 			fields: fields{CPE: "cpe:2.3:a:vendor:product:-:*:*:*:*:windows:*:*"},
 			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:9.9.9:*:*:*:*:linux:*:*"}},
-			want:   ccTypes.MatchQualityNone,
+			want:   ccTypes.MatchQualityUnknown,
 		},
 		{
 			name:   "concrete criterion, query version ANY -> VersionUnconfirmed",
@@ -484,25 +484,25 @@ func TestCriterion_Match(t *testing.T) {
 			name:   "concrete version mismatch -> None",
 			fields: fields{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"},
 			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:2.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityNone,
+			want:   ccTypes.MatchQualityUnknown,
 		},
 		{
 			name:   "range out of bounds -> None",
 			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "1.0.0"}},
 			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:2.0.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityNone,
+			want:   ccTypes.MatchQualityUnknown,
 		},
 		{
 			name:   "non-semver query against semver range (compare error) -> None (no RPM fallback)",
 			fields: fields{CPE: "cpe:2.3:o:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "22.2"}},
 			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:o:vendor:product:21.4r3:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityNone,
+			want:   ccTypes.MatchQualityUnknown,
 		},
 		{
 			name:   "part disjoint -> None",
 			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"},
 			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:o:vendor:product:1.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityNone,
+			want:   ccTypes.MatchQualityUnknown,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
@@ -387,19 +387,19 @@ func TestCriterion_Accept(t *testing.T) {
 				CPEMatches: tt.fields.CPEMatches,
 				Fixed:      tt.fields.Fixed,
 			}
-			got, err := c.Accept(tt.args.query)
+			quality, err := c.Accept(tt.args.query)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Accept() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("Accept() = %v, want %v", got, tt.want)
+			if accepted := quality != ccTypes.MatchQualityNone; accepted != tt.want {
+				t.Errorf("Accept() accepted = %v (quality %s), want %v", accepted, quality, tt.want)
 			}
 		})
 	}
 }
 
-func TestCriterion_Match(t *testing.T) {
+func TestCriterion_AcceptQuality(t *testing.T) {
 	type fields struct {
 		CPE        ccTypes.CPE
 		Range      *ccRangeTypes.Range
@@ -466,7 +466,7 @@ func TestCriterion_Match(t *testing.T) {
 			name:   "criterion version NA, disjoint target_sw -> None",
 			fields: fields{CPE: "cpe:2.3:a:vendor:product:-:*:*:*:*:windows:*:*"},
 			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:9.9.9:*:*:*:*:linux:*:*"}},
-			want:   ccTypes.MatchQualityUnknown,
+			want:   ccTypes.MatchQualityNone,
 		},
 		{
 			name:   "concrete criterion, query version ANY -> VersionUnconfirmed",
@@ -484,25 +484,25 @@ func TestCriterion_Match(t *testing.T) {
 			name:   "concrete version mismatch -> None",
 			fields: fields{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"},
 			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:2.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityUnknown,
+			want:   ccTypes.MatchQualityNone,
 		},
 		{
 			name:   "range out of bounds -> None",
 			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "1.0.0"}},
 			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:2.0.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityUnknown,
+			want:   ccTypes.MatchQualityNone,
 		},
 		{
 			name:   "non-semver query against semver range (compare error) -> None (no RPM fallback)",
 			fields: fields{CPE: "cpe:2.3:o:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "22.2"}},
 			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:o:vendor:product:21.4r3:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityUnknown,
+			want:   ccTypes.MatchQualityNone,
 		},
 		{
 			name:   "part disjoint -> None",
 			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"},
 			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:o:vendor:product:1.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityUnknown,
+			want:   ccTypes.MatchQualityNone,
 		},
 	}
 	for _, tt := range tests {
@@ -513,13 +513,13 @@ func TestCriterion_Match(t *testing.T) {
 				Range:      tt.fields.Range,
 				CPEMatches: tt.fields.CPEMatches,
 			}
-			got, err := c.Match(tt.args.query)
+			got, err := c.Accept(tt.args.query)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Match() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Accept() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("Match() = %v, want %v", got, tt.want)
+				t.Errorf("Accept() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
@@ -24,186 +24,218 @@ func TestCriterion_Accept(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    bool
+		want    ccTypes.MatchQuality
 		wantErr bool
 	}{
 		{
-			name: "cpe in semver range",
+			name: "cpe in semver range -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "0.0.2"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:0.0.1:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "accept with target_sw in pattern, wildcard in query",
+			name: "accept with target_sw in pattern, wildcard in query -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:wordpress:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.8"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.5:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "not accept with different target_sw",
+			name: "different target_sw -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:wordpress:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.5:*:*:*:*:node.js:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "not accept with different part",
+			name: "different part -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:o:vendor:product:1.0:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "query version wildcard with range",
+			name: "query version wildcard with range -> VersionUnconfirmed",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "0.0.2"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityVersionUnconfirmed,
 		},
 		{
-			name: "query version wildcard without range",
+			name: "version=* criterion, query version wildcard, no range -> Exact (all versions)",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "query version wildcard against specific pattern version",
+			name: "concrete criterion, query version wildcard, no range -> VersionUnconfirmed",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityVersionUnconfirmed,
 		},
 		{
-			name: "pattern version ANY, query version NA",
+			name: "version=* criterion with range, query version NA -> VersionUnconfirmed",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "1.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityVersionUnconfirmed,
 		},
 		{
-			name: "pattern version ANY, query version not in range",
+			name: "version=* criterion with range, concrete query out of range -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "0.0.2"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "pattern version NA",
+			name: "criterion version NA, query version wildcard -> VersionUnconfirmed",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityVersionUnconfirmed,
 		},
 		{
-			name: "pattern version NA with range, range is ignored",
+			name: "criterion version NA with range (range ignored), query wildcard -> VersionUnconfirmed",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "0.0.2"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityVersionUnconfirmed,
 		},
 		{
-			name: "pattern specific version with range, query same version in range",
+			// version=NA fixes the product but not the version, so a concrete
+			// scan version still matches at version-unconfirmed quality (e.g.
+			// linux_kernel:- meaning "all versions" — go-cve-dictionary parity).
+			name: "criterion version NA, concrete query -> VersionUnconfirmed",
+			fields: fields{
+				Vulnerable: true,
+				CPE:        "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*",
+			},
+			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:9.9.9:*:*:*:*:*:*:*"}},
+			want: ccTypes.MatchQualityVersionUnconfirmed,
+		},
+		{
+			// A version=NA criterion still gates on non-version attributes:
+			// a disjoint target_sw is not a match.
+			name: "criterion version NA, disjoint target_sw -> None",
+			fields: fields{
+				Vulnerable: true,
+				CPE:        "cpe:2.3:a:vendor:product:-:*:*:*:*:windows:*:*",
+			},
+			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:9.9.9:*:*:*:*:linux:*:*"}},
+			want: ccTypes.MatchQualityNone,
+		},
+		{
+			name: "concrete criterion, no range, concrete query equal -> Exact",
+			fields: fields{
+				Vulnerable: true,
+				CPE:        "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*",
+			},
+			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"}},
+			want: ccTypes.MatchQualityExact,
+		},
+		{
+			name: "concrete criterion with range, concrete query in range -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "pattern specific version with range, query same version out of range",
+			name: "concrete criterion with range, same concrete query out of range -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:3.0.0:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:3.0.0:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "pattern specific version, query different specific version: CPE attr disjoint (Range never consulted)",
+			name: "concrete criterion, different concrete query: CPE attr disjoint (Range never consulted) -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:3.0.0:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:2.0.0:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "pattern specific version with range, query version ANY",
+			name: "concrete criterion with range, query version ANY -> VersionUnconfirmed",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityVersionUnconfirmed,
 		},
 		{
-			name: "pattern specific version outside range, query version ANY short-circuits",
+			name: "concrete criterion outside range, query version ANY short-circuits -> VersionUnconfirmed",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:3.0.0:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityVersionUnconfirmed,
 		},
 		{
-			name: "ge/lt range, query in range",
+			name: "ge/lt range, query in range -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, GreaterEqual: "1.0.0", LessThan: "2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.5.0:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "ge/lt range, query below lower bound",
+			name: "ge/lt range, query below lower bound -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, GreaterEqual: "1.0.0", LessThan: "2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:0.9.0:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "cpe_matches: main CPE and every CPEMatches entry disjoint from query → false",
+			name: "cpe_matches: main CPE and every CPEMatches entry disjoint from query -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
@@ -213,10 +245,10 @@ func TestCriterion_Accept(t *testing.T) {
 				},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:other:product:1.0:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "cpe_matches: query matches one entry exactly via cpematch fallback",
+			name: "cpe_matches: query matches one entry exactly via cpematch fallback -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:productX:*:*:*:*:*:*:*:*",
@@ -225,7 +257,7 @@ func TestCriterion_Accept(t *testing.T) {
 				},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:productY:15.4\\(2\\)t1:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
 			// go-cpe matching mis-classifies pairs of concrete values where one
@@ -233,38 +265,40 @@ func TestCriterion_Accept(t *testing.T) {
 			// IsDisjoint("5.15.10", "5.15.103") returns false. The
 			// concretelyDisjoint spot-check rescues the byte-wise truth so
 			// the main CPE path does not falsely match.
-			name: "go-cpe over-match guard: main CPE concrete-vs-concrete substring → false",
+			name: "go-cpe over-match guard: main CPE concrete-vs-concrete substring -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:o:linux:linux_kernel:5.15.10:*:*:*:*:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:o:linux:linux_kernel:5.15.103:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
 			// Same over-match guard applied along the CPEMatches loop — a
 			// cpematch entry "5.15.10" must NOT swallow a "5.15.103" query.
-			name: "go-cpe over-match guard: CPEMatches concrete-vs-concrete substring → false",
+			name: "go-cpe over-match guard: CPEMatches concrete-vs-concrete substring -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
 				CPEMatches: []ccTypes.CPE{"cpe:2.3:o:linux:linux_kernel:5.15.10:*:*:*:*:*:*:*"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:o:linux:linux_kernel:5.15.103:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "unparseable query version with range yields false",
+			// Non-semver query against a semver range: the comparator errors
+			// (swallowed as non-match), and there is no RPM-style fallback.
+			name: "non-semver query against semver range (compare error) -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:15.4\\(2\\)t1:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "Range out, CPEMatches in: NVD listed an out-of-range version",
+			name: "Range out, CPEMatches in: NVD listed an out-of-range version -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
@@ -272,10 +306,10 @@ func TestCriterion_Accept(t *testing.T) {
 				CPEMatches: []ccTypes.CPE{"cpe:2.3:a:vendor:product:3.5.0:*:*:*:*:*:*:*"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:3.5.0:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "Range in, CPEMatches non-matching: Range short-circuits",
+			name: "Range in, CPEMatches non-matching: Range short-circuits -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
@@ -283,10 +317,10 @@ func TestCriterion_Accept(t *testing.T) {
 				CPEMatches: []ccTypes.CPE{"cpe:2.3:a:vendor:product:3.5.0:*:*:*:*:*:*:*"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.5.0:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "Range out, CPEMatches non-matching: neither narrowing matches",
+			name: "Range out, CPEMatches non-matching: neither narrowing matches -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
@@ -294,55 +328,55 @@ func TestCriterion_Accept(t *testing.T) {
 				CPEMatches: []ccTypes.CPE{"cpe:2.3:a:vendor:product:3.5.0:*:*:*:*:*:*:*"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:5.0.0:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "accept (no narrowing): wildcard pattern matches concrete query",
+			name: "no narrowing: version=* pattern matches concrete query -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:0.0.1:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "different vendor",
+			name: "different vendor -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:other:product:0.0.1:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "different product",
+			name: "different product -> None",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:other:0.0.1:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "pattern has target_sw, query has same target_sw",
+			name: "pattern has target_sw, query has same target_sw -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:wordpress:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:wordpress:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "pattern has sw_edition, query has wildcard",
+			name: "pattern has sw_edition, query has wildcard -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:enterprise:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "FixStatus + Fixed are metadata: in-range query still accepted",
+			name: "FixStatus + Fixed are metadata: in-range query still Exact",
 			fields: fields{
 				Vulnerable: true,
 				FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed, Vendor: "vendor"},
@@ -351,10 +385,10 @@ func TestCriterion_Accept(t *testing.T) {
 				Fixed:      []string{"2.0.0", "2.0.1"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.5.0:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "FixStatus + Fixed are metadata: query matching a Fixed entry is still rejected if Range excludes it",
+			name: "FixStatus + Fixed are metadata: query matching a Fixed entry still None if Range excludes it",
 			fields: fields{
 				Vulnerable: true,
 				FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed, Vendor: "vendor"},
@@ -363,10 +397,10 @@ func TestCriterion_Accept(t *testing.T) {
 				Fixed:      []string{"2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:2.0.0:*:*:*:*:*:*:*"}},
-			want: false,
+			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "non-semver Range stored as-is, CPEMatches covers all enumerated versions",
+			name: "non-semver Range stored as-is, CPEMatches covers the enumerated version -> Exact",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
@@ -374,7 +408,7 @@ func TestCriterion_Accept(t *testing.T) {
 				CPEMatches: []ccTypes.CPE{"cpe:2.3:a:vendor:product:15.4\\(2\\)t1:*:*:*:*:*:*:*"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:15.4\\(2\\)t1:*:*:*:*:*:*:*"}},
-			want: true,
+			want: ccTypes.MatchQualityExact,
 		},
 	}
 	for _, tt := range tests {
@@ -387,139 +421,13 @@ func TestCriterion_Accept(t *testing.T) {
 				CPEMatches: tt.fields.CPEMatches,
 				Fixed:      tt.fields.Fixed,
 			}
-			quality, err := c.Accept(tt.args.query)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Accept() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if accepted := quality != ccTypes.MatchQualityNone; accepted != tt.want {
-				t.Errorf("Accept() accepted = %v (quality %s), want %v", accepted, quality, tt.want)
-			}
-		})
-	}
-}
-
-func TestCriterion_AcceptQuality(t *testing.T) {
-	type fields struct {
-		CPE        ccTypes.CPE
-		Range      *ccRangeTypes.Range
-		CPEMatches []ccTypes.CPE
-	}
-	type args struct {
-		query ccTypes.Query
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    ccTypes.MatchQuality
-		wantErr bool
-	}{
-		{
-			name:   "concrete version equality, no narrowing -> Exact",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityExact,
-		},
-		{
-			name:   "range accepts concrete version -> Exact",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"}},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityExact,
-		},
-		{
-			name:   "cpematches accepts concrete version -> Exact",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "1.0.0"}, CPEMatches: []ccTypes.CPE{"cpe:2.3:a:vendor:product:15.4\\(2\\)t1:*:*:*:*:*:*:*"}},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:15.4\\(2\\)t1:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityExact,
-		},
-		{
-			name:   "version=* no range/cpematches, concrete query -> Exact (all versions)",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityExact,
-		},
-		{
-			name:   "version=* no range/cpematches, version-less query -> Exact (all-versions precedence)",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityExact,
-		},
-		{
-			name:   "criterion version NA, version-less query -> VersionUnconfirmed",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*"},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityVersionUnconfirmed,
-		},
-		{
-			// version=NA fixes the product but not the version, so a concrete
-			// scan version still matches at version-unconfirmed quality (e.g.
-			// linux_kernel:- meaning "all versions" — go-cve-dictionary parity).
-			name:   "criterion version NA, concrete query -> VersionUnconfirmed",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*"},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:9.9.9:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityVersionUnconfirmed,
-		},
-		{
-			// A version=NA criterion still gates on non-version attributes:
-			// a disjoint target_sw is not a match.
-			name:   "criterion version NA, disjoint target_sw -> None",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:-:*:*:*:*:windows:*:*"},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:9.9.9:*:*:*:*:linux:*:*"}},
-			want:   ccTypes.MatchQualityNone,
-		},
-		{
-			name:   "concrete criterion, query version ANY -> VersionUnconfirmed",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityVersionUnconfirmed,
-		},
-		{
-			name:   "ranged criterion, query version ANY -> VersionUnconfirmed",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"}},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityVersionUnconfirmed,
-		},
-		{
-			name:   "concrete version mismatch -> None",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:2.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityNone,
-		},
-		{
-			name:   "range out of bounds -> None",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "1.0.0"}},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:2.0.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityNone,
-		},
-		{
-			name:   "non-semver query against semver range (compare error) -> None (no RPM fallback)",
-			fields: fields{CPE: "cpe:2.3:o:vendor:product:*:*:*:*:*:*:*:*", Range: &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "22.2"}},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:o:vendor:product:21.4r3:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityNone,
-		},
-		{
-			name:   "part disjoint -> None",
-			fields: fields{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"},
-			args:   args{query: ccTypes.Query{CPE: "cpe:2.3:o:vendor:product:1.0:*:*:*:*:*:*:*"}},
-			want:   ccTypes.MatchQualityNone,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := ccTypes.Criterion{
-				Vulnerable: true,
-				CPE:        tt.fields.CPE,
-				Range:      tt.fields.Range,
-				CPEMatches: tt.fields.CPEMatches,
-			}
 			got, err := c.Accept(tt.args.query)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Accept() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("Accept() = %v, want %v", got, tt.want)
+				t.Errorf("Accept() = %s, want %s", got, tt.want)
 			}
 		})
 	}

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/cpecriterion_test.go
@@ -66,14 +66,14 @@ func TestCriterion_Accept(t *testing.T) {
 			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "query version wildcard with range -> VersionUnconfirmed",
+			name: "query version wildcard with range -> Exact (query=ANY)",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "0.0.2"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: ccTypes.MatchQualityVersionUnconfirmed,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
 			name: "version=* criterion, query version wildcard, no range -> Exact (all versions)",
@@ -85,13 +85,13 @@ func TestCriterion_Accept(t *testing.T) {
 			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "concrete criterion, query version wildcard, no range -> VersionUnconfirmed",
+			name: "concrete criterion, query version wildcard, no range -> Exact (query=ANY)",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: ccTypes.MatchQualityVersionUnconfirmed,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
 			name: "version=* criterion with range, query version NA -> VersionUnconfirmed",
@@ -114,23 +114,23 @@ func TestCriterion_Accept(t *testing.T) {
 			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "criterion version NA, query version wildcard -> VersionUnconfirmed",
+			name: "criterion version NA, query version wildcard -> Exact (query=ANY)",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*",
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: ccTypes.MatchQualityVersionUnconfirmed,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "criterion version NA with range (range ignored), query wildcard -> VersionUnconfirmed",
+			name: "criterion version NA with range (range ignored), query wildcard -> Exact (query=ANY)",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:-:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "0.0.2"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: ccTypes.MatchQualityVersionUnconfirmed,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
 			// version=NA fixes the product but not the version, so a concrete
@@ -195,24 +195,24 @@ func TestCriterion_Accept(t *testing.T) {
 			want: ccTypes.MatchQualityNone,
 		},
 		{
-			name: "concrete criterion with range, query version ANY -> VersionUnconfirmed",
+			name: "concrete criterion with range, query version ANY -> Exact (query=ANY)",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: ccTypes.MatchQualityVersionUnconfirmed,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
-			name: "concrete criterion outside range, query version ANY short-circuits -> VersionUnconfirmed",
+			name: "concrete criterion outside range, query version ANY short-circuits -> Exact (query=ANY)",
 			fields: fields{
 				Vulnerable: true,
 				CPE:        "cpe:2.3:a:vendor:product:3.0.0:*:*:*:*:*:*:*",
 				Range:      &ccRangeTypes.Range{Type: ccRangeTypes.RangeTypeSEMVER, LessThan: "2.0.0"},
 			},
 			args: args{query: ccTypes.Query{CPE: "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"}},
-			want: ccTypes.MatchQualityVersionUnconfirmed,
+			want: ccTypes.MatchQualityExact,
 		},
 		{
 			name: "ge/lt range, query in range -> Exact",

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/criterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/criterion.go
@@ -248,11 +248,11 @@ func (c Criterion) Contains(query Query, repositories []string) (bool, error) {
 		}
 
 		for _, q := range query.CPE {
-			isAccepted, err := c.CPE.Accept(q)
+			quality, err := c.CPE.Accept(q)
 			if err != nil {
 				return false, errors.Wrap(err, "cpe criterion accept")
 			}
-			if isAccepted {
+			if quality == ccTypes.MatchQualityExact || quality == ccTypes.MatchQualityVersionUnconfirmed {
 				return true, nil
 			}
 		}
@@ -363,15 +363,19 @@ func (c Criterion) Accept(query Query, repositories []string) (FilteredCriterion
 
 		var accepts CPEAccepts
 		for i, q := range query.CPE {
-			quality, err := c.CPE.Match(q)
+			quality, err := c.CPE.Accept(q)
 			if err != nil {
-				return FilteredCriterion{}, errors.Wrap(err, "cpe criterion match")
+				return FilteredCriterion{}, errors.Wrap(err, "cpe criterion accept")
 			}
 			switch quality {
+			case ccTypes.MatchQualityNone:
+				// evaluated, no match; contributes no index
 			case ccTypes.MatchQualityExact:
 				accepts.Exact = append(accepts.Exact, i)
 			case ccTypes.MatchQualityVersionUnconfirmed:
 				accepts.VersionUnconfirmed = append(accepts.VersionUnconfirmed, i)
+			default:
+				return FilteredCriterion{}, errors.Errorf("unexpected cpe match quality. expected: %q, actual: %q", []ccTypes.MatchQuality{ccTypes.MatchQualityNone, ccTypes.MatchQualityExact, ccTypes.MatchQualityVersionUnconfirmed}, quality)
 			}
 		}
 		return FilteredCriterion{
@@ -392,7 +396,7 @@ func (fc FilteredCriterion) Affected() (bool, error) {
 	case CriterionTypeKB:
 		return fc.Accepts.KB.Covered || fc.Accepts.KB.Unapplied, nil
 	case CriterionTypeCPE:
-		return !fc.Accepts.CPE.IsZero(), nil
+		return len(fc.Accepts.CPE.Exact) > 0 || len(fc.Accepts.CPE.VersionUnconfirmed) > 0, nil
 	default:
 		return false, errors.Errorf("unexpected criterion type. expected: %q, actual: %q", []CriterionType{CriterionTypeVersion, CriterionTypeNoneExist, CriterionTypeKB, CriterionTypeCPE}, fc.Criterion.Type)
 	}

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/criterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/criterion.go
@@ -252,8 +252,13 @@ func (c Criterion) Contains(query Query, repositories []string) (bool, error) {
 			if err != nil {
 				return false, errors.Wrap(err, "cpe criterion accept")
 			}
-			if quality == ccTypes.MatchQualityExact || quality == ccTypes.MatchQualityVersionUnconfirmed {
+			switch quality {
+			case ccTypes.MatchQualityNone:
+				// not matched by this query; try the next
+			case ccTypes.MatchQualityExact, ccTypes.MatchQualityVersionUnconfirmed:
 				return true, nil
+			default:
+				return false, errors.Errorf("unexpected cpe match quality. expected: %q, actual: %q", []ccTypes.MatchQuality{ccTypes.MatchQualityNone, ccTypes.MatchQualityExact, ccTypes.MatchQualityVersionUnconfirmed}, quality)
 			}
 		}
 		return false, nil

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/criterion.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/criterion.go
@@ -276,11 +276,25 @@ type KB struct {
 	Unapplied bool `json:"unapplied,omitempty"`
 }
 
+// CPEAccepts records the indices of accepted CPE queries grouped by match
+// quality (see cpecriterion.MatchQuality). Exact holds version-confirmed
+// matches; VersionUnconfirmed holds matches accepted on attribute equality but
+// without version confirmation. Projecting these onto a consumer's confidence
+// model (e.g. vuls0's exact / vendor:product tiers) is the consumer's concern.
+type CPEAccepts struct {
+	Exact              []int `json:"exact,omitempty"`
+	VersionUnconfirmed []int `json:"version_unconfirmed,omitempty"`
+}
+
+func (a CPEAccepts) IsZero() bool {
+	return len(a.Exact) == 0 && len(a.VersionUnconfirmed) == 0
+}
+
 type AcceptQueries struct {
-	Version   []int `json:"version,omitempty"`
-	NoneExist bool  `json:"none_exist,omitempty"`
-	KB        KB    `json:"kb,omitzero"`
-	CPE       []int `json:"cpe,omitempty"`
+	Version   []int      `json:"version,omitempty"`
+	NoneExist bool       `json:"none_exist,omitempty"`
+	KB        KB         `json:"kb,omitzero"`
+	CPE       CPEAccepts `json:"cpe,omitzero"`
 }
 
 func (c Criterion) Accept(query Query, repositories []string) (FilteredCriterion, error) {
@@ -347,19 +361,22 @@ func (c Criterion) Accept(query Query, repositories []string) (FilteredCriterion
 			return FilteredCriterion{Criterion: c, Accepts: AcceptQueries{}}, nil
 		}
 
-		var is []int
+		var accepts CPEAccepts
 		for i, q := range query.CPE {
-			isAccepted, err := c.CPE.Accept(q)
+			quality, err := c.CPE.Match(q)
 			if err != nil {
-				return FilteredCriterion{}, errors.Wrap(err, "cpe criterion accept")
+				return FilteredCriterion{}, errors.Wrap(err, "cpe criterion match")
 			}
-			if isAccepted {
-				is = append(is, i)
+			switch quality {
+			case ccTypes.MatchQualityExact:
+				accepts.Exact = append(accepts.Exact, i)
+			case ccTypes.MatchQualityVersionUnconfirmed:
+				accepts.VersionUnconfirmed = append(accepts.VersionUnconfirmed, i)
 			}
 		}
 		return FilteredCriterion{
 			Criterion: c,
-			Accepts:   AcceptQueries{CPE: is},
+			Accepts:   AcceptQueries{CPE: accepts},
 		}, nil
 	default:
 		return FilteredCriterion{}, errors.Errorf("unexpected criterion type. expected: %q, actual: %q", []CriterionType{CriterionTypeVersion, CriterionTypeNoneExist, CriterionTypeKB, CriterionTypeCPE}, c.Type)
@@ -375,7 +392,7 @@ func (fc FilteredCriterion) Affected() (bool, error) {
 	case CriterionTypeKB:
 		return fc.Accepts.KB.Covered || fc.Accepts.KB.Unapplied, nil
 	case CriterionTypeCPE:
-		return len(fc.Accepts.CPE) > 0, nil
+		return !fc.Accepts.CPE.IsZero(), nil
 	default:
 		return false, errors.Errorf("unexpected criterion type. expected: %q, actual: %q", []CriterionType{CriterionTypeVersion, CriterionTypeNoneExist, CriterionTypeKB, CriterionTypeCPE}, fc.Criterion.Type)
 	}


### PR DESCRIPTION
## What

`cpecriterion.Criterion.Accept` now returns a **match quality** (`MatchQuality`) instead of a bool: `Unknown` (iota-zero sentinel — never returned, signals a bug), `None` (evaluated, no match), `Exact`, or `VersionUnconfirmed`. `AcceptQueries.CPE` changes from `[]int` to a categorized `CPEAccepts{Exact, VersionUnconfirmed}`.

`Accept` returning a richer value (rather than a separate `Match` method + bool wrapper) matches the other criterion kinds' vocabulary — `kbcriterion.Accept` already returns `(bool, bool, error)`.

## Why

The exact-vs-vendor:product judgement for CPE detection was being **re-derived in the vuls0 detector** from raw CPEs (duplicating match semantics, plus an ad-hoc `vendorProductEligible` fallback). Once the RPM fuzzy fallback was removed, the remaining quality judgement is a pure, source-agnostic property of the CPE criterion vs query, so it belongs in this matcher. vuls0 then only needs to *project* the result.

## How

- `Accept` returns:
  - **Exact** — concrete query version confirmed by equality / range / cpematch enumeration, OR a `version=*` criterion with no range/cpematches ("all versions affected"; checked before the version-less-query rule).
  - **VersionUnconfirmed** — accepted on attributes but the query version is unconfirmed (query version ANY/NA, or criterion version NA).
  - **None** — evaluated, no match. **Unknown** — zero value only; `Accept` never returns it, so `criterion.Accept`'s switch errors on it (and any unhandled value) via the `default` case.
- **version=NA criterion** (e.g. `cisco:ios:-`, `linux_kernel:-`) fixes the product but not the version, so it matches a *concrete*-version scan at `VersionUnconfirmed` (the criterion version is neutralised to ANY before the `IsDisjoint` check, since go-cpe treats NA-vs-concrete as disjoint). This mirrors go-cve-dictionary's `VendorProductMatch` for `-` entries and keeps "all versions" CVEs (e.g. CVE-1999-0524) detectable; non-version attributes still gate.
- `criterion.Criterion.Accept` buckets query indices by quality; `FilteredCriterion.Affected` checks the two index slices.

- **query version=ANY → Exact** (scan asks for "all versions of this product"). A scan CPE whose version is ANY is the operator/query author deliberately asking for *every* CVE of the product, so an accepted criterion is reported at `Exact` regardless of how it narrows versions — kept distinct from `VersionUnconfirmed` ("we can't confirm the version"). `query=NA` stays `VersionUnconfirmed` (per the CPE spec, NA is a distinct point value, not "all versions"). This is a deliberate divergence from go-cve-dictionary (which reports a version-less query at vendor:product), so version=ANY matches stay above low-reliability confidence filters; concrete-version detection is unchanged (the vuls-compare parity gate still holds).

## Breaking change

`AcceptQueries.CPE` shape changes (`"cpe":[0]` → `"cpe":{"exact":[0]}` / `{"version_unconfirmed":[0]}`). This is a **detect-time** `FilteredCondition` type — **not persisted to the DB** and not imported by `filter-vuls-data-extracted-redhat`. Consumers `vuls2` and `vuls0` are updated in lockstep (see Coordination).

## Testing

`GOEXPERIMENT=jsonv2 go test ./pkg/extract/types/...` green. `TestCriterion_Accept` covers accept/reject; `TestCriterion_AcceptQuality` covers the quality rules incl. NA-vs-concrete and disjoint-target_sw gating. End-to-end `vuls-compare` (with vuls2 + vuls0) is **byte-identical** before/after on juniper / safari / cisco / linux fixtures (go-cve-dictionary parity).

## Coordination (dependency order)

1. **this PR** (vuls-data-update, base `nightly`)
2. MaineK00n/vuls2#388 (`shino/cpe-match-quality`) — bump go.mod after this merges
3. future-architect/vuls#2575 — bump go.mod after vuls2 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

