### PR TITLE
fix(extract/mitre/cwe): add ranking data for 2019 CWE Top 25

### DIFF
--- a/pkg/extract/mitre/cwe/rankingdata.go
+++ b/pkg/extract/mitre/cwe/rankingdata.go
@@ -18,6 +18,7 @@ type rankingEntry struct {
 //	CWE-750  https://cwe.mitre.org/top25/archive/2009/2009_cwe_sans_top25.html
 //	CWE-800  https://cwe.mitre.org/top25/archive/2010/2010_cwe_sans_top25.html
 //	CWE-900  https://cwe.mitre.org/top25/archive/2011/2011_cwe_sans_top25.html
+//	CWE-1200 https://cwe.mitre.org/top25/archive/2019/2019_cwe_top25.html
 //	CWE-1337 https://cwe.mitre.org/top25/archive/2021/2021_cwe_top25.html
 //	CWE-1350 https://cwe.mitre.org/top25/archive/2020/2020_cwe_top25.html
 //	CWE-1387 https://cwe.mitre.org/top25/archive/2022/2022_cwe_top25.html
@@ -48,6 +49,15 @@ var supplementalRankings = map[string][]rankingEntry{
 		{"CWE-732", 65.5}, {"CWE-676", 64.6}, {"CWE-327", 64.1}, {"CWE-131", 62.4},
 		{"CWE-307", 61.5}, {"CWE-601", 61.1}, {"CWE-134", 61.0}, {"CWE-190", 60.3},
 		{"CWE-759", 59.9},
+	},
+	"CWE-1200": { // 2019 CWE Top 25 Most Dangerous Software Errors
+		{"CWE-119", 75.56}, {"CWE-79", 45.69}, {"CWE-20", 43.61}, {"CWE-200", 32.12},
+		{"CWE-125", 26.53}, {"CWE-89", 24.54}, {"CWE-416", 17.94}, {"CWE-190", 17.35},
+		{"CWE-352", 15.54}, {"CWE-22", 14.10}, {"CWE-78", 11.47}, {"CWE-787", 11.08},
+		{"CWE-287", 10.78}, {"CWE-476", 9.74}, {"CWE-732", 6.33}, {"CWE-434", 5.50},
+		{"CWE-611", 5.48}, {"CWE-94", 5.36}, {"CWE-798", 5.12}, {"CWE-400", 5.04},
+		{"CWE-772", 5.04}, {"CWE-426", 4.40}, {"CWE-502", 4.30}, {"CWE-269", 4.23},
+		{"CWE-295", 4.06},
 	},
 	"CWE-1337": { // 2021 CWE Top 25 Most Dangerous Software Weaknesses
 		{"CWE-787", 65.93}, {"CWE-79", 46.84}, {"CWE-125", 24.9}, {"CWE-20", 20.47},

--- a/pkg/extract/mitre/cwe/testdata/fixtures/view/1200.json
+++ b/pkg/extract/mitre/cwe/testdata/fixtures/view/1200.json
@@ -1,0 +1,29 @@
+{
+	"id": "1200",
+	"name": "Weaknesses in the 2019 CWE Top 25 Most Dangerous Software Errors",
+	"type": "Graph",
+	"status": "Obsolete",
+	"objective": "CWE entries in this view are listed in the 2019 CWE Top 25 Most Dangerous Software Errors.",
+	"members": [
+		{
+			"cweid": "119",
+			"view_id": "1200"
+		},
+		{
+			"cweid": "79",
+			"view_id": "1200"
+		},
+		{
+			"cweid": "20",
+			"view_id": "1200"
+		},
+		{
+			"cweid": "200",
+			"view_id": "1200"
+		},
+		{
+			"cweid": "125",
+			"view_id": "1200"
+		}
+	]
+}

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1200.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1200.json
@@ -1,0 +1,44 @@
+{
+	"id": "CWE-1200",
+	"kind": "view",
+	"name": "Weaknesses in the 2019 CWE Top 25 Most Dangerous Software Errors",
+	"status": "Obsolete",
+	"description": "CWE entries in this view are listed in the 2019 CWE Top 25 Most Dangerous Software Errors.",
+	"view": {
+		"type": "Graph",
+		"members": [
+			{
+				"cweid": "CWE-119",
+				"view_id": "CWE-1200"
+			},
+			{
+				"cweid": "CWE-125",
+				"view_id": "CWE-1200"
+			},
+			{
+				"cweid": "CWE-20",
+				"view_id": "CWE-1200"
+			},
+			{
+				"cweid": "CWE-200",
+				"view_id": "CWE-1200"
+			},
+			{
+				"cweid": "CWE-79",
+				"view_id": "CWE-1200"
+			}
+		]
+	},
+	"references": [
+		{
+			"source": "cwe.mitre.org",
+			"url": "https://cwe.mitre.org/data/definitions/1200.html"
+		}
+	],
+	"data_source": {
+		"id": "mitre-cwe",
+		"raws": [
+			"fixtures/view/1200.json"
+		]
+	}
+}

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-79.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-79.json
@@ -10,6 +10,12 @@
 		"diagram": "/data/images/CWE-79-Diagram.png",
 		"rankings": [
 			{
+				"view_id": "CWE-1200",
+				"view_name": "Weaknesses in the 2019 CWE Top 25 Most Dangerous Software Errors",
+				"rank": 2,
+				"score": 45.69
+			},
+			{
 				"view_id": "CWE-1344",
 				"view_name": "Weaknesses in OWASP Top Ten (2021)",
 				"category_id": "CWE-1347",
@@ -54,6 +60,7 @@
 		"raws": [
 			"fixtures/category/1347.json",
 			"fixtures/category/1440.json",
+			"fixtures/view/1200.json",
 			"fixtures/view/1344.json",
 			"fixtures/view/1430.json",
 			"fixtures/view/1435.json",


### PR DESCRIPTION
## What
Add the 2019 CWE Top 25 (view **CWE-1200**) rank+score data to `supplementalRankings`, and add a `view/1200.json` golden-test fixture.

## Why
The MITRE CWE catalog now includes view CWE-1200 ("Weaknesses in the 2019 CWE Top 25 Most Dangerous Software Errors"). Its name matches the `"CWE Top 25 Most Dangerous Software"` branch in `buildRankings`, but there was no entry in `supplementalRankings`, so extraction failed hard:

```
no supplemental ranking data for "Weaknesses in the 2019 CWE Top 25 Most Dangerous Software Errors" (CWE-1200)
  at pkg/extract/mitre/cwe/cwe.go:212 (buildRankings)
```

This is the cause of the failed `Extract vuls-data-extracted-mitre-cwe` job in vuls-data-db ([run 28060598969](https://github.com/vulsio/vuls-data-db/actions/runs/28060598969/job/83075931619)).

## How
- Transcribe the 25 rank+score rows from <https://cwe.mitre.org/top25/archive/2019/2019_cwe_top25.html>, cross-checked against the member list/order on <https://cwe.mitre.org/data/definitions/1200.html>.
- Insert the `CWE-1200` entry in numeric order (between `CWE-900` and `CWE-1337`) and add its archive URL to the provenance comment block.
- Add `testdata/fixtures/view/1200.json` (trimmed to a representative member subset, matching the existing 900/1430/1435 fixtures) so the golden test exercises the new ranking; regenerate goldens (`CWE-1200.json` new; `CWE-79.json` gains its 2019 rank 2 / score 45.69 placement).

## Testing
- `GOEXPERIMENT=jsonv2 go build ./...`
- `GOEXPERIMENT=jsonv2 go vet ./pkg/extract/mitre/cwe/...`
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/mitre/cwe/...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)