### PR TITLE
fix(extract): emit vulnerability segment only when detections exist

### DIFF
--- a/pkg/extract/nvd/api/cve/cve.go
+++ b/pkg/extract/nvd/api/cve/cve.go
@@ -328,7 +328,16 @@ func (e extractor) buildData(fetched cveTypes.CVE) (dataTypes.Data, error) {
 					Published: utiltime.Parse([]string{"2006-01-02T15:04:05.000"}, fetched.Published),
 					Modified:  utiltime.Parse([]string{"2006-01-02T15:04:05.000"}, fetched.LastModified),
 				},
-				Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeCPE}},
+				// A segment ties the vulnerability to a detection in the same
+				// ecosystem; when the record produced no detections (no
+				// configurations) a segment would dangle, so it is emitted
+				// only alongside detections.
+				Segments: func() []segmentTypes.Segment {
+					if len(ds) == 0 {
+						return nil
+					}
+					return []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeCPE}}
+				}(),
 			},
 		},
 		Detections: ds,

--- a/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2023/CVE-2023-7259.json
+++ b/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2023/CVE-2023-7259.json
@@ -70,12 +70,7 @@
 				],
 				"published": "2024-05-24T07:15:08.93Z",
 				"modified": "2024-08-02T09:15:55.73Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "cpe"
-				}
-			]
+			}
 		}
 	],
 	"data_source": {

--- a/pkg/extract/nvd/feed/cve/v2/testdata/fixtures/no-detection/vuls-data-raw-nvd-feed-cpematch-v2/67f7a4ef/2D49E611-5D53-479D-A981-42388FDC0E8D.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/fixtures/no-detection/vuls-data-raw-nvd-feed-cpematch-v2/67f7a4ef/2D49E611-5D53-479D-A981-42388FDC0E8D.json
@@ -1,0 +1,7 @@
+{
+	"criteria": "cpe:2.3:o:google:android:16.0:*:*:*:*:*:*:*",
+	"matchCriteriaId": "2D49E611-5D53-479D-A981-42388FDC0E8D",
+	"created": "2025-09-02T19:02:13.967",
+	"lastModified": "2025-09-02T19:02:13.967",
+	"status": "Active"
+}

--- a/pkg/extract/nvd/feed/cve/v2/testdata/fixtures/no-detection/vuls-data-raw-nvd-feed-cve-v2/2024/CVE-2024-0094.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/fixtures/no-detection/vuls-data-raw-nvd-feed-cve-v2/2024/CVE-2024-0094.json
@@ -1,0 +1,65 @@
+{
+	"id": "CVE-2024-0094",
+	"sourceIdentifier": "psirt@nvidia.com",
+	"vulnStatus": "Deferred",
+	"published": "2024-06-13T22:15:13.080",
+	"lastModified": "2026-04-15T00:35:42.020",
+	"descriptions": [
+		{
+			"lang": "en",
+			"value": "NVIDIA vGPU software for Linux contains a vulnerability in the Virtual GPU Manager, where an untrusted guest VM can cause improper control of the interaction frequency in the host. A successful exploit of this vulnerability might lead to denial of service."
+		},
+		{
+			"lang": "es",
+			"value": "El software NVIDIA vGPU para Linux contiene una vulnerabilidad en Virtual GPU Manager, donde una VM invitada que no es de confianza puede provocar un control inadecuado de la frecuencia de interacción en el host. Una explotación exitosa de esta vulnerabilidad podría provocar una denegación de servicio."
+		}
+	],
+	"references": [
+		{
+			"source": "psirt@nvidia.com",
+			"url": "https://nvidia.custhelp.com/app/answers/detail/a_id/5551"
+		},
+		{
+			"source": "af854a3a-2127-422b-91ae-364da2661108",
+			"url": "https://nvidia.custhelp.com/app/answers/detail/a_id/5551"
+		}
+	],
+	"metrics": {
+		"cvssMetricV31": [
+			{
+				"source": "psirt@nvidia.com",
+				"type": "Secondary",
+				"cvssData": {
+					"version": "3.1",
+					"vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+					"attackVector": "LOCAL",
+					"attackComplexity": "LOW",
+					"privilegesRequired": "LOW",
+					"userInteraction": "NONE",
+					"scope": "UNCHANGED",
+					"confidentialityImpact": "NONE",
+					"integrityImpact": "NONE",
+					"availabilityImpact": "HIGH",
+					"baseScore": 5.5,
+					"baseSeverity": "MEDIUM",
+					"temporalScore": 0,
+					"environmentalScore": 0
+				},
+				"exploitabilityScore": 1.8,
+				"impactScore": 3.6
+			}
+		]
+	},
+	"weaknesses": [
+		{
+			"source": "psirt@nvidia.com",
+			"type": "Secondary",
+			"description": [
+				{
+					"lang": "en",
+					"value": "CWE-799"
+				}
+			]
+		}
+	]
+}

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/no-detection/data/2024/CVE-2024-0094.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/no-detection/data/2024/CVE-2024-0094.json
@@ -1,0 +1,56 @@
+{
+	"id": "CVE-2024-0094",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-0094",
+				"description": "NVIDIA vGPU software for Linux contains a vulnerability in the Virtual GPU Manager, where an untrusted guest VM can cause improper control of the interaction frequency in the host. A successful exploit of this vulnerability might lead to denial of service.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "psirt@nvidia.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+							"base_score": 5.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "psirt@nvidia.com",
+						"cwe": [
+							"CWE-799"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "af854a3a-2127-422b-91ae-364da2661108",
+						"url": "https://nvidia.custhelp.com/app/answers/detail/a_id/5551"
+					},
+					{
+						"source": "nvd.nist.gov",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0094"
+					},
+					{
+						"source": "psirt@nvidia.com",
+						"url": "https://nvidia.custhelp.com/app/answers/detail/a_id/5551"
+					}
+				],
+				"published": "2024-06-13T22:15:13.08Z",
+				"modified": "2026-04-15T00:35:42.02Z"
+			}
+		}
+	],
+	"data_source": {
+		"id": "nvd-feed-cve-v2",
+		"raws": [
+			"vuls-data-raw-nvd-feed-cve-v2/2024/CVE-2024-0094.json"
+		]
+	}
+}

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/no-detection/datasource.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/no-detection/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "nvd-feed-cve-v2",
+	"name": "NVD Feed CVE v2"
+}

--- a/pkg/extract/nvd/feed/cve/v2/v2.go
+++ b/pkg/extract/nvd/feed/cve/v2/v2.go
@@ -393,7 +393,16 @@ func (e extractor) buildData(fetched cveTypes.CVE) (dataTypes.Data, error) {
 					Published: utiltime.Parse([]string{"2006-01-02T15:04:05.000"}, fetched.Published),
 					Modified:  utiltime.Parse([]string{"2006-01-02T15:04:05.000"}, fetched.LastModified),
 				},
-				Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeCPE}},
+				// A segment ties the vulnerability to a detection in the same
+				// ecosystem; when the record produced no detections (no
+				// configurations) a segment would dangle, so it is emitted
+				// only alongside detections.
+				Segments: func() []segmentTypes.Segment {
+					if len(ds) == 0 {
+						return nil
+					}
+					return []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeCPE}}
+				}(),
 			},
 		},
 		Detections: ds,

--- a/pkg/extract/nvd/feed/cve/v2/v2_test.go
+++ b/pkg/extract/nvd/feed/cve/v2/v2_test.go
@@ -129,6 +129,20 @@ func TestExtract(t *testing.T) {
 			hasError: true,
 		},
 		{
+			// A CVE with no configurations (CVE-2024-0094, Deferred): no
+			// detections are built, and the vulnerability must not carry a
+			// segment either — a segment ties the vulnerability to a
+			// detection, so without detections it would dangle. The cpematch
+			// fixture entry is unused (nothing references it); it only keeps
+			// the directory non-empty.
+			name: "no-detection",
+			args: args{
+				cveDir:      "./testdata/fixtures/no-detection/vuls-data-raw-nvd-feed-cve-v2",
+				cpematchDir: "./testdata/fixtures/no-detection/vuls-data-raw-nvd-feed-cpematch-v2",
+			},
+			golden: "./testdata/golden/no-detection",
+		},
+		{
 			// negate=true on a configuration object is not implemented.
 			// The extractor must return an explicit error rather than
 			// silently emit non-negated criteria, which would invert

--- a/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
+++ b/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
@@ -448,7 +448,16 @@ func (e extractor) buildData(fetched nistnvd2Types.CVE) (dataTypes.Data, error) 
 					Published: utiltime.Parse([]string{"2006-01-02T15:04:05.999999999"}, fetched.Published),
 					Modified:  utiltime.Parse([]string{"2006-01-02T15:04:05.999999999"}, fetched.LastModified),
 				},
-				Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeCPE}},
+				// A segment ties the vulnerability to a detection in the same
+				// ecosystem; when the record produced no detections (Rejected,
+				// or no vcConfigurations/vcVulnerableCPEs) a segment would
+				// dangle, so it is emitted only alongside detections.
+				Segments: func() []segmentTypes.Segment {
+					if len(ds) == 0 {
+						return nil
+					}
+					return []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeCPE}}
+				}(),
 			},
 		},
 		Detections: ds,

--- a/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
+++ b/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
@@ -449,9 +449,9 @@ func (e extractor) buildData(fetched nistnvd2Types.CVE) (dataTypes.Data, error) 
 					Modified:  utiltime.Parse([]string{"2006-01-02T15:04:05.999999999"}, fetched.LastModified),
 				},
 				// A segment ties the vulnerability to a detection in the same
-				// ecosystem; when the record produced no detections (Rejected,
-				// or no vcConfigurations/vcVulnerableCPEs) a segment would
-				// dangle, so it is emitted only alongside detections.
+				// ecosystem; when the record produced no detections (no
+				// vcConfigurations/vcVulnerableCPEs) a segment would dangle,
+				// so it is emitted only alongside detections.
 				Segments: func() []segmentTypes.Segment {
 					if len(ds) == 0 {
 						return nil

--- a/pkg/extract/vulncheck/nist-nvd2/nist-nvd2_test.go
+++ b/pkg/extract/vulncheck/nist-nvd2/nist-nvd2_test.go
@@ -92,6 +92,16 @@ func TestExtract(t *testing.T) {
 			golden: "./testdata/golden/rejected",
 		},
 		{
+			// A live (non-Rejected) entry with neither vcConfigurations nor
+			// vcVulnerableCPEs (CVE-2024-0094, Deferred): no detections are
+			// built, and the vulnerability must not carry a segment either —
+			// a segment ties the vulnerability to a detection, so without
+			// detections it would dangle.
+			name:   "no-detection",
+			args:   "./testdata/fixtures/no-detection/vuls-data-raw-vulncheck-nist-nvd2",
+			golden: "./testdata/golden/no-detection",
+		},
+		{
 			// negate=true on a configuration cannot be expressed in the
 			// criteria tree and never appears in the real feed, so the
 			// extractor fails hard rather than silently emitting inverted

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/fixtures/no-detection/vuls-data-raw-vulncheck-nist-nvd2/2024/CVE-2024-0094.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/fixtures/no-detection/vuls-data-raw-vulncheck-nist-nvd2/2024/CVE-2024-0094.json
@@ -1,0 +1,65 @@
+{
+	"id": "CVE-2024-0094",
+	"sourceIdentifier": "psirt@nvidia.com",
+	"vulnStatus": "Deferred",
+	"published": "2024-06-13T22:15:13.080",
+	"lastModified": "2026-04-15T00:35:42.020",
+	"descriptions": [
+		{
+			"lang": "en",
+			"value": "NVIDIA vGPU software for Linux contains a vulnerability in the Virtual GPU Manager, where an untrusted guest VM can cause improper control of the interaction frequency in the host. A successful exploit of this vulnerability might lead to denial of service."
+		},
+		{
+			"lang": "es",
+			"value": "El software NVIDIA vGPU para Linux contiene una vulnerabilidad en Virtual GPU Manager, donde una VM invitada que no es de confianza puede provocar un control inadecuado de la frecuencia de interacción en el host. Una explotación exitosa de esta vulnerabilidad podría provocar una denegación de servicio."
+		}
+	],
+	"references": [
+		{
+			"source": "psirt@nvidia.com",
+			"url": "https://nvidia.custhelp.com/app/answers/detail/a_id/5551"
+		},
+		{
+			"source": "af854a3a-2127-422b-91ae-364da2661108",
+			"url": "https://nvidia.custhelp.com/app/answers/detail/a_id/5551"
+		}
+	],
+	"metrics": {
+		"cvssMetricV31": [
+			{
+				"source": "psirt@nvidia.com",
+				"type": "Secondary",
+				"cvssData": {
+					"version": "3.1",
+					"vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+					"attackVector": "LOCAL",
+					"attackComplexity": "LOW",
+					"privilegesRequired": "LOW",
+					"userInteraction": "NONE",
+					"scope": "UNCHANGED",
+					"confidentialityImpact": "NONE",
+					"integrityImpact": "NONE",
+					"availabilityImpact": "HIGH",
+					"baseScore": 5.5,
+					"baseSeverity": "MEDIUM",
+					"temporalScore": 0,
+					"environmentalScore": 0
+				},
+				"exploitabilityScore": 1.8,
+				"impactScore": 3.6
+			}
+		]
+	},
+	"weaknesses": [
+		{
+			"source": "psirt@nvidia.com",
+			"type": "Secondary",
+			"description": [
+				{
+					"lang": "en",
+					"value": "CWE-799"
+				}
+			]
+		}
+	]
+}

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/no-detection/README.md
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/no-detection/README.md
@@ -1,0 +1,12 @@
+## Repository of VulnCheck NVD++ (nist-nvd2) data accumulation
+
+All the data in this repository are fetched from VulnCheck by its API.
+
+- https://docs.vulncheck.com/
+- https://docs.vulncheck.com/api
+- https://docs.vulncheck.com/community/nist-nvd/attribution
+
+**CAUTION**
+
+When you use the data in this repository, you *MUST* comply with the terms and conditions of VulnCheck NVD++: https://docs.vulncheck.com/community/nist-nvd/attribution
+Notably, you must show "prominent attribution" to show the data is from VulnCheck NVD++ to users.

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/no-detection/data/2024/CVE-2024-0094.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/no-detection/data/2024/CVE-2024-0094.json
@@ -1,0 +1,56 @@
+{
+	"id": "CVE-2024-0094",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-0094",
+				"description": "NVIDIA vGPU software for Linux contains a vulnerability in the Virtual GPU Manager, where an untrusted guest VM can cause improper control of the interaction frequency in the host. A successful exploit of this vulnerability might lead to denial of service.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "psirt@nvidia.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+							"base_score": 5.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "psirt@nvidia.com",
+						"cwe": [
+							"CWE-799"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "af854a3a-2127-422b-91ae-364da2661108",
+						"url": "https://nvidia.custhelp.com/app/answers/detail/a_id/5551"
+					},
+					{
+						"source": "psirt@nvidia.com",
+						"url": "https://nvidia.custhelp.com/app/answers/detail/a_id/5551"
+					},
+					{
+						"source": "vulncheck.com",
+						"url": "https://vulncheck.com/cve/CVE-2024-0094"
+					}
+				],
+				"published": "2024-06-13T22:15:13.08Z",
+				"modified": "2026-04-15T00:35:42.02Z"
+			}
+		}
+	],
+	"data_source": {
+		"id": "vulncheck-nist-nvd2",
+		"raws": [
+			"vuls-data-raw-vulncheck-nist-nvd2/2024/CVE-2024-0094.json"
+		]
+	}
+}

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/no-detection/datasource.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/no-detection/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "vulncheck-nist-nvd2",
+	"name": "VulnCheck NIST NVD 2.0"
+}

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
@@ -13,7 +13,12 @@
 				],
 				"published": "2025-02-26T07:01:03.62Z",
 				"modified": "2026-03-24T09:16:18.79Z"
-			}
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
 		}
 	],
 	"detections": [

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2022/CVE-2022-49267.json
@@ -13,12 +13,7 @@
 				],
 				"published": "2025-02-26T07:01:03.62Z",
 				"modified": "2026-03-24T09:16:18.79Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "cpe"
-				}
-			]
+			}
 		}
 	],
 	"detections": [

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2024/CVE-2024-2652.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/rejected/data/2024/CVE-2024-2652.json
@@ -13,12 +13,7 @@
 				],
 				"published": "2025-02-11T02:15:34.433Z",
 				"modified": "2025-02-11T02:15:34.433Z"
-			},
-			"segments": [
-				{
-					"ecosystem": "cpe"
-				}
-			]
+			}
 		}
 	],
 	"data_source": {


### PR DESCRIPTION
## What

Stop emitting a dangling `segments` entry on vulnerabilities whose record produced no detections, in three extractors sharing the same shape:

- `extract/vulncheck/nist-nvd2`
- `extract/nvd/feed/cve/v2`
- `extract/nvd/api/cve`

## Why

A segment ties a vulnerability/advisory to a detection in the same ecosystem. All three extractors set `Segments: [{ecosystem: cpe}]` unconditionally, so a record with no detections (Rejected, or no `configurations` / `vcConfigurations` / `vcVulnerableCPEs`) carried a segment pointing at nothing — an internally inconsistent dataset. `fortinet/csaf` already follows the "no detection → no segment" principle; this aligns these three with it.

Confirmed against real data:
- vulncheck raw feed: CVE-2024-0070 (Rejected), CVE-2024-0094 (Deferred, no vc fields) → extracted output carried `segments` without `detections`
- published `vuls-data-extracted-nvd-feed-cve-v2`: the same two CVEs show `segments` without `detections`

## How

`Segments` is now emitted only when the built detections slice is non-empty (per-extractor comment explains the invariant).

## Testing

- New golden case `no-detection` (real CVE-2024-0094 data) in `vulncheck/nist-nvd2` and `nvd/feed/cve/v2`
- Existing goldens updated: `vulncheck/nist-nvd2` `rejected` (2 files), `nvd/api/cve` `happy` (CVE-2023-7259) — diff is exactly the segment removal
- `GOEXPERIMENT=jsonv2 go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)