### PR TITLE
fix(extract/fortinet): classify exact vs train versions per product

### DIFF
--- a/pkg/extract/fortinet/csaf/csaf.go
+++ b/pkg/extract/fortinet/csaf/csaf.go
@@ -590,8 +590,8 @@ func toCriterion(productID string, refMap map[string]productRef) (criterionTypes
 //   - (nil,   "",   nil): whole product — leave the CPE version wildcarded
 //
 // The product name decides the exact-vs-train split for a bare version token
-// (product.IsExactVersion): "23.4" is a concrete FortiSandbox Cloud release to
-// bake, but a FortiSandbox train to range-over. The whole-product outcome
+// (product.IsExactVersion): "7.166" is a concrete IPS Engine build to bake,
+// but "7.4" is a FortiOS train to range-over. The whole-product outcome
 // covers an empty/"all versions" expression. A non-numeric "<x> all versions"
 // (e.g. a product name leaked into the version, "FortiClient iOS all
 // versions") is not silently widened to whole product — it hard-errors, since

--- a/pkg/extract/fortinet/csaf/csaf.go
+++ b/pkg/extract/fortinet/csaf/csaf.go
@@ -610,7 +610,7 @@ func resolveVersion(productName, exp string) (*ccRangeTypes.Range, string, error
 		if _, err := numericVersion.NewVersion(train); err != nil {
 			return nil, "", errors.Wrapf(err, "unexpected non-numeric train %q in %q", train, exp)
 		}
-		r, err := product.TrainRange(train)
+		r, err := product.TrainRange(productName, train)
 		if err != nil {
 			return nil, "", errors.Wrap(err, "train range")
 		}
@@ -655,7 +655,7 @@ func resolveVersion(productName, exp string) (*ccRangeTypes.Range, string, error
 		return &r, "", nil
 	case !product.IsExactVersion(productName, exp):
 		// Bare train like "7.0" without the "all versions" suffix.
-		r, err := product.TrainRange(exp)
+		r, err := product.TrainRange(productName, exp)
 		if err != nil {
 			return nil, "", errors.Wrap(err, "train range")
 		}

--- a/pkg/extract/fortinet/csaf/csaf.go
+++ b/pkg/extract/fortinet/csaf/csaf.go
@@ -509,7 +509,7 @@ func toCriterion(productID string, refMap map[string]productRef) (criterionTypes
 		return criterionTypes.Criterion{}, errors.Errorf("unknown fortinet product %q (known_affected %q; add it to internal/product)", ref.productName, productID)
 	}
 
-	r, bakeVersion, err := resolveVersion(ref.versionExp)
+	r, bakeVersion, err := resolveVersion(ref.productName, ref.versionExp)
 	if err != nil {
 		return criterionTypes.Criterion{}, errors.Wrapf(err, "resolve version for %q", productID)
 	}
@@ -582,17 +582,21 @@ func toCriterion(productID string, refMap map[string]productRef) (criterionTypes
 	}, nil
 }
 
-// resolveVersion interprets a CSAF Fortinet version expression and returns
-// exactly one of three outcomes, so the caller never has to guess:
+// resolveVersion interprets a CSAF Fortinet version expression for the named
+// product and returns exactly one of three outcomes, so the caller never has
+// to guess:
 //   - (range, "",   nil): narrow the CPE by this version range
 //   - (nil,   ver,  nil): bake this concrete version into the CPE
 //   - (nil,   "",   nil): whole product — leave the CPE version wildcarded
 //
-// The whole-product outcome covers an empty/"all versions" expression. A
-// non-numeric "<x> all versions" (e.g. a product name leaked into the version,
-// "FortiClient iOS all versions") is not silently widened to whole product —
-// it hard-errors, since it never legitimately appears in known_affected data.
-func resolveVersion(exp string) (*ccRangeTypes.Range, string, error) {
+// The product name decides the exact-vs-train split for a bare version token
+// (product.IsExactVersion): "23.4" is a concrete FortiSandbox Cloud release to
+// bake, but a FortiSandbox train to range-over. The whole-product outcome
+// covers an empty/"all versions" expression. A non-numeric "<x> all versions"
+// (e.g. a product name leaked into the version, "FortiClient iOS all
+// versions") is not silently widened to whole product — it hard-errors, since
+// it never legitimately appears in known_affected data.
+func resolveVersion(productName, exp string) (*ccRangeTypes.Range, string, error) {
 	switch {
 	case exp == "" || exp == "all versions":
 		return nil, "", nil
@@ -649,7 +653,7 @@ func resolveVersion(exp string) (*ccRangeTypes.Range, string, error) {
 			*bound = v
 		}
 		return &r, "", nil
-	case !product.IsConcrete(exp):
+	case !product.IsExactVersion(productName, exp):
 		// Bare train like "7.0" without the "all versions" suffix.
 		r, err := product.TrainRange(exp)
 		if err != nil {

--- a/pkg/extract/fortinet/csaf/testdata/fixtures/2025/FG-IR-25-454.json
+++ b/pkg/extract/fortinet/csaf/testdata/fixtures/2025/FG-IR-25-454.json
@@ -1,0 +1,231 @@
+{
+	"document": {
+		"acknowledgments": [
+			{
+				"summary": "Internally discovered and reported by Théo Leleu of Fortinet Product Security team."
+			}
+		],
+		"category": "Fortinet PSIRT Advisories",
+		"csaf_version": "2.0",
+		"publisher": {
+			"category": "vendor",
+			"contact_details": "https://fortiguard.fortinet.com/faq/psirt-contact",
+			"issuing_authority": "Fortinet PSIRT",
+			"name": "Fortinet PSIRT",
+			"namespace": "https://fortiguard.fortinet.com/psirt"
+		},
+		"title": "OS command injection in GUI backup options",
+		"tracking": {
+			"current_release_date": "2026-01-14T00:00:00",
+			"id": "FG-IR-25-454",
+			"initial_release_date": "2025-12-09T00:00:00",
+			"revision_history": [
+				{
+					"date": "2025-12-09T00:00:00",
+					"number": "1",
+					"summary": "Initial Publication"
+				}
+			],
+			"status": "final",
+			"version": "0"
+		}
+	},
+	"product_tree": {
+		"branches": [
+			{
+				"branches": [
+					{
+						"branches": [
+							{
+								"category": "product_version_range",
+								"name": "FortiSandbox/>=5.0.0|<=5.0.2",
+								"product": {
+									"name": "FortiSandbox",
+									"product_id": "FortiSandbox >=5.0.0|<=5.0.2"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSandbox/>=4.4.0|<=4.4.7",
+								"product": {
+									"name": "FortiSandbox",
+									"product_id": "FortiSandbox >=4.4.0|<=4.4.7"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSandbox/4.2 all versions",
+								"product": {
+									"name": "FortiSandbox",
+									"product_id": "FortiSandbox 4.2 all versions"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSandbox/4.0 all versions",
+								"product": {
+									"name": "FortiSandbox",
+									"product_id": "FortiSandbox 4.0 all versions"
+								}
+							}
+						],
+						"category": "product",
+						"name": "FortiSandbox"
+					},
+					{
+						"branches": [
+							{
+								"category": "product_version",
+								"name": "FortiSandbox Cloud/24.1",
+								"product": {
+									"name": "FortiSandbox Cloud",
+									"product_id": "FortiSandbox Cloud 24.1"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSandbox Cloud/23 all versions",
+								"product": {
+									"name": "FortiSandbox Cloud",
+									"product_id": "FortiSandbox Cloud 23 all versions"
+								}
+							}
+						],
+						"category": "product",
+						"name": "FortiSandbox Cloud"
+					}
+				],
+				"category": "vendor",
+				"name": "Fortinet PSIRT"
+			}
+		]
+	},
+	"vulnerabilities": [
+		{
+			"cve": "CVE-2025-53679",
+			"cwe": {
+				"id": "CWE-78",
+				"name": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+			},
+			"notes": [
+				{
+					"category": "summary",
+					"text": "Improper neutralization of special elements used in an OS command vulnerability in FortiSandbox\n\n",
+					"title": "Summary"
+				},
+				{
+					"category": "general",
+					"text": "N/A",
+					"title": "Workarounds"
+				}
+			],
+			"product_status": {
+				"known_affected": [
+					"FortiSandbox >=5.0.0|<=5.0.2",
+					"FortiSandbox >=4.4.0|<=4.4.7",
+					"FortiSandbox 4.2 all versions",
+					"FortiSandbox 4.0 all versions"
+				],
+				"known_not_affected": [
+					"FortiSandbox-5.0.3",
+					"FortiSandbox-4.4.8"
+				]
+			},
+			"references": [
+				{
+					"summary": "An improper neutralization of special elements used in an OS command ('OS Command Injection') vulnerability [CWE-78] in FortiSandbox GUI may allow an authenticated privileged attacker to execute unauthorized code or commands via crafted HTTP or HTTPS requests.",
+					"url": "https://fortiguard.fortinet.com/psirt/FG-IR-25-454"
+				}
+			],
+			"remediations": [
+				{
+					"category": "vendor_fix",
+					"details": "FortiSandbox 5.0: Upgrade to 5.0.3 or above\nFortiSandbox 4.4: Upgrade to 4.4.8 or above\nFortiSandbox 4.2: Migrate to a fixed release\nFortiSandbox 4.0: Migrate to a fixed release",
+					"product_ids": [
+						"FortiSandbox"
+					]
+				}
+			],
+			"scores": [
+				{
+					"cvss_v3": {
+						"baseScore": 6.9,
+						"baseSeverity": "MEDIUM",
+						"vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:O/RC:C",
+						"version": "3.1"
+					},
+					"products": [
+						"FortiSandbox"
+					]
+				}
+			],
+			"threats": [
+				{
+					"category": "impact",
+					"details": "Execute unauthorized code or commands"
+				}
+			],
+			"title": "FortiSandbox - MEDIUM - FG-IR-25-454"
+		},
+		{
+			"cve": "CVE-2025-53679",
+			"cwe": {
+				"id": "CWE-78",
+				"name": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+			},
+			"notes": [
+				{
+					"category": "summary",
+					"text": "Improper neutralization of special elements used in an OS command vulnerability in FortiSandbox\n\n",
+					"title": "Summary"
+				},
+				{
+					"category": "general",
+					"text": "N/A",
+					"title": "Workarounds"
+				}
+			],
+			"product_status": {
+				"known_affected": [
+					"FortiSandbox Cloud 24.1",
+					"FortiSandbox Cloud 23 all versions"
+				]
+			},
+			"references": [
+				{
+					"summary": "An improper neutralization of special elements used in an OS command ('OS Command Injection') vulnerability [CWE-78] in FortiSandbox GUI may allow an authenticated privileged attacker to execute unauthorized code or commands via crafted HTTP or HTTPS requests.",
+					"url": "https://fortiguard.fortinet.com/psirt/FG-IR-25-454"
+				}
+			],
+			"remediations": [
+				{
+					"category": "vendor_fix",
+					"details": "FortiSandbox Cloud 24: Fortinet remediated this issue in 24.2 (not released) and hence customers do not need to perform any action.\nFortiSandbox Cloud 23: Migrate to a fixed release",
+					"product_ids": [
+						"FortiSandbox Cloud"
+					]
+				}
+			],
+			"scores": [
+				{
+					"cvss_v3": {
+						"baseScore": 6.9,
+						"baseSeverity": "MEDIUM",
+						"vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:O/RC:C",
+						"version": "3.1"
+					},
+					"products": [
+						"FortiSandbox Cloud"
+					]
+				}
+			],
+			"threats": [
+				{
+					"category": "impact",
+					"details": "Execute unauthorized code or commands"
+				}
+			],
+			"title": "FortiSandbox Cloud - MEDIUM - FG-IR-25-454"
+		}
+	]
+}

--- a/pkg/extract/fortinet/csaf/testdata/golden/data/2025/FG-IR-25-454.json
+++ b/pkg/extract/fortinet/csaf/testdata/golden/data/2025/FG-IR-25-454.json
@@ -1,0 +1,180 @@
+{
+	"id": "FG-IR-25-454",
+	"advisories": [
+		{
+			"content": {
+				"id": "FG-IR-25-454",
+				"title": "OS command injection in GUI backup options",
+				"references": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"url": "https://fortiguard.fortinet.com/psirt/FG-IR-25-454"
+					}
+				],
+				"published": "2025-12-09T00:00:00Z",
+				"modified": "2026-01-14T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "CVE-2025-53679"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2025-53679",
+				"title": "OS command injection in GUI backup options",
+				"description": "Improper neutralization of special elements used in an OS command vulnerability in FortiSandbox",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fortiguard.fortinet.com",
+						"vendor": "Execute unauthorized code or commands"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "fortiguard.fortinet.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:X/RL:O/RC:C",
+							"base_score": 7.2,
+							"base_severity": "HIGH",
+							"temporal_score": 6.9,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.9,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"cwe": [
+							"CWE-78"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"url": "https://fortiguard.fortinet.com/psirt/FG-IR-25-454"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "CVE-2025-53679"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:a:fortinet:fortisandbox_cloud:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "fortinet-fortisandbox_cloud",
+										"ge": "23",
+										"lt": "24"
+									}
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:a:fortinet:fortisandbox_cloud:24.1:*:*:*:*:*:*:*"
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:o:fortinet:fortisandbox:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "fortinet-fortisandbox",
+										"ge": "4.0",
+										"lt": "4.1"
+									}
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:o:fortinet:fortisandbox:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "fortinet-fortisandbox",
+										"ge": "4.2",
+										"lt": "4.3"
+									}
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:o:fortinet:fortisandbox:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "fortinet-fortisandbox",
+										"ge": "4.4.0",
+										"le": "4.4.7"
+									}
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:o:fortinet:fortisandbox:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "fortinet-fortisandbox",
+										"ge": "5.0.0",
+										"le": "5.0.2"
+									}
+								}
+							}
+						]
+					},
+					"tag": "CVE-2025-53679"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "fortinet-csaf",
+		"raws": [
+			"fixtures/2025/FG-IR-25-454.json"
+		]
+	}
+}

--- a/pkg/extract/fortinet/csaf/testdata/golden/data/2025/FG-IR-25-454.json
+++ b/pkg/extract/fortinet/csaf/testdata/golden/data/2025/FG-IR-25-454.json
@@ -101,7 +101,12 @@
 									"fix_status": {
 										"class": "unknown"
 									},
-									"cpe": "cpe:2.3:a:fortinet:fortisandbox_cloud:24.1:*:*:*:*:*:*:*"
+									"cpe": "cpe:2.3:a:fortinet:fortisandbox_cloud:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "fortinet-fortisandbox_cloud",
+										"ge": "24.1",
+										"lt": "24.2"
+									}
 								}
 							},
 							{

--- a/pkg/extract/fortinet/cvrf/cvrf.go
+++ b/pkg/extract/fortinet/cvrf/cvrf.go
@@ -277,7 +277,7 @@ func buildProductMap(fetched cvrfTypes.CVRF) map[string]productVersion {
 // Only concrete versions are kept. CVRF enumerates affected versions
 // explicitly, so a coarse train (e.g. "5.0" for FortiOS) is dropped rather
 // than ranged-over: ranging "5.0" would cover all 5.0.x and over-detect.
-// Exact-vs-train is decided per product (product.IsExactVersion), since a few
+// Exact-vs-train is decided per product (productpkg.IsExactVersion), since a few
 // products version their releases with two components. Because detection ORs
 // the CVRF and CSAF datasets, the companion CSAF source supplies the precise
 // ranges for the advisories present there, and the exact CVRF enumeration
@@ -312,7 +312,7 @@ func knownAffectedCriterions(productIDs []string, prodMap map[string]productVers
 			// Coarse trains are dropped by design (rationale in the function
 			// comment above); only exact versions are enumerated. What counts as
 			// exact depends on the product's version arity (see
-			// product.IsExactVersion): "7.166" is an exact IPS Engine build but
+			// productpkg.IsExactVersion): "7.166" is an exact IPS Engine build but
 			// "7.4" is a FortiOS train.
 			continue
 		}

--- a/pkg/extract/fortinet/cvrf/cvrf.go
+++ b/pkg/extract/fortinet/cvrf/cvrf.go
@@ -312,8 +312,8 @@ func knownAffectedCriterions(productIDs []string, prodMap map[string]productVers
 			// Coarse trains are dropped by design (rationale in the function
 			// comment above); only exact versions are enumerated. What counts as
 			// exact depends on the product's version arity (see
-			// product.IsExactVersion): "23.4" is an exact FortiSandbox Cloud
-			// release but a train for FortiSandbox proper.
+			// product.IsExactVersion): "7.166" is an exact IPS Engine build but
+			// "7.4" is a FortiOS train.
 			continue
 		}
 

--- a/pkg/extract/fortinet/cvrf/cvrf.go
+++ b/pkg/extract/fortinet/cvrf/cvrf.go
@@ -275,11 +275,13 @@ func buildProductMap(fetched cvrfTypes.CVRF) map[string]productVersion {
 // version-unconfirmed.)
 //
 // Only concrete versions are kept. CVRF enumerates affected versions
-// explicitly, so a coarse "X.Y" / "X" train (e.g. "5.0") is dropped rather than
-// ranged-over: ranging "5.0" would cover all 5.0.x and over-detect. Because
-// detection ORs the CVRF and CSAF datasets, the companion CSAF source supplies
-// the precise ranges for the advisories present there, and the exact CVRF
-// enumeration covers the rest.
+// explicitly, so a coarse train (e.g. "5.0" for FortiOS) is dropped rather
+// than ranged-over: ranging "5.0" would cover all 5.0.x and over-detect.
+// Exact-vs-train is decided per product (product.IsExactVersion), since a few
+// products version their releases with two components. Because detection ORs
+// the CVRF and CSAF datasets, the companion CSAF source supplies the precise
+// ranges for the advisories present there, and the exact CVRF enumeration
+// covers the rest.
 //
 // It hard-errors when a product_id is absent from the tree or the product is
 // not whitelisted — a new Fortinet product or a resolver bug must fail the
@@ -306,9 +308,12 @@ func knownAffectedCriterions(productIDs []string, prodMap map[string]productVers
 		// prefix (e.g. "FortiSandbox Cloud 24"); strip it to leave the bare
 		// version token.
 		ver := strings.TrimSpace(strings.TrimPrefix(pv.version, pv.productName))
-		if !isExactVersion(ver) {
-			// Coarse "X.Y" / "X" trains are dropped by design (rationale in the
-			// function comment above); only exact versions are enumerated.
+		if !productpkg.IsExactVersion(pv.productName, ver) {
+			// Coarse trains are dropped by design (rationale in the function
+			// comment above); only exact versions are enumerated. What counts as
+			// exact depends on the product's version arity (see
+			// product.IsExactVersion): "23.4" is an exact FortiSandbox Cloud
+			// release but a train for FortiSandbox proper.
 			continue
 		}
 
@@ -342,15 +347,6 @@ func knownAffectedCriterions(productIDs []string, prodMap map[string]productVers
 		})
 	}
 	return criterions, nil
-}
-
-// isExactVersion reports whether a CVRF version token is a concrete release —
-// three or more dot-separated components (e.g. "7.4.3", or the FortiSASE forms
-// "25.2.a" / "25.1.a.2") — rather than a coarse "X.Y" / "X" train. Only exact
-// versions are enumerated into a criterion's CPEMatches; trains are dropped
-// (see knownAffectedCriterions).
-func isExactVersion(ver string) bool {
-	return strings.Count(ver, ".") >= 2
 }
 
 // advisorySeverity returns the advisory's CVSS severity. CVRF carries a single

--- a/pkg/extract/fortinet/cvrf/cvrf_test.go
+++ b/pkg/extract/fortinet/cvrf/cvrf_test.go
@@ -85,30 +85,6 @@ func TestKnownAffectedCriterionsWhitelist(t *testing.T) {
 	}
 }
 
-// isExactVersion keeps only concrete x.y.z[...] releases; coarse trains are
-// dropped from the enumeration.
-func TestIsExactVersion(t *testing.T) {
-	tests := []struct {
-		ver  string
-		want bool
-	}{
-		{ver: "7.4.3", want: true},
-		{ver: "7.4.3.1", want: true},
-		{ver: "25.2.a", want: true},
-		{ver: "25.1.a.2", want: true},
-		{ver: "7.4", want: false},
-		{ver: "24", want: false},
-		{ver: "", want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.ver, func(t *testing.T) {
-			if got := cvrf.IsExactVersion(tt.ver); got != tt.want {
-				t.Errorf("IsExactVersion(%q) = %v, want %v", tt.ver, got, tt.want)
-			}
-		})
-	}
-}
-
 // The only product-status type observed across the corpus is "Known Affected";
 // an empty type is a content-only advisory, and any other type must fail loudly
 // rather than silently emit no detection.

--- a/pkg/extract/fortinet/cvrf/export_test.go
+++ b/pkg/extract/fortinet/cvrf/export_test.go
@@ -16,9 +16,6 @@ func NewProductVersion(productName, version string) ProductVersion {
 // whitelist-enforcement tests.
 var KnownAffectedCriterions = knownAffectedCriterions
 
-// IsExactVersion exposes isExactVersion for version-classification tests.
-var IsExactVersion = isExactVersion
-
 // ExtractData exposes the per-advisory extract function for status-type
 // validation tests.
 var ExtractData = extract

--- a/pkg/extract/fortinet/cvrf/testdata/fixtures/2022/FG-IR-22-021.json
+++ b/pkg/extract/fortinet/cvrf/testdata/fixtures/2022/FG-IR-22-021.json
@@ -1,0 +1,126 @@
+{
+	"document_title": "XSS vulnerability in OWA login page",
+	"document_type": "Fortinet PSIRT Advisories",
+	"documentpublisher": {
+		"type": "Vendor",
+		"contact_details": "\n            Fortinet PSIRT Contact:\n            Website: https://fortiguard.fortinet.com/faq/psirt-contact\n        "
+	},
+	"documenttracking": {
+		"identification": {
+			"id": "FG-IR-22-021"
+		},
+		"status": "Final",
+		"version": "1",
+		"revisionhistory": {
+			"revision": {
+				"number": "1",
+				"date": "2022-06-07T00:00:00",
+				"description": "Current version"
+			}
+		},
+		"initial_release_date": "2022-06-07T00:00:00",
+		"current_release_date": "2022-06-07T00:00:00"
+	},
+	"documentnotes": {
+		"note": [
+			{
+				"text": "\n            An improper neutralization of input during web page generation vulnerability [CWE-79] in FortiAuthenticator OWA Agent may allow an unauthenticated attacker to perform an XSS attack via crafted HTTP GET requests.\n        ",
+				"title": "Summary",
+				"type": "Summary",
+				"ordinal": "1"
+			},
+			{
+				"text": "\n            None\n        ",
+				"title": "Description",
+				"type": "General",
+				"ordinal": "2"
+			},
+			{
+				"text": "\n            Information disclosure\n        ",
+				"title": "Impact",
+				"type": "General",
+				"ordinal": "3"
+			},
+			{
+				"text": "\n            FortiAuthenticator OutlookAgent version 2.1 through 2.2\n        ",
+				"title": "Affected Products",
+				"type": "General",
+				"ordinal": "4"
+			},
+			{
+				"text": "\n            Please upgrade to FortiAuthenticator Agent for Microsoft OWA version 2.3 or above.\n        ",
+				"title": "Solutions",
+				"type": "General",
+				"ordinal": "5"
+			}
+		]
+	},
+	"acknowledgments": {
+		"acknowledgment": [
+			{
+				"description": "Fortinet is pleased to thank Mohamad Hammad for bringing this issue to our attention under responsible disclosure."
+			}
+		]
+	},
+	"vulnerability": {
+		"ordinal": "1",
+		"title": "XSS vulnerability in OWA login page",
+		"references": {
+			"type": "Self",
+			"reference": [
+				{
+					"url": "https://fortiguard.fortinet.com/psirt/FG-IR-22-021",
+					"description": "XSS vulnerability in OWA login page"
+				}
+			]
+		},
+		"cve": [
+			"CVE-2022-22304"
+		],
+		"product_statuses": {
+			"status": {
+				"type": "Known Affected",
+				"product_id": [
+					"FortiAuthenticator OutlookAgent-2.2",
+					"FortiAuthenticator OutlookAgent-2.1"
+				]
+			}
+		},
+		"cvss_scoresets": {
+			"scoreset_v3": {
+				"base_score_v3": "6.1",
+				"vector_v3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N/E:U/RL:X/RC:X"
+			}
+		}
+	},
+	"product_tree": {
+		"branch": {
+			"name": "Fortinet",
+			"type": "Vendor",
+			"branch": [
+				{
+					"name": "FortiAuthenticator OutlookAgent",
+					"type": "Product Name",
+					"branch": [
+						{
+							"name": "2.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiAuthenticator OutlookAgent 2.2",
+								"product_id": "FortiAuthenticator OutlookAgent-2.2"
+							}
+						},
+						{
+							"name": "2.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiAuthenticator OutlookAgent 2.1",
+								"product_id": "FortiAuthenticator OutlookAgent-2.1"
+							}
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/pkg/extract/fortinet/cvrf/testdata/fixtures/2022/FG-IR-22-074.json
+++ b/pkg/extract/fortinet/cvrf/testdata/fixtures/2022/FG-IR-22-074.json
@@ -1,0 +1,1094 @@
+{
+	"document_title": "Evasion by manipulating MIME attachment",
+	"document_type": "Fortinet PSIRT Advisories",
+	"documentpublisher": {
+		"type": "Vendor",
+		"contact_details": "\n            Fortinet PSIRT Contact:\n            Website: https://fortiguard.fortinet.com/faq/psirt-contact\n        "
+	},
+	"documenttracking": {
+		"identification": {
+			"id": "FG-IR-22-074"
+		},
+		"status": "Final",
+		"version": "1",
+		"revisionhistory": {
+			"revision": {
+				"number": "1",
+				"date": "2022-11-01T00:00:00",
+				"description": "Current version"
+			}
+		},
+		"initial_release_date": "2022-11-01T00:00:00",
+		"current_release_date": "2022-11-01T00:00:00"
+	},
+	"documentnotes": {
+		"note": [
+			{
+				"text": "\n            An insufficient verification of data authenticity vulnerability [CWE-345] in FortiClient, FortiMail and FortiOS AV engines may allow an attacker to bypass the AV engine via manipulating MIME attachment with junk and pad characters in base64.\n        ",
+				"title": "Summary",
+				"type": "Summary",
+				"ordinal": "1"
+			},
+			{
+				"text": "\n            None\n        ",
+				"title": "Description",
+				"type": "General",
+				"ordinal": "2"
+			},
+			{
+				"text": "\n            Denial of service\n        ",
+				"title": "Impact",
+				"type": "General",
+				"ordinal": "3"
+			},
+			{
+				"text": "\n            FortiOS version 7.2.0FortiOS version 7.0.0 through 7.0.6FortiOS 6.4 all versionsFortiOS 6.2 all versionsFortiOS 6.0 all versionsFortiMail 7.2 all versions are not affectedFortiMail version 7.0.0 through 7.0.2FortiMail version 6.4.0 through 6.4.6FortiMail 6.2 all versionsFortiMail 6.0 all versionsAV Engine 6.4 all versions are not affectedAV Engine 6.2 all versions are not affectedAV Engine 6.0 all versions are not affectedAV Engine 6 all versionsAV Engine 4.4 all versionsAV Engine 2.0 all versionsAV Engine 0.4 all versions\n        ",
+				"title": "Affected Products",
+				"type": "General",
+				"ordinal": "4"
+			},
+			{
+				"text": "\n            Please upgrade AV engine to version 6.00169 or above.Please upgrade AV engine to version 6.00275 or above.Please upgrade to FortiMail version 7.2.0 or abovePlease upgrade to FortiMail version 7.0.3 or abovePlease upgrade to FortiMail version 6.4.7 or abovePlease upgrade to FortiOS version 7.0.8 or above.Please upgrade to FortiOS version 7.2.2 or above.Please upgrade FortiOS AV engine to version 6.00169 or above.Please upgrade FortiOS AV engine to version 6.00275 or above.\n        ",
+				"title": "Solutions",
+				"type": "General",
+				"ordinal": "5"
+			}
+		]
+	},
+	"vulnerability": {
+		"ordinal": "1",
+		"title": "Evasion by manipulating MIME attachment",
+		"references": {
+			"type": "Self",
+			"reference": [
+				{
+					"url": "https://fortiguard.fortinet.com/psirt/FG-IR-22-074",
+					"description": "Evasion by manipulating MIME attachment"
+				}
+			]
+		},
+		"cve": [
+			"CVE-2022-26122"
+		],
+		"product_statuses": {
+			"status": {
+				"type": "Known Affected",
+				"product_id": [
+					"AV Engine-6.253",
+					"AV Engine-6.252",
+					"AV Engine-6.243",
+					"AV Engine-6.157",
+					"AV Engine-6.156",
+					"AV Engine-6.145",
+					"AV Engine-6.144",
+					"AV Engine-6.142",
+					"AV Engine-6.137",
+					"AV Engine-6.33",
+					"AV Engine-4.4.54",
+					"AV Engine-2.0.60",
+					"AV Engine-2.0.49",
+					"AV Engine-0.4.23",
+					"FortiMail-7.0.2",
+					"FortiMail-7.0.1",
+					"FortiMail-7.0.0",
+					"FortiMail-6.4.6",
+					"FortiMail-6.4.5",
+					"FortiMail-6.4.4",
+					"FortiMail-6.4.3",
+					"FortiMail-6.4.2",
+					"FortiMail-6.4.1",
+					"FortiMail-6.4.0",
+					"FortiMail-6.2.9",
+					"FortiMail-6.2.8",
+					"FortiMail-6.2.7",
+					"FortiMail-6.2.6",
+					"FortiMail-6.2.5",
+					"FortiMail-6.2.4",
+					"FortiMail-6.2.3",
+					"FortiMail-6.2.2",
+					"FortiMail-6.2.1",
+					"FortiMail-6.2.0",
+					"FortiMail-6.0.12",
+					"FortiMail-6.0.11",
+					"FortiMail-6.0.10",
+					"FortiMail-6.0.9",
+					"FortiMail-6.0.8",
+					"FortiMail-6.0.7",
+					"FortiMail-6.0.6",
+					"FortiMail-6.0.5",
+					"FortiMail-6.0.4",
+					"FortiMail-6.0.3",
+					"FortiMail-6.0.2",
+					"FortiMail-6.0.1",
+					"FortiMail-6.0.0",
+					"FortiOS-7.2.0",
+					"FortiOS-7.0.6",
+					"FortiOS-7.0.5",
+					"FortiOS-7.0.4",
+					"FortiOS-7.0.3",
+					"FortiOS-7.0.2",
+					"FortiOS-7.0.1",
+					"FortiOS-7.0.0",
+					"FortiOS-6.4.16",
+					"FortiOS-6.4.15",
+					"FortiOS-6.4.14",
+					"FortiOS-6.4.13",
+					"FortiOS-6.4.12",
+					"FortiOS-6.4.11",
+					"FortiOS-6.4.10",
+					"FortiOS-6.4.9",
+					"FortiOS-6.4.8",
+					"FortiOS-6.4.7",
+					"FortiOS-6.4.6",
+					"FortiOS-6.4.5",
+					"FortiOS-6.4.4",
+					"FortiOS-6.4.3",
+					"FortiOS-6.4.2",
+					"FortiOS-6.4.1",
+					"FortiOS-6.4.0",
+					"FortiOS-6.2.17",
+					"FortiOS-6.2.16",
+					"FortiOS-6.2.15",
+					"FortiOS-6.2.14",
+					"FortiOS-6.2.13",
+					"FortiOS-6.2.12",
+					"FortiOS-6.2.11",
+					"FortiOS-6.2.10",
+					"FortiOS-6.2.9",
+					"FortiOS-6.2.8",
+					"FortiOS-6.2.7",
+					"FortiOS-6.2.6",
+					"FortiOS-6.2.5",
+					"FortiOS-6.2.4",
+					"FortiOS-6.2.3",
+					"FortiOS-6.2.2",
+					"FortiOS-6.2.1",
+					"FortiOS-6.2.0",
+					"FortiOS-6.0.18",
+					"FortiOS-6.0.17",
+					"FortiOS-6.0.16",
+					"FortiOS-6.0.15",
+					"FortiOS-6.0.14",
+					"FortiOS-6.0.13",
+					"FortiOS-6.0.12",
+					"FortiOS-6.0.11",
+					"FortiOS-6.0.10",
+					"FortiOS-6.0.9",
+					"FortiOS-6.0.8",
+					"FortiOS-6.0.7",
+					"FortiOS-6.0.6",
+					"FortiOS-6.0.5",
+					"FortiOS-6.0.4",
+					"FortiOS-6.0.3",
+					"FortiOS-6.0.2",
+					"FortiOS-6.0.1",
+					"FortiOS-6.0.0"
+				]
+			}
+		},
+		"cvss_scoresets": {
+			"scoreset_v3": {
+				"base_score_v3": "4.3",
+				"vector_v3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:N/I:L/A:N/E:P/RL:U/RC:R"
+			}
+		}
+	},
+	"product_tree": {
+		"branch": {
+			"name": "Fortinet",
+			"type": "Vendor",
+			"branch": [
+				{
+					"name": "AV Engine",
+					"type": "Product Name",
+					"branch": [
+						{
+							"name": "6.253",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 6.253",
+								"product_id": "AV Engine-6.253"
+							}
+						},
+						{
+							"name": "6.252",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 6.252",
+								"product_id": "AV Engine-6.252"
+							}
+						},
+						{
+							"name": "6.243",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 6.243",
+								"product_id": "AV Engine-6.243"
+							}
+						},
+						{
+							"name": "6.157",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 6.157",
+								"product_id": "AV Engine-6.157"
+							}
+						},
+						{
+							"name": "6.156",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 6.156",
+								"product_id": "AV Engine-6.156"
+							}
+						},
+						{
+							"name": "6.145",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 6.145",
+								"product_id": "AV Engine-6.145"
+							}
+						},
+						{
+							"name": "6.144",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 6.144",
+								"product_id": "AV Engine-6.144"
+							}
+						},
+						{
+							"name": "6.142",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 6.142",
+								"product_id": "AV Engine-6.142"
+							}
+						},
+						{
+							"name": "6.137",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 6.137",
+								"product_id": "AV Engine-6.137"
+							}
+						},
+						{
+							"name": "6.33",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 6.33",
+								"product_id": "AV Engine-6.33"
+							}
+						},
+						{
+							"name": "4.4.54",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 4.4.54",
+								"product_id": "AV Engine-4.4.54"
+							}
+						},
+						{
+							"name": "2.0.60",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 2.0.60",
+								"product_id": "AV Engine-2.0.60"
+							}
+						},
+						{
+							"name": "2.0.49",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 2.0.49",
+								"product_id": "AV Engine-2.0.49"
+							}
+						},
+						{
+							"name": "0.4.23",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "AV Engine 0.4.23",
+								"product_id": "AV Engine-0.4.23"
+							}
+						}
+					]
+				},
+				{
+					"name": "FortiMail",
+					"type": "Product Name",
+					"branch": [
+						{
+							"name": "7.0.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 7.0.2",
+								"product_id": "FortiMail-7.0.2"
+							}
+						},
+						{
+							"name": "7.0.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 7.0.1",
+								"product_id": "FortiMail-7.0.1"
+							}
+						},
+						{
+							"name": "7.0.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 7.0.0",
+								"product_id": "FortiMail-7.0.0"
+							}
+						},
+						{
+							"name": "6.4.6",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.4.6",
+								"product_id": "FortiMail-6.4.6"
+							}
+						},
+						{
+							"name": "6.4.5",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.4.5",
+								"product_id": "FortiMail-6.4.5"
+							}
+						},
+						{
+							"name": "6.4.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.4.4",
+								"product_id": "FortiMail-6.4.4"
+							}
+						},
+						{
+							"name": "6.4.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.4.3",
+								"product_id": "FortiMail-6.4.3"
+							}
+						},
+						{
+							"name": "6.4.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.4.2",
+								"product_id": "FortiMail-6.4.2"
+							}
+						},
+						{
+							"name": "6.4.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.4.1",
+								"product_id": "FortiMail-6.4.1"
+							}
+						},
+						{
+							"name": "6.4.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.4.0",
+								"product_id": "FortiMail-6.4.0"
+							}
+						},
+						{
+							"name": "6.2.9",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.2.9",
+								"product_id": "FortiMail-6.2.9"
+							}
+						},
+						{
+							"name": "6.2.8",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.2.8",
+								"product_id": "FortiMail-6.2.8"
+							}
+						},
+						{
+							"name": "6.2.7",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.2.7",
+								"product_id": "FortiMail-6.2.7"
+							}
+						},
+						{
+							"name": "6.2.6",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.2.6",
+								"product_id": "FortiMail-6.2.6"
+							}
+						},
+						{
+							"name": "6.2.5",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.2.5",
+								"product_id": "FortiMail-6.2.5"
+							}
+						},
+						{
+							"name": "6.2.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.2.4",
+								"product_id": "FortiMail-6.2.4"
+							}
+						},
+						{
+							"name": "6.2.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.2.3",
+								"product_id": "FortiMail-6.2.3"
+							}
+						},
+						{
+							"name": "6.2.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.2.2",
+								"product_id": "FortiMail-6.2.2"
+							}
+						},
+						{
+							"name": "6.2.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.2.1",
+								"product_id": "FortiMail-6.2.1"
+							}
+						},
+						{
+							"name": "6.2.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.2.0",
+								"product_id": "FortiMail-6.2.0"
+							}
+						},
+						{
+							"name": "6.0.12",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.12",
+								"product_id": "FortiMail-6.0.12"
+							}
+						},
+						{
+							"name": "6.0.11",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.11",
+								"product_id": "FortiMail-6.0.11"
+							}
+						},
+						{
+							"name": "6.0.10",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.10",
+								"product_id": "FortiMail-6.0.10"
+							}
+						},
+						{
+							"name": "6.0.9",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.9",
+								"product_id": "FortiMail-6.0.9"
+							}
+						},
+						{
+							"name": "6.0.8",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.8",
+								"product_id": "FortiMail-6.0.8"
+							}
+						},
+						{
+							"name": "6.0.7",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.7",
+								"product_id": "FortiMail-6.0.7"
+							}
+						},
+						{
+							"name": "6.0.6",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.6",
+								"product_id": "FortiMail-6.0.6"
+							}
+						},
+						{
+							"name": "6.0.5",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.5",
+								"product_id": "FortiMail-6.0.5"
+							}
+						},
+						{
+							"name": "6.0.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.4",
+								"product_id": "FortiMail-6.0.4"
+							}
+						},
+						{
+							"name": "6.0.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.3",
+								"product_id": "FortiMail-6.0.3"
+							}
+						},
+						{
+							"name": "6.0.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.2",
+								"product_id": "FortiMail-6.0.2"
+							}
+						},
+						{
+							"name": "6.0.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.1",
+								"product_id": "FortiMail-6.0.1"
+							}
+						},
+						{
+							"name": "6.0.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiMail 6.0.0",
+								"product_id": "FortiMail-6.0.0"
+							}
+						}
+					]
+				},
+				{
+					"name": "FortiOS",
+					"type": "Product Name",
+					"branch": [
+						{
+							"name": "7.2.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.2.0",
+								"product_id": "FortiOS-7.2.0"
+							}
+						},
+						{
+							"name": "7.0.6",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.6",
+								"product_id": "FortiOS-7.0.6"
+							}
+						},
+						{
+							"name": "7.0.5",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.5",
+								"product_id": "FortiOS-7.0.5"
+							}
+						},
+						{
+							"name": "7.0.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.4",
+								"product_id": "FortiOS-7.0.4"
+							}
+						},
+						{
+							"name": "7.0.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.3",
+								"product_id": "FortiOS-7.0.3"
+							}
+						},
+						{
+							"name": "7.0.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.2",
+								"product_id": "FortiOS-7.0.2"
+							}
+						},
+						{
+							"name": "7.0.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.1",
+								"product_id": "FortiOS-7.0.1"
+							}
+						},
+						{
+							"name": "7.0.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.0",
+								"product_id": "FortiOS-7.0.0"
+							}
+						},
+						{
+							"name": "6.4.16",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.16",
+								"product_id": "FortiOS-6.4.16"
+							}
+						},
+						{
+							"name": "6.4.15",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.15",
+								"product_id": "FortiOS-6.4.15"
+							}
+						},
+						{
+							"name": "6.4.14",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.14",
+								"product_id": "FortiOS-6.4.14"
+							}
+						},
+						{
+							"name": "6.4.13",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.13",
+								"product_id": "FortiOS-6.4.13"
+							}
+						},
+						{
+							"name": "6.4.12",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.12",
+								"product_id": "FortiOS-6.4.12"
+							}
+						},
+						{
+							"name": "6.4.11",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.11",
+								"product_id": "FortiOS-6.4.11"
+							}
+						},
+						{
+							"name": "6.4.10",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.10",
+								"product_id": "FortiOS-6.4.10"
+							}
+						},
+						{
+							"name": "6.4.9",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.9",
+								"product_id": "FortiOS-6.4.9"
+							}
+						},
+						{
+							"name": "6.4.8",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.8",
+								"product_id": "FortiOS-6.4.8"
+							}
+						},
+						{
+							"name": "6.4.7",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.7",
+								"product_id": "FortiOS-6.4.7"
+							}
+						},
+						{
+							"name": "6.4.6",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.6",
+								"product_id": "FortiOS-6.4.6"
+							}
+						},
+						{
+							"name": "6.4.5",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.5",
+								"product_id": "FortiOS-6.4.5"
+							}
+						},
+						{
+							"name": "6.4.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.4",
+								"product_id": "FortiOS-6.4.4"
+							}
+						},
+						{
+							"name": "6.4.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.3",
+								"product_id": "FortiOS-6.4.3"
+							}
+						},
+						{
+							"name": "6.4.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.2",
+								"product_id": "FortiOS-6.4.2"
+							}
+						},
+						{
+							"name": "6.4.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.1",
+								"product_id": "FortiOS-6.4.1"
+							}
+						},
+						{
+							"name": "6.4.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.0",
+								"product_id": "FortiOS-6.4.0"
+							}
+						},
+						{
+							"name": "6.2.17",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.17",
+								"product_id": "FortiOS-6.2.17"
+							}
+						},
+						{
+							"name": "6.2.16",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.16",
+								"product_id": "FortiOS-6.2.16"
+							}
+						},
+						{
+							"name": "6.2.15",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.15",
+								"product_id": "FortiOS-6.2.15"
+							}
+						},
+						{
+							"name": "6.2.14",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.14",
+								"product_id": "FortiOS-6.2.14"
+							}
+						},
+						{
+							"name": "6.2.13",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.13",
+								"product_id": "FortiOS-6.2.13"
+							}
+						},
+						{
+							"name": "6.2.12",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.12",
+								"product_id": "FortiOS-6.2.12"
+							}
+						},
+						{
+							"name": "6.2.11",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.11",
+								"product_id": "FortiOS-6.2.11"
+							}
+						},
+						{
+							"name": "6.2.10",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.10",
+								"product_id": "FortiOS-6.2.10"
+							}
+						},
+						{
+							"name": "6.2.9",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.9",
+								"product_id": "FortiOS-6.2.9"
+							}
+						},
+						{
+							"name": "6.2.8",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.8",
+								"product_id": "FortiOS-6.2.8"
+							}
+						},
+						{
+							"name": "6.2.7",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.7",
+								"product_id": "FortiOS-6.2.7"
+							}
+						},
+						{
+							"name": "6.2.6",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.6",
+								"product_id": "FortiOS-6.2.6"
+							}
+						},
+						{
+							"name": "6.2.5",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.5",
+								"product_id": "FortiOS-6.2.5"
+							}
+						},
+						{
+							"name": "6.2.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.4",
+								"product_id": "FortiOS-6.2.4"
+							}
+						},
+						{
+							"name": "6.2.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.3",
+								"product_id": "FortiOS-6.2.3"
+							}
+						},
+						{
+							"name": "6.2.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.2",
+								"product_id": "FortiOS-6.2.2"
+							}
+						},
+						{
+							"name": "6.2.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.1",
+								"product_id": "FortiOS-6.2.1"
+							}
+						},
+						{
+							"name": "6.2.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.2.0",
+								"product_id": "FortiOS-6.2.0"
+							}
+						},
+						{
+							"name": "6.0.18",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.18",
+								"product_id": "FortiOS-6.0.18"
+							}
+						},
+						{
+							"name": "6.0.17",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.17",
+								"product_id": "FortiOS-6.0.17"
+							}
+						},
+						{
+							"name": "6.0.16",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.16",
+								"product_id": "FortiOS-6.0.16"
+							}
+						},
+						{
+							"name": "6.0.15",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.15",
+								"product_id": "FortiOS-6.0.15"
+							}
+						},
+						{
+							"name": "6.0.14",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.14",
+								"product_id": "FortiOS-6.0.14"
+							}
+						},
+						{
+							"name": "6.0.13",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.13",
+								"product_id": "FortiOS-6.0.13"
+							}
+						},
+						{
+							"name": "6.0.12",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.12",
+								"product_id": "FortiOS-6.0.12"
+							}
+						},
+						{
+							"name": "6.0.11",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.11",
+								"product_id": "FortiOS-6.0.11"
+							}
+						},
+						{
+							"name": "6.0.10",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.10",
+								"product_id": "FortiOS-6.0.10"
+							}
+						},
+						{
+							"name": "6.0.9",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.9",
+								"product_id": "FortiOS-6.0.9"
+							}
+						},
+						{
+							"name": "6.0.8",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.8",
+								"product_id": "FortiOS-6.0.8"
+							}
+						},
+						{
+							"name": "6.0.7",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.7",
+								"product_id": "FortiOS-6.0.7"
+							}
+						},
+						{
+							"name": "6.0.6",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.6",
+								"product_id": "FortiOS-6.0.6"
+							}
+						},
+						{
+							"name": "6.0.5",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.5",
+								"product_id": "FortiOS-6.0.5"
+							}
+						},
+						{
+							"name": "6.0.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.4",
+								"product_id": "FortiOS-6.0.4"
+							}
+						},
+						{
+							"name": "6.0.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.3",
+								"product_id": "FortiOS-6.0.3"
+							}
+						},
+						{
+							"name": "6.0.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.2",
+								"product_id": "FortiOS-6.0.2"
+							}
+						},
+						{
+							"name": "6.0.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.1",
+								"product_id": "FortiOS-6.0.1"
+							}
+						},
+						{
+							"name": "6.0.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.0.0",
+								"product_id": "FortiOS-6.0.0"
+							}
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/pkg/extract/fortinet/cvrf/testdata/fixtures/2023/FG-IR-23-090.json
+++ b/pkg/extract/fortinet/cvrf/testdata/fixtures/2023/FG-IR-23-090.json
@@ -1,0 +1,393 @@
+{
+	"document_title": "IPS Engine evasion using custom TCP flags",
+	"document_type": "Fortinet PSIRT Advisories",
+	"documentpublisher": {
+		"type": "Vendor",
+		"contact_details": "\n            Fortinet PSIRT Contact:\n            Website: https://fortiguard.fortinet.com/faq/psirt-contact\n        "
+	},
+	"documenttracking": {
+		"identification": {
+			"id": "FG-IR-23-090"
+		},
+		"status": "Final",
+		"version": "1",
+		"revisionhistory": {
+			"revision": {
+				"number": "1",
+				"date": "2023-10-10T00:00:00",
+				"description": "Current version"
+			}
+		},
+		"initial_release_date": "2023-10-10T00:00:00",
+		"current_release_date": "2023-10-10T00:00:00"
+	},
+	"documentnotes": {
+		"note": [
+			{
+				"text": "\n            An interpretation conflict vulnerability [CWE-436] in FortiOS IPS Engine may allow an unauthenticated remote attacker to evade NGFW policies or IPS Engine protection via crafted TCP packets.\n        ",
+				"title": "Summary",
+				"type": "Summary",
+				"ordinal": "1"
+			},
+			{
+				"text": "\n            None\n        ",
+				"title": "Description",
+				"type": "General",
+				"ordinal": "2"
+			},
+			{
+				"text": "\n            Improper access control\n        ",
+				"title": "Impact",
+				"type": "General",
+				"ordinal": "3"
+			},
+			{
+				"text": "\n            FortiOS 7.4 all versions are not affectedFortiOS version 7.2.0 through 7.2.4FortiOS version 7.0.2 through 7.0.11FortiOS version 6.4.0 through 6.4.12At leastIPS Engine version 7.321IPS Engine version 7.166IPS Engine version 6.158\n        ",
+				"title": "Affected Products",
+				"type": "General",
+				"ordinal": "4"
+			},
+			{
+				"text": "\n            IPS Engine manual download is not needed unless device is offline and cannot download IPS Engine update automatically.Fixed in IPS Engine version 6.0159 and later.FortiOS 6.4.13 and later contains IPS engine 6.0160 as the default IPS Engine.IPS Engine 6.0162 is downloadable from FortiGuard by FortiGate units with a valid subscription running FortiOS 6.4.x.Fixed in IPS Engine version 7.0166 and later.FortiOS 7.0.12 and later contains IPS engine 7.0167 as the default IPS Engine.Fixed in IPS Engine version 7.0313 and later.FortiOS 7.2.5 and later contains IPS engine 7.0314 as the default IPS Engine.IPS Engine 7.0322 is downloadable from FortiGuard by FortiGate units with a valid subscription running FortiOS 7.2.x.FortiOS 7.4.0 and later contains IPS engine 7.0493 as the default IPS Engine.\n        ",
+				"title": "Solutions",
+				"type": "General",
+				"ordinal": "5"
+			}
+		]
+	},
+	"acknowledgments": {
+		"acknowledgment": [
+			{
+				"description": "Fortinet is pleased to thank DISO and Cybersecurity Lab of the University of Udine to report this vulnerability."
+			}
+		]
+	},
+	"vulnerability": {
+		"ordinal": "1",
+		"title": "IPS Engine evasion using custom TCP flags",
+		"references": {
+			"type": "Self",
+			"reference": [
+				{
+					"url": "https://fortiguard.fortinet.com/psirt/FG-IR-23-090",
+					"description": "IPS Engine evasion using custom TCP flags"
+				}
+			]
+		},
+		"cve": [
+			"CVE-2023-40718"
+		],
+		"product_statuses": {
+			"status": {
+				"type": "Known Affected",
+				"product_id": [
+					"FortiOS-7.2.4",
+					"FortiOS-7.2.3",
+					"FortiOS-7.2.2",
+					"FortiOS-7.2.1",
+					"FortiOS-7.2.0",
+					"FortiOS-7.0.11",
+					"FortiOS-7.0.10",
+					"FortiOS-7.0.9",
+					"FortiOS-7.0.8",
+					"FortiOS-7.0.7",
+					"FortiOS-7.0.6",
+					"FortiOS-7.0.5",
+					"FortiOS-7.0.4",
+					"FortiOS-7.0.3",
+					"FortiOS-7.0.2",
+					"FortiOS-6.4.12",
+					"FortiOS-6.4.11",
+					"FortiOS-6.4.10",
+					"FortiOS-6.4.9",
+					"FortiOS-6.4.8",
+					"FortiOS-6.4.7",
+					"FortiOS-6.4.6",
+					"FortiOS-6.4.5",
+					"FortiOS-6.4.4",
+					"FortiOS-6.4.3",
+					"FortiOS-6.4.2",
+					"FortiOS-6.4.1",
+					"FortiOS-6.4.0",
+					"IPS Engine-7.321",
+					"IPS Engine-7.166",
+					"IPS Engine-6.158"
+				]
+			}
+		},
+		"cvss_scoresets": {
+			"scoreset_v3": {
+				"base_score_v3": "6.7",
+				"vector_v3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N/E:F/RL:O/RC:R"
+			}
+		}
+	},
+	"product_tree": {
+		"branch": {
+			"name": "Fortinet",
+			"type": "Vendor",
+			"branch": [
+				{
+					"name": "FortiOS",
+					"type": "Product Name",
+					"branch": [
+						{
+							"name": "7.2.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.2.4",
+								"product_id": "FortiOS-7.2.4"
+							}
+						},
+						{
+							"name": "7.2.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.2.3",
+								"product_id": "FortiOS-7.2.3"
+							}
+						},
+						{
+							"name": "7.2.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.2.2",
+								"product_id": "FortiOS-7.2.2"
+							}
+						},
+						{
+							"name": "7.2.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.2.1",
+								"product_id": "FortiOS-7.2.1"
+							}
+						},
+						{
+							"name": "7.2.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.2.0",
+								"product_id": "FortiOS-7.2.0"
+							}
+						},
+						{
+							"name": "7.0.11",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.11",
+								"product_id": "FortiOS-7.0.11"
+							}
+						},
+						{
+							"name": "7.0.10",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.10",
+								"product_id": "FortiOS-7.0.10"
+							}
+						},
+						{
+							"name": "7.0.9",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.9",
+								"product_id": "FortiOS-7.0.9"
+							}
+						},
+						{
+							"name": "7.0.8",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.8",
+								"product_id": "FortiOS-7.0.8"
+							}
+						},
+						{
+							"name": "7.0.7",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.7",
+								"product_id": "FortiOS-7.0.7"
+							}
+						},
+						{
+							"name": "7.0.6",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.6",
+								"product_id": "FortiOS-7.0.6"
+							}
+						},
+						{
+							"name": "7.0.5",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.5",
+								"product_id": "FortiOS-7.0.5"
+							}
+						},
+						{
+							"name": "7.0.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.4",
+								"product_id": "FortiOS-7.0.4"
+							}
+						},
+						{
+							"name": "7.0.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.3",
+								"product_id": "FortiOS-7.0.3"
+							}
+						},
+						{
+							"name": "7.0.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 7.0.2",
+								"product_id": "FortiOS-7.0.2"
+							}
+						},
+						{
+							"name": "6.4.12",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.12",
+								"product_id": "FortiOS-6.4.12"
+							}
+						},
+						{
+							"name": "6.4.11",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.11",
+								"product_id": "FortiOS-6.4.11"
+							}
+						},
+						{
+							"name": "6.4.10",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.10",
+								"product_id": "FortiOS-6.4.10"
+							}
+						},
+						{
+							"name": "6.4.9",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.9",
+								"product_id": "FortiOS-6.4.9"
+							}
+						},
+						{
+							"name": "6.4.8",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.8",
+								"product_id": "FortiOS-6.4.8"
+							}
+						},
+						{
+							"name": "6.4.7",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.7",
+								"product_id": "FortiOS-6.4.7"
+							}
+						},
+						{
+							"name": "6.4.6",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.6",
+								"product_id": "FortiOS-6.4.6"
+							}
+						},
+						{
+							"name": "6.4.5",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.5",
+								"product_id": "FortiOS-6.4.5"
+							}
+						},
+						{
+							"name": "6.4.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.4",
+								"product_id": "FortiOS-6.4.4"
+							}
+						},
+						{
+							"name": "6.4.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.3",
+								"product_id": "FortiOS-6.4.3"
+							}
+						},
+						{
+							"name": "6.4.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.2",
+								"product_id": "FortiOS-6.4.2"
+							}
+						},
+						{
+							"name": "6.4.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.1",
+								"product_id": "FortiOS-6.4.1"
+							}
+						},
+						{
+							"name": "6.4.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiOS 6.4.0",
+								"product_id": "FortiOS-6.4.0"
+							}
+						}
+					]
+				},
+				{
+					"name": "IPS Engine",
+					"type": "Product Name",
+					"branch": [
+						{
+							"name": "7.321",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "IPS Engine 7.321",
+								"product_id": "IPS Engine-7.321"
+							}
+						},
+						{
+							"name": "7.166",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "IPS Engine 7.166",
+								"product_id": "IPS Engine-7.166"
+							}
+						},
+						{
+							"name": "6.158",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "IPS Engine 6.158",
+								"product_id": "IPS Engine-6.158"
+							}
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/pkg/extract/fortinet/cvrf/testdata/golden/data/2022/FG-IR-22-021.json
+++ b/pkg/extract/fortinet/cvrf/testdata/golden/data/2022/FG-IR-22-021.json
@@ -1,0 +1,94 @@
+{
+	"id": "FG-IR-22-021",
+	"advisories": [
+		{
+			"content": {
+				"id": "FG-IR-22-021",
+				"title": "XSS vulnerability in OWA login page",
+				"description": "An improper neutralization of input during web page generation vulnerability [CWE-79] in FortiAuthenticator OWA Agent may allow an unauthenticated attacker to perform an XSS attack via crafted HTTP GET requests.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "fortiguard.fortinet.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N/E:U/RL:X/RC:X",
+							"base_score": 6.1,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.6,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.6,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"cwe": [
+							"CWE-79"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"url": "https://fortiguard.fortinet.com/psirt/FG-IR-22-021"
+					}
+				],
+				"published": "2022-06-07T00:00:00Z",
+				"modified": "2022-06-07T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-22304"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:a:fortinet:fortiauthenticator:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:a:fortinet:fortiauthenticator:2.1:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortiauthenticator:2.2:*:*:*:*:*:*:*"
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "fortinet-cvrf",
+		"raws": [
+			"fixtures/2022/FG-IR-22-021.json"
+		]
+	}
+}

--- a/pkg/extract/fortinet/cvrf/testdata/golden/data/2022/FG-IR-22-074.json
+++ b/pkg/extract/fortinet/cvrf/testdata/golden/data/2022/FG-IR-22-074.json
@@ -1,0 +1,225 @@
+{
+	"id": "FG-IR-22-074",
+	"advisories": [
+		{
+			"content": {
+				"id": "FG-IR-22-074",
+				"title": "Evasion by manipulating MIME attachment",
+				"description": "An insufficient verification of data authenticity vulnerability [CWE-345] in FortiClient, FortiMail and FortiOS AV engines may allow an attacker to bypass the AV engine via manipulating MIME attachment with junk and pad characters in base64.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "fortiguard.fortinet.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:N/I:L/A:N/E:P/RL:U/RC:R",
+							"base_score": 4.7,
+							"base_severity": "MEDIUM",
+							"temporal_score": 4.3,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 4.3,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"cwe": [
+							"CWE-345"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"url": "https://fortiguard.fortinet.com/psirt/FG-IR-22-074"
+					}
+				],
+				"published": "2022-11-01T00:00:00Z",
+				"modified": "2022-11-01T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2022-26122"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:a:fortinet:antivirus_engine:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:a:fortinet:antivirus_engine:0.4.23:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:2.0.49:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:2.0.60:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:4.4.54:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:6.137:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:6.142:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:6.144:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:6.145:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:6.156:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:6.157:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:6.243:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:6.252:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:6.253:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:antivirus_engine:6.33:*:*:*:*:*:*:*"
+									]
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:o:fortinet:fortimail:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:o:fortinet:fortimail:6.0.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.10:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.11:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.12:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.1:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.3:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.4:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.5:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.6:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.7:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.8:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.0.9:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.2.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.2.1:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.2.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.2.3:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.2.4:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.2.5:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.2.6:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.2.7:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.2.8:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.2.9:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.4.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.4.1:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.4.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.4.3:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.4.4:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.4.5:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:6.4.6:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:7.0.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:7.0.1:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortimail:7.0.2:*:*:*:*:*:*:*"
+									]
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:o:fortinet:fortios:6.0.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.10:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.11:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.12:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.13:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.14:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.15:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.16:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.17:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.18:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.1:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.3:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.4:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.5:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.6:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.7:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.8:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.0.9:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.10:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.11:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.12:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.13:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.14:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.15:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.16:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.17:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.1:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.3:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.4:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.5:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.6:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.7:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.8:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.2.9:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.10:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.11:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.12:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.13:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.14:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.15:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.16:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.1:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.3:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.4:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.5:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.6:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.7:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.8:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.9:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.1:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.3:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.4:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.5:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.6:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.2.0:*:*:*:*:*:*:*"
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "fortinet-cvrf",
+		"raws": [
+			"fixtures/2022/FG-IR-22-074.json"
+		]
+	}
+}

--- a/pkg/extract/fortinet/cvrf/testdata/golden/data/2023/FG-IR-23-090.json
+++ b/pkg/extract/fortinet/cvrf/testdata/golden/data/2023/FG-IR-23-090.json
@@ -1,0 +1,135 @@
+{
+	"id": "FG-IR-23-090",
+	"advisories": [
+		{
+			"content": {
+				"id": "FG-IR-23-090",
+				"title": "IPS Engine evasion using custom TCP flags",
+				"description": "An interpretation conflict vulnerability [CWE-436] in FortiOS IPS Engine may allow an unauthenticated remote attacker to evade NGFW policies or IPS Engine protection via crafted TCP packets.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "fortiguard.fortinet.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N/E:F/RL:O/RC:R",
+							"base_score": 7.5,
+							"base_severity": "HIGH",
+							"temporal_score": 6.7,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.7,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"cwe": [
+							"CWE-436"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"url": "https://fortiguard.fortinet.com/psirt/FG-IR-23-090"
+					}
+				],
+				"published": "2023-10-10T00:00:00Z",
+				"modified": "2023-10-10T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-40718"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:a:fortinet:fortios_ips_engine:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:a:fortinet:fortios_ips_engine:6.158:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortios_ips_engine:7.166:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortios_ips_engine:7.321:*:*:*:*:*:*:*"
+									]
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:o:fortinet:fortios:6.4.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.10:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.11:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.12:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.1:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.3:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.4:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.5:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.6:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.7:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.8:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:6.4.9:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.10:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.11:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.3:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.4:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.5:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.6:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.7:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.8:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.0.9:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.2.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.2.1:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.2.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.2.3:*:*:*:*:*:*:*",
+										"cpe:2.3:o:fortinet:fortios:7.2.4:*:*:*:*:*:*:*"
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "fortinet-cvrf",
+		"raws": [
+			"fixtures/2023/FG-IR-23-090.json"
+		]
+	}
+}

--- a/pkg/extract/fortinet/cvrf/testdata/golden/data/2026/FG-IR-26-136.json
+++ b/pkg/extract/fortinet/cvrf/testdata/golden/data/2026/FG-IR-26-136.json
@@ -37,72 +37,14 @@
 				],
 				"published": "2026-05-12T00:00:00Z",
 				"modified": "2026-05-12T00:00:00Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "cpe"
-				}
-			]
+			}
 		}
 	],
 	"vulnerabilities": [
 		{
 			"content": {
 				"id": "CVE-2026-26083"
-			},
-			"segments": [
-				{
-					"ecosystem": "cpe"
-				}
-			]
-		}
-	],
-	"detections": [
-		{
-			"ecosystem": "cpe",
-			"conditions": [
-				{
-					"criteria": {
-						"operator": "OR",
-						"criterions": [
-							{
-								"type": "cpe",
-								"cpe": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "unknown"
-									},
-									"cpe": "cpe:2.3:a:fortinet:fortisandbox_cloud:*:*:*:*:*:*:*:*",
-									"cpe_matches": [
-										"cpe:2.3:a:fortinet:fortisandbox_cloud:5.0:*:*:*:*:*:*:*"
-									]
-								}
-							},
-							{
-								"type": "cpe",
-								"cpe": {
-									"vulnerable": true,
-									"fix_status": {
-										"class": "unknown"
-									},
-									"cpe": "cpe:2.3:a:fortinet:fortisandbox_paas:*:*:*:*:*:*:*:*",
-									"cpe_matches": [
-										"cpe:2.3:a:fortinet:fortisandbox_paas:21.3:*:*:*:*:*:*:*",
-										"cpe:2.3:a:fortinet:fortisandbox_paas:21.4:*:*:*:*:*:*:*",
-										"cpe:2.3:a:fortinet:fortisandbox_paas:22.1:*:*:*:*:*:*:*",
-										"cpe:2.3:a:fortinet:fortisandbox_paas:22.2:*:*:*:*:*:*:*",
-										"cpe:2.3:a:fortinet:fortisandbox_paas:23.1:*:*:*:*:*:*:*",
-										"cpe:2.3:a:fortinet:fortisandbox_paas:23.3:*:*:*:*:*:*:*",
-										"cpe:2.3:a:fortinet:fortisandbox_paas:23.4:*:*:*:*:*:*:*",
-										"cpe:2.3:a:fortinet:fortisandbox_paas:4.4:*:*:*:*:*:*:*",
-										"cpe:2.3:a:fortinet:fortisandbox_paas:5.0:*:*:*:*:*:*:*"
-									]
-								}
-							}
-						]
-					}
-				}
-			]
+			}
 		}
 	],
 	"data_source": {

--- a/pkg/extract/fortinet/cvrf/testdata/golden/data/2026/FG-IR-26-136.json
+++ b/pkg/extract/fortinet/cvrf/testdata/golden/data/2026/FG-IR-26-136.json
@@ -37,14 +37,72 @@
 				],
 				"published": "2026-05-12T00:00:00Z",
 				"modified": "2026-05-12T00:00:00Z"
-			}
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
 		}
 	],
 	"vulnerabilities": [
 		{
 			"content": {
 				"id": "CVE-2026-26083"
-			}
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:a:fortinet:fortisandbox_cloud:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:a:fortinet:fortisandbox_cloud:5.0:*:*:*:*:*:*:*"
+									]
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:a:fortinet:fortisandbox_paas:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:a:fortinet:fortisandbox_paas:21.3:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortisandbox_paas:21.4:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortisandbox_paas:22.1:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortisandbox_paas:22.2:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortisandbox_paas:23.1:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortisandbox_paas:23.3:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortisandbox_paas:23.4:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortisandbox_paas:4.4:*:*:*:*:*:*:*",
+										"cpe:2.3:a:fortinet:fortisandbox_paas:5.0:*:*:*:*:*:*:*"
+									]
+								}
+							}
+						]
+					}
+				}
+			]
 		}
 	],
 	"data_source": {

--- a/pkg/extract/fortinet/internal/product/product.go
+++ b/pkg/extract/fortinet/internal/product/product.go
@@ -43,17 +43,6 @@ func BakeVersion(cpe, version string) (string, error) {
 	return naming.BindToFS(wfn), nil
 }
 
-// isConcrete reports whether v has 3 or more dot-separated components (i.e.
-// at least two dots, e.g. 7.4.3). It is a purely format-level check with no
-// product context, kept internal so that all classification goes through the
-// product-aware IsExactVersion; TrainRange also uses it as its input guard —
-// a token with three or more components is a concrete release for every
-// product, never a train (the converse does not hold: a 1-2 component token
-// may still be an exact release of a twoComponentVersions product).
-func isConcrete(v string) bool {
-	return strings.Count(v, ".") >= 2
-}
-
 // IsExactVersion reports whether ver is a concrete, enumerable release of the
 // named product rather than a coarse release train. Most Fortinet products cut
 // releases with three or more dot-separated components (e.g. FortiOS "7.4.3",
@@ -69,22 +58,23 @@ func IsExactVersion(name, ver string) bool {
 	if nameToProduct[strings.TrimSpace(name)].twoComponentVersions {
 		return strings.Count(ver, ".") >= 1
 	}
-	return isConcrete(ver)
+	return strings.Count(ver, ".") >= 2
 }
 
-// TrainRange builds a range spanning an entire release train: ge train,
-// lt <next train>, where <next> increments the train's last numeric component
-// (7.0 -> 7.1, 7 -> 8). It errors when the input is a concrete version rather
-// than a train, or when the last component is not numeric. The Range Type is left
-// unset; the caller sets the per-product range type (it has the product, this
-// helper does not).
-func TrainRange(train string) (ccRangeTypes.Range, error) {
-	// A train is 1-2 components ("7", "7.0"); a concrete version ("7.0.0") is not a
-	// train. Incrementing its last component would silently narrow the range to a
-	// single patch ("7.0.0" -> [7.0.0, 7.0.1)) instead of spanning a train, a
-	// detection false negative, so reject it as unexpected input.
-	if isConcrete(train) {
-		return ccRangeTypes.Range{}, errors.Errorf("expected a release train (1-2 components), got concrete version %q", train)
+// TrainRange builds a range spanning an entire release train of the named
+// product: ge train, lt <next train>, where <next> increments the train's
+// last numeric component (7.0 -> 7.1, 7 -> 8). It errors when the input is a
+// concrete release of that product rather than a train (IsExactVersion — for
+// a twoComponentVersions product even "7.166" is concrete), or when the last
+// component is not numeric. The Range Type is left unset; the caller sets the
+// per-product range type.
+func TrainRange(name, train string) (ccRangeTypes.Range, error) {
+	// Spanning a concrete release would silently narrow the range ("7.0.0" ->
+	// [7.0.0, 7.0.1) instead of the 7.0 train; IPS Engine "7.166" -> [7.166,
+	// 7.167) instead of the single build) — a detection false negative or a
+	// bogus range, so reject it as unexpected input.
+	if IsExactVersion(name, train) {
+		return ccRangeTypes.Range{}, errors.Errorf("expected a release train of %q, got concrete version %q", name, train)
 	}
 	ss := strings.Split(train, ".")
 	last, err := strconv.Atoi(ss[len(ss)-1])

--- a/pkg/extract/fortinet/internal/product/product.go
+++ b/pkg/extract/fortinet/internal/product/product.go
@@ -45,9 +45,30 @@ func BakeVersion(cpe, version string) (string, error) {
 
 // IsConcrete reports whether v is a concrete release (3 or more
 // dot-separated components, i.e. at least two dots, e.g. 7.4.3) as opposed
-// to a release train (7 or 7.4).
+// to a release train (7 or 7.4). It is a purely format-level check with no
+// product context; for the exact-vs-train split that respects per-product
+// version arity, see IsExactVersion.
 func IsConcrete(v string) bool {
 	return strings.Count(v, ".") >= 2
+}
+
+// IsExactVersion reports whether ver is a concrete, enumerable release of the
+// named product rather than a coarse release train. Most Fortinet products cut
+// releases with three or more dot-separated components (e.g. FortiOS "7.4.3",
+// FortiSASE "25.2.a"), so a one- or two-component token ("7", "7.4") is a
+// train. A few products version their releases with two components (e.g.
+// FortiAuthenticator OutlookAgent "2.1", IPS Engine "7.166", FortiSandbox
+// Cloud "23.4"); those are marked twoComponentVersions in the table, and for
+// them a two-component token is a concrete release — only a bare major ("24")
+// is a train. The distinction cannot be made from the version string alone:
+// the same "X.Y" shape is exact for FortiSandbox Cloud/PaaS but a train for
+// FortiSandbox proper, even within a single advisory (e.g. FG-IR-26-136). An
+// unknown product name falls back to the three-component rule.
+func IsExactVersion(name, ver string) bool {
+	if nameToProduct[strings.TrimSpace(name)].twoComponentVersions {
+		return strings.Count(ver, ".") >= 1
+	}
+	return strings.Count(ver, ".") >= 2
 }
 
 // TrainRange builds a range spanning an entire release train: ge train,

--- a/pkg/extract/fortinet/internal/product/product.go
+++ b/pkg/extract/fortinet/internal/product/product.go
@@ -43,12 +43,12 @@ func BakeVersion(cpe, version string) (string, error) {
 	return naming.BindToFS(wfn), nil
 }
 
-// IsConcrete reports whether v is a concrete release (3 or more
-// dot-separated components, i.e. at least two dots, e.g. 7.4.3) as opposed
-// to a release train (7 or 7.4). It is a purely format-level check with no
-// product context; for the exact-vs-train split that respects per-product
-// version arity, see IsExactVersion.
-func IsConcrete(v string) bool {
+// isConcrete reports whether v has 3 or more dot-separated components (i.e.
+// at least two dots, e.g. 7.4.3). It is a purely format-level check with no
+// product context, kept internal so that all classification goes through the
+// product-aware IsExactVersion; TrainRange also uses it to reject inputs that
+// cannot be a train under any product's versioning scheme.
+func isConcrete(v string) bool {
 	return strings.Count(v, ".") >= 2
 }
 
@@ -68,7 +68,7 @@ func IsExactVersion(name, ver string) bool {
 	if nameToProduct[strings.TrimSpace(name)].twoComponentVersions {
 		return strings.Count(ver, ".") >= 1
 	}
-	return strings.Count(ver, ".") >= 2
+	return isConcrete(ver)
 }
 
 // TrainRange builds a range spanning an entire release train: ge train,
@@ -82,7 +82,7 @@ func TrainRange(train string) (ccRangeTypes.Range, error) {
 	// train. Incrementing its last component would silently narrow the range to a
 	// single patch ("7.0.0" -> [7.0.0, 7.0.1)) instead of spanning a train, a
 	// detection false negative, so reject it as unexpected input.
-	if IsConcrete(train) {
+	if isConcrete(train) {
 		return ccRangeTypes.Range{}, errors.Errorf("expected a release train (1-2 components), got concrete version %q", train)
 	}
 	ss := strings.Split(train, ".")

--- a/pkg/extract/fortinet/internal/product/product.go
+++ b/pkg/extract/fortinet/internal/product/product.go
@@ -57,12 +57,11 @@ func isConcrete(v string) bool {
 // releases with three or more dot-separated components (e.g. FortiOS "7.4.3",
 // FortiSASE "25.2.a"), so a one- or two-component token ("7", "7.4") is a
 // train. A few products version their releases with two components (e.g.
-// FortiAuthenticator OutlookAgent "2.1", IPS Engine "7.166", FortiSandbox
-// Cloud "23.4"); those are marked twoComponentVersions in the table, and for
-// them a two-component token is a concrete release — only a bare major ("24")
+// FortiAuthenticator OutlookAgent "2.1", IPS Engine "7.166"); those are marked
+// twoComponentVersions in the table (see its comment for the evidence bar),
+// and for them a two-component token is a concrete release — only a bare major
 // is a train. The distinction cannot be made from the version string alone:
-// the same "X.Y" shape is exact for FortiSandbox Cloud/PaaS but a train for
-// FortiSandbox proper, even within a single advisory (e.g. FG-IR-26-136). An
+// the same "X.Y" shape is an exact IPS Engine build but a FortiOS train. An
 // unknown product name falls back to the three-component rule.
 func IsExactVersion(name, ver string) bool {
 	if nameToProduct[strings.TrimSpace(name)].twoComponentVersions {

--- a/pkg/extract/fortinet/internal/product/product.go
+++ b/pkg/extract/fortinet/internal/product/product.go
@@ -46,8 +46,10 @@ func BakeVersion(cpe, version string) (string, error) {
 // isConcrete reports whether v has 3 or more dot-separated components (i.e.
 // at least two dots, e.g. 7.4.3). It is a purely format-level check with no
 // product context, kept internal so that all classification goes through the
-// product-aware IsExactVersion; TrainRange also uses it to reject inputs that
-// cannot be a train under any product's versioning scheme.
+// product-aware IsExactVersion; TrainRange also uses it as its input guard —
+// a token with three or more components is a concrete release for every
+// product, never a train (the converse does not hold: a 1-2 component token
+// may still be an exact release of a twoComponentVersions product).
 func isConcrete(v string) bool {
 	return strings.Count(v, ".") >= 2
 }

--- a/pkg/extract/fortinet/internal/product/product_test.go
+++ b/pkg/extract/fortinet/internal/product/product_test.go
@@ -49,26 +49,6 @@ func TestBakeVersion(t *testing.T) {
 	}
 }
 
-func TestIsConcrete(t *testing.T) {
-	tests := []struct {
-		v    string
-		want bool
-	}{
-		{v: "7.4.3", want: true},
-		{v: "7.4.3.1", want: true},
-		{v: "7.4", want: false},
-		{v: "7", want: false},
-		{v: "24", want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.v, func(t *testing.T) {
-			if got := product.IsConcrete(tt.v); got != tt.want {
-				t.Errorf("IsConcrete(%q) = %v, want %v", tt.v, got, tt.want)
-			}
-		})
-	}
-}
-
 // IsExactVersion honors per-product version arity: the same "X.Y" token is a
 // concrete release for a two-component product but a train for a
 // three-component one (both shapes co-exist in e.g. FG-IR-26-136).

--- a/pkg/extract/fortinet/internal/product/product_test.go
+++ b/pkg/extract/fortinet/internal/product/product_test.go
@@ -50,8 +50,11 @@ func TestBakeVersion(t *testing.T) {
 }
 
 // IsExactVersion honors per-product version arity: the same "X.Y" token is a
-// concrete release for a two-component product but a train for a
-// three-component one (both shapes co-exist in e.g. FG-IR-26-136).
+// concrete release for a two-component product (IPS Engine "7.166") but a
+// train for a three-component one (FortiOS "7.4"). FortiSandbox Cloud/PaaS
+// stay on the three-component rule: their two-component tokens ("23.4",
+// "5.0") sit above real build-suffixed releases ("23.4.4350", "5.0.4") in the
+// corpus, i.e. they are trains.
 func TestIsExactVersion(t *testing.T) {
 	type args struct {
 		name string
@@ -73,11 +76,16 @@ func TestIsExactVersion(t *testing.T) {
 		// Two-component products: "X.Y" is exact, a bare major is a train.
 		{args: args{name: "FortiAuthenticator OutlookAgent", ver: "2.1"}, want: true},
 		{args: args{name: "IPS Engine", ver: "7.166"}, want: true},
+		{args: args{name: "IPS Engine", ver: "7"}, want: false},
 		{args: args{name: "AV Engine", ver: "6.137"}, want: true},
-		{args: args{name: "FortiSandbox Cloud", ver: "23.4"}, want: true},
-		{args: args{name: "FortiSandbox PaaS", ver: "23.4"}, want: true},
-		{args: args{name: "FortiSandbox Cloud", ver: "24"}, want: false},
-		{args: args{name: "FortiSandbox Cloud", ver: ""}, want: false},
+		{args: args{name: "AV Engine", ver: "4.4.54"}, want: true},
+		{args: args{name: "AV Engine", ver: ""}, want: false},
+		// FortiSandbox Cloud/PaaS mix year-based and build-suffixed schemes;
+		// their two-component tokens are trains (23.4 < 23.4.4350 exists).
+		{args: args{name: "FortiSandbox Cloud", ver: "23.4"}, want: false},
+		{args: args{name: "FortiSandbox Cloud", ver: "5.0.4"}, want: true},
+		{args: args{name: "FortiSandbox PaaS", ver: "23.4"}, want: false},
+		{args: args{name: "FortiSandbox PaaS", ver: "23.4.4350"}, want: true},
 		// Unknown product falls back to the three-component rule.
 		{args: args{name: "FortiNonexistent", ver: "1.2"}, want: false},
 		{args: args{name: "FortiNonexistent", ver: "1.2.3"}, want: true},

--- a/pkg/extract/fortinet/internal/product/product_test.go
+++ b/pkg/extract/fortinet/internal/product/product_test.go
@@ -69,6 +69,48 @@ func TestIsConcrete(t *testing.T) {
 	}
 }
 
+// IsExactVersion honors per-product version arity: the same "X.Y" token is a
+// concrete release for a two-component product but a train for a
+// three-component one (both shapes co-exist in e.g. FG-IR-26-136).
+func TestIsExactVersion(t *testing.T) {
+	type args struct {
+		name string
+		ver  string
+	}
+	tests := []struct {
+		args args
+		want bool
+	}{
+		// Three-component products: >= 3 components is exact, "X.Y" / "X" are trains.
+		{args: args{name: "FortiOS", ver: "7.4.3"}, want: true},
+		{args: args{name: "FortiOS", ver: "7.4.3.1"}, want: true},
+		{args: args{name: "FortiSASE", ver: "25.2.a"}, want: true},
+		{args: args{name: "FortiSASE", ver: "25.1.a.2"}, want: true},
+		{args: args{name: "FortiOS", ver: "7.4"}, want: false},
+		{args: args{name: "FortiOS", ver: "24"}, want: false},
+		{args: args{name: "FortiOS", ver: ""}, want: false},
+		{args: args{name: "FortiSandbox", ver: "5.0"}, want: false},
+		// Two-component products: "X.Y" is exact, a bare major is a train.
+		{args: args{name: "FortiAuthenticator OutlookAgent", ver: "2.1"}, want: true},
+		{args: args{name: "IPS Engine", ver: "7.166"}, want: true},
+		{args: args{name: "AV Engine", ver: "6.137"}, want: true},
+		{args: args{name: "FortiSandbox Cloud", ver: "23.4"}, want: true},
+		{args: args{name: "FortiSandbox PaaS", ver: "23.4"}, want: true},
+		{args: args{name: "FortiSandbox Cloud", ver: "24"}, want: false},
+		{args: args{name: "FortiSandbox Cloud", ver: ""}, want: false},
+		// Unknown product falls back to the three-component rule.
+		{args: args{name: "FortiNonexistent", ver: "1.2"}, want: false},
+		{args: args{name: "FortiNonexistent", ver: "1.2.3"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.args.name+"/"+tt.args.ver, func(t *testing.T) {
+			if got := product.IsExactVersion(tt.args.name, tt.args.ver); got != tt.want {
+				t.Errorf("IsExactVersion(%q, %q) = %v, want %v", tt.args.name, tt.args.ver, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTrainRange(t *testing.T) {
 	tests := []struct {
 		train   string

--- a/pkg/extract/fortinet/internal/product/product_test.go
+++ b/pkg/extract/fortinet/internal/product/product_test.go
@@ -101,29 +101,36 @@ func TestIsExactVersion(t *testing.T) {
 
 func TestTrainRange(t *testing.T) {
 	tests := []struct {
+		name    string
 		train   string
 		want    ccRangeTypes.Range
 		wantErr bool
 	}{
-		{train: "7.0", want: ccRangeTypes.Range{GreaterEqual: "7.0", LessThan: "7.1"}},
-		{train: "7", want: ccRangeTypes.Range{GreaterEqual: "7", LessThan: "8"}},
-		{train: "6.253", want: ccRangeTypes.Range{GreaterEqual: "6.253", LessThan: "6.254"}},
-		{train: "24", want: ccRangeTypes.Range{GreaterEqual: "24", LessThan: "25"}},
-		{train: "abc", wantErr: true},
-		{train: "7.0.0", wantErr: true}, // concrete version is not a train
-		{train: "7.4.3.1", wantErr: true},
+		{name: "FortiOS", train: "7.0", want: ccRangeTypes.Range{GreaterEqual: "7.0", LessThan: "7.1"}},
+		{name: "FortiOS", train: "7", want: ccRangeTypes.Range{GreaterEqual: "7", LessThan: "8"}},
+		{name: "FortiSandbox Cloud", train: "24", want: ccRangeTypes.Range{GreaterEqual: "24", LessThan: "25"}},
+		// Unknown product falls back to the three-component rule; also
+		// exercises the multi-digit last-component increment.
+		{name: "FortiNonexistent", train: "6.253", want: ccRangeTypes.Range{GreaterEqual: "6.253", LessThan: "6.254"}},
+		{name: "FortiOS", train: "abc", wantErr: true},
+		{name: "FortiOS", train: "7.0.0", wantErr: true}, // concrete version is not a train
+		{name: "FortiOS", train: "7.4.3.1", wantErr: true},
+		// For a twoComponentVersions product even "X.Y" is a concrete release,
+		// not a train; a bare major still ranges.
+		{name: "IPS Engine", train: "7.166", wantErr: true},
+		{name: "IPS Engine", train: "7", want: ccRangeTypes.Range{GreaterEqual: "7", LessThan: "8"}},
 	}
 	for _, tt := range tests {
-		t.Run(tt.train, func(t *testing.T) {
-			got, err := product.TrainRange(tt.train)
+		t.Run(tt.name+"/"+tt.train, func(t *testing.T) {
+			got, err := product.TrainRange(tt.name, tt.train)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("TrainRange(%q) error = %v, wantErr %v", tt.train, err, tt.wantErr)
+				t.Fatalf("TrainRange(%q, %q) error = %v, wantErr %v", tt.name, tt.train, err, tt.wantErr)
 			}
 			if err != nil {
 				return
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("TrainRange(%q) (-want +got):\n%s", tt.train, diff)
+				t.Errorf("TrainRange(%q, %q) (-want +got):\n%s", tt.name, tt.train, diff)
 			}
 		})
 	}

--- a/pkg/extract/fortinet/internal/product/product_test.go
+++ b/pkg/extract/fortinet/internal/product/product_test.go
@@ -61,37 +61,38 @@ func TestIsExactVersion(t *testing.T) {
 		ver  string
 	}
 	tests := []struct {
+		name string
 		args args
 		want bool
 	}{
 		// Three-component products: >= 3 components is exact, "X.Y" / "X" are trains.
-		{args: args{name: "FortiOS", ver: "7.4.3"}, want: true},
-		{args: args{name: "FortiOS", ver: "7.4.3.1"}, want: true},
-		{args: args{name: "FortiSASE", ver: "25.2.a"}, want: true},
-		{args: args{name: "FortiSASE", ver: "25.1.a.2"}, want: true},
-		{args: args{name: "FortiOS", ver: "7.4"}, want: false},
-		{args: args{name: "FortiOS", ver: "24"}, want: false},
-		{args: args{name: "FortiOS", ver: ""}, want: false},
-		{args: args{name: "FortiSandbox", ver: "5.0"}, want: false},
+		{name: "three-component product: three components is exact", args: args{name: "FortiOS", ver: "7.4.3"}, want: true},
+		{name: "three-component product: four components is exact", args: args{name: "FortiOS", ver: "7.4.3.1"}, want: true},
+		{name: "three-component product: letter component is exact", args: args{name: "FortiSASE", ver: "25.2.a"}, want: true},
+		{name: "three-component product: four components with letter is exact", args: args{name: "FortiSASE", ver: "25.1.a.2"}, want: true},
+		{name: "three-component product: two components is a train", args: args{name: "FortiOS", ver: "7.4"}, want: false},
+		{name: "three-component product: bare major is a train", args: args{name: "FortiOS", ver: "24"}, want: false},
+		{name: "three-component product: empty version is not exact", args: args{name: "FortiOS", ver: ""}, want: false},
+		{name: "FortiSandbox stays on the three-component rule", args: args{name: "FortiSandbox", ver: "5.0"}, want: false},
 		// Two-component products: "X.Y" is exact, a bare major is a train.
-		{args: args{name: "FortiAuthenticator OutlookAgent", ver: "2.1"}, want: true},
-		{args: args{name: "IPS Engine", ver: "7.166"}, want: true},
-		{args: args{name: "IPS Engine", ver: "7"}, want: false},
-		{args: args{name: "AV Engine", ver: "6.137"}, want: true},
-		{args: args{name: "AV Engine", ver: "4.4.54"}, want: true},
-		{args: args{name: "AV Engine", ver: ""}, want: false},
+		{name: "two-component product: two components is exact", args: args{name: "FortiAuthenticator OutlookAgent", ver: "2.1"}, want: true},
+		{name: "two-component product: large minor is exact", args: args{name: "IPS Engine", ver: "7.166"}, want: true},
+		{name: "two-component product: bare major is a train", args: args{name: "IPS Engine", ver: "7"}, want: false},
+		{name: "two-component product: AV Engine two components is exact", args: args{name: "AV Engine", ver: "6.137"}, want: true},
+		{name: "two-component product: legacy three components is still exact", args: args{name: "AV Engine", ver: "4.4.54"}, want: true},
+		{name: "two-component product: empty version is not exact", args: args{name: "AV Engine", ver: ""}, want: false},
 		// FortiSandbox Cloud/PaaS mix year-based and build-suffixed schemes;
 		// their two-component tokens are trains (23.4 < 23.4.4350 exists).
-		{args: args{name: "FortiSandbox Cloud", ver: "23.4"}, want: false},
-		{args: args{name: "FortiSandbox Cloud", ver: "5.0.4"}, want: true},
-		{args: args{name: "FortiSandbox PaaS", ver: "23.4"}, want: false},
-		{args: args{name: "FortiSandbox PaaS", ver: "23.4.4350"}, want: true},
+		{name: "FortiSandbox Cloud: year-based two components is a train", args: args{name: "FortiSandbox Cloud", ver: "23.4"}, want: false},
+		{name: "FortiSandbox Cloud: three components is exact", args: args{name: "FortiSandbox Cloud", ver: "5.0.4"}, want: true},
+		{name: "FortiSandbox PaaS: year-based two components is a train", args: args{name: "FortiSandbox PaaS", ver: "23.4"}, want: false},
+		{name: "FortiSandbox PaaS: build-suffixed release is exact", args: args{name: "FortiSandbox PaaS", ver: "23.4.4350"}, want: true},
 		// Unknown product falls back to the three-component rule.
-		{args: args{name: "FortiNonexistent", ver: "1.2"}, want: false},
-		{args: args{name: "FortiNonexistent", ver: "1.2.3"}, want: true},
+		{name: "unknown product: two components is a train", args: args{name: "FortiNonexistent", ver: "1.2"}, want: false},
+		{name: "unknown product: three components is exact", args: args{name: "FortiNonexistent", ver: "1.2.3"}, want: true},
 	}
 	for _, tt := range tests {
-		t.Run(tt.args.name+"/"+tt.args.ver, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			if got := product.IsExactVersion(tt.args.name, tt.args.ver); got != tt.want {
 				t.Errorf("IsExactVersion(%q, %q) = %v, want %v", tt.args.name, tt.args.ver, got, tt.want)
 			}
@@ -100,37 +101,41 @@ func TestIsExactVersion(t *testing.T) {
 }
 
 func TestTrainRange(t *testing.T) {
+	type args struct {
+		name  string
+		train string
+	}
 	tests := []struct {
 		name    string
-		train   string
+		args    args
 		want    ccRangeTypes.Range
 		wantErr bool
 	}{
-		{name: "FortiOS", train: "7.0", want: ccRangeTypes.Range{GreaterEqual: "7.0", LessThan: "7.1"}},
-		{name: "FortiOS", train: "7", want: ccRangeTypes.Range{GreaterEqual: "7", LessThan: "8"}},
-		{name: "FortiSandbox Cloud", train: "24", want: ccRangeTypes.Range{GreaterEqual: "24", LessThan: "25"}},
+		{name: "two-component train", args: args{name: "FortiOS", train: "7.0"}, want: ccRangeTypes.Range{GreaterEqual: "7.0", LessThan: "7.1"}},
+		{name: "bare major train", args: args{name: "FortiOS", train: "7"}, want: ccRangeTypes.Range{GreaterEqual: "7", LessThan: "8"}},
+		{name: "year-based bare major train", args: args{name: "FortiSandbox Cloud", train: "24"}, want: ccRangeTypes.Range{GreaterEqual: "24", LessThan: "25"}},
 		// Unknown product falls back to the three-component rule; also
 		// exercises the multi-digit last-component increment.
-		{name: "FortiNonexistent", train: "6.253", want: ccRangeTypes.Range{GreaterEqual: "6.253", LessThan: "6.254"}},
-		{name: "FortiOS", train: "abc", wantErr: true},
-		{name: "FortiOS", train: "7.0.0", wantErr: true}, // concrete version is not a train
-		{name: "FortiOS", train: "7.4.3.1", wantErr: true},
+		{name: "unknown product multi-digit last component", args: args{name: "FortiNonexistent", train: "6.253"}, want: ccRangeTypes.Range{GreaterEqual: "6.253", LessThan: "6.254"}},
+		{name: "non-numeric token", args: args{name: "FortiOS", train: "abc"}, wantErr: true},
+		{name: "concrete three-component version is not a train", args: args{name: "FortiOS", train: "7.0.0"}, wantErr: true},
+		{name: "concrete four-component version is not a train", args: args{name: "FortiOS", train: "7.4.3.1"}, wantErr: true},
 		// For a twoComponentVersions product even "X.Y" is a concrete release,
 		// not a train; a bare major still ranges.
-		{name: "IPS Engine", train: "7.166", wantErr: true},
-		{name: "IPS Engine", train: "7", want: ccRangeTypes.Range{GreaterEqual: "7", LessThan: "8"}},
+		{name: "two-component product: two components is not a train", args: args{name: "IPS Engine", train: "7.166"}, wantErr: true},
+		{name: "two-component product: bare major train", args: args{name: "IPS Engine", train: "7"}, want: ccRangeTypes.Range{GreaterEqual: "7", LessThan: "8"}},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name+"/"+tt.train, func(t *testing.T) {
-			got, err := product.TrainRange(tt.name, tt.train)
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := product.TrainRange(tt.args.name, tt.args.train)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("TrainRange(%q, %q) error = %v, wantErr %v", tt.name, tt.train, err, tt.wantErr)
+				t.Fatalf("TrainRange(%q, %q) error = %v, wantErr %v", tt.args.name, tt.args.train, err, tt.wantErr)
 			}
 			if err != nil {
 				return
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("TrainRange(%q, %q) (-want +got):\n%s", tt.name, tt.train, diff)
+				t.Errorf("TrainRange(%q, %q) (-want +got):\n%s", tt.args.name, tt.args.train, diff)
 			}
 		})
 	}

--- a/pkg/extract/fortinet/internal/product/table.go
+++ b/pkg/extract/fortinet/internal/product/table.go
@@ -18,8 +18,9 @@ import (
 // e.g. IPS Engine "7.166") is itself a concrete release rather than a train;
 // for them only a bare major is a train (see IsExactVersion). It does NOT
 // claim every release of the product has two components: AV Engine also has
-// older three-component exacts ("4.4.54"), which remain exact under the
-// default rule. Mark a product ONLY with corpus evidence that no
+// older three-component exacts ("4.4.54"), which the marked rule likewise
+// classifies exact (it accepts any token with one or more dots). Mark a
+// product ONLY with corpus evidence that no
 // three-component release exists under any of its two-component tokens:
 // FortiSandbox Cloud/PaaS look two-component in some advisories ("23.4",
 // "5.0") but other advisories enumerate build-suffixed releases under those

--- a/pkg/extract/fortinet/internal/product/table.go
+++ b/pkg/extract/fortinet/internal/product/table.go
@@ -15,8 +15,13 @@ import (
 // carries its own range type so a product whose version scheme later diverges
 // gets its own comparator without affecting any other (see cpecriterion/range).
 // twoComponentVersions marks the few products whose concrete releases have two
-// dot-separated components (e.g. IPS Engine "7.166", FortiSandbox Cloud
-// "23.4") instead of the usual three (see IsExactVersion).
+// dot-separated components (e.g. IPS Engine "7.166") instead of the usual
+// three (see IsExactVersion). Mark a product ONLY with corpus evidence that no
+// three-component release exists under its two-component tokens: FortiSandbox
+// Cloud/PaaS look two-component in some advisories ("23.4", "5.0") but other
+// advisories enumerate build-suffixed releases under those very tokens
+// ("23.4.4350", "5.0.4"), so their two-component tokens are trains and they
+// must NOT be marked.
 type productInfo struct {
 	cpe                  string
 	rangeType            ccRangeTypes.RangeType
@@ -82,8 +87,8 @@ var nameToProduct = map[string]productInfo{
 	"FortiSOAR on-premise":                 {cpe: "cpe:2.3:a:fortinet:fortisoar:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSOAR},
 	"FortiSRA":                             {cpe: "cpe:2.3:a:fortinet:fortisra:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSRA},
 	"FortiSandbox":                         {cpe: "cpe:2.3:o:fortinet:fortisandbox:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSandbox},
-	"FortiSandbox Cloud":                   {cpe: "cpe:2.3:a:fortinet:fortisandbox_cloud:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSandboxCloud, twoComponentVersions: true},
-	"FortiSandbox PaaS":                    {cpe: "cpe:2.3:a:fortinet:fortisandbox_paas:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSandboxPaaS, twoComponentVersions: true},
+	"FortiSandbox Cloud":                   {cpe: "cpe:2.3:a:fortinet:fortisandbox_cloud:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSandboxCloud},
+	"FortiSandbox PaaS":                    {cpe: "cpe:2.3:a:fortinet:fortisandbox_paas:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSandboxPaaS},
 	"FortiSwitch":                          {cpe: "cpe:2.3:o:fortinet:fortiswitch:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSwitch},
 	"FortiSwitchAXFixed":                   {cpe: "cpe:2.3:a:fortinet:fortiswitchaxfixed:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSwitchAXFixed},
 	"FortiSwitchManager":                   {cpe: "cpe:2.3:o:fortinet:fortiswitchmanager:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSwitchManager},

--- a/pkg/extract/fortinet/internal/product/table.go
+++ b/pkg/extract/fortinet/internal/product/table.go
@@ -14,13 +14,17 @@ import (
 // productInfo is a product's CPE and its per-product range type. Each product
 // carries its own range type so a product whose version scheme later diverges
 // gets its own comparator without affecting any other (see cpecriterion/range).
+// twoComponentVersions marks the few products whose concrete releases have two
+// dot-separated components (e.g. IPS Engine "7.166", FortiSandbox Cloud
+// "23.4") instead of the usual three (see IsExactVersion).
 type productInfo struct {
-	cpe       string
-	rangeType ccRangeTypes.RangeType
+	cpe                  string
+	rangeType            ccRangeTypes.RangeType
+	twoComponentVersions bool
 }
 
 var nameToProduct = map[string]productInfo{
-	"AV Engine":                            {cpe: "cpe:2.3:a:fortinet:antivirus_engine:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetAntivirusEngine},
+	"AV Engine":                            {cpe: "cpe:2.3:a:fortinet:antivirus_engine:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetAntivirusEngine, twoComponentVersions: true},
 	"AscenLink":                            {cpe: "cpe:2.3:o:fortinet:ascenlink:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetAscenLink},
 	"FortiADC":                             {cpe: "cpe:2.3:o:fortinet:fortiadc:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiADC},
 	"FortiADCManager":                      {cpe: "cpe:2.3:a:fortinet:fortiadc_manager:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiADCManager},
@@ -34,7 +38,7 @@ var nameToProduct = map[string]productInfo{
 	"FortiAnalyzer Cloud":                  {cpe: "cpe:2.3:a:fortinet:fortianalyzer_cloud:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiAnalyzerCloud},
 	"FortiAnalyzer-BigData":                {cpe: "cpe:2.3:o:fortinet:fortianalyzer-bigdata:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiAnalyzerBigData},
 	"FortiAuthenticator":                   {cpe: "cpe:2.3:o:fortinet:fortiauthenticator:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiAuthenticator},
-	"FortiAuthenticator OutlookAgent":      {cpe: "cpe:2.3:a:fortinet:fortiauthenticator:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiAuthenticator},
+	"FortiAuthenticator OutlookAgent":      {cpe: "cpe:2.3:a:fortinet:fortiauthenticator:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiAuthenticator, twoComponentVersions: true},
 	"FortiCache":                           {cpe: "cpe:2.3:o:fortinet:forticache:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiCache},
 	"FortiCamera":                          {cpe: "cpe:2.3:o:fortinet:forticamera:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiCamera},
 	"FortiClientAndroid":                   {cpe: "cpe:2.3:a:fortinet:forticlient:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiClient},
@@ -78,8 +82,8 @@ var nameToProduct = map[string]productInfo{
 	"FortiSOAR on-premise":                 {cpe: "cpe:2.3:a:fortinet:fortisoar:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSOAR},
 	"FortiSRA":                             {cpe: "cpe:2.3:a:fortinet:fortisra:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSRA},
 	"FortiSandbox":                         {cpe: "cpe:2.3:o:fortinet:fortisandbox:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSandbox},
-	"FortiSandbox Cloud":                   {cpe: "cpe:2.3:a:fortinet:fortisandbox_cloud:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSandboxCloud},
-	"FortiSandbox PaaS":                    {cpe: "cpe:2.3:a:fortinet:fortisandbox_paas:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSandboxPaaS},
+	"FortiSandbox Cloud":                   {cpe: "cpe:2.3:a:fortinet:fortisandbox_cloud:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSandboxCloud, twoComponentVersions: true},
+	"FortiSandbox PaaS":                    {cpe: "cpe:2.3:a:fortinet:fortisandbox_paas:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSandboxPaaS, twoComponentVersions: true},
 	"FortiSwitch":                          {cpe: "cpe:2.3:o:fortinet:fortiswitch:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSwitch},
 	"FortiSwitchAXFixed":                   {cpe: "cpe:2.3:a:fortinet:fortiswitchaxfixed:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSwitchAXFixed},
 	"FortiSwitchManager":                   {cpe: "cpe:2.3:o:fortinet:fortiswitchmanager:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSwitchManager},
@@ -95,6 +99,6 @@ var nameToProduct = map[string]productInfo{
 	"FortiWLM":                             {cpe: "cpe:2.3:o:fortinet:fortiwlm:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiWLM},
 	"FortiWeb":                             {cpe: "cpe:2.3:o:fortinet:fortiweb:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiWeb},
 	"FortiWebManager":                      {cpe: "cpe:2.3:a:fortinet:fortiweb_manager:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiWebManager},
-	"IPS Engine":                           {cpe: "cpe:2.3:a:fortinet:fortios_ips_engine:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiOSIPSEngine},
+	"IPS Engine":                           {cpe: "cpe:2.3:a:fortinet:fortios_ips_engine:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiOSIPSEngine, twoComponentVersions: true},
 	"Meru AP":                              {cpe: "cpe:2.3:a:fortinet:meru:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetMeru},
 }

--- a/pkg/extract/fortinet/internal/product/table.go
+++ b/pkg/extract/fortinet/internal/product/table.go
@@ -14,14 +14,17 @@ import (
 // productInfo is a product's CPE and its per-product range type. Each product
 // carries its own range type so a product whose version scheme later diverges
 // gets its own comparator without affecting any other (see cpecriterion/range).
-// twoComponentVersions marks the few products whose concrete releases have two
-// dot-separated components (e.g. IPS Engine "7.166") instead of the usual
-// three (see IsExactVersion). Mark a product ONLY with corpus evidence that no
-// three-component release exists under its two-component tokens: FortiSandbox
-// Cloud/PaaS look two-component in some advisories ("23.4", "5.0") but other
-// advisories enumerate build-suffixed releases under those very tokens
-// ("23.4.4350", "5.0.4"), so their two-component tokens are trains and they
-// must NOT be marked.
+// twoComponentVersions marks products for which a two-component token ("X.Y",
+// e.g. IPS Engine "7.166") is itself a concrete release rather than a train;
+// for them only a bare major is a train (see IsExactVersion). It does NOT
+// claim every release of the product has two components: AV Engine also has
+// older three-component exacts ("4.4.54"), which remain exact under the
+// default rule. Mark a product ONLY with corpus evidence that no
+// three-component release exists under any of its two-component tokens:
+// FortiSandbox Cloud/PaaS look two-component in some advisories ("23.4",
+// "5.0") but other advisories enumerate build-suffixed releases under those
+// very tokens ("23.4.4350", "5.0.4"), so their two-component tokens are
+// trains and they must NOT be marked.
 type productInfo struct {
 	cpe                  string
 	rangeType            ccRangeTypes.RangeType


### PR DESCRIPTION
## What

Fortinet extractors classified a version token as "exact release" vs "release train" by shape alone (`>= 3 dot-separated components`). That misclassified real releases of products that version with **two** components — FortiAuthenticator OutlookAgent (`2.1`), IPS Engine (`7.166`), AV Engine (`6.137`) — as coarse trains; the CVRF extractor dropped them, losing those products' detection criteria entirely.

This PR makes the classification product-aware. The version arity is recorded per product in the shared `internal/product` table (`twoComponentVersions`, marked for the three products above on corpus evidence — see Evidence below), and every exact-vs-train decision — the CVRF exact-only enumeration, CSAF's bare-token range-vs-bake split, and `TrainRange`'s input guard — now goes through a single product-aware classifier, `product.IsExactVersion(productName, ver)`. The format-only `IsConcrete` helper is gone.

## Why

The token shape alone cannot distinguish a two-component *release* from a two-component *train*: `7.166` is an exact IPS Engine build while FortiOS `7.4` is a train. Only per-product knowledge separates the two. Concrete loss: FG-IR-22-021 (OutlookAgent 2.1–2.2) has no CSAF counterpart, so its affected versions were not detectable from either dataset.

CSAF had no false negatives (a mis-ranged two-component release still fell inside its train range), but keeping two near-identical classifiers invited divergence, so every call site — CVRF enumeration, CSAF range-vs-bake, and TrainRange's input guard — now goes through the single product-aware `IsExactVersion`.

## Evidence: which products are genuinely two-component

Basis: all 1108 raw CVRF advisories (`vuls-data-raw-fortinet-cvrf`), tallying every **Known Affected** version token per product (product-name prefix stripped), grouped by component count.

**Marked (no 3-component release exists under any of their 2-component tokens, corpus-wide):**

| Product | 2-component tokens (all of them) | Supporting evidence |
|---|---|---|
| FortiAuthenticator OutlookAgent | `2.1`, `2.2` | Only versions the product ever shows. FortiGuard advisory FG-IR-22-021 lists "OutlookAgent version 2.1 through 2.2" affected, fix "2.3 or above" — two components is the full release granularity |
| IPS Engine | `6.158`, `7.166`, `7.321` | Engine builds; no 3-component IPS Engine token exists anywhere in the corpus |
| AV Engine | `6.33`, `6.137`, `6.142`, `6.144`, `6.145`, `6.156`, `6.157`, `6.243`, `6.252`, `6.253` | FG-IR-22-074 enumerates old-era 3-component exacts (`4.4.54`, `2.0.49`, …) and new-era 2-component 6.x builds side by side in one Known Affected list — both eras are exact releases; no 3-component 6.x exists |

**Explicitly NOT marked — the counter-evidence that killed the naive "2 components = exact" rule:**

| Product | 2-component token (advisory) | 3-component release beneath it (advisory) |
|---|---|---|
| FortiSandbox PaaS | `23.4` (FG-IR-26-136) | `23.4.4350`, `23.4.4374` (FG-IR-26-100, FG-IR-26-113) |
| FortiSandbox Cloud | `5.0` (FG-IR-26-136/141) | `5.0.4` (FG-IR-26-096, FG-IR-26-115) |
| FortiSandbox (proper) | `4.4`, `5.0` (FG-IR-26-136) | `4.4.x`, `5.0.x` trains (e.g. FG-IR-25-093) |

Cloud/PaaS mix year-based and build-suffixed schemes, so their two-component tokens are trains; baking PaaS `=23.4` would not match a host at `23.4.4350` (an under-detection). They stay on the 3-component rule: CVRF drops their trains (CSAF supplies ranges), CSAF ranges them (`ge 23.4, lt 23.5` covers the builds). All other products with 2-component Known Affected tokens (FortiOS `7.4`, FortiMail `7.2`, …) are ordinary trains of 3-component products and were already handled.

The evidence bar for marking a product is documented in `table.go`: only with corpus evidence that no three-component release exists under its two-component tokens.

## How

- `internal/product/table.go`: `twoComponentVersions` flag on the three products above, with the marking contract and the Cloud/PaaS counter-example in the type comment
- `internal/product/product.go`: `IsExactVersion(name, ver)` — `>= 1` dot for marked products, `>= 2` dots otherwise (unknown names fall back to the three-component rule); `TrainRange(name, train)` guards with it; `isConcrete` no longer exists
- `cvrf.go` / `csaf.go`: both extractors classify through `product.IsExactVersion` only

Behavioral note from the `TrainRange` change: for a marked product, a hypothetical `"<X.Y> all versions"` CSAF expression now hard-errors instead of silently ranging an exact release. No such expression exists today — the three marked products do not appear in CSAF at all.

## Output impact (full-corpus verified vs nightly)

- **CVRF (1108 advisories)**: exactly 3 advisories change, all purely additive — FG-IR-22-021 (OutlookAgent 2.1/2.2), FG-IR-22-074 (AV Engine 6.x builds), FG-IR-23-090 (IPS Engine 6.158/7.166/7.321).
- **CSAF (162 advisories)**: no diff. Additionally verified byte-identical CVRF+CSAF output before/after the `TrainRange`/`isConcrete` refactor.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/...` passes
- New CVRF fixtures + goldens for all three advisories this branch changes — FG-IR-22-021 (OutlookAgent 2.1/2.2 enumerated), FG-IR-22-074 (AV Engine mixed-era enumeration: 3-component 4.4.54-era and 2-component 6.x builds together), FG-IR-23-090 (IPS Engine 6.158/7.166/7.321) — so every marked product is locked by a golden test
- CVRF fixture FG-IR-26-136 locks the negative case: FortiSandbox proper/Cloud/PaaS 2-component tokens all remain dropped
- New CSAF fixture + golden FG-IR-25-454 locks Cloud `24.1` staying a train range (`ge 24.1, lt 24.2`)
- `TestIsExactVersion` covers the three marked products, the Cloud/PaaS counter-cases (`23.4` → train, `23.4.4350` → exact), and the unknown-product fallback; `TestTrainRange` covers the product-aware guard (IPS Engine `7.166` → error, bare major `7` → range)

## Checklist

- [x] Tests pass (`GOEXPERIMENT=jsonv2 go test ./pkg/extract/...`)
- [x] Golden files updated (CVRF FG-IR-22-021/FG-IR-22-074/FG-IR-23-090 added, FG-IR-26-136 locked; CSAF FG-IR-25-454 added)
- [ ] Deterministic output verified — n/a, no changes under `pkg/extract/types/`
- [ ] Backward compatibility maintained — n/a, no changes to shared types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

