### PR TITLE
feat(extract/jvn): add CWE (Ja) catalog output from feed rss/detail

### DIFF
--- a/pkg/extract/jvn/feed/detail/detail.go
+++ b/pkg/extract/jvn/feed/detail/detail.go
@@ -13,6 +13,7 @@ import (
 	"github.com/knqyf263/go-cpe/naming"
 	"github.com/pkg/errors"
 
+	cwecatalogTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe"
 	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
 	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
 	advisoryContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory/content"
@@ -73,6 +74,7 @@ func Extract(args string, opts ...Option) error {
 	}
 
 	slog.Info("Extract JVN Feed Detail")
+	cwes := make(map[string]cwecatalogTypes.CWE)
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -109,9 +111,40 @@ func Extract(args string, opts ...Option) error {
 			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", data.ID)))
 		}
 
+		for _, item := range fetched.VulinfoData.Related.RelatedItem {
+			if item.Type != "cwe" || !strings.HasPrefix(item.VulinfoID, "CWE-") {
+				continue
+			}
+			if _, ok := cwes[item.VulinfoID]; ok {
+				continue
+			}
+			cwes[item.VulinfoID] = cwecatalogTypes.CWE{
+				ID:   item.VulinfoID,
+				Name: strings.TrimSuffix(item.Title, fmt.Sprintf("(%s)", item.VulinfoID)),
+				References: func() []referenceTypes.Reference {
+					if item.URL == "" {
+						return nil
+					}
+					return []referenceTypes.Reference{{
+						Source: "jvndb.jvn.jp",
+						URL:    item.URL,
+					}}
+				}(),
+				DataSource: sourceTypes.Source{
+					ID: sourceTypes.JVNFeedDetail,
+				},
+			}
+		}
+
 		return nil
 	}); err != nil {
 		return errors.Wrapf(err, "walk %s", args)
+	}
+
+	for id, c := range cwes {
+		if err := util.Write(filepath.Join(options.dir, "cwe", fmt.Sprintf("%s.json", id)), c, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "cwe", fmt.Sprintf("%s.json", id)))
+		}
 	}
 
 	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{

--- a/pkg/extract/jvn/feed/detail/testdata/golden/cwe/CWE-352.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/cwe/CWE-352.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-352",
+	"name": "クロスサイトリクエストフォージェリ",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "https://jvndb.jvn.jp/ja/cwe/CWE-352.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-detail"
+	}
+}

--- a/pkg/extract/jvn/feed/detail/testdata/golden/cwe/CWE-476.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/cwe/CWE-476.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-476",
+	"name": "NULL ポインタデリファレンス",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "http://cwe.mitre.org/data/definitions/476.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-detail"
+	}
+}

--- a/pkg/extract/jvn/feed/detail/testdata/golden/cwe/CWE-79.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/cwe/CWE-79.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-79",
+	"name": "クロスサイトスクリプティング",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "https://jvndb.jvn.jp/ja/cwe/CWE-79.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-detail"
+	}
+}

--- a/pkg/extract/jvn/feed/detail/testdata/golden/cwe/CWE-89.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/cwe/CWE-89.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-89",
+	"name": "SQLインジェクション",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "https://jvndb.jvn.jp/ja/cwe/CWE-89.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-detail"
+	}
+}

--- a/pkg/extract/jvn/feed/rss/rss.go
+++ b/pkg/extract/jvn/feed/rss/rss.go
@@ -13,6 +13,7 @@ import (
 	"github.com/knqyf263/go-cpe/naming"
 	"github.com/pkg/errors"
 
+	cwecatalogTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe"
 	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
 	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
 	advisoryContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory/content"
@@ -73,6 +74,7 @@ func Extract(args string, opts ...Option) error {
 	}
 
 	slog.Info("Extract JVN Feed RSS")
+	cwes := make(map[string]cwecatalogTypes.CWE)
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -109,9 +111,43 @@ func Extract(args string, opts ...Option) error {
 			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", splitted[1], fmt.Sprintf("%s.json", data.ID)))
 		}
 
+		for _, ref := range fetched.References {
+			// CWE classification entries are the references with no source
+			// attribute; CWE-prefixed entries that do carry a source (e.g.
+			// related documents) are not CWE classifications, so skip them.
+			if ref.Source != "" || !strings.HasPrefix(ref.ID, "CWE-") {
+				continue
+			}
+			if _, ok := cwes[ref.ID]; ok {
+				continue
+			}
+			cwes[ref.ID] = cwecatalogTypes.CWE{
+				ID:   ref.ID,
+				Name: strings.TrimSuffix(ref.Title, fmt.Sprintf("(%s)", ref.ID)),
+				References: func() []referenceTypes.Reference {
+					if ref.Text == "" {
+						return nil
+					}
+					return []referenceTypes.Reference{{
+						Source: "jvndb.jvn.jp",
+						URL:    ref.Text,
+					}}
+				}(),
+				DataSource: sourceTypes.Source{
+					ID: sourceTypes.JVNFeedRSS,
+				},
+			}
+		}
+
 		return nil
 	}); err != nil {
 		return errors.Wrapf(err, "walk %s", args)
+	}
+
+	for id, c := range cwes {
+		if err := util.Write(filepath.Join(options.dir, "cwe", fmt.Sprintf("%s.json", id)), c, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "cwe", fmt.Sprintf("%s.json", id)))
+		}
 	}
 
 	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{

--- a/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-476.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-476.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-476",
+	"name": "NULL ポインタデリファレンス",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "http://cwe.mitre.org/data/definitions/476.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss"
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-640.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-640.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-640",
+	"name": "パスワードを忘れた場合の脆弱なパスワードリカバリの仕組み",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "https://cwe.mitre.org/data/definitions/640.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss"
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-79.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-79.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-79",
+	"name": "クロスサイトスクリプティング",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "https://jvndb.jvn.jp/ja/cwe/CWE-79.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss"
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-94.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-94.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-94",
+	"name": "コード・インジェクション",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "https://jvndb.jvn.jp/ja/cwe/CWE-94.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss"
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-noinfo.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-noinfo.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-noinfo",
+	"name": "情報不足",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "https://www.ipa.go.jp/security/vuln/scap/cwe.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss"
+	}
+}


### PR DESCRIPTION
## What
Add a Japanese CWE name catalog output (`cwe/CWE-<id>.json`) to the JVN feed `rss` and `detail` extractors. The CWEs referenced by each feed item are aggregated per ID and written under `cwe/`, alongside the existing `data/` and `datasource.json`.

```json
// cwe/CWE-79.json
{
  "id": "CWE-79",
  "name": "クロスサイトスクリプティング",
  "references": [{ "source": "jvndb.jvn.jp", "url": "https://jvndb.jvn.jp/ja/cwe/CWE-79.html" }],
  "data_source": { "id": "jvn-feed-rss" }
}
```

## Why
JVN provides Japanese names for CWEs. Turning them into a catalog yields a localized CWE-ID → Japanese-name dictionary.

## How
- Reuse the existing `pkg/extract/types/cwe.CWE` type, storing the Japanese title in `name`. This needs no changes to `util.Write` / the golden `Diff` helper, and lets the localized names merge by ID with the MITRE CWE catalog downstream.
- Normalize the title by stripping the trailing `(CWE-xx)` suffix, so `rss` and `detail` converge on the same `name`.
- The CWE extraction filter matches the existing `extract()` logic. On the `rss` side, CWE-prefixed entries that carry a `source` attribute (e.g. related documents) are not CWE classifications and are skipped; this is now noted with a comment.
- `data_source` carries no `raws` (a single CWE is referenced by thousands of advisories, which would bloat the file).
- Output trees are per feed, so the same CWE-ID may have a different URL depending on the feed (`rss` often `jvndb.jvn.jp`, `detail` often `cwe.mitre.org`). `reference.source` is fixed to the provider, `jvndb.jvn.jp`.

## Testing
- Added golden tests (`testdata/golden/cwe/`); `GOEXPERIMENT=jsonv2 go test ./pkg/extract/jvn/...` passes.
- Verified that `data/` and `datasource.json` are byte-for-byte identical to before (purely additive).
- Ran against the real dataset (under `ghcr.io/vulsio/vuls-data-db`, ~288k files each):
  - Emitted 693 CWEs for `rss` / 692 for `detail`, all valid JSON.
  - Zero empty names, invalid IDs, filename mismatches, or normalization leftovers.
  - No fatal errors or panics (the only warnings are the pre-existing CPE-parse warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)