### PR TITLE
fix(extract/redhat/vex): skip CVE-2026-7323 flatpak rpmmod and allow pkg:golang purl

### DIFF
--- a/pkg/extract/redhat/vex/v1/testdata/fixtures/vex/2026/CVE-2026-7323.json
+++ b/pkg/extract/redhat/vex/v1/testdata/fixtures/vex/2026/CVE-2026-7323.json
@@ -1,0 +1,187 @@
+{
+	"document": {
+		"aggregate_severity": {
+			"namespace": "https://access.redhat.com/security/updates/classification/",
+			"text": "Important"
+		},
+		"category": "csaf_vex",
+		"csaf_version": "2.0",
+		"distribution": {
+			"text": "Copyright © Red Hat, Inc. All rights reserved.",
+			"tlp": {
+				"label": "WHITE",
+				"url": "https://www.first.org/tlp/"
+			}
+		},
+		"lang": "en",
+		"publisher": {
+			"category": "vendor",
+			"contact_details": "https://access.redhat.com/security/team/contact/",
+			"issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+			"name": "Red Hat Product Security",
+			"namespace": "https://www.redhat.com"
+		},
+		"references": [
+			{
+				"category": "self",
+				"summary": "Canonical URL",
+				"url": "https://security.access.redhat.com/data/csaf/v2/vex/2026/cve-2026-7323.json"
+			}
+		],
+		"title": "Synthetic fixture: RHEL 10 flatpak SRPM (colonless rpmmod) and pkg:golang purl",
+		"tracking": {
+			"current_release_date": "2026-01-19T00:00:00+00:00",
+			"generator": {
+				"date": "2026-01-19T00:00:00+00:00",
+				"engine": {
+					"name": "Red Hat SDEngine",
+					"version": "4.6.8"
+				}
+			},
+			"id": "CVE-2026-7323",
+			"initial_release_date": "2026-01-19T00:00:00+00:00",
+			"revision_history": [
+				{
+					"date": "2026-01-19T00:00:00+00:00",
+					"number": "1",
+					"summary": "Initial version"
+				}
+			],
+			"status": "final",
+			"version": "1"
+		}
+	},
+	"product_tree": {
+		"branches": [
+			{
+				"branches": [
+					{
+						"category": "product_name",
+						"name": "Red Hat Enterprise Linux 10",
+						"product": {
+							"name": "Red Hat Enterprise Linux 10",
+							"product_id": "red_hat_enterprise_linux_10",
+							"product_identification_helper": {
+								"cpe": "cpe:/o:redhat:enterprise_linux:10::appstream"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "firefox-flatpak",
+						"product": {
+							"name": "firefox-flatpak",
+							"product_id": "firefox-flatpak-src",
+							"product_identification_helper": {
+								"purl": "pkg:rpm/redhat/firefox-flatpak?arch=src&rpmmod=rhel10"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "ose-openstack-machine-controllers-container",
+						"product": {
+							"name": "ose-openstack-machine-controllers-container",
+							"product_id": "golang-container",
+							"product_identification_helper": {
+								"purl": "pkg:golang/redhat/ose-openstack-machine-controllers-container"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "firefox",
+						"product": {
+							"name": "firefox",
+							"product_id": "firefox-x86_64",
+							"product_identification_helper": {
+								"purl": "pkg:rpm/redhat/firefox@128.0-1.el10?arch=x86_64&epoch=0"
+							}
+						}
+					}
+				],
+				"category": "vendor",
+				"name": "Red Hat"
+			}
+		],
+		"relationships": [
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "firefox-flatpak as a component of Red Hat Enterprise Linux 10",
+					"product_id": "red_hat_enterprise_linux_10:firefox-flatpak-src"
+				},
+				"product_reference": "firefox-flatpak-src",
+				"relates_to_product_reference": "red_hat_enterprise_linux_10"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "ose-openstack-machine-controllers-container as a component of Red Hat Enterprise Linux 10",
+					"product_id": "red_hat_enterprise_linux_10:golang-container"
+				},
+				"product_reference": "golang-container",
+				"relates_to_product_reference": "red_hat_enterprise_linux_10"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "firefox as a component of Red Hat Enterprise Linux 10",
+					"product_id": "red_hat_enterprise_linux_10:firefox-x86_64"
+				},
+				"product_reference": "firefox-x86_64",
+				"relates_to_product_reference": "red_hat_enterprise_linux_10"
+			}
+		]
+	},
+	"vulnerabilities": [
+		{
+			"cve": "CVE-2026-7323",
+			"notes": [
+				{
+					"category": "description",
+					"text": "Synthetic vulnerability used to exercise the RHEL 10 flatpak SRPM (rpmmod without a stream) and pkg:golang purl code paths.",
+					"title": "Vulnerability description"
+				}
+			],
+			"product_status": {
+				"known_affected": [
+					"red_hat_enterprise_linux_10:firefox-flatpak-src",
+					"red_hat_enterprise_linux_10:golang-container",
+					"red_hat_enterprise_linux_10:firefox-x86_64"
+				]
+			},
+			"references": [
+				{
+					"category": "self",
+					"summary": "Canonical URL",
+					"url": "https://access.redhat.com/security/cve/CVE-2026-7323"
+				}
+			],
+			"release_date": "2026-01-19T00:00:00+00:00",
+			"remediations": [
+				{
+					"category": "none_available",
+					"details": "Affected",
+					"product_ids": [
+						"red_hat_enterprise_linux_10:firefox-flatpak-src",
+						"red_hat_enterprise_linux_10:golang-container",
+						"red_hat_enterprise_linux_10:firefox-x86_64"
+					]
+				}
+			],
+			"threats": [
+				{
+					"category": "impact",
+					"details": "Important",
+					"product_ids": [
+						"red_hat_enterprise_linux_10:firefox-flatpak-src",
+						"red_hat_enterprise_linux_10:golang-container",
+						"red_hat_enterprise_linux_10:firefox-x86_64"
+					]
+				}
+			],
+			"title": "Synthetic fixture: RHEL 10 flatpak SRPM (colonless rpmmod) and pkg:golang purl"
+		}
+	]
+}

--- a/pkg/extract/redhat/vex/v1/testdata/fixtures/vex_rpmmod_error/2026/CVE-2026-88888.json
+++ b/pkg/extract/redhat/vex/v1/testdata/fixtures/vex_rpmmod_error/2026/CVE-2026-88888.json
@@ -1,0 +1,73 @@
+{
+	"document": {
+		"category": "csaf_vex",
+		"csaf_version": "2.0",
+		"publisher": {
+			"category": "vendor",
+			"name": "Red Hat Product Security",
+			"namespace": "https://www.redhat.com"
+		},
+		"title": "Synthetic fixture: bare-module rpmmod outside CVE-2026-7323 must error",
+		"tracking": {
+			"current_release_date": "2026-01-19T00:00:00+00:00",
+			"id": "CVE-2026-88888",
+			"initial_release_date": "2026-01-19T00:00:00+00:00",
+			"status": "final",
+			"version": "1"
+		}
+	},
+	"product_tree": {
+		"branches": [
+			{
+				"branches": [
+					{
+						"category": "product_name",
+						"name": "Red Hat Enterprise Linux 10",
+						"product": {
+							"name": "Red Hat Enterprise Linux 10",
+							"product_id": "red_hat_enterprise_linux_10",
+							"product_identification_helper": {
+								"cpe": "cpe:/o:redhat:enterprise_linux:10::appstream"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "firefox-flatpak",
+						"product": {
+							"name": "firefox-flatpak",
+							"product_id": "firefox-flatpak-src",
+							"product_identification_helper": {
+								"purl": "pkg:rpm/redhat/firefox-flatpak?arch=src&rpmmod=rhel10"
+							}
+						}
+					}
+				],
+				"category": "vendor",
+				"name": "Red Hat"
+			}
+		],
+		"relationships": [
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "firefox-flatpak as a component of Red Hat Enterprise Linux 10",
+					"product_id": "red_hat_enterprise_linux_10:firefox-flatpak-src"
+				},
+				"product_reference": "firefox-flatpak-src",
+				"relates_to_product_reference": "red_hat_enterprise_linux_10"
+			}
+		]
+	},
+	"vulnerabilities": [
+		{
+			"cve": "CVE-2026-88888",
+			"product_status": {
+				"known_affected": [
+					"red_hat_enterprise_linux_10:firefox-flatpak-src"
+				]
+			},
+			"title": "Synthetic fixture: bare-module rpmmod outside CVE-2026-7323 must error"
+		}
+	]
+}

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2026/CVE-2026-7323.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2026/CVE-2026-7323.json
@@ -1,0 +1,79 @@
+{
+	"id": "CVE-2026-7323",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-7323",
+				"title": "Synthetic fixture: RHEL 10 flatpak SRPM (colonless rpmmod) and pkg:golang purl",
+				"description": "Synthetic vulnerability used to exercise the RHEL 10 flatpak SRPM (rpmmod without a stream) and pkg:golang purl code paths.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Important"
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://access.redhat.com/security/cve/CVE-2026-7323"
+					}
+				],
+				"published": "2026-01-19T00:00:00Z",
+				"modified": "2026-01-19T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "redhat:10",
+					"tag": "9eb0cd25-2c35-ba83-43be-5f9911935160"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "redhat:10",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Affected"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "firefox",
+													"architectures": [
+														"x86_64"
+													]
+												}
+											}
+										}
+									}
+								]
+							}
+						]
+					},
+					"tag": "9eb0cd25-2c35-ba83-43be-5f9911935160"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "redhat-vex",
+		"raws": [
+			"repository2cpe/repository-to-cpe.json",
+			"vex/2026/CVE-2026-7323.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/vex/v1/v1.go
+++ b/pkg/extract/redhat/vex/v1/v1.go
@@ -177,7 +177,7 @@ func Extract(vexDir, repository2cpeDir string, opts ...Option) error {
 }
 
 func (e extractor) extract(vuln v1.VEX, c2r map[string][]string) (dataTypes.Data, error) {
-	pm, err := walkProductTree(vuln.ProductTree, c2r)
+	pm, err := walkProductTree(vuln.Document.Tracking.ID, vuln.ProductTree, c2r)
 	if err != nil {
 		return dataTypes.Data{}, errors.Wrap(err, "walk product_tree")
 	}
@@ -237,7 +237,7 @@ type status struct {
 	affected_status string
 }
 
-func walkProductTree(pt v1.ProductTree, c2r map[string][]string) (map[v1.ProductID][]product, error) {
+func walkProductTree(trackingID string, pt v1.ProductTree, c2r map[string][]string) (map[v1.ProductID][]product, error) {
 	var f func(m map[v1.ProductID]v1.FullProductName, branch v1.Branch) error
 	f = func(m map[v1.ProductID]v1.FullProductName, branch v1.Branch) error {
 		for _, b := range branch.Branches {
@@ -370,7 +370,26 @@ func walkProductTree(pt v1.ProductTree, c2r map[string][]string) (map[v1.Product
 							case "":
 								ss := strings.Split(rpmmod, ":")
 								if len(ss) < 2 {
-									return nil, errors.Errorf("unexpected purl format. expected: %q, actual: %q", "pkg:rpm/redhat/<name>?arch=<arch>(&epoch=<epoch>)&rpmmod=<<module>:<stream>>", fpn.ProductIdentificationHelper.PURL)
+									// The RHEL 10 flatpak SRPMs firefox-flatpak
+									// and thunderbird-flatpak in CVE-2026-7323
+									// carry rpmmod="rhel10", a bare module name
+									// with no ":<stream>" suffix. It is the only
+									// 1-part rpmmod in the feed and cannot form a
+									// module:stream modularitylabel, so the entry
+									// is malformed and unusable for version
+									// detection — skip it rather than emit a
+									// bogus package. Scope the exception to this
+									// exact vetted (advisory, value) pair so any
+									// other colonless rpmmod, or rpmmod="rhel10"
+									// resurfacing in a different advisory, still
+									// fails loudly for a human to review.
+									switch {
+									case trackingID == "CVE-2026-7323" && rpmmod == "rhel10":
+										slog.Warn("skipping CVE-2026-7323 flatpak SRPM with bare-module rpmmod", slog.String("purl", fpn.ProductIdentificationHelper.PURL))
+										return nil, nil
+									default:
+										return nil, errors.Errorf("unexpected purl format. expected: %q, actual: %q", "pkg:rpm/redhat/<name>?arch=<arch>(&epoch=<epoch>)&rpmmod=<<module>:<stream>>", fpn.ProductIdentificationHelper.PURL)
+									}
 								}
 								p.modularitylabel = fmt.Sprintf("%s:%s", ss[0], ss[1])
 								p.name = instance.Name
@@ -423,7 +442,7 @@ func walkProductTree(pt v1.ProductTree, c2r map[string][]string) (map[v1.Product
 						// processed or just added to this skip list — silent
 						// data loss is worse than a loud failure.
 						for _, s := range []string{
-							"pkg:generic/", "pkg:maven/", "pkg:npm/", "pkg:oci/", "pkg:pypi/",
+							"pkg:generic/", "pkg:golang/", "pkg:maven/", "pkg:npm/", "pkg:oci/", "pkg:pypi/",
 						} {
 							if strings.HasPrefix(fpn.ProductIdentificationHelper.PURL, s) {
 								return nil, nil

--- a/pkg/extract/redhat/vex/v1/v1_test.go
+++ b/pkg/extract/redhat/vex/v1/v1_test.go
@@ -25,6 +25,17 @@ func TestExtract(t *testing.T) {
 				repository2cpe: "./testdata/fixtures/repository2cpe",
 			},
 		},
+		{
+			// A bare-module rpmmod ("rhel10") is tolerated only for the
+			// vetted CVE-2026-7323 flatpak SRPMs; the same value in any other
+			// advisory must fail loudly.
+			name: "bare-module rpmmod outside CVE-2026-7323 errors",
+			args: args{
+				vex:            "./testdata/fixtures/vex_rpmmod_error",
+				repository2cpe: "./testdata/fixtures/repository2cpe",
+			},
+			hasError: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/extract/redhat/vex/v2/testdata/fixtures/vex/2026/CVE-2026-7323.json
+++ b/pkg/extract/redhat/vex/v2/testdata/fixtures/vex/2026/CVE-2026-7323.json
@@ -1,0 +1,187 @@
+{
+	"document": {
+		"aggregate_severity": {
+			"namespace": "https://access.redhat.com/security/updates/classification/",
+			"text": "Important"
+		},
+		"category": "csaf_vex",
+		"csaf_version": "2.0",
+		"distribution": {
+			"text": "Copyright © Red Hat, Inc. All rights reserved.",
+			"tlp": {
+				"label": "WHITE",
+				"url": "https://www.first.org/tlp/"
+			}
+		},
+		"lang": "en",
+		"publisher": {
+			"category": "vendor",
+			"contact_details": "https://access.redhat.com/security/team/contact/",
+			"issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+			"name": "Red Hat Product Security",
+			"namespace": "https://www.redhat.com"
+		},
+		"references": [
+			{
+				"category": "self",
+				"summary": "Canonical URL",
+				"url": "https://security.access.redhat.com/data/csaf/v2/vex/2026/cve-2026-7323.json"
+			}
+		],
+		"title": "Synthetic fixture: RHEL 10 flatpak SRPM (colonless rpmmod) and pkg:golang purl",
+		"tracking": {
+			"current_release_date": "2026-01-19T00:00:00+00:00",
+			"generator": {
+				"date": "2026-01-19T00:00:00+00:00",
+				"engine": {
+					"name": "Red Hat SDEngine",
+					"version": "4.6.8"
+				}
+			},
+			"id": "CVE-2026-7323",
+			"initial_release_date": "2026-01-19T00:00:00+00:00",
+			"revision_history": [
+				{
+					"date": "2026-01-19T00:00:00+00:00",
+					"number": "1",
+					"summary": "Initial version"
+				}
+			],
+			"status": "final",
+			"version": "1"
+		}
+	},
+	"product_tree": {
+		"branches": [
+			{
+				"branches": [
+					{
+						"category": "product_name",
+						"name": "Red Hat Enterprise Linux 10",
+						"product": {
+							"name": "Red Hat Enterprise Linux 10",
+							"product_id": "rhel-10.2.z.eus",
+							"product_identification_helper": {
+								"cpe": "cpe:/o:redhat:enterprise_linux:10::appstream"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "firefox-flatpak",
+						"product": {
+							"name": "firefox-flatpak",
+							"product_id": "rhel10/firefox-flatpak.src",
+							"product_identification_helper": {
+								"purl": "pkg:rpm/redhat/firefox-flatpak?arch=src&rpmmod=rhel10"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "ose-openstack-machine-controllers-container",
+						"product": {
+							"name": "ose-openstack-machine-controllers-container",
+							"product_id": "ose-openstack-machine-controllers-container",
+							"product_identification_helper": {
+								"purl": "pkg:golang/redhat/ose-openstack-machine-controllers-container"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "firefox-0:128.0-1.el10",
+						"product": {
+							"name": "firefox-0:128.0-1.el10",
+							"product_id": "firefox-0:128.0-1.el10",
+							"product_identification_helper": {
+								"purl": "pkg:rpm/redhat/firefox@128.0-1.el10?epoch=0"
+							}
+						}
+					}
+				],
+				"category": "vendor",
+				"name": "Red Hat"
+			}
+		],
+		"relationships": [
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "firefox-flatpak as a component of Red Hat Enterprise Linux 10",
+					"product_id": "rhel-10.2.z.eus:rhel10/firefox-flatpak.src"
+				},
+				"product_reference": "rhel10/firefox-flatpak.src",
+				"relates_to_product_reference": "rhel-10.2.z.eus"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "ose-openstack-machine-controllers-container as a component of Red Hat Enterprise Linux 10",
+					"product_id": "rhel-10.2.z.eus:ose-openstack-machine-controllers-container"
+				},
+				"product_reference": "ose-openstack-machine-controllers-container",
+				"relates_to_product_reference": "rhel-10.2.z.eus"
+			},
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "firefox-0:128.0-1.el10 as a component of Red Hat Enterprise Linux 10",
+					"product_id": "rhel-10.2.z.eus:firefox-0:128.0-1.el10"
+				},
+				"product_reference": "firefox-0:128.0-1.el10",
+				"relates_to_product_reference": "rhel-10.2.z.eus"
+			}
+		]
+	},
+	"vulnerabilities": [
+		{
+			"cve": "CVE-2026-7323",
+			"notes": [
+				{
+					"category": "description",
+					"text": "Synthetic vulnerability used to exercise the RHEL 10 flatpak SRPM (rpmmod without a stream) and pkg:golang purl code paths.",
+					"title": "Vulnerability description"
+				}
+			],
+			"product_status": {
+				"known_affected": [
+					"rhel-10.2.z.eus:rhel10/firefox-flatpak.src",
+					"rhel-10.2.z.eus:ose-openstack-machine-controllers-container",
+					"rhel-10.2.z.eus:firefox-0:128.0-1.el10"
+				]
+			},
+			"references": [
+				{
+					"category": "self",
+					"summary": "Canonical URL",
+					"url": "https://access.redhat.com/security/cve/CVE-2026-7323"
+				}
+			],
+			"release_date": "2026-01-19T00:00:00+00:00",
+			"remediations": [
+				{
+					"category": "none_available",
+					"details": "Affected",
+					"product_ids": [
+						"rhel-10.2.z.eus:rhel10/firefox-flatpak.src",
+						"rhel-10.2.z.eus:ose-openstack-machine-controllers-container",
+						"rhel-10.2.z.eus:firefox-0:128.0-1.el10"
+					]
+				}
+			],
+			"threats": [
+				{
+					"category": "impact",
+					"details": "Important",
+					"product_ids": [
+						"rhel-10.2.z.eus:rhel10/firefox-flatpak.src",
+						"rhel-10.2.z.eus:ose-openstack-machine-controllers-container",
+						"rhel-10.2.z.eus:firefox-0:128.0-1.el10"
+					]
+				}
+			],
+			"title": "Synthetic fixture: RHEL 10 flatpak SRPM (colonless rpmmod) and pkg:golang purl"
+		}
+	]
+}

--- a/pkg/extract/redhat/vex/v2/testdata/fixtures/vex_rpmmod_error/2026/CVE-2026-88888.json
+++ b/pkg/extract/redhat/vex/v2/testdata/fixtures/vex_rpmmod_error/2026/CVE-2026-88888.json
@@ -1,0 +1,73 @@
+{
+	"document": {
+		"category": "csaf_vex",
+		"csaf_version": "2.0",
+		"publisher": {
+			"category": "vendor",
+			"name": "Red Hat Product Security",
+			"namespace": "https://www.redhat.com"
+		},
+		"title": "Synthetic fixture: bare-module rpmmod outside CVE-2026-7323 must error",
+		"tracking": {
+			"current_release_date": "2026-01-19T00:00:00+00:00",
+			"id": "CVE-2026-88888",
+			"initial_release_date": "2026-01-19T00:00:00+00:00",
+			"status": "final",
+			"version": "1"
+		}
+	},
+	"product_tree": {
+		"branches": [
+			{
+				"branches": [
+					{
+						"category": "product_name",
+						"name": "Red Hat Enterprise Linux 10",
+						"product": {
+							"name": "Red Hat Enterprise Linux 10",
+							"product_id": "rhel-10.2.z.eus",
+							"product_identification_helper": {
+								"cpe": "cpe:/o:redhat:enterprise_linux:10::appstream"
+							}
+						}
+					},
+					{
+						"category": "product_version",
+						"name": "firefox-flatpak",
+						"product": {
+							"name": "firefox-flatpak",
+							"product_id": "rhel10/firefox-flatpak.src",
+							"product_identification_helper": {
+								"purl": "pkg:rpm/redhat/firefox-flatpak?arch=src&rpmmod=rhel10"
+							}
+						}
+					}
+				],
+				"category": "vendor",
+				"name": "Red Hat"
+			}
+		],
+		"relationships": [
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "firefox-flatpak as a component of Red Hat Enterprise Linux 10",
+					"product_id": "rhel-10.2.z.eus:rhel10/firefox-flatpak.src"
+				},
+				"product_reference": "rhel10/firefox-flatpak.src",
+				"relates_to_product_reference": "rhel-10.2.z.eus"
+			}
+		]
+	},
+	"vulnerabilities": [
+		{
+			"cve": "CVE-2026-88888",
+			"product_status": {
+				"known_affected": [
+					"rhel-10.2.z.eus:rhel10/firefox-flatpak.src"
+				]
+			},
+			"title": "Synthetic fixture: bare-module rpmmod outside CVE-2026-7323 must error"
+		}
+	]
+}

--- a/pkg/extract/redhat/vex/v2/testdata/golden/data/2026/CVE-2026-7323.json
+++ b/pkg/extract/redhat/vex/v2/testdata/golden/data/2026/CVE-2026-7323.json
@@ -1,0 +1,76 @@
+{
+	"id": "CVE-2026-7323",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-7323",
+				"title": "Synthetic fixture: RHEL 10 flatpak SRPM (colonless rpmmod) and pkg:golang purl",
+				"description": "Synthetic vulnerability used to exercise the RHEL 10 flatpak SRPM (rpmmod without a stream) and pkg:golang purl code paths.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Important"
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://access.redhat.com/security/cve/CVE-2026-7323"
+					}
+				],
+				"published": "2026-01-19T00:00:00Z",
+				"modified": "2026-01-19T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "redhat:10",
+					"tag": "7b84d3c5-44f6-07de-a173-1cd1804e6498"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "redhat:10",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed",
+												"vendor": "Affected"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "firefox"
+												}
+											}
+										}
+									}
+								]
+							}
+						]
+					},
+					"tag": "7b84d3c5-44f6-07de-a173-1cd1804e6498"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "redhat-vex-v2",
+		"raws": [
+			"repository2cpe/repository-to-cpe.json",
+			"vex/2026/CVE-2026-7323.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/vex/v2/v2.go
+++ b/pkg/extract/redhat/vex/v2/v2.go
@@ -326,7 +326,7 @@ func walkProductTree(trackingID string, pt v2.ProductTree, c2r map[string][]stri
 						names[branch.Product.ProductID] = *n
 					}
 				case "product_version":
-					v, err := parseRPMPurl(pih.PURL)
+					v, err := parseRPMPurl(trackingID, pih.PURL)
 					if err != nil {
 						return errors.Wrapf(err, "parse purl. tracking_id: %q, product_id: %q", trackingID, branch.Product.ProductID)
 					}
@@ -387,7 +387,7 @@ func walkProductTree(trackingID string, pt v2.ProductTree, c2r map[string][]stri
 // (cargo, gem, generic, golang, maven, npm, oci, pypi) which the RPM-based
 // extractor does not handle. Any other prefix is an error so a new artifact
 // class triggers a deliberate decision instead of silent data loss.
-func parseRPMPurl(s string) (*versionInfo, error) {
+func parseRPMPurl(trackingID, s string) (*versionInfo, error) {
 	if s == "" {
 		return nil, nil
 	}
@@ -437,7 +437,22 @@ func parseRPMPurl(s string) (*versionInfo, error) {
 	if rpmmod := quals["rpmmod"]; rpmmod != "" {
 		parts := strings.Split(rpmmod, ":")
 		if len(parts) < 2 {
-			return nil, errors.Errorf("unexpected rpmmod format. expected: %q, actual: %q", "<module>:<stream>[:<version>:<context>]", rpmmod)
+			// The RHEL 10 flatpak SRPMs firefox-flatpak and thunderbird-flatpak
+			// in CVE-2026-7323 carry rpmmod="rhel10", a bare module name with no
+			// ":<stream>" suffix. It is the only 1-part rpmmod in the feed and
+			// cannot form a module:stream modularitylabel, so the entry is
+			// malformed and unusable for version detection — skip it rather than
+			// emit a bogus package. Scope the exception to this exact vetted
+			// (advisory, value) pair so any other colonless rpmmod, or
+			// rpmmod="rhel10" resurfacing in a different advisory, still fails
+			// loudly for a human to review.
+			switch {
+			case trackingID == "CVE-2026-7323" && rpmmod == "rhel10":
+				slog.Warn("skipping CVE-2026-7323 flatpak SRPM with bare-module rpmmod", slog.String("purl", s))
+				return nil, nil
+			default:
+				return nil, errors.Errorf("unexpected rpmmod format. expected: %q, actual: %q", "<module>:<stream>[:<version>:<context>]", rpmmod)
+			}
 		}
 		out.modularitylabel = fmt.Sprintf("%s:%s", parts[0], parts[1])
 	}

--- a/pkg/extract/redhat/vex/v2/v2_test.go
+++ b/pkg/extract/redhat/vex/v2/v2_test.go
@@ -25,6 +25,17 @@ func TestExtract(t *testing.T) {
 				repository2cpe: "./testdata/fixtures/repository2cpe",
 			},
 		},
+		{
+			// A bare-module rpmmod ("rhel10") is tolerated only for the
+			// vetted CVE-2026-7323 flatpak SRPMs; the same value in any other
+			// advisory must fail loudly.
+			name: "bare-module rpmmod outside CVE-2026-7323 errors",
+			args: args{
+				vex:            "./testdata/fixtures/vex_rpmmod_error",
+				repository2cpe: "./testdata/fixtures/repository2cpe",
+			},
+			hasError: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What

Fixes `extract redhat-vex-v1` and `extract redhat-vex-v2` both failing (exit 1) on the latest 2026 Red Hat CSAF data.

Two new upstream data forms were unhandled:

1. **RHEL 10 flatpak SRPMs** (`firefox-flatpak`, `thunderbird-flatpak` in **CVE-2026-7323**, present in both feeds) carry `rpmmod="rhel10"` — a bare module name with no `:<stream>` suffix. It is the **only 1-part `rpmmod`** in the entire feed, cannot form a `module:stream` modularitylabel, and the purl also has **no version**, so the entry is unusable for version detection. The parser aborted the whole extract.
2. **v1** additionally hit an unhandled `pkg:golang/` purl prefix (**CVE-2026-25681**); v2's skip list already covered `golang`.

## Why

These broke the nightly extract pipeline for `vuls-data-extracted-redhat-vex-v1`/`-v2`
(see vulsio/vuls-data-db Actions run 28753182195).

## How

- **rpmmod=rhel10**: skip the flatpak entry (with a `slog.Warn`) instead of emitting a bogus package, but scope the exception **strictly to the vetted `(advisory, value)` pair** — `tracking_id == "CVE-2026-7323" && rpmmod == "rhel10"`. Any *other* colonless `rpmmod`, or `rpmmod="rhel10"` resurfacing in a *different* advisory, still fails loudly so an unvetted form stops for human review (consistent with the "error on unknown, allow the vetted" pattern; cf. #839, #817). Applied to both v1 (`walkProductTree`) and v2 (`parseRPMPurl`), both of which now take the tracking ID.
- **pkg:golang/**: added to v1's non-RPM purl skip list, matching v2 (cf. #817 which added `pkg:pypi/`).

The malformed `rpmmod=rhel10` is being reported upstream to Red Hat separately.

## Testing

- Re-ran both extractors over the **full** raw repositories to **exit 0** (v1: ~254k files, v2: ~46k files). In the real `CVE-2026-7323` output, both flatpak SRPMs are **absent** while the normal `firefox` package is **retained**.
- Golden fixtures (`CVE-2026-7323`) in both v1 and v2 exercise the skipped flatpak (`rpmmod=rhel10`) and `pkg:golang` entries alongside a kept regular RPM.
- Added a `vex_rpmmod_error` fixture + `hasError` test case asserting that a bare `rpmmod` **outside** CVE-2026-7323 still errors. `go test ./pkg/extract/redhat/vex/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)