### PR TITLE
feat(extract/vulncheck/nist-nvd2): emit detections for rejected CVEs

### DIFF
--- a/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
+++ b/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
@@ -265,14 +265,12 @@ func (e extractor) buildData(fetched nistnvd2Types.CVE) (dataTypes.Data, error) 
 	// Both are built from VulnCheck's enriched fields only — never the plain NVD
 	// configurations.
 	ds, err := func() ([]detectionType.Detection, error) {
-		// A Rejected CVE is withdrawn, so it must not produce detections —
-		// VulnCheck keeps vcConfigurations on some rejected entries, and
-		// emitting them would flag a withdrawn CVE (a false positive). The
-		// vulnerability content (the rejection reason) is still emitted, as
-		// other extractors (nvd/feed/cve/v2, mitre/v5) keep rejected records.
-		if fetched.VulnStatus == "Rejected" {
-			return nil, nil
-		}
+		// Detections are emitted even for a Rejected CVE, matching the other
+		// extractors (nvd/feed/cve/v2, mitre/v5) that keep rejected records
+		// whole rather than stripping them. The rejection reason stays on the
+		// vulnerability content's description ("Rejected reason: ..."), leaving
+		// it to the consumer to drop the withdrawn CVE — consistent with how
+		// rejected Red Hat records are handled downstream.
 
 		// Accumulate the present groups directly into the root OR criteria.
 		criteria := criteriaTypes.Criteria{Operator: criteriaTypes.CriteriaOperatorTypeOR}

--- a/pkg/extract/vulncheck/nist-nvd2/nist-nvd2_test.go
+++ b/pkg/extract/vulncheck/nist-nvd2/nist-nvd2_test.go
@@ -81,13 +81,12 @@ func TestExtract(t *testing.T) {
 			golden: "./testdata/golden/non-vulnerable-platform",
 		},
 		{
-			// vulnStatus=Rejected entries: the vulnerability content (the
-			// rejection reason) is still emitted, but detections are
-			// suppressed — a rejected CVE is withdrawn, so flagging it would
-			// be a false positive. Covers a hollow reject (CVE-2024-2652, no
-			// vcConfigurations) and a reject that still carries
-			// vcConfigurations (CVE-2022-49267), proving the latter's
-			// detections are dropped.
+			// vulnStatus=Rejected entries are kept whole: both the vulnerability
+			// content (the rejection reason) AND the detections are emitted, so
+			// the consumer decides whether to drop the withdrawn CVE. Covers a
+			// hollow reject (CVE-2024-2652, no vcConfigurations → no detections)
+			// and a reject that still carries vcConfigurations (CVE-2022-49267),
+			// proving the latter's detections are now emitted.
 			name:   "rejected",
 			args:   "./testdata/fixtures/rejected/vuls-data-raw-vulncheck-nist-nvd2",
 			golden: "./testdata/golden/rejected",

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
@@ -21,6 +21,108 @@
 			]
 		}
 	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterias": [
+									{
+										"operator": "OR",
+										"criterias": [
+											{
+												"operator": "OR",
+												"criterions": [
+													{
+														"type": "cpe",
+														"cpe": {
+															"vulnerable": true,
+															"fix_status": {
+																"class": "unknown"
+															},
+															"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+															"range": {
+																"type": "semver",
+																"ge": "5.15",
+																"lt": "5.15.198"
+															}
+														}
+													},
+													{
+														"type": "cpe",
+														"cpe": {
+															"vulnerable": true,
+															"fix_status": {
+																"class": "unknown"
+															},
+															"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+															"range": {
+																"type": "semver",
+																"ge": "5.16",
+																"lt": "5.16.19"
+															}
+														}
+													},
+													{
+														"type": "cpe",
+														"cpe": {
+															"vulnerable": true,
+															"fix_status": {
+																"class": "unknown"
+															},
+															"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+															"range": {
+																"type": "semver",
+																"ge": "5.17",
+																"lt": "5.17.2"
+															}
+														}
+													},
+													{
+														"type": "cpe",
+														"cpe": {
+															"vulnerable": true,
+															"fix_status": {
+																"class": "unknown"
+															},
+															"cpe": "cpe:2.3:o:linux:linux_kernel:2.6.12:*:*:*:*:*:*:*"
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unknown"
+											},
+											"cpe": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+											"cpe_matches": [
+												"cpe:2.3:o:linux:linux_kernel:5.15.0-58:*:*:*:*:*:*:*"
+											]
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
 	"data_source": {
 		"id": "vulncheck-nist-nvd2",
 		"raws": [


### PR DESCRIPTION
## What

Stop dropping detections for `vulnStatus == \"Rejected\"` VulnCheck (nist-nvd2) CVEs. Rejected records are now emitted whole: both the vulnerability content **and** the CPE detection tree.

## Why

The extractor previously returned no detections for a rejected CVE:

```go
if fetched.VulnStatus == "Rejected" {
    return nil, nil
}
```

A rejected VulnCheck CVE that still carries `vcConfigurations` therefore produced **no** CPE detection, which is inconsistent with:

- the other CVE-keyed extractors — `nvd/feed/cve/v2`, `mitre/cve/v5` — which keep rejected records whole, and
- Red Hat, whose rejected records are emitted with the `** REJECT **` / `[REJECTED CVE]` marker in the description and filtered **by the consumer**, not stripped at extract time.

Keeping the detection but leaving the rejection reason on the vulnerability content (`description: \"Rejected reason: ...\"`) lets a downstream consumer (e.g. vuls' `detector/vuls2` `ignoreVulnerability`) make one consistent drop decision by description, exactly as it already does for Red Hat / Ubuntu — instead of the source deciding unilaterally and losing the data.

## How

- Remove the `vulnStatus == \"Rejected\"` early-return in the detection builder; update the surrounding comment.
- Entries with no CPE data (`vcConfigurations` and `vcVulnerableCPEs` both empty) still yield no detection, unchanged.
- Update the `rejected` golden-test case comment to describe the new behavior.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/vulncheck/...` — pass.
- Regenerated the `rejected` golden via the extractor: `CVE-2022-49267` now carries its detection tree; `CVE-2024-2652` (a hollow reject with no `vcConfigurations`) is unchanged.

## Notes

- This change is independent of the lifecycle-`Status` work in #870 — it relies only on the existing `description` text, so it needs no schema change.
- Consumer-side filtering (drop rejected CPE detections by description) is implemented separately in the `vuls` repo's `detector/vuls2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)