### PR TITLE
fix(extract/paloalto/json): PAN-OS cpes[] criterion by part:vendor:product

### DIFF
--- a/pkg/extract/paloalto/json/json.go
+++ b/pkg/extract/paloalto/json/json.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/knqyf263/go-cpe/common"
 	"github.com/knqyf263/go-cpe/naming"
 	"github.com/pkg/errors"
 
@@ -475,20 +476,45 @@ func detections(fetched paloaltoJSON.CVE) ([]detectionTypes.Detection, error) {
 			// The PAN-OS cpes[] enumeration (present in 2024+ records) carries
 			// the same affected set as versions[] expanded to hotfix
 			// granularity, with the hotfix in the CPE update attribute. Keep
-			// it verbatim as a separate enumeration criterion: it adds recall
-			// for NVD-style "pan-os:<ver>:<hotfix>" queries and is inert for
-			// queries that carry "<ver>-h<hotfix>" in the version attribute.
+			// the entries verbatim, but emit one enumeration criterion per
+			// part:vendor:product group, with the group's PVP as the
+			// criterion's main CPE: upstream mixes vendor spellings
+			// (paloaltonetworks vs palo_alto_networks), and enumeration
+			// entries whose PVP differs from the main CPE are dead data — the
+			// criterion is unreachable through the db-side part:vendor:product
+			// index (built from main CPEs only) for queries in the divergent
+			// spelling, and Accept's attribute comparison rejects them for
+			// queries in the main CPE's spelling. Grouping keeps each spelling
+			// reachable by a query in that spelling; the enumeration adds
+			// recall for NVD-style "pan-os:<ver>:<hotfix>" queries and is
+			// inert for queries that carry "<ver>-h<hotfix>" in the version
+			// attribute.
 			cpes, err := validCPEs(fetched.CVEMetadata.CVEID, a.Cpes)
 			if err != nil {
 				return nil, errors.Wrapf(err, "valid cpes for %q", *a.Product)
 			}
-			if len(cpes) > 0 {
+			groups := make(map[string][]ccTypes.CPE)
+			for _, c := range cpes {
+				wfn, err := naming.UnbindFS(string(c))
+				if err != nil {
+					return nil, errors.Wrapf(err, "unbind %q", string(c))
+				}
+				mwfn := common.NewWellFormedName()
+				for _, attr := range []string{common.AttributePart, common.AttributeVendor, common.AttributeProduct} {
+					if err := mwfn.Set(attr, wfn.Get(attr)); err != nil {
+						return nil, errors.Wrapf(err, "set %s of %q", attr, string(c))
+					}
+				}
+				main := naming.BindToFS(mwfn)
+				groups[main] = append(groups[main], c)
+			}
+			for main, cs := range groups {
 				cns = append(cns, criterionTypes.Criterion{
 					Type: criterionTypes.CriterionTypeCPE,
 					CPE: &ccTypes.Criterion{
 						Vulnerable: true,
-						CPE:        ccTypes.CPE("cpe:2.3:o:paloaltonetworks:pan-os:*:*:*:*:*:*:*:*"),
-						CPEMatches: cpes,
+						CPE:        ccTypes.CPE(main),
+						CPEMatches: cs,
 					},
 				})
 			}

--- a/pkg/extract/paloalto/json/testdata/fixtures/2025/CVE-2025-99999.json
+++ b/pkg/extract/paloalto/json/testdata/fixtures/2025/CVE-2025-99999.json
@@ -12,11 +12,11 @@
       "providerMetadata": {
         "orgId": "00000000-0000-4000-9000-000000000000"
       },
-      "title": "PAN-OS: Denial of Service (DoS) in GlobalProtect",
+      "title": "SYNTHETIC TEST FIXTURE (not a real advisory; derived from CVE-2025-0114 with cpes rewritten to mix vendor spellings): PAN-OS: Denial of Service (DoS) in GlobalProtect",
       "descriptions": [
         {
           "lang": "en",
-          "value": "A Denial of Service (DoS) vulnerability in the GlobalProtect feature of Palo Alto Networks PAN-OS software enables an unauthenticated attacker to render the service unavailable by sending a large number of specially crafted packets over a period of time. This issue affects both the GlobalProtect portal and the GlobalProtect gateway.\n\nThis issue does not apply to Cloud NGFWs or Prisma Access software.",
+          "value": "SYNTHETIC TEST FIXTURE (not a real advisory; derived from CVE-2025-0114 with cpes rewritten to mix vendor spellings): A Denial of Service (DoS) vulnerability in the GlobalProtect feature of Palo Alto Networks PAN-OS software enables an unauthenticated attacker to render the service unavailable by sending a large number of specially crafted packets over a period of time. This issue affects both the GlobalProtect portal and the GlobalProtect gateway.\n\nThis issue does not apply to Cloud NGFWs or Prisma Access software.",
           "supportingMedia": [
             {
               "base64": false,

--- a/pkg/extract/paloalto/json/testdata/fixtures/2025/CVE-2025-99999.json
+++ b/pkg/extract/paloalto/json/testdata/fixtures/2025/CVE-2025-99999.json
@@ -1,0 +1,437 @@
+{
+  "dataType": "CVE_RECORD",
+  "dataVersion": "5.0",
+  "cveMetadata": {
+    "cveId": "CVE-2025-99999",
+    "assignerOrgId": "00000000-0000-4000-9000-000000000000",
+    "serial": 1,
+    "state": "PUBLISHED"
+  },
+  "containers": {
+    "cna": {
+      "providerMetadata": {
+        "orgId": "00000000-0000-4000-9000-000000000000"
+      },
+      "title": "PAN-OS: Denial of Service (DoS) in GlobalProtect",
+      "descriptions": [
+        {
+          "lang": "en",
+          "value": "A Denial of Service (DoS) vulnerability in the GlobalProtect feature of Palo Alto Networks PAN-OS software enables an unauthenticated attacker to render the service unavailable by sending a large number of specially crafted packets over a period of time. This issue affects both the GlobalProtect portal and the GlobalProtect gateway.\n\nThis issue does not apply to Cloud NGFWs or Prisma Access software.",
+          "supportingMedia": [
+            {
+              "base64": false,
+              "type": "text/html",
+              "value": "A Denial of Service (DoS) vulnerability in the GlobalProtect feature of Palo Alto Networks PAN-OS software enables an unauthenticated attacker to render the service unavailable by sending a large number of specially crafted packets over a period of time. This issue affects both the GlobalProtect portal and the GlobalProtect gateway.<br><br>This issue does not apply to Cloud NGFWs or Prisma Access software."
+            }
+          ]
+        }
+      ],
+      "affected": [
+        {
+          "vendor": "Palo Alto Networks",
+          "product": "PAN-OS",
+          "cpes": [
+            "cpe:2.3:o:paloaltonetworks:pan-os:10.2.4:*:*:*:*:*:*:*",
+            "cpe:2.3:o:paloaltonetworks:pan-os:11.0.0:*:*:*:*:*:*:*",
+            "cpe:2.3:o:paloaltonetworks:pan-os:11.0.1:*:*:*:*:*:*:*",
+            "cpe:2.3:o:palo_alto_networks:pan-os:10.2.5:*:*:*:*:*:*:*",
+            "cpe:2.3:o:palo_alto_networks:pan-os:11.0.2:*:*:*:*:*:*:*",
+            "cpe:2.3:o:palo_alto_networks:pan-os:11.0.2:h1:*:*:*:*:*:*"
+          ],
+          "defaultStatus": "unaffected",
+          "versions": [
+            {
+              "status": "unaffected",
+              "versionType": "custom",
+              "version": "11.2.0"
+            },
+            {
+              "status": "unaffected",
+              "versionType": "custom",
+              "version": "11.1.0"
+            },
+            {
+              "status": "affected",
+              "versionType": "custom",
+              "version": "11.0.0",
+              "lessThan": "11.0.2",
+              "changes": [
+                {
+                  "at": "11.0.2",
+                  "status": "unaffected"
+                }
+              ]
+            },
+            {
+              "status": "affected",
+              "versionType": "custom",
+              "version": "10.2.0",
+              "lessThan": "10.2.5",
+              "changes": [
+                {
+                  "at": "10.2.5",
+                  "status": "unaffected"
+                }
+              ]
+            },
+            {
+              "status": "affected",
+              "versionType": "custom",
+              "version": "10.1.0",
+              "lessThan": "10.1.14-h11",
+              "changes": [
+                {
+                  "at": "10.1.14-h11",
+                  "status": "unaffected"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "vendor": "Palo Alto Networks",
+          "product": "Cloud NGFW",
+          "defaultStatus": "unaffected",
+          "versions": [
+            {
+              "status": "unaffected",
+              "versionType": "custom",
+              "version": "All"
+            }
+          ]
+        },
+        {
+          "vendor": "Palo Alto Networks",
+          "product": "Prisma Access",
+          "defaultStatus": "unaffected",
+          "versions": [
+            {
+              "status": "unaffected",
+              "versionType": "custom",
+              "version": "All"
+            }
+          ]
+        }
+      ],
+      "problemTypes": [
+        {
+          "descriptions": [
+            {
+              "type": "CWE",
+              "lang": "en",
+              "description": "CWE-400 Uncontrolled Resource Consumption",
+              "cweId": "CWE-400"
+            }
+          ]
+        }
+      ],
+      "impacts": [
+        {
+          "descriptions": [
+            {
+              "lang": "en",
+              "value": "CAPEC-125 Flooding"
+            }
+          ],
+          "capecId": "CAPEC-125"
+        }
+      ],
+      "metrics": [
+        {
+          "format": "CVSS",
+          "scenarios": [
+            {
+              "lang": "en",
+              "value": "GENERAL"
+            }
+          ],
+          "cvssV4_0": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:U/AU:N/R:U/V:C/RE:M/U:Amber",
+            "baseScore": 8.2,
+            "baseSeverity": "HIGH",
+            "attackVector": "NETWORK",
+            "attackComplexity": "HIGH",
+            "attackRequirements": "NONE",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "vulnConfidentialityImpact": "NONE",
+            "vulnIntegrityImpact": "NONE",
+            "vulnAvailabilityImpact": "HIGH",
+            "subConfidentialityImpact": "NONE",
+            "subIntegrityImpact": "NONE",
+            "subAvailabilityImpact": "NONE",
+            "exploitMaturity": "UNREPORTED",
+            "Safety": "NOT_DEFINED",
+            "Automatable": "NO",
+            "Recovery": "USER",
+            "valueDensity": "CONCENTRATED",
+            "vulnerabilityResponseEffort": "MODERATE",
+            "providerUrgency": "AMBER",
+            "threatScore": 4.6,
+            "threatSeverity": "MEDIUM"
+          }
+        }
+      ],
+      "workarounds": [
+        {
+          "lang": "en",
+          "value": "No workaround or mitigation is available.\n",
+          "supportingMedia": [
+            {
+              "base64": false,
+              "type": "text/html",
+              "value": "No workaround or mitigation is available."
+            }
+          ]
+        }
+      ],
+      "solutions": [
+        {
+          "lang": "eng",
+          "value": "VERSION           MINOR VERSION            SUGGESTED SOLUTION\nPAN-OS 11.0       11.0.0 through 11.0.1    Upgrade to 11.0.2 or later\nPAN-OS 10.2       10.2.0 through 10.2.4    Upgrade to 10.2.5 or later\nPAN-OS 10.1       10.1.0 through 10.1.14   Upgrade to 10.1.14-h11 or later\nAll other older                            Upgrade to a supported fixed version.\nunsupported\nPAN-OS versions",
+          "supportingMedia": [
+            {
+              "base64": false,
+              "type": "text/html",
+              "value": "<table class=\"tbl\"><thead><tr><th>Version<br></th><th>Minor Version<br></th><th>Suggested Solution<br></th></tr></thead><tbody><tr><td>PAN-OS 11.0</td><td>11.0.0 through 11.0.1</td><td>Upgrade to 11.0.2 or later</td></tr><tr><td>PAN-OS 10.2</td><td>10.2.0 through 10.2.4<br></td><td>Upgrade to 10.2.5 or later</td></tr><tr><td>PAN-OS 10.1<br></td><td>10.1.0 through 10.1.14<br></td><td>Upgrade to 10.1.14-h11 or later<br></td></tr><tr><td>All other older<br>unsupported<br>PAN-OS versions</td><td>&nbsp;</td><td>Upgrade to a supported fixed version.</td></tr></tbody></table>"
+            }
+          ]
+        }
+      ],
+      "exploits": [
+        {
+          "lang": "en",
+          "value": "Palo Alto Networks is not aware of any malicious exploitation of this issue.",
+          "supportingMedia": [
+            {
+              "base64": false,
+              "type": "text/html",
+              "value": "Palo Alto Networks is not aware of any malicious exploitation of this issue."
+            }
+          ]
+        }
+      ],
+      "configurations": [
+        {
+          "lang": "en",
+          "value": "This issue is applicable only to PAN-OS firewall configurations with an enabled GlobalProtect portal or gateway. You can verify whether you have a GlobalProtect portal or gateway configured on your firewall by checking entries in the firewall web interface (Network > GlobalProtect > Portals and Network > GlobalProtect > Gateways).",
+          "supportingMedia": [
+            {
+              "base64": false,
+              "type": "text/html",
+              "value": "This issue is applicable only to PAN-OS firewall configurations with an enabled GlobalProtect portal or gateway. You can verify whether you have a GlobalProtect portal or gateway configured on your firewall by checking entries in the firewall web interface (<b>Network</b> &gt; <b>GlobalProtect</b> &gt; <b>Portals</b> and <b>Network</b> &gt; <b>GlobalProtect</b> &gt; <b>Gateways</b>)."
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://security.paloaltonetworks.com/CVE-2025-99999"
+        }
+      ],
+      "timeline": [
+        {
+          "time": "2025-03-12T16:00:00.000Z",
+          "lang": "en",
+          "value": "Initial Publication"
+        }
+      ],
+      "credits": [
+        {
+          "type": "finder",
+          "lang": "en",
+          "value": "an external reporter"
+        }
+      ],
+      "source": {
+        "defect": [
+          "PAN-209208"
+        ],
+        "discovery": "EXTERNAL"
+      },
+      "datePublic": "2025-03-12T16:00:00.000Z",
+      "x_generator": {
+        "engine": "Vulnogram 0.1.0-dev"
+      },
+      "x_affectedList": [
+        "PAN-OS 11.0.1-h5",
+        "PAN-OS 11.0.1-h4",
+        "PAN-OS 11.0.1-h3",
+        "PAN-OS 11.0.1-h2",
+        "PAN-OS 11.0.1-h1",
+        "PAN-OS 11.0.1",
+        "PAN-OS 11.0.0-h4",
+        "PAN-OS 11.0.0-h3",
+        "PAN-OS 11.0.0-h2",
+        "PAN-OS 11.0.0-h1",
+        "PAN-OS 11.0.0",
+        "PAN-OS 10.2.4-h32",
+        "PAN-OS 10.2.4-h31",
+        "PAN-OS 10.2.4-h30",
+        "PAN-OS 10.2.4-h29",
+        "PAN-OS 10.2.4-h28",
+        "PAN-OS 10.2.4-h27",
+        "PAN-OS 10.2.4-h26",
+        "PAN-OS 10.2.4-h25",
+        "PAN-OS 10.2.4-h24",
+        "PAN-OS 10.2.4-h23",
+        "PAN-OS 10.2.4-h22",
+        "PAN-OS 10.2.4-h21",
+        "PAN-OS 10.2.4-h20",
+        "PAN-OS 10.2.4-h19",
+        "PAN-OS 10.2.4-h18",
+        "PAN-OS 10.2.4-h17",
+        "PAN-OS 10.2.4-h16",
+        "PAN-OS 10.2.4-h15",
+        "PAN-OS 10.2.4-h14",
+        "PAN-OS 10.2.4-h13",
+        "PAN-OS 10.2.4-h12",
+        "PAN-OS 10.2.4-h11",
+        "PAN-OS 10.2.4-h10",
+        "PAN-OS 10.2.4-h9",
+        "PAN-OS 10.2.4-h8",
+        "PAN-OS 10.2.4-h7",
+        "PAN-OS 10.2.4-h6",
+        "PAN-OS 10.2.4-h5",
+        "PAN-OS 10.2.4-h4",
+        "PAN-OS 10.2.4-h3",
+        "PAN-OS 10.2.4-h2",
+        "PAN-OS 10.2.4-h1",
+        "PAN-OS 10.2.4",
+        "PAN-OS 10.2.3-h14",
+        "PAN-OS 10.2.3-h13",
+        "PAN-OS 10.2.3-h12",
+        "PAN-OS 10.2.3-h11",
+        "PAN-OS 10.2.3-h10",
+        "PAN-OS 10.2.3-h9",
+        "PAN-OS 10.2.3-h8",
+        "PAN-OS 10.2.3-h7",
+        "PAN-OS 10.2.3-h6",
+        "PAN-OS 10.2.3-h5",
+        "PAN-OS 10.2.3-h4",
+        "PAN-OS 10.2.3-h3",
+        "PAN-OS 10.2.3-h2",
+        "PAN-OS 10.2.3-h1",
+        "PAN-OS 10.2.3",
+        "PAN-OS 10.2.2-h6",
+        "PAN-OS 10.2.2-h5",
+        "PAN-OS 10.2.2-h4",
+        "PAN-OS 10.2.2-h3",
+        "PAN-OS 10.2.2-h2",
+        "PAN-OS 10.2.2-h1",
+        "PAN-OS 10.2.2",
+        "PAN-OS 10.2.1-h3",
+        "PAN-OS 10.2.1-h2",
+        "PAN-OS 10.2.1-h1",
+        "PAN-OS 10.2.1",
+        "PAN-OS 10.2.0-h4",
+        "PAN-OS 10.2.0-h3",
+        "PAN-OS 10.2.0-h2",
+        "PAN-OS 10.2.0-h1",
+        "PAN-OS 10.2.0",
+        "PAN-OS 10.1.14-h10",
+        "PAN-OS 10.1.14-h9",
+        "PAN-OS 10.1.14-h8",
+        "PAN-OS 10.1.14-h7",
+        "PAN-OS 10.1.14-h6",
+        "PAN-OS 10.1.14-h5",
+        "PAN-OS 10.1.14-h4",
+        "PAN-OS 10.1.14-h3",
+        "PAN-OS 10.1.14-h2",
+        "PAN-OS 10.1.14-h1",
+        "PAN-OS 10.1.14",
+        "PAN-OS 10.1.13-h5",
+        "PAN-OS 10.1.13-h4",
+        "PAN-OS 10.1.13-h3",
+        "PAN-OS 10.1.13-h2",
+        "PAN-OS 10.1.13-h1",
+        "PAN-OS 10.1.13",
+        "PAN-OS 10.1.12-h3",
+        "PAN-OS 10.1.12-h2",
+        "PAN-OS 10.1.12-h1",
+        "PAN-OS 10.1.12",
+        "PAN-OS 10.1.11-h10",
+        "PAN-OS 10.1.11-h9",
+        "PAN-OS 10.1.11-h8",
+        "PAN-OS 10.1.11-h7",
+        "PAN-OS 10.1.11-h6",
+        "PAN-OS 10.1.11-h5",
+        "PAN-OS 10.1.11-h4",
+        "PAN-OS 10.1.11-h3",
+        "PAN-OS 10.1.11-h2",
+        "PAN-OS 10.1.11-h1",
+        "PAN-OS 10.1.11",
+        "PAN-OS 10.1.10-h9",
+        "PAN-OS 10.1.10-h8",
+        "PAN-OS 10.1.10-h7",
+        "PAN-OS 10.1.10-h6",
+        "PAN-OS 10.1.10-h5",
+        "PAN-OS 10.1.10-h4",
+        "PAN-OS 10.1.10-h3",
+        "PAN-OS 10.1.10-h2",
+        "PAN-OS 10.1.10-h1",
+        "PAN-OS 10.1.10",
+        "PAN-OS 10.1.9-h14",
+        "PAN-OS 10.1.9-h13",
+        "PAN-OS 10.1.9-h12",
+        "PAN-OS 10.1.9-h11",
+        "PAN-OS 10.1.9-h10",
+        "PAN-OS 10.1.9-h9",
+        "PAN-OS 10.1.9-h8",
+        "PAN-OS 10.1.9-h7",
+        "PAN-OS 10.1.9-h6",
+        "PAN-OS 10.1.9-h5",
+        "PAN-OS 10.1.9-h4",
+        "PAN-OS 10.1.9-h3",
+        "PAN-OS 10.1.9-h2",
+        "PAN-OS 10.1.9-h1",
+        "PAN-OS 10.1.9",
+        "PAN-OS 10.1.8-h8",
+        "PAN-OS 10.1.8-h7",
+        "PAN-OS 10.1.8-h6",
+        "PAN-OS 10.1.8-h5",
+        "PAN-OS 10.1.8-h4",
+        "PAN-OS 10.1.8-h3",
+        "PAN-OS 10.1.8-h2",
+        "PAN-OS 10.1.8-h1",
+        "PAN-OS 10.1.8",
+        "PAN-OS 10.1.7-h1",
+        "PAN-OS 10.1.7",
+        "PAN-OS 10.1.6-h9",
+        "PAN-OS 10.1.6-h8",
+        "PAN-OS 10.1.6-h7",
+        "PAN-OS 10.1.6-h6",
+        "PAN-OS 10.1.6-h5",
+        "PAN-OS 10.1.6-h4",
+        "PAN-OS 10.1.6-h3",
+        "PAN-OS 10.1.6-h2",
+        "PAN-OS 10.1.6-h1",
+        "PAN-OS 10.1.6",
+        "PAN-OS 10.1.5-h4",
+        "PAN-OS 10.1.5-h3",
+        "PAN-OS 10.1.5-h2",
+        "PAN-OS 10.1.5-h1",
+        "PAN-OS 10.1.5",
+        "PAN-OS 10.1.4-h6",
+        "PAN-OS 10.1.4-h5",
+        "PAN-OS 10.1.4-h4",
+        "PAN-OS 10.1.4-h3",
+        "PAN-OS 10.1.4-h2",
+        "PAN-OS 10.1.4-h1",
+        "PAN-OS 10.1.4",
+        "PAN-OS 10.1.3-h4",
+        "PAN-OS 10.1.3-h3",
+        "PAN-OS 10.1.3-h2",
+        "PAN-OS 10.1.3-h1",
+        "PAN-OS 10.1.3",
+        "PAN-OS 10.1.2",
+        "PAN-OS 10.1.1",
+        "PAN-OS 10.1.0"
+      ]
+    }
+  }
+}

--- a/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-4619.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-4619.json
@@ -64,7 +64,7 @@
 								"type": "cpe",
 								"cpe": {
 									"vulnerable": true,
-									"cpe": "cpe:2.3:o:paloaltonetworks:pan-os:*:*:*:*:*:*:*:*",
+									"cpe": "cpe:2.3:o:palo_alto_networks:pan-os:*:*:*:*:*:*:*:*",
 									"cpe_matches": [
 										"cpe:2.3:o:palo_alto_networks:pan-os:10.2.0:*:*:*:*:*:*:*",
 										"cpe:2.3:o:palo_alto_networks:pan-os:10.2.10:h10:*:*:*:*:*:*",

--- a/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-99999.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-99999.json
@@ -4,8 +4,8 @@
 		{
 			"content": {
 				"id": "CVE-2025-99999",
-				"title": "PAN-OS: Denial of Service (DoS) in GlobalProtect",
-				"description": "A Denial of Service (DoS) vulnerability in the GlobalProtect feature of Palo Alto Networks PAN-OS software enables an unauthenticated attacker to render the service unavailable by sending a large number of specially crafted packets over a period of time. This issue affects both the GlobalProtect portal and the GlobalProtect gateway.\n\nThis issue does not apply to Cloud NGFWs or Prisma Access software.",
+				"title": "SYNTHETIC TEST FIXTURE (not a real advisory; derived from CVE-2025-0114 with cpes rewritten to mix vendor spellings): PAN-OS: Denial of Service (DoS) in GlobalProtect",
+				"description": "SYNTHETIC TEST FIXTURE (not a real advisory; derived from CVE-2025-0114 with cpes rewritten to mix vendor spellings): A Denial of Service (DoS) vulnerability in the GlobalProtect feature of Palo Alto Networks PAN-OS software enables an unauthenticated attacker to render the service unavailable by sending a large number of specially crafted packets over a period of time. This issue affects both the GlobalProtect portal and the GlobalProtect gateway.\n\nThis issue does not apply to Cloud NGFWs or Prisma Access software.",
 				"severity": [
 					{
 						"type": "cvss_v40",

--- a/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-99999.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-99999.json
@@ -1,0 +1,144 @@
+{
+	"id": "CVE-2025-99999",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2025-99999",
+				"title": "PAN-OS: Denial of Service (DoS) in GlobalProtect",
+				"description": "A Denial of Service (DoS) vulnerability in the GlobalProtect feature of Palo Alto Networks PAN-OS software enables an unauthenticated attacker to render the service unavailable by sending a large number of specially crafted packets over a period of time. This issue affects both the GlobalProtect portal and the GlobalProtect gateway.\n\nThis issue does not apply to Cloud NGFWs or Prisma Access software.",
+				"severity": [
+					{
+						"type": "cvss_v40",
+						"source": "security.paloaltonetworks.com",
+						"cvss_v40": {
+							"vector": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:U/AU:N/R:U/V:C/RE:M/U:Amber",
+							"score": 4.6,
+							"severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "security.paloaltonetworks.com",
+						"cwe": [
+							"CWE-400"
+						]
+					}
+				],
+				"mitigations": [
+					{
+						"source": "security.paloaltonetworks.com",
+						"description": "VERSION           MINOR VERSION            SUGGESTED SOLUTION\nPAN-OS 11.0       11.0.0 through 11.0.1    Upgrade to 11.0.2 or later\nPAN-OS 10.2       10.2.0 through 10.2.4    Upgrade to 10.2.5 or later\nPAN-OS 10.1       10.1.0 through 10.1.14   Upgrade to 10.1.14-h11 or later\nAll other older                            Upgrade to a supported fixed version.\nunsupported\nPAN-OS versions"
+					}
+				],
+				"workarounds": [
+					{
+						"source": "security.paloaltonetworks.com",
+						"description": "No workaround or mitigation is available.\n"
+					}
+				],
+				"references": [
+					{
+						"source": "security.paloaltonetworks.com",
+						"url": "https://security.paloaltonetworks.com/CVE-2025-99999"
+					}
+				],
+				"published": "2025-03-12T16:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:o:palo_alto_networks:pan-os:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:o:palo_alto_networks:pan-os:10.2.5:*:*:*:*:*:*:*",
+										"cpe:2.3:o:palo_alto_networks:pan-os:11.0.2:*:*:*:*:*:*:*",
+										"cpe:2.3:o:palo_alto_networks:pan-os:11.0.2:h1:*:*:*:*:*:*"
+									]
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:o:paloaltonetworks:pan-os:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:o:paloaltonetworks:pan-os:10.2.4:*:*:*:*:*:*:*",
+										"cpe:2.3:o:paloaltonetworks:pan-os:11.0.0:*:*:*:*:*:*:*",
+										"cpe:2.3:o:paloaltonetworks:pan-os:11.0.1:*:*:*:*:*:*:*"
+									]
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:o:paloaltonetworks:pan-os:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "pan-os",
+										"ge": "10.1.0",
+										"lt": "10.1.14-h11"
+									},
+									"fixed": [
+										"10.1.14-h11"
+									]
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:o:paloaltonetworks:pan-os:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "pan-os",
+										"ge": "10.2.0",
+										"lt": "10.2.5"
+									},
+									"fixed": [
+										"10.2.5"
+									]
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:o:paloaltonetworks:pan-os:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "pan-os",
+										"ge": "11.0.0",
+										"lt": "11.0.2"
+									},
+									"fixed": [
+										"11.0.2"
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "paloalto-json",
+		"raws": [
+			"fixtures/2025/CVE-2025-99999.json"
+		]
+	}
+}


### PR DESCRIPTION
## What

The PAN-OS `cpes[]` enumeration criterion is now emitted as one criterion per `part:vendor:product` group, with the group's PVP (remaining attributes ANY) as the criterion's main CPE — instead of a single criterion with a hardcoded `cpe:2.3:o:paloaltonetworks:pan-os:*:...` main CPE holding all entries.

## Why

Upstream PAN advisories mix vendor spellings in `cpes[]`: `paloaltonetworks` vs `palo_alto_networks`. Enumeration entries whose PVP differs from the main CPE are dead data, on both ends of the detect flow:

- the criterion is unreachable through the db-side `part:vendor:product` index (vuls2 builds it from main CPEs only) for queries in the divergent spelling, and
- `cpecriterion.Accept`'s attribute comparison rejects them for queries in the canonical spelling.

As of 2026-07-03 this affects **3,079 of 5,793 enumerated CPEs across 25 CVEs** (all `palo_alto_networks:pan-os` under a `paloaltonetworks:pan-os` main CPE; CVE-2025-0115 and later).

Grouping restores the per-criterion invariant **"CPEMatches share the main CPE's PVP"**, which makes vuls2's main-CPE-only index complete by construction — no vuls2 change needed (MaineK00n/vuls2#397, an index-side fix for the same gap, was closed in favor of this).

Entries stay verbatim — deliberately no vendor-spelling normalization: e.g. CVE-2025-4614's `cpes[]` enumerates 11.1.8–11.1.11 while its `versions[]` declares the 11.1 line fixed at 11.1.6-h21 (upstream contradiction; `cpes[]` has prior malformation history — see `validCPEs`). Folding the divergent spelling into the canonical criterion would turn that contradiction into false positives for canonical queries.

## How

In `detections()`, unbind each valid `cpes[]` entry, group by a main CPE built from its part/vendor/product with all other attributes ANY (`common.NewWellFormedName` + `naming.BindToFS`), and emit one criterion per group. For groups spelled canonically the constructed main CPE is byte-identical to the previous hardcoded string, so canonical-only records are unchanged.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` passes; golden updated (`CVE-2025-4619.json`, one line — the divergent enumeration criterion's main CPE flips spelling).
- Full corpus (538 files, 2,096 CPE criteria) re-extracted: zero main-vs-matches PVP divergence after the change. Criterion count unchanged — the 25 affected criteria were 100% divergent, so they flip spelling rather than split.
- With an **unmodified vuls2 nightly build**: `db add` of the re-extracted corpus, then `db search package cpe 'o:palo_alto_networks:pan\-os'` returns exactly the 25 affected roots (previously `ErrNotFoundIndex`); `o:paloaltonetworks:pan\-os` returns 294 as before. Detect-level checks (hand-built scan results): canonical `pan-os:10.1.0` → CVE-2025-0137 detected (range); canonical `pan-os:10.2.9:h10` → CVE-2025-4619 detected (hotfix folding → range); canonical `pan-os:11.1.9` → CVE-2025-4614 correctly NOT detected (per upstream `versions[]`); divergent `palo_alto_networks:pan-os:10.1.0` → CVE-2025-0137 detected (enumeration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)