### PR TITLE
fix(fetch/paloalto/json): drop the known-404 workaround now upstream healed

### DIFF
--- a/pkg/fetch/paloalto/json/json.go
+++ b/pkg/fetch/paloalto/json/json.go
@@ -145,31 +145,6 @@ func Fetch(ids []string, opts ...Option) error {
 			}
 
 			return nil
-		case http.StatusNotFound:
-			_, _ = io.Copy(io.Discard, resp.Body)
-			id := path.Base(resp.Request.URL.Path)
-			// A handful of advisories listed by /json/?page= return 404 on the
-			// per-advisory endpoint (a known upstream regression); tolerate only these
-			// IDs so a 404 on any other advisory still fails loudly as a new regression.
-			// Empty this list once upstream restores the endpoints — see #864.
-			switch id {
-			case "CVE-2022-42889",
-				"PAN-SA-2014-0001", "PAN-SA-2014-0002", "PAN-SA-2014-0004", "PAN-SA-2014-0006",
-				"PAN-SA-2015-0003", "PAN-SA-2015-0005", "PAN-SA-2015-0006",
-				"PAN-SA-2016-0006", "PAN-SA-2016-0007", "PAN-SA-2016-0008", "PAN-SA-2016-0010",
-				"PAN-SA-2016-0011", "PAN-SA-2016-0013", "PAN-SA-2016-0014", "PAN-SA-2016-0015",
-				"PAN-SA-2016-0016", "PAN-SA-2016-0017", "PAN-SA-2016-0018", "PAN-SA-2016-0019",
-				"PAN-SA-2016-0020", "PAN-SA-2016-0022", "PAN-SA-2016-0023", "PAN-SA-2016-0024",
-				"PAN-SA-2016-0025", "PAN-SA-2016-0026", "PAN-SA-2016-0028", "PAN-SA-2016-0029",
-				"PAN-SA-2016-0030", "PAN-SA-2016-0031", "PAN-SA-2016-0032", "PAN-SA-2016-0033",
-				"PAN-SA-2018-0001", "PAN-SA-2018-0011", "PAN-SA-2018-0015",
-				"PAN-SA-2019-0004", "PAN-SA-2019-0011", "PAN-SA-2019-0012", "PAN-SA-2019-0013",
-				"PAN-SA-2022-0006", "PAN-SA-2022-0007":
-				slog.Warn("skip advisory: known upstream 404 regression", "id", id)
-				return nil
-			default:
-				return errors.Errorf("unexpected 404 for advisory %q (not a known upstream regression)", id)
-			}
 		default:
 			_, _ = io.Copy(io.Discard, resp.Body)
 			return errors.Errorf("error response with status code %d for advisory %q", resp.StatusCode, path.Base(resp.Request.URL.Path))

--- a/pkg/fetch/paloalto/json/json_test.go
+++ b/pkg/fetch/paloalto/json/json_test.go
@@ -63,6 +63,8 @@ func TestFetch(t *testing.T) {
 					switch path.Base(r.URL.Path) {
 					case "PAN-SA-9999-0500":
 						http.Error(w, "internal server error", http.StatusInternalServerError)
+					case "PAN-SA-0000-0000":
+						http.NotFound(w, r)
 					default:
 						http.ServeFile(w, r, filepath.Join("testdata", "fixtures", path.Base(r.URL.Path)))
 					}

--- a/pkg/fetch/paloalto/json/json_test.go
+++ b/pkg/fetch/paloalto/json/json_test.go
@@ -35,20 +35,11 @@ func TestFetch(t *testing.T) {
 			},
 		},
 		{
-			name: "include known 404 (skipped)",
+			name: "include 404 (fails)",
 			args: args{
 				ids: []string{
 					"CVE-2025-0114",
-					"PAN-SA-2016-0011", // known upstream 404 regression
-				},
-			},
-		},
-		{
-			name: "include unknown 404 (fails)",
-			args: args{
-				ids: []string{
-					"CVE-2025-0114",
-					"PAN-SA-0000-0000", // 404 but not a known regression
+					"PAN-SA-0000-0000", // per-advisory endpoint returns 404
 				},
 			},
 			hasError: true,


### PR DESCRIPTION
## What
Remove the hardcoded known-404 allowlist and per-advisory 404 tolerance added in #863 from the paloalto-json fetcher. A 404 on any per-advisory `/json/` endpoint now fails the fetch loudly again.

## Why
The upstream regression #863 worked around (a handful of older advisories returning 404 on the per-advisory endpoint) has been **resolved upstream**. A scheduled fetch on 2026-07-10 ([vuls-data-db run 29062223684](https://github.com/vulsio/vuls-data-db/actions/runs/29062223684/job/86285426145)) retrieved **all ~41 previously-404 advisories with zero skips**; the recovery workflow flagged every one with an `upstream 404 healed` warning, and their content matches the current live upstream data (verified against `/json`, `/csaf`, and the HTML advisory pages). This closes the follow-up tracked in #864.

## How
- Delete the `case http.StatusNotFound` branch (allowlist + `slog.Warn` skip); a 404 now falls through to the default arm and returns an error like any other non-OK status.

## Testing
- `GOEXPERIMENT=jsonv2 go test ./pkg/fetch/paloalto/...` passes.
- Reworked the fetcher test: dropped the "known 404 (skipped)" case (that behaviour no longer exists) and kept "include 404 (fails)" asserting any 404 now errors.

## Follow-up (separate, not in this PR)
The `vuls-data-db` recovery workflow's `KNOWN_404_IDS` allowlist / restore step can now be retired too; that lives in the pipeline repo and will be a separate change.