### PR TITLE
fix(extract/microsoft/cvrf): add Microsoft Office 365 for Mac product

### DIFF
--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -1200,6 +1200,7 @@ func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criter
 
 		// Microsoft Office for Mac
 		case "Microsoft Office 2019 for Mac",
+			"Microsoft Office 365 for Mac",
 			"Microsoft Office for Mac",
 			"Microsoft Office LTSC for Mac 2021",
 			"Microsoft Office LTSC for Mac 2024":

--- a/pkg/extract/microsoft/cvrf/cvrf_test.go
+++ b/pkg/extract/microsoft/cvrf/cvrf_test.go
@@ -121,6 +121,30 @@ func TestBuildFixedBuildCriterion(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "Microsoft Office 365 for Mac",
+			args: args{
+				cveID:         "CVE-2026-44817",
+				productName:   "Microsoft Office 365 for Mac",
+				rawFixedBuild: "16.110.26061317",
+			},
+			want: &criterionTypes.Criterion{
+				Type: criterionTypes.CriterionTypeVersion,
+				Version: &vcTypes.Criterion{
+					Vulnerable: true,
+					FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed},
+					Package: packageTypes.Package{
+						Type:   packageTypes.PackageTypeBinary,
+						Binary: &binaryTypes.Package{Name: "Microsoft Office 365 for Mac"},
+					},
+					Affected: &affectedTypes.Affected{
+						Type:  affectedrangeTypes.RangeTypeMicrosoftOfficeMac,
+						Range: []affectedrangeTypes.Range{{LessThan: "16.110.26061317"}},
+						Fixed: []string{"16.110.26061317"},
+					},
+				},
+			},
+		},
+		{
 			name: "Branch-leaked Win11 21H2 x64 FixedBuild applies override end-to-end (CVE-2023-21817)",
 			args: args{
 				cveID:         "CVE-2023-21817",


### PR DESCRIPTION
## What
Add the product name `Microsoft Office 365 for Mac` to `buildFixedBuildCriterion` in `pkg/extract/microsoft/cvrf/cvrf.go`, plus a regression test.

## Why
`vuls-data-db` CI (`extract microsoft-cvrf`) was failing on both `main` and `nightly` ([run 28313008647](https://github.com/vulsio/vuls-data-db/actions/runs/28313008647)):

```
unknown product "Microsoft Office 365 for Mac" (matches prefix "Microsoft Office ") not listed in buildFixedBuildCriterion, please add it
→ unexpected FixedBuild format for CVE-2026-44817 (Microsoft Office 365 for Mac): "16.110.26061317"
```

June 2026 CVRF introduced the new product name `Microsoft Office 365 for Mac` (CVE-2026-44817, FixedBuild `16.110.26061317`). It matched the `"Microsoft Office "` prefix guard in the `default` case, which intentionally errors on unlisted Office products, aborting the whole extraction. This product appeared after #-era `add June 2026 products` work, so it was still unhandled.

## How
Add it to the existing *Microsoft Office for Mac* case so its FixedBuild is validated via `officemacversion` and mapped to `RangeTypeMicrosoftOfficeMac` (the `16.110.26061317` build parses cleanly as `<major>.<minor>.<build>`).

## Testing
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/microsoft/cvrf/` — pass (incl. new `Microsoft Office 365 for Mac` case in `TestBuildFixedBuildCriterion`)
- Ran `extract microsoft-cvrf` against the full real raw dataset (25,838 files) → exit 0; `CVE-2026-44817.json` now contains the product with build `16.110.26061317`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)