### PR TITLE
feat(extract/types): add lifecycle Status to advisory/vulnerability content

### DIFF
--- a/pkg/extract/debian/tracker/salsa/salsa.go
+++ b/pkg/extract/debian/tracker/salsa/salsa.go
@@ -36,6 +36,7 @@ import (
 	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
 	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
@@ -971,6 +972,12 @@ func (e extractor) readCVE(path string) (vulnerabilityContentTypes.Content, []fe
 			return vulnerabilityContentTypes.Content{
 				ID:          vulnerabilityContentTypes.VulnerabilityID(b.Header.Name),
 				Description: ann.Type,
+				Status: func() statusTypes.Status {
+					if ann.Type == "REJECTED" {
+						return statusTypes.StatusRejected
+					}
+					return ""
+				}(),
 				References: []referenceTypes.Reference{{
 					Source: "security-tracker.debian.org",
 					URL:    fmt.Sprintf("https://security-tracker.debian.org/tracker/%s", b.Header.Name),

--- a/pkg/extract/debian/tracker/salsa/testdata/golden/data/CVE/2023/CVE-2023-46517.json
+++ b/pkg/extract/debian/tracker/salsa/testdata/golden/data/CVE/2023/CVE-2023-46517.json
@@ -4,8 +4,8 @@
 		{
 			"content": {
 				"id": "CVE-2023-46517",
-				"description": "REJECTED",
 				"status": "rejected",
+				"description": "REJECTED",
 				"references": [
 					{
 						"source": "security-tracker.debian.org",

--- a/pkg/extract/debian/tracker/salsa/testdata/golden/data/CVE/2023/CVE-2023-46517.json
+++ b/pkg/extract/debian/tracker/salsa/testdata/golden/data/CVE/2023/CVE-2023-46517.json
@@ -5,6 +5,7 @@
 			"content": {
 				"id": "CVE-2023-46517",
 				"description": "REJECTED",
+				"status": "rejected",
 				"references": [
 					{
 						"source": "security-tracker.debian.org",

--- a/pkg/extract/jvn/feed/detail/detail.go
+++ b/pkg/extract/jvn/feed/detail/detail.go
@@ -13,6 +13,7 @@ import (
 	"github.com/knqyf263/go-cpe/naming"
 	"github.com/pkg/errors"
 
+	jvnutil "github.com/MaineK00n/vuls-data-update/pkg/extract/jvn/internal"
 	cwecatalogTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe"
 	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
 	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
@@ -313,6 +314,7 @@ func extract(fetched fetchTypes.Vulinfo, raws []string) (dataTypes.Data, error) 
 				ID:          advisoryContentTypes.AdvisoryID(fetched.VulinfoID),
 				Title:       fetched.VulinfoData.Title,
 				Description: fetched.VulinfoData.VulinfoDescription.Overview,
+				Status:      jvnutil.Status(fetched.VulinfoData.Title, fetched.VulinfoData.VulinfoDescription.Overview),
 				Severity:    ss,
 				CWE:         cwes,
 				References:  refs,

--- a/pkg/extract/jvn/feed/rss/rss.go
+++ b/pkg/extract/jvn/feed/rss/rss.go
@@ -13,6 +13,7 @@ import (
 	"github.com/knqyf263/go-cpe/naming"
 	"github.com/pkg/errors"
 
+	jvnutil "github.com/MaineK00n/vuls-data-update/pkg/extract/jvn/internal"
 	cwecatalogTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/cwe"
 	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
 	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
@@ -313,6 +314,7 @@ func extract(fetched fetchTypes.Item, raws []string) (dataTypes.Data, error) {
 				ID:          advisoryContentTypes.AdvisoryID(fetched.Identifier),
 				Title:       fetched.Title,
 				Description: fetched.Description,
+				Status:      jvnutil.Status(fetched.Title, fetched.Description),
 				Severity:    ss,
 				CWE:         cwes,
 				References:  refs,

--- a/pkg/extract/jvn/feed/rss/testdata/fixtures/2024/JVNDB-2024-003157.json
+++ b/pkg/extract/jvn/feed/rss/testdata/fixtures/2024/JVNDB-2024-003157.json
@@ -1,0 +1,39 @@
+{
+	"about": "https://jvndb.jvn.jp/ja/contents/2024/JVNDB-2024-003157.html",
+	"title": "** 削除 ** Linux の Linux Kernel における解放済みメモリ使用 (Use After Free) の脆弱性",
+	"link": "https://jvndb.jvn.jp/ja/contents/2024/JVNDB-2024-003157.html",
+	"description": "** 削除 ** 本件は CVE-2024-26904 として採番されていましたが、取り消されました。\r\n\r\n",
+	"identifier": "JVNDB-2024-003157",
+	"references": [
+		{
+			"text": "https://www.cve.org/CVERecord?id=CVE-2024-26904",
+			"source": "CVE",
+			"id": "CVE-2024-26904"
+		},
+		{
+			"text": "https://nvd.nist.gov/vuln/detail/CVE-2024-26904",
+			"source": "NVD",
+			"id": "CVE-2024-26904"
+		}
+	],
+	"cpe": [
+		{
+			"text": "cpe:/o:linux:linux_kernel",
+			"version": "2.2",
+			"vendor": "Linux",
+			"product": "Linux Kernel"
+		}
+	],
+	"cvss": [
+		{
+			"version": "3.0",
+			"score": "7.8",
+			"type": "Base",
+			"severity": "High",
+			"vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+		}
+	],
+	"date": "2024-05-01T00:00+09:00",
+	"issued": "2024-05-01T00:00+09:00",
+	"modified": "2024-05-01T00:00+09:00"
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2024/JVNDB-2024-003157.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2024/JVNDB-2024-003157.json
@@ -4,9 +4,9 @@
 		{
 			"content": {
 				"id": "JVNDB-2024-003157",
+				"status": "withdrawn",
 				"title": "** 削除 ** Linux の Linux Kernel における解放済みメモリ使用 (Use After Free) の脆弱性",
 				"description": "** 削除 ** 本件は CVE-2024-26904 として採番されていましたが、取り消されました。\r\n\r\n",
-				"status": "withdrawn",
 				"severity": [
 					{
 						"type": "cvss_v30",

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2024/JVNDB-2024-003157.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2024/JVNDB-2024-003157.json
@@ -1,0 +1,94 @@
+{
+	"id": "JVNDB-2024-003157",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2024-003157",
+				"title": "** 削除 ** Linux の Linux Kernel における解放済みメモリ使用 (Use After Free) の脆弱性",
+				"description": "** 削除 ** 本件は CVE-2024-26904 として採番されていましたが、取り消されました。\r\n\r\n",
+				"status": "withdrawn",
+				"severity": [
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+							"base_score": 7.8,
+							"base_severity": "HIGH",
+							"temporal_score": 7.8,
+							"temporal_severity": "HIGH",
+							"environmental_score": 7.8,
+							"environmental_severity": "HIGH"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-26904"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-26904"
+					}
+				],
+				"published": "2024-05-01T00:00:00+09:00",
+				"modified": "2024-05-01T00:00:00+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-26904",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-26904"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-26904"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*"
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss",
+		"raws": [
+			"fixtures/2024/JVNDB-2024-003157.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/internal/status.go
+++ b/pkg/extract/jvn/internal/status.go
@@ -1,0 +1,29 @@
+package internal
+
+import (
+	"strings"
+
+	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
+)
+
+// Status maps JVN's in-place invalidation markers to a normalized Status.
+//
+// JVN does not remove an entry it has invalidated; it keeps the record and
+// prefixes the title (and sometimes the description) with a "** ... **" marker.
+// go-cve-dictionary drops such entries at fetch time (fetcher/jvn/jvn.go); we
+// instead preserve the record and record its state here so consumers can
+// decide what to do with it. The first matching text wins; an empty result
+// means no marker (treat as active).
+func Status(texts ...string) statusTypes.Status {
+	for _, t := range texts {
+		switch {
+		case strings.Contains(t, "** 削除 **"):
+			return statusTypes.StatusWithdrawn
+		case strings.Contains(t, "** 未確定 **"):
+			return statusTypes.StatusUnconfirmed
+		case strings.Contains(t, "** サポート外 **"):
+			return statusTypes.StatusUnsupported
+		}
+	}
+	return ""
+}

--- a/pkg/extract/jvn/internal/status_test.go
+++ b/pkg/extract/jvn/internal/status_test.go
@@ -1,0 +1,54 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/jvn/internal"
+	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
+)
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		texts []string
+		want  statusTypes.Status
+	}{
+		{
+			name:  "deleted",
+			texts: []string{"** 削除 ** Linux の Linux Kernel における脆弱性"},
+			want:  statusTypes.StatusWithdrawn,
+		},
+		{
+			name:  "unconfirmed",
+			texts: []string{"** 未確定 ** 何らかの脆弱性"},
+			want:  statusTypes.StatusUnconfirmed,
+		},
+		{
+			name:  "unsupported",
+			texts: []string{"** サポート外 ** 何らかの脆弱性"},
+			want:  statusTypes.StatusUnsupported,
+		},
+		{
+			name:  "no marker",
+			texts: []string{"Linux Kernel における権限昇格の脆弱性"},
+			want:  "",
+		},
+		{
+			name:  "marker in second text",
+			texts: []string{"", "** 削除 ** foo"},
+			want:  statusTypes.StatusWithdrawn,
+		},
+		{
+			name:  "first match wins",
+			texts: []string{"** 未確定 ** foo", "** 削除 ** bar"},
+			want:  statusTypes.StatusUnconfirmed,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := internal.Status(tt.texts...); got != tt.want {
+				t.Errorf("Status(%q) = %q, want %q", tt.texts, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/extract/mitre/cve/v5/testdata/golden/data/2024/CVE-2024-40946.json
+++ b/pkg/extract/mitre/cve/v5/testdata/golden/data/2024/CVE-2024-40946.json
@@ -4,8 +4,8 @@
 		{
 			"content": {
 				"id": "CVE-2024-40946",
-				"description": "This CVE ID has been rejected or withdrawn by its CVE Numbering Authority.",
 				"status": "rejected",
+				"description": "This CVE ID has been rejected or withdrawn by its CVE Numbering Authority.",
 				"published": "2024-07-12T12:31:52.12Z",
 				"modified": "2024-07-15T06:58:44.244Z"
 			}

--- a/pkg/extract/mitre/cve/v5/testdata/golden/data/2024/CVE-2024-40946.json
+++ b/pkg/extract/mitre/cve/v5/testdata/golden/data/2024/CVE-2024-40946.json
@@ -5,6 +5,7 @@
 			"content": {
 				"id": "CVE-2024-40946",
 				"description": "This CVE ID has been rejected or withdrawn by its CVE Numbering Authority.",
+				"status": "rejected",
 				"published": "2024-07-12T12:31:52.12Z",
 				"modified": "2024-07-15T06:58:44.244Z"
 			}

--- a/pkg/extract/mitre/cve/v5/v5.go
+++ b/pkg/extract/mitre/cve/v5/v5.go
@@ -20,6 +20,7 @@ import (
 	v31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
 	v40Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v40"
 	ssvcTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/ssvc"
+	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
 	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
@@ -387,6 +388,7 @@ func extract(fetched v5.CVE, raws []string) (dataTypes.Data, error) {
 						}
 						return ""
 					}(),
+					Status: statusTypes.StatusRejected,
 					Published: func() *time.Time {
 						if fetched.CVEMetadata.DatePublished != nil {
 							return utiltime.Parse([]string{"2006-01-02T15:04:05.000Z"}, *fetched.CVEMetadata.DatePublished)

--- a/pkg/extract/nvd/api/cve/cve.go
+++ b/pkg/extract/nvd/api/cve/cve.go
@@ -32,6 +32,7 @@ import (
 	v30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
 	v31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
 	v40Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v40"
+	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
 	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
@@ -289,6 +290,12 @@ func (e extractor) buildData(fetched cveTypes.CVE) (dataTypes.Data, error) {
 							if d.Lang == "en" {
 								return d.Value
 							}
+						}
+						return ""
+					}(),
+					Status: func() statusTypes.Status {
+						if fetched.VulnStatus == "Rejected" {
+							return statusTypes.StatusRejected
 						}
 						return ""
 					}(),

--- a/pkg/extract/nvd/api/cve/cve.go
+++ b/pkg/extract/nvd/api/cve/cve.go
@@ -293,12 +293,7 @@ func (e extractor) buildData(fetched cveTypes.CVE) (dataTypes.Data, error) {
 						}
 						return ""
 					}(),
-					Status: func() statusTypes.Status {
-						if fetched.VulnStatus == "Rejected" {
-							return statusTypes.StatusRejected
-						}
-						return ""
-					}(),
+					Status:   statusTypes.Normalize(fetched.VulnStatus),
 					Severity: ss,
 					CWE: func() []cweTypes.CWE {
 						if len(fetched.Weaknesses) == 0 {

--- a/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2018/CVE-2018-1202.json
+++ b/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2018/CVE-2018-1202.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2018-1202",
+				"status": "analyzed",
 				"description": "Dell EMC Isilon versions between 8.1.0.0 - 8.1.0.1, 8.0.1.0 - 8.0.1.2, and 8.0.0.0 - 8.0.0.6, and version 7.1.1.11 is affected by a cross-site scripting vulnerability in the NDMP Page within the OneFS web administration interface. A malicious administrator may potentially inject arbitrary HTML or JavaScript code in the user's browser session in the context of the OneFS website.",
 				"severity": [
 					{

--- a/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2022/CVE-2022-26582.json
+++ b/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2022/CVE-2022-26582.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2022-26582",
+				"status": "modified",
 				"description": "PAX A930 device with PayDroid_7.1.1_Virgo_V04.3.26T1_20210419 can allow an attacker to gain root access through command injection in systool client. The attacker must have shell access to the device in order to exploit this vulnerability.",
 				"severity": [
 					{

--- a/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2023/CVE-2023-7259.json
+++ b/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2023/CVE-2023-7259.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2023-7259",
+				"status": "awaiting-analysis",
 				"description": "** DISPUTED ** A vulnerability was found in zzdevelop lenosp up to 20230831. It has been classified as problematic. This affects an unknown part of the component Adduser Page. The manipulation of the argument username with the input <script>alert(1)</script> leads to cross site scripting. It is possible to initiate the attack remotely. The exploit has been disclosed to the public and may be used. The real existence of this vulnerability is still doubted at the moment. The associated identifier of this vulnerability is VDB-266127. NOTE: The vendor rejected the issue because he claims that XSS which require administrative privileges are not of any use for attackers.",
 				"severity": [
 					{

--- a/pkg/extract/nvd/api/cve/testdata/golden/with-and/data/2024/CVE-2024-0158.json
+++ b/pkg/extract/nvd/api/cve/testdata/golden/with-and/data/2024/CVE-2024-0158.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-0158",
+				"status": "analyzed",
 				"description": "Dell BIOS contains an improper input validation vulnerability. A local authenticated malicious user with admin privileges may potentially exploit this vulnerability to modify a UEFI variable, leading to denial of service and escalation of privileges",
 				"severity": [
 					{

--- a/pkg/extract/nvd/api/cve/testdata/golden/with-cpematch/data/2024/CVE-2024-20253.json
+++ b/pkg/extract/nvd/api/cve/testdata/golden/with-cpematch/data/2024/CVE-2024-20253.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-20253",
+				"status": "modified",
 				"description": "A vulnerability in multiple Cisco Unified Communications and Contact Center Solutions products could allow an unauthenticated, remote attacker to execute arbitrary code on an affected device. This vulnerability is due to the improper processing of user-provided data that is being read into memory. An attacker could exploit this vulnerability by sending a crafted message to a listening port of an affected device. A successful exploit could allow the attacker to execute arbitrary commands on the underlying operating system with the privileges of the web services user. With access to the underlying operating system, the attacker could also establish root access on the affected device.",
 				"severity": [
 					{

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/and-vulnerable-mixed/data/2024/CVE-2024-2049.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/and-vulnerable-mixed/data/2024/CVE-2024-2049.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-2049",
+				"status": "analyzed",
 				"description": "Server-Side Request Forgery (SSRF) in Citrix SD-WAN Standard/Premium Editions on or after 11.4.0 and before 11.4.4.46 allows an attacker to disclose limited information from the appliance via Access to management IP.",
 				"severity": [
 					{

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/cpematch-missing-semver/data/2024/CVE-2024-0028.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/cpematch-missing-semver/data/2024/CVE-2024-0028.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-0028",
+				"status": "analyzed",
 				"description": "Test fixture: SEMVER range whose matchCriteriaId is missing from the cpematch fixture dir. The extractor must log WARN, drop the expansion, and still emit the range criterion.",
 				"references": [
 					{

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/exact-match/data/2024/CVE-2024-0028.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/exact-match/data/2024/CVE-2024-0028.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-0028",
+				"status": "analyzed",
 				"description": "In Audio Service, there is a possible way to obtain MAC addresses of nearby Bluetooth devices due to a missing permission check. This could lead to local escalation of privilege with no additional execution privileges needed. User interaction is not needed for exploitation.",
 				"severity": [
 					{

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/non-semver-range/data/2024/CVE-2024-20282.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/non-semver-range/data/2024/CVE-2024-20282.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-20282",
+				"status": "analyzed",
 				"description": "A vulnerability in Cisco Nexus Dashboard could allow an authenticated, local attacker with valid rescue-user credentials to elevate privileges to root on an affected device.\r\n\r This vulnerability is due to insufficient protections for a sensitive access token. An attacker could exploit this vulnerability by using this token to access resources within the device infrastructure. A successful exploit could allow an attacker to gain root access to the filesystem or hosted containers on an affected device.",
 				"severity": [
 					{

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/reference-tags/data/2024/CVE-2024-0028.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/reference-tags/data/2024/CVE-2024-0028.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-0028",
+				"status": "analyzed",
 				"description": "In Audio Service, there is a possible way to obtain MAC addresses of nearby Bluetooth devices due to a missing permission check. This could lead to local escalation of privilege with no additional execution privileges needed. User interaction is not needed for exploitation.",
 				"severity": [
 					{

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/semver-range-mixed/data/2021/CVE-2021-1569.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/semver-range-mixed/data/2021/CVE-2021-1569.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2021-1569",
+				"status": "modified",
 				"description": "Multiple vulnerabilities in Cisco Jabber for Windows, Cisco Jabber for Mac, and Cisco Jabber for mobile platforms could allow an attacker to access sensitive information or cause a denial of service (DoS) condition. For more information about these vulnerabilities, see the Details section of this advisory.",
 				"severity": [
 					{

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/semver-range/data/2024/CVE-2024-0008.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/semver-range/data/2024/CVE-2024-0008.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-0008",
+				"status": "analyzed",
 				"description": "Web sessions in the management interface in Palo Alto Networks PAN-OS software do not expire in certain situations, making it susceptible to unauthorized access.",
 				"severity": [
 					{

--- a/pkg/extract/nvd/feed/cve/v2/v2.go
+++ b/pkg/extract/nvd/feed/cve/v2/v2.go
@@ -36,6 +36,7 @@ import (
 	v30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
 	v31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
 	v40Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v40"
+	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
 	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
@@ -326,6 +327,12 @@ func (e extractor) buildData(fetched cveTypes.CVE) (dataTypes.Data, error) {
 							if d.Lang == "en" {
 								return d.Value
 							}
+						}
+						return ""
+					}(),
+					Status: func() statusTypes.Status {
+						if fetched.VulnStatus == "Rejected" {
+							return statusTypes.StatusRejected
 						}
 						return ""
 					}(),

--- a/pkg/extract/nvd/feed/cve/v2/v2.go
+++ b/pkg/extract/nvd/feed/cve/v2/v2.go
@@ -330,12 +330,7 @@ func (e extractor) buildData(fetched cveTypes.CVE) (dataTypes.Data, error) {
 						}
 						return ""
 					}(),
-					Status: func() statusTypes.Status {
-						if fetched.VulnStatus == "Rejected" {
-							return statusTypes.StatusRejected
-						}
-						return ""
-					}(),
+					Status:   statusTypes.Normalize(fetched.VulnStatus),
 					Severity: ss,
 					CWE: func() []cweTypes.CWE {
 						if len(fetched.Weaknesses) == 0 {

--- a/pkg/extract/types/data/advisory/content/content.go
+++ b/pkg/extract/types/data/advisory/content/content.go
@@ -11,12 +11,14 @@ import (
 	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
 	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
 )
 
 type Content struct {
 	ID          AdvisoryID                     `json:"id,omitempty"`
 	Title       string                         `json:"title,omitempty"`
 	Description string                         `json:"description,omitempty"`
+	Status      statusTypes.Status             `json:"status,omitempty"`
 	Severity    []severityTypes.Severity       `json:"severity,omitempty"`
 	CWE         []cweTypes.CWE                 `json:"cwe,omitempty"`
 	Mitigations []remediationTypes.Remediation `json:"mitigations,omitempty"`
@@ -59,6 +61,7 @@ func Compare(x, y Content) int {
 		cmp.Compare(x.ID, y.ID),
 		cmp.Compare(x.Title, y.Title),
 		cmp.Compare(x.Description, y.Description),
+		statusTypes.Compare(x.Status, y.Status),
 		slices.CompareFunc(x.Severity, y.Severity, severityTypes.Compare),
 		slices.CompareFunc(x.CWE, y.CWE, cweTypes.Compare),
 		slices.CompareFunc(x.Mitigations, y.Mitigations, remediationTypes.Compare),

--- a/pkg/extract/types/data/advisory/content/content.go
+++ b/pkg/extract/types/data/advisory/content/content.go
@@ -16,9 +16,9 @@ import (
 
 type Content struct {
 	ID          AdvisoryID                     `json:"id,omitempty"`
+	Status      statusTypes.Status             `json:"status,omitempty"`
 	Title       string                         `json:"title,omitempty"`
 	Description string                         `json:"description,omitempty"`
-	Status      statusTypes.Status             `json:"status,omitempty"`
 	Severity    []severityTypes.Severity       `json:"severity,omitempty"`
 	CWE         []cweTypes.CWE                 `json:"cwe,omitempty"`
 	Mitigations []remediationTypes.Remediation `json:"mitigations,omitempty"`
@@ -59,9 +59,9 @@ func (c *Content) Sort() {
 func Compare(x, y Content) int {
 	return cmp.Or(
 		cmp.Compare(x.ID, y.ID),
+		statusTypes.Compare(x.Status, y.Status),
 		cmp.Compare(x.Title, y.Title),
 		cmp.Compare(x.Description, y.Description),
-		statusTypes.Compare(x.Status, y.Status),
 		slices.CompareFunc(x.Severity, y.Severity, severityTypes.Compare),
 		slices.CompareFunc(x.CWE, y.CWE, cweTypes.Compare),
 		slices.CompareFunc(x.Mitigations, y.Mitigations, remediationTypes.Compare),

--- a/pkg/extract/types/data/status/status.go
+++ b/pkg/extract/types/data/status/status.go
@@ -1,0 +1,37 @@
+package status
+
+import "cmp"
+
+// Status is the lifecycle state of a record as published by a data source.
+//
+// It is carried on both advisory and vulnerability content so each source can
+// record the state of the entity it actually publishes: an advisory-keyed
+// source (e.g. JVN, whose root is a JVNDB record) sets it on the advisory
+// content, while a CVE-keyed source (e.g. NVD / VulnCheck, whose root is the
+// CVE) sets it on the vulnerability content.
+//
+// The raw upstream marker (e.g. a "** REJECT **" / "** 削除 **" title or
+// description prefix) is still preserved verbatim in Title/Description; Status
+// is the normalized, machine-readable projection of it so consumers do not have
+// to string-match. An empty Status means unspecified (treat as active).
+type Status string
+
+const (
+	// StatusRejected marks a CVE rejected/withdrawn by its CNA, e.g. NVD
+	// "** REJECT **" / "[REJECTED CVE]", VulnCheck "Rejected reason:".
+	StatusRejected Status = "rejected"
+	// StatusDisputed marks a disputed CVE, e.g. NVD "** DISPUTED **".
+	StatusDisputed Status = "disputed"
+	// StatusWithdrawn marks a withdrawn record, e.g. JVN "** 削除 **",
+	// OSV withdrawn.
+	StatusWithdrawn Status = "withdrawn"
+	// StatusUnconfirmed marks an unconfirmed record, e.g. JVN "** 未確定 **".
+	StatusUnconfirmed Status = "unconfirmed"
+	// StatusUnsupported marks an out-of-support record, e.g. JVN
+	// "** サポート外 **".
+	StatusUnsupported Status = "unsupported"
+)
+
+func Compare(x, y Status) int {
+	return cmp.Compare(x, y)
+}

--- a/pkg/extract/types/data/status/status.go
+++ b/pkg/extract/types/data/status/status.go
@@ -1,6 +1,9 @@
 package status
 
-import "cmp"
+import (
+	"cmp"
+	"strings"
+)
 
 // Status is the lifecycle state of a record as published by a data source.
 //
@@ -14,14 +17,20 @@ import "cmp"
 // description prefix) is still preserved verbatim in Title/Description; Status
 // is the normalized, machine-readable projection of it so consumers do not have
 // to string-match. An empty Status means unspecified (treat as active).
+//
+// Status is an open string, not a closed enum. The constants below are the
+// invalidation subset that consumers filter on (a rejected/withdrawn/etc.
+// record should be dropped from detection). Any other value is an informational
+// source status carried through verbatim — for example NVD/VulnCheck record
+// their analysis progress (analyzed, modified, deferred, ...) via Normalize —
+// which consumers may display (e.g. in `vuls db search`) but must not treat as
+// invalidation.
 type Status string
 
 const (
-	// StatusRejected marks a CVE rejected/withdrawn by its CNA, e.g. NVD
-	// "** REJECT **" / "[REJECTED CVE]", VulnCheck "Rejected reason:".
+	// StatusRejected marks a CVE rejected/withdrawn by its CNA, e.g. NVD /
+	// VulnCheck vulnStatus "Rejected", MITRE/Debian "REJECTED".
 	StatusRejected Status = "rejected"
-	// StatusDisputed marks a disputed CVE, e.g. NVD "** DISPUTED **".
-	StatusDisputed Status = "disputed"
 	// StatusWithdrawn marks a withdrawn record, e.g. JVN "** 削除 **",
 	// OSV withdrawn.
 	StatusWithdrawn Status = "withdrawn"
@@ -31,6 +40,17 @@ const (
 	// "** サポート外 **".
 	StatusUnsupported Status = "unsupported"
 )
+
+// Normalize projects a raw upstream status string (e.g. an NVD/VulnCheck
+// vulnStatus like "Awaiting Analysis" or "Rejected") into a Status token by
+// lower-casing and replacing spaces with hyphens. Invalidation values collapse
+// onto the constants above (e.g. "Rejected" -> StatusRejected); other values
+// (e.g. "analyzed", "deferred") are preserved as informational, source-specific
+// strings that consumers may display but must not treat as invalidation. An
+// empty input yields an empty Status.
+func Normalize(s string) Status {
+	return Status(strings.ReplaceAll(strings.ToLower(s), " ", "-"))
+}
 
 func Compare(x, y Status) int {
 	return cmp.Compare(x, y)

--- a/pkg/extract/types/data/status/status_test.go
+++ b/pkg/extract/types/data/status/status_test.go
@@ -1,0 +1,26 @@
+package status_test
+
+import (
+	"testing"
+
+	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
+)
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name string
+		x, y statusTypes.Status
+		want int
+	}{
+		{name: "equal", x: statusTypes.StatusRejected, y: statusTypes.StatusRejected, want: 0},
+		{name: "empty less", x: "", y: statusTypes.StatusRejected, want: -1},
+		{name: "greater", x: statusTypes.StatusWithdrawn, y: statusTypes.StatusRejected, want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := statusTypes.Compare(tt.x, tt.y); got != tt.want {
+				t.Errorf("Compare(%q, %q) = %d, want %d", tt.x, tt.y, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/extract/types/data/status/status_test.go
+++ b/pkg/extract/types/data/status/status_test.go
@@ -6,6 +6,30 @@ import (
 	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
 )
 
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want statusTypes.Status
+	}{
+		{name: "empty", s: "", want: ""},
+		{name: "rejected collapses onto constant", s: "Rejected", want: statusTypes.StatusRejected},
+		{name: "analyzed", s: "Analyzed", want: "analyzed"},
+		{name: "awaiting analysis", s: "Awaiting Analysis", want: "awaiting-analysis"},
+		{name: "undergoing analysis", s: "Undergoing Analysis", want: "undergoing-analysis"},
+		{name: "modified", s: "Modified", want: "modified"},
+		{name: "deferred", s: "Deferred", want: "deferred"},
+		{name: "received", s: "Received", want: "received"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := statusTypes.Normalize(tt.s); got != tt.want {
+				t.Errorf("Normalize(%q) = %q, want %q", tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCompare(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/extract/types/data/vulnerability/content/content.go
+++ b/pkg/extract/types/data/vulnerability/content/content.go
@@ -15,12 +15,14 @@ import (
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 	snortTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/snort"
 	ssvcTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/ssvc"
+	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
 )
 
 type Content struct {
 	ID          VulnerabilityID                `json:"id,omitempty"`
 	Title       string                         `json:"title,omitempty"`
 	Description string                         `json:"description,omitempty"`
+	Status      statusTypes.Status             `json:"status,omitempty"`
 	Severity    []severityTypes.Severity       `json:"severity,omitempty"`
 	CWE         []cweTypes.CWE                 `json:"cwe,omitempty"`
 	Mitigations []remediationTypes.Remediation `json:"mitigations,omitempty"`
@@ -79,6 +81,7 @@ func Compare(x, y Content) int {
 		cmp.Compare(x.ID, y.ID),
 		cmp.Compare(x.Title, y.Title),
 		cmp.Compare(x.Description, y.Description),
+		statusTypes.Compare(x.Status, y.Status),
 		slices.CompareFunc(x.Severity, y.Severity, severityTypes.Compare),
 		slices.CompareFunc(x.CWE, y.CWE, cweTypes.Compare),
 		slices.CompareFunc(x.Mitigations, y.Mitigations, remediationTypes.Compare),

--- a/pkg/extract/types/data/vulnerability/content/content.go
+++ b/pkg/extract/types/data/vulnerability/content/content.go
@@ -20,9 +20,9 @@ import (
 
 type Content struct {
 	ID          VulnerabilityID                `json:"id,omitempty"`
+	Status      statusTypes.Status             `json:"status,omitempty"`
 	Title       string                         `json:"title,omitempty"`
 	Description string                         `json:"description,omitempty"`
-	Status      statusTypes.Status             `json:"status,omitempty"`
 	Severity    []severityTypes.Severity       `json:"severity,omitempty"`
 	CWE         []cweTypes.CWE                 `json:"cwe,omitempty"`
 	Mitigations []remediationTypes.Remediation `json:"mitigations,omitempty"`
@@ -79,9 +79,9 @@ func (c *Content) Sort() {
 func Compare(x, y Content) int {
 	return cmp.Or(
 		cmp.Compare(x.ID, y.ID),
+		statusTypes.Compare(x.Status, y.Status),
 		cmp.Compare(x.Title, y.Title),
 		cmp.Compare(x.Description, y.Description),
-		statusTypes.Compare(x.Status, y.Status),
 		slices.CompareFunc(x.Severity, y.Severity, severityTypes.Compare),
 		slices.CompareFunc(x.CWE, y.CWE, cweTypes.Compare),
 		slices.CompareFunc(x.Mitigations, y.Mitigations, remediationTypes.Compare),

--- a/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
+++ b/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
@@ -380,12 +380,7 @@ func (e extractor) buildData(fetched nistnvd2Types.CVE) (dataTypes.Data, error) 
 						}
 						return ""
 					}(),
-					Status: func() statusTypes.Status {
-						if fetched.VulnStatus == "Rejected" {
-							return statusTypes.StatusRejected
-						}
-						return ""
-					}(),
+					Status:   statusTypes.Normalize(fetched.VulnStatus),
 					Severity: ss,
 					CWE: func() []cweTypes.CWE {
 						if len(fetched.Weaknesses) == 0 {

--- a/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
+++ b/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
@@ -266,14 +266,10 @@ func (e extractor) buildData(fetched nistnvd2Types.CVE) (dataTypes.Data, error) 
 	// Both are built from VulnCheck's enriched fields only — never the plain NVD
 	// configurations.
 	ds, err := func() ([]detectionType.Detection, error) {
-		// A Rejected CVE is withdrawn, so it must not produce detections —
-		// VulnCheck keeps vcConfigurations on some rejected entries, and
-		// emitting them would flag a withdrawn CVE (a false positive). The
-		// vulnerability content (the rejection reason) is still emitted, as
-		// other extractors (nvd/feed/cve/v2, mitre/v5) keep rejected records.
-		if fetched.VulnStatus == "Rejected" {
-			return nil, nil
-		}
+		// Detections are emitted even for a Rejected CVE. The rejection is
+		// recorded on the vulnerability content's Status (StatusRejected)
+		// instead, leaving it to the consumer to drop the withdrawn CVE.
+		// (Previously rejected entries produced no detections here.)
 
 		// Accumulate the present groups directly into the root OR criteria.
 		criteria := criteriaTypes.Criteria{Operator: criteriaTypes.CriteriaOperatorTypeOR}

--- a/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
+++ b/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
@@ -37,6 +37,7 @@ import (
 	v30Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v30"
 	v31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
 	v40Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v40"
+	statusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/status"
 	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
@@ -380,6 +381,12 @@ func (e extractor) buildData(fetched nistnvd2Types.CVE) (dataTypes.Data, error) 
 							if d.Lang == "en" {
 								return d.Value
 							}
+						}
+						return ""
+					}(),
+					Status: func() statusTypes.Status {
+						if fetched.VulnStatus == "Rejected" {
+							return statusTypes.StatusRejected
 						}
 						return ""
 					}(),

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/and-operator/data/2024/CVE-2024-25741.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/and-operator/data/2024/CVE-2024-25741.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-25741",
+				"status": "modified",
 				"description": "printer_write in drivers/usb/gadget/function/f_printer.c in the Linux kernel through 6.7.4 does not properly call usb_ep_queue, which might allow attackers to cause a denial of service or have unspecified other impact.",
 				"severity": [
 					{

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/exact-match/data/2024/CVE-2024-25741.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/exact-match/data/2024/CVE-2024-25741.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-25741",
+				"status": "modified",
 				"description": "printer_write in drivers/usb/gadget/function/f_printer.c in the Linux kernel through 6.7.4 does not properly call usb_ep_queue, which might allow attackers to cause a denial of service or have unspecified other impact.",
 				"severity": [
 					{

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/happy/data/2024/CVE-2024-0001.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/happy/data/2024/CVE-2024-0001.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-0001",
+				"status": "analyzed",
 				"description": "A condition exists in FlashArray Purity whereby a local account intended for initial array configuration remains active potentially allowing a malicious actor to gain elevated privileges.",
 				"severity": [
 					{

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/non-semver-range/data/2024/CVE-2024-5400.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/non-semver-range/data/2024/CVE-2024-5400.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-5400",
+				"status": "analyzed",
 				"description": "Openfind Mail2000 does not properly filter parameters of specific CGI. Remote attackers with regular privileges can exploit this vulnerability to execute arbitrary system commands on the remote server.",
 				"severity": [
 					{

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/non-vulnerable-platform/data/2024/CVE-2024-0002.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/non-vulnerable-platform/data/2024/CVE-2024-0002.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-0002",
+				"status": "analyzed",
 				"description": "Example app is vulnerable when running on the example OS platform.",
 				"severity": [
 					{

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
@@ -22,6 +22,108 @@
 			]
 		}
 	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterias": [
+									{
+										"operator": "OR",
+										"criterias": [
+											{
+												"operator": "OR",
+												"criterions": [
+													{
+														"type": "cpe",
+														"cpe": {
+															"vulnerable": true,
+															"fix_status": {
+																"class": "unknown"
+															},
+															"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+															"range": {
+																"type": "semver",
+																"ge": "5.15",
+																"lt": "5.15.198"
+															}
+														}
+													},
+													{
+														"type": "cpe",
+														"cpe": {
+															"vulnerable": true,
+															"fix_status": {
+																"class": "unknown"
+															},
+															"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+															"range": {
+																"type": "semver",
+																"ge": "5.16",
+																"lt": "5.16.19"
+															}
+														}
+													},
+													{
+														"type": "cpe",
+														"cpe": {
+															"vulnerable": true,
+															"fix_status": {
+																"class": "unknown"
+															},
+															"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+															"range": {
+																"type": "semver",
+																"ge": "5.17",
+																"lt": "5.17.2"
+															}
+														}
+													},
+													{
+														"type": "cpe",
+														"cpe": {
+															"vulnerable": true,
+															"fix_status": {
+																"class": "unknown"
+															},
+															"cpe": "cpe:2.3:o:linux:linux_kernel:2.6.12:*:*:*:*:*:*:*"
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unknown"
+											},
+											"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+											"cpe_matches": [
+												"cpe:2.3:o:linux:linux_kernel:5.15.0-58:*:*:*:*:*:*:*"
+											]
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
 	"data_source": {
 		"id": "vulncheck-nist-nvd2",
 		"raws": [

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
@@ -4,8 +4,8 @@
 		{
 			"content": {
 				"id": "CVE-2022-49267",
-				"description": "Rejected reason: This CVE ID has been rejected or withdrawn by its CVE Numbering Authority.",
 				"status": "rejected",
+				"description": "Rejected reason: This CVE ID has been rejected or withdrawn by its CVE Numbering Authority.",
 				"references": [
 					{
 						"source": "vulncheck.com",

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
@@ -5,6 +5,7 @@
 			"content": {
 				"id": "CVE-2022-49267",
 				"description": "Rejected reason: This CVE ID has been rejected or withdrawn by its CVE Numbering Authority.",
+				"status": "rejected",
 				"references": [
 					{
 						"source": "vulncheck.com",

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2024/CVE-2024-2652.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2024/CVE-2024-2652.json
@@ -5,6 +5,7 @@
 			"content": {
 				"id": "CVE-2024-2652",
 				"description": "Rejected reason: This CVE ID has been rejected or withdrawn by its CVE Numbering Authority.",
+				"status": "rejected",
 				"references": [
 					{
 						"source": "vulncheck.com",

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2024/CVE-2024-2652.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2024/CVE-2024-2652.json
@@ -4,8 +4,8 @@
 		{
 			"content": {
 				"id": "CVE-2024-2652",
-				"description": "Rejected reason: This CVE ID has been rejected or withdrawn by its CVE Numbering Authority.",
 				"status": "rejected",
+				"description": "Rejected reason: This CVE ID has been rejected or withdrawn by its CVE Numbering Authority.",
 				"references": [
 					{
 						"source": "vulncheck.com",

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/vc-only/data/2024/CVE-2024-43228.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/vc-only/data/2024/CVE-2024-43228.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2024-43228",
+				"status": "deferred",
 				"description": "Missing Authorization vulnerability in SecuPress SecuPress Free secupress.This issue affects SecuPress Free: from n/a through <= 2.2.5.3.",
 				"severity": [
 					{

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/vuln-cpes/data/2018/CVE-2018-2611.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/vuln-cpes/data/2018/CVE-2018-2611.json
@@ -4,6 +4,7 @@
 		{
 			"content": {
 				"id": "CVE-2018-2611",
+				"status": "modified",
 				"description": "Vulnerability in the Sun ZFS Storage Appliance Kit (AK) component of Oracle Sun Systems Products Suite (subcomponent: Core Services). The supported version that is affected is Prior to 8.7.13. Easily exploitable vulnerability allows unauthenticated attacker with network access via HTTP to compromise Sun ZFS Storage Appliance Kit (AK). While the vulnerability is in Sun ZFS Storage Appliance Kit (AK), attacks may significantly impact additional products. Successful attacks of this vulnerability can result in takeover of Sun ZFS Storage Appliance Kit (AK). CVSS 3.0 Base Score 10.0 (Confidentiality, Integrity and Availability impacts). CVSS Vector: (CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H).",
 				"severity": [
 					{


### PR DESCRIPTION
## What

Add a `Status` field to advisory and vulnerability `Content` that records the lifecycle/workflow state a data source publishes for a record, and stop dropping detections for rejected CVEs at extract time.

- New `pkg/extract/types/data/status` package. `Status` is an **open string** type: the named constants (`rejected`, `withdrawn`, `unconfirmed`, `unsupported`) are the *invalidation subset* a consumer filters on; any other value is an informational source status carried through verbatim.
- `status.Normalize(raw)` projects a raw upstream status (e.g. an NVD/VulnCheck `vulnStatus`) into a `Status` token (lower-case, spaces→hyphens). `"Rejected"` collapses onto `StatusRejected`; others (`analyzed`, `modified`, `deferred`, `received`, ...) pass through as analysis-progress info.
- `Status` sits directly below `id` in both `advisory/content` and `vulnerability/content` (struct + `Compare`).
- Producers now set `Status`:
  - **NVD** (`api/cve`, `feed/cve/v2`) & **VulnCheck** (`nist-nvd2`): `Status = Normalize(vulnStatus)` for every record.
  - **JVN** (`feed/rss`, `feed/detail`): `withdrawn` / `unconfirmed` / `unsupported` from the `** 削除 **` / `** 未確定 **` / `** サポート外 **` markers (shared helper in `jvn/internal`).
  - **MITRE** (`cve/v5`) & **Debian** (`tracker/salsa`): `rejected` for REJECTED records.
- **VulnCheck `nist-nvd2` no longer drops detections when `vulnStatus == "Rejected"`.** The detection tree is emitted and the rejection is instead carried by `Status`, so the consumer decides whether to filter (see Why).

## Why

Previously each fetcher/extractor silently dropped rejected/withdrawn records (or their detections), which diverges across backends: go-cve-dictionary keeps some of what vuls2 drops and vice-versa. Carrying a machine-readable `Status` lets the **consumer** (`vuls` `detector/vuls2` `ignoreVulnerability`) make one consistent filtering decision instead of each source deciding unilaterally, and keeps the underlying detection data lossless.

Keeping `Status` an open string (rather than a closed enum) additionally preserves NVD/VulnCheck analysis progress (`analyzed`/`deferred`/...) for display/search use cases such as `vuls db search`, without conflating it with the invalidation axis the filter uses.

## How

- `Status` field + `omitempty`; `Sort()`/`Compare()` updated to keep deterministic JSON output (backward-compatible additive field).
- Dead `StatusDisputed` (no producer/consumer) removed.

## Testing

- `GOEXPERIMENT=jsonv2 go build ./...` — ok.
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/...` — pass. Added unit tests for `status.Normalize`/`Compare` and the JVN marker helper.
- Added a JVN `** 削除 **` golden case (`JVNDB-2024-003157`, withdrawn) that keeps the CPE detection while marking the advisory `status: withdrawn`.
- Regenerated all affected NVD / VulnCheck / JVN / MITRE / Debian goldens via the actual extractors.

## Follow-up (separate `vuls` repo, not in this PR)

Extend `detector/vuls2` `ignoreVulnerability` to consume `Status` for the CPE ecosystem (currently `default: return false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)