### PR TITLE
feat(extract/vulncheck): write attribution README for kev and nist-nvd2

### DIFF
--- a/pkg/extract/util/test/test.go
+++ b/pkg/extract/util/test/test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"encoding/json/v2"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/url"
 	"os"
@@ -23,7 +24,7 @@ import (
 )
 
 func Diff(t *testing.T, expectedAbsPath, gotAbsPath string) {
-	for _, name := range []string{"datasource.json", "data", "cpe", "cwe", "capec", "attack", "microsoftkb", "eol"} {
+	for _, name := range []string{"datasource.json", "README.md", "data", "cpe", "cwe", "capec", "attack", "microsoftkb", "eol"} {
 		if _, err := os.Stat(filepath.Join(gotAbsPath, name)); err != nil {
 			continue
 		}
@@ -70,6 +71,16 @@ func Diff(t *testing.T, expectedAbsPath, gotAbsPath string) {
 				got.Sort()
 
 				diff = cmp.Diff(want, got)
+			case "README.md":
+				want, err := io.ReadAll(ef)
+				if err != nil {
+					return err
+				}
+				got, err := io.ReadAll(gf)
+				if err != nil {
+					return err
+				}
+				diff = cmp.Diff(string(want), string(got))
 			case "data":
 				var want, got dataTypes.Data
 				if err := json.UnmarshalRead(ef, &want); err != nil {

--- a/pkg/extract/vulncheck/kev/kev.go
+++ b/pkg/extract/vulncheck/kev/kev.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -57,6 +58,26 @@ func Extract(args string, opts ...Option) error {
 	}
 
 	slog.Info("Extract VulnCheck KEV")
+
+	if err := os.MkdirAll(options.dir, 0755); err != nil {
+		return errors.Wrapf(err, "mkdir %s", options.dir)
+	}
+	if err := os.WriteFile(filepath.Join(options.dir, "README.md"), []byte(`## Repository of VulnCheck KEV data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/vulncheck-kev/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck KEV: https://docs.vulncheck.com/community/vulncheck-kev/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck KEV to users.
+`), 0666); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "README.md"))
+	}
+
 	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/extract/vulncheck/kev/testdata/golden/README.md
+++ b/pkg/extract/vulncheck/kev/testdata/golden/README.md
@@ -1,0 +1,12 @@
+## Repository of VulnCheck KEV data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/vulncheck-kev/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck KEV: https://docs.vulncheck.com/community/vulncheck-kev/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck KEV to users.

--- a/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
+++ b/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -114,6 +115,25 @@ func Extract(args string, opts ...Option) error {
 	}
 
 	slog.Info("Extract VulnCheck NIST NVD2")
+
+	if err := os.MkdirAll(options.dir, 0755); err != nil {
+		return errors.Wrapf(err, "mkdir %s", options.dir)
+	}
+	if err := os.WriteFile(filepath.Join(options.dir, "README.md"), []byte(`## Repository of VulnCheck NVD++ (nist-nvd2) data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/nist-nvd/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck NVD++: https://docs.vulncheck.com/community/nist-nvd/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck NVD++ to users.
+`), 0666); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "README.md"))
+	}
 
 	g, ctx := errgroup.WithContext(context.Background())
 	// +1 for the producer goroutine below: counting it inside the

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/and-operator/README.md
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/and-operator/README.md
@@ -1,0 +1,12 @@
+## Repository of VulnCheck NVD++ (nist-nvd2) data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/nist-nvd/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck NVD++: https://docs.vulncheck.com/community/nist-nvd/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck NVD++ to users.

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/exact-match/README.md
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/exact-match/README.md
@@ -1,0 +1,12 @@
+## Repository of VulnCheck NVD++ (nist-nvd2) data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/nist-nvd/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck NVD++: https://docs.vulncheck.com/community/nist-nvd/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck NVD++ to users.

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/happy/README.md
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/happy/README.md
@@ -1,0 +1,12 @@
+## Repository of VulnCheck NVD++ (nist-nvd2) data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/nist-nvd/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck NVD++: https://docs.vulncheck.com/community/nist-nvd/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck NVD++ to users.

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/non-semver-range/README.md
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/non-semver-range/README.md
@@ -1,0 +1,12 @@
+## Repository of VulnCheck NVD++ (nist-nvd2) data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/nist-nvd/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck NVD++: https://docs.vulncheck.com/community/nist-nvd/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck NVD++ to users.

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/non-vulnerable-platform/README.md
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/non-vulnerable-platform/README.md
@@ -1,0 +1,12 @@
+## Repository of VulnCheck NVD++ (nist-nvd2) data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/nist-nvd/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck NVD++: https://docs.vulncheck.com/community/nist-nvd/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck NVD++ to users.

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/README.md
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/README.md
@@ -1,0 +1,12 @@
+## Repository of VulnCheck NVD++ (nist-nvd2) data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/nist-nvd/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck NVD++: https://docs.vulncheck.com/community/nist-nvd/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck NVD++ to users.

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/vc-only/README.md
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/vc-only/README.md
@@ -1,0 +1,12 @@
+## Repository of VulnCheck NVD++ (nist-nvd2) data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/nist-nvd/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck NVD++: https://docs.vulncheck.com/community/nist-nvd/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck NVD++ to users.

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/vuln-cpes/README.md
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/vuln-cpes/README.md
@@ -1,0 +1,12 @@
+## Repository of VulnCheck NVD++ (nist-nvd2) data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/nist-nvd/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck NVD++: https://docs.vulncheck.com/community/nist-nvd/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck NVD++ to users.


### PR DESCRIPTION
## What
Emit the VulnCheck attribution notice as `README.md` in the **extract** output of `vulncheck/kev` and `vulncheck/nist-nvd2`, mirroring the notice the fetch side already writes.

## Why
VulnCheck's terms require **prominent attribution** when using KEV / NVD++ data. Until now the notice only lived in the fetched raw repositories; the extracted datasets (consumed downstream) carried no attribution. Adding it to the extract output keeps the requirement traveling with the data.

## How
- `pkg/extract/vulncheck/kev/kev.go` and `pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go`: after `RemoveAll`, `MkdirAll` the output dir and write `README.md`. The notice text is hardcoded in source, identical to the fetch side (`pkg/fetch/vulncheck/{kev,nist-nvd2}`).
- `pkg/extract/util/test/test.go`: the golden `Diff` helper now also compares `README.md` (raw-text compare), ordered right after `datasource.json`. Other extractors that don't emit a `README.md` are unaffected (the `os.Stat` guard skips it).
- Added golden `README.md` fixtures for the kev case and all 8 nist-nvd2 golden cases.

## Testing
- `GOEXPERIMENT=jsonv2 go build ./cmd/vuls-data-update`
- `GOEXPERIMENT=jsonv2 go test ./...` — all green
- `go vet ./pkg/extract/util/test/... ./pkg/extract/vulncheck/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)