### PR TITLE
feat(fetch/jvn/feed): fetch JPCERT-AT reference page titles

### DIFF
--- a/pkg/fetch/jvn/feed/detail/detail.go
+++ b/pkg/fetch/jvn/feed/detail/detail.go
@@ -100,10 +100,15 @@ func Fetch(opts ...Option) error {
 		}
 	}
 
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
+	// A single JPCERT-AT alert is referenced by many advisories, so cache the
+	// fetched title per URL to avoid refetching.
+	certTitles := make(map[string]string)
+
 	for _, c := range filtered {
 		slog.Info("Fetch JVNDB Detail Feed", slog.String("feed", c.Filename))
 		vs, err := func() ([]Vulinfo, error) {
-			resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(c.URL)
+			resp, err := client.Get(c.URL)
 			if err != nil {
 				return nil, errors.Wrap(err, "fetch jvndb detail")
 			}
@@ -140,6 +145,28 @@ func Fetch(opts ...Option) error {
 
 		bar := progressbar.Default(int64(len(vs)))
 		for _, a := range vs {
+			for i, ref := range a.VulinfoData.Related.RelatedItem {
+				// Only JPCERT-AT alert pages ("/at/") carry a fetchable title; other
+				// cited JPCERT reference types (weekly reports, press releases) are
+				// skipped by IsAlertURL. Match on the URL rather than VulinfoID/Name,
+				// which are inconsistent in the feed. Trim once so the cache key,
+				// fetch target, and error context all use the same canonical URL.
+				u := strings.TrimSpace(ref.URL)
+				if !jvnutil.IsAlertURL(u) {
+					continue
+				}
+				title, ok := certTitles[u]
+				if !ok {
+					t, err := jvnutil.FetchTitle(client, u)
+					if err != nil {
+						return errors.Wrapf(err, "fetch JPCERT-AT title %s", u)
+					}
+					title = t
+					certTitles[u] = title
+				}
+				a.VulinfoData.Related.RelatedItem[i].FetchedTitle = title
+			}
+
 			splitted, err := util.Split(a.VulinfoID, "-", "-")
 			if err != nil {
 				return errors.Wrapf(err, "unexpected ID format. expected: %q, actual: %q", "JVNDB-yyyy-\\d{6}", a.VulinfoID)

--- a/pkg/fetch/jvn/feed/detail/detail_test.go
+++ b/pkg/fetch/jvn/feed/detail/detail_test.go
@@ -34,24 +34,46 @@ func TestFetch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch path.Base(r.URL.Path) {
-				case "checksum.txt":
+				switch {
+				case path.Base(r.URL.Path) == "checksum.txt":
 					f, err := os.Open(strings.TrimPrefix(r.URL.Path, "/"))
 					if err != nil {
 						http.NotFound(w, r)
+						return
 					}
 					defer f.Close()
 
 					bs, err := io.ReadAll(f)
 					if err != nil {
 						http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+						return
 					}
 
 					s := strings.ReplaceAll(string(bs), "https://jvndb.jvn.jp/ja/feed/detail", fmt.Sprintf("http://%s/testdata/fixtures", r.Host))
 
 					http.ServeContent(w, r, "checksum.txt", time.Now(), strings.NewReader(s))
+				case strings.HasPrefix(r.URL.Path, "/at/"):
+					// Real JPCERT-AT alert page saved under testdata/fixtures.
+					http.ServeFile(w, r, filepath.Join("testdata", "fixtures", strings.TrimPrefix(r.URL.Path, "/")))
 				default:
-					http.ServeFile(w, r, strings.TrimPrefix(r.URL.Path, "/"))
+					f, err := os.Open(strings.TrimPrefix(r.URL.Path, "/"))
+					if err != nil {
+						http.NotFound(w, r)
+						return
+					}
+					defer f.Close()
+
+					bs, err := io.ReadAll(f)
+					if err != nil {
+						http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+						return
+					}
+
+					// Rewrite JPCERT-AT reference URLs so they are fetched from this
+					// test server instead of the real host.
+					s := strings.ReplaceAll(string(bs), "https://www.jpcert.or.jp", fmt.Sprintf("http://%s", r.Host))
+
+					http.ServeContent(w, r, path.Base(r.URL.Path), time.Now(), strings.NewReader(s))
 				}
 			}))
 			defer ts.Close()
@@ -88,6 +110,10 @@ func TestFetch(t *testing.T) {
 					if err != nil {
 						return err
 					}
+
+					// The test server rewrites JPCERT-AT reference URLs to its own
+					// host; normalize them back so the golden stays deterministic.
+					got = []byte(strings.ReplaceAll(string(got), ts.URL, "https://www.jpcert.or.jp"))
 
 					if diff := cmp.Diff(want, got); diff != "" {
 						t.Errorf("Fetch(). (-expected +got):\n%s", diff)

--- a/pkg/fetch/jvn/feed/detail/testdata/fixtures/at/2021/at210050.html
+++ b/pkg/fetch/jvn/feed/detail/testdata/fixtures/at/2021/at210050.html
@@ -1,0 +1,683 @@
+<!DOCTYPE html>
+<html lang="ja-jp">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	
+	<title>Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起</title>
+	<meta name="keywords" content="" />
+	<meta name="description" content="" />
+	<meta property="og:locale" content="ja_JP" />
+	<meta property="og:site_name" content="JPCERT/CC" />
+	<meta property="og:url" content="https://www.jpcert.or.jp/at/2021/at210050.html">
+	<meta property="og:title" content="Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起">
+	
+	<meta property="og:image" content="https://www.jpcert.or.jp/common/image/ogp_image.jpg">
+	
+	<link rel="alternate" type="application/rss+xml" title="注意喚起、Weekly Report、脆弱性情報（JVN）、JPCERT/CCからのお知らせやイベントの新着情報をまとめて提供" href="/rss/jpcert-all.rdf" />
+	<link rel="alternate" type="application/rss+xml" title="注意喚起と緊急報告、Weekly Report の新着情報" href="/rss/jpcert.rdf" />
+	<link rel="alternate" type="application/rss+xml" title="JPCERT/CCからのお知らせ、イベントの新着情報" href="/rss/whatsnew.rdf" />
+	<link rel="stylesheet" href="/common/css/html5reset-1.6.1.css">
+	<link rel="stylesheet" href="/common/css/common.css">
+	<link rel="stylesheet" href="/common/css/page.css">
+	<link rel="stylesheet" href="/common/css/print.css" media="print" />
+	<link rel="stylesheet" href="/common/slide/slide.css"/>
+	
+</head>
+<body class="category_a">
+
+
+<!-- guidance_sp -->
+<div id="guidance_sp" style="display:none;">
+<div class="title"><img src="/common/guidance/g_guidance_title.png" alt="スマートフォン用で表示" /><a href="/m/at/2021/at210050.html" id="show_sp_site"><img src="/common/guidance/g_button_show.png" alt="" /></a></div>
+<div class="message"><a href="javascript:;" id="check_no_message"><img src="/common/guidance/g_check_off.png" alt="" /><img src="/common/guidance/g_guidance_message.png" alt="" /></a></div>
+</div>
+<!-- /guidance_sp -->
+
+<header class="sh_uoh">
+	<div class="top">
+		<h2><img src="/common/image/h2_image.png" width="330" height="25" alt="サイバーインシデントがなくなるその日まで" /></h2>
+		<ul>
+			<li><a href="/reference.html">お問い合わせ</a></li>
+			<li><a href="/recruit/index.html">採用情報</a></li>
+			<li><a href="/sitemap.html">サイトマップ</a></li>
+			<li><a href="/english/">English</a></li>
+		</ul>
+	</div>
+
+	<div class="main">
+		<h1><a href="/"><img src="/common/image/header_logo.svg" width="198" height="66" alt="JPCERT Coordination Center" /></a></h1>
+
+<!-- googlr search area
+		<div class="search_area">
+			<form id="cse-search-box" action="https://www.google.com/cse">
+				<input value="011276954563619633753:gam5ydxz2ni" name="cx" type="hidden">
+				<input value="UTF-8" name="ie" type="hidden">
+				<input name="q" id="q" value="" type="text" placeholder="検索キーワードを入力" /><input name="sa" id="sa" type="submit" value="検索" />
+			</form>
+		</div>
+-->
+		
+<!-- yahoo custom search area		
+		<div id="yahoo_search_area" class="watermark">
+
+			<form action="https://custom.search.yahoo.co.jp/search" method="get" id="srch">
+				<p id="srchForm">
+					<input type="text" name="p" id="srchInput">
+					<input type="submit" value="検索" id="srchBtn" onclick="document.getElementById('srchInput').focus();">
+					<input type="hidden" id="fr" name="fr" value="cse">
+					<input type="hidden" id="ei" name="ei" value="UTF-8">
+					<input type="hidden" id="csid" name="csid" value="YZgbsqsHFIwmPApo7sIjK_PtheLpmwnBs_eTDxVthQ--">
+				</p>
+				<input type="hidden" name="vs" value="www.jpcert.or.jp" id="yjInsite">
+			</form>
+		</div>
+-->
+		<div id="yahoo_search_new_area" style="width:396px;">
+			<form action="https://search.yahoo.co.jp/search" method="get" style="margin:0;padding:0;">
+			<p style="margin:0;padding:0;">
+				<a href="https://www.yahoo.co.jp/" target="_blank" style="font-size: 10px;">
+					powered by Yahoo! JAPAN
+				</a>
+				<input type="text" name="p" size="28" style="margin:0 3px;width:50%;">
+				<input type="hidden" name="fr" value="ysiw">
+				<input type="hidden" name="ei" value="utf-8">
+				<input type="submit" value="検索" style="margin:0;color:#595757;font-size:10pt;">
+			</p>
+			<ul style="margin:2px 0 0 0;padding:0;font-size:10pt;list-style:none;">
+				<li style="display:inline;font-size:10pt;">
+					<input name="vs" type="radio" value="www.jpcert.or.jp" checked="checked">
+					このサイト内を検索
+				</li>
+				<li style="display:inline;font-size:10pt;">
+					<input name="vs" type="radio" value="">
+					ウェブ全体を検索
+				</li>
+			</ul>
+			</form>
+			<img src="https://custom.search.yahoo.co.jp/images/window/006c75a92ba244c6b4cbe2709aa17d7b.gif" width="1" height="1" style="display:block;position:absolute">
+		</div>
+		<ul class="links">
+			<li class="icon_rss">最新情報を取得 (<a href="/rss/">RSS</a> | <a href="/announce.html">メーリングリスト</a>) </li>
+			<li><a href="https://www.jpcert.or.jp/" class="icon_https">HTTPS</a></li>
+			<li><a href="/m/" class="icon_mobile">モバイル</a></li>
+		</ul>
+		<script type="text/javascript">
+			(function() {
+			var sb = document.getElementById('srchBox');
+			if (sb && sb.className == 'watermark') {
+  			var si = document.getElementById('srchInput');
+  			var f = function() { si.className = 'nomark'; };
+  			var b = function() {
+    			if (si.value == '') {
+      			si.className = '';
+    			}
+  			};
+  			si.onfocus = f;
+  			si.onblur = b;
+  			if (!/[&?]p=[^&]/.test(location.search)) {
+    			b();
+  			} else {
+    			f();
+  			}
+			}
+			})();
+			</script>
+			
+	</div>
+</header>
+
+<nav>
+	<ul class="menu contents_area_view">
+		<li class="category_a "><a href="/aboutincident.html">インシデントとは</a></li>
+		<li class="category_a selected">
+			<a href="/menu_alertsandadvisories.html">緊急情報を確認する</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">緊急情報を確認する</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/at/">注意喚起</a></li>
+							<li><a href="/tsubame/">インターネット定点観測</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="https://jvn.jp/">JVN</a></li>
+							<li><a href="/vh/top.html">脆弱性対策情報</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_reporttojpcert.html">依頼・相談する</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">依頼・相談する</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/ir/">インシデント対応とは</a></li>
+							<li><a href="/form/">インシデント対応依頼</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/ir/consult.html">インシデント相談・情報提供</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_documents.html">公開資料を見る</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">公開資料を見る</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/wr/">Weekly Report</a></li>
+							<li><a href="/qr/index.html">四半期レポート</a></li>
+							<li><a href="/tsubame/report/">インターネット定点観測レポート</a></li>
+							<li><a href="/report/press.html">ソフトウェア等の脆弱性関連情報に関する届出状況</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/research/">研究・調査・翻訳レポート</a></li>
+							<li><a href="/csirt_material/">CSIRTマテリアル</a></li>
+							<li><a href="/securecoding/">セキュアコーディング</a></li>
+							<li><a href="/ics/">制御システムセキュリティ</a></li>
+							<li><a href="/magazine/">ライブラリ</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_receiveinformation.html">情報を受け取る</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">情報を受け取る</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/cista/">CISTA（シスタ）</a></li>
+							<li><a href="/vh/register.html">製品開発者登録</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/announce.html">メーリングリスト</a></li>
+							<li><a href="/rss/">RSS</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_b ">
+			<a href="/menu_columnblog.html">コラム＆ブログ</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">コラム＆ブログ</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/newsflash/">CyberNewsFlash</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="https://blogs.jpcert.or.jp/ja/">JPCERT/CC Eyes～JPCERT/CC公式ブログ～ </a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_b ">
+			<a href="/menu_aboutjpcert.html">JPCERT/CCについて</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">JPCERT/CCについて</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/about/">JPCERT/CCとは</a></li>
+							<li class="level2"><a href="/message.html">代表理事挨拶</a></li>
+							<li class="level2"><a href="/profile.html">組織概要</a></li>
+							<li class="level2"><a href="/about/01.html">事業概要</a></li>
+							<li><a href="/recruit/">採用情報</a></li>
+							<li><a href="/solicitation/">公募・入札情報</a></li>
+							<li><a href="/press/pressroom.html">プレスルーム</a></li>
+							<li class="level2"><a href="/press/2026.html">プレスリリース</a></li>
+							<li class="level2"><a href="/press/contact.html">広報へのお問い合わせ</a></li>
+							<li class="level2"><a href="/press/request.html">講演依頼</a></li>
+							<li class="level2"><a href="/press/nominal-support.html">後援申請</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/event/">イベント</a></li>
+							<li><a href="/kouen/">講演・執筆一覧</a></li>
+							<li><a href="/twitter.html">X（旧Twitter）一覧</a></li>
+							<li><a href="/jpcert-pgp.html">PGP公開鍵</a></li>
+							<li><a href="/related/">関連組織</a></li>
+							<li><a href="/reference.html">お問い合わせ</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+	</ul>
+</nav>
+
+<div class="breadcrumb_list_area contents_area_view sh_uoh cf">
+	<ul class="breadcrumb_list fl">
+		<li><a href="/">HOME</a></li><li><a href="/menu_alertsandadvisories.html">緊急情報を確認する</a></li><li>Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起</li>
+	</ul>
+	
+	<ul id="page_layout_utility" class="page_layout_utility fr" style="display:none;">
+		<li class="to_normal_layout_group"><a href="javascript:;" class="icon_normal_layout">通常レイアウトに戻す</a></li>
+		<li class="to_normal_layout_group"><a href="javascript:;" class="icon_print">印刷</a></li>
+		<li class="to_print_layout_group"><a href="javascript:;" class="icon_print_layout">印刷用レイアウト</a></li>
+		<li class="to_print_layout_group"><span class="icon_print_disabled">印刷</span></li>
+	</ul>
+	
+</div>
+
+
+<div class="contents_body contents_area_view cf">
+	<div id="link_pgtop" class="contents_right_body">
+		<div class="contents_right_body_wrapper">
+			<div class="page_title_area">
+				<h3>Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起</h3>
+				<span>最終更新: 2022-01-04</span>
+			</div>
+
+			<div class="contents_container">
+<div class="social_links cf">
+	<div class="mail">
+		<a href="mailto:?subject=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7&amp;body=https%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html">
+			<img src="/common/social_links/images/btn_share_mail_jp.png" alt="" />
+		</a>
+	</div>
+	<div class="tweet window">
+		<a href="https://twitter.com/intent/tweet?text=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7%0Ahttps%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html%0A%40jpcert" target="_blank">
+			<img src="/common/social_links/images/btn_share_post_jp.png" alt="" />
+		</a>
+	</div>
+</div>
+
+				<article class="">
+<!-- content_area -->
+<div class="at">
+JPCERT-AT-2021-0050<br />
+JPCERT/CC<br />
+2021-12-11（新規）<br />
+2022-01-04（更新）<br />
+<br />
+<br />
+<h4>I. 概要</h4><br />
+<br />
+<p class="headline_blue">更新: 2022年1月4日記載 </p><div class="update_details">現時点で不明な点もあることから、今後の動向次第で下記掲載内容を修正、更新する予定がありますので、関連情報への注視のほか、本注意喚起の更新内容も逐次ご確認ください。<br />
+<br />
+次の更新を行いました。詳細は「III. 対策」を参照してください。<br />
+<br />
+- Apache Log4jのバージョン2.17.1（Java 8以降のユーザー向け）、2.12.4（Java 7のユーザー向け）及び2.3.2（Java 6のユーザー向け）が公開されました<br />
+<br />
+</div><br />
+<br />
+JavaベースのオープンソースのロギングライブラリのApache Log4jには、任意のコード実行の脆弱性（CVE-2021-44228）があります。Apache Log4jが動作するサーバーにおいて、遠隔の第三者が本脆弱性を悪用する細工したデータを送信することで、任意のコードを実行する可能性があります。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.15.0<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html">https://logging.apache.org/log4j/2.x/security.html</a><br />
+<br />
+Apache Log4jにはLookupと呼ばれる機能があり、ログとして記録された文字列から、一部の文字列を変数として置換します。その内、JNDI Lookup機能が悪用されると、遠隔の第三者が細工した文字列を送信し、Log4jがログとして記録することで、Log4jはLookupにより指定された通信先もしくは内部パスからjava classファイルを読み込み実行し、結果として任意のコードが実行される可能性があります。<br />
+<br />
+2021年12月11日現在、JPCERT/CCは、本脆弱性を悪用する実証コードが公開されていること、及び国内にて本脆弱性の悪用を試みる通信を確認しています。Apache Log4jを利用している場合には、The Apache Software Foundationなどが提供する最新の情報を確認し、バージョンアップや回避策の適用などの実施を検討することを推奨します。<br />
+<br />
+また、Apache Log4jを使用するアプリケーションやソフトウェアなどで、今後セキュリティアップデートが公開される可能性があります。関連する情報を注視し、必要な対策や対応の実施をご検討ください。<br />
+<br />
+<br />
+<h4>II. 対象</h4>対象となるバージョンは次のとおりです。<br />
+<br />
+- Apache Log4j-core 2.15.0より前の2系のバージョン<br />
+<br />
+なお、すでにEnd of Lifeを迎えているApache Log4j 1系のバージョンは、Lookup機能が含まれておらず、JMS Appenderが有効でもクラス情報がデシリアライズされないため影響を受けないとの情報を確認しています。<br />
+<br />
+また、影響を受けるバージョンや条件に関する情報が変更あるいは更新される可能性や、Apache Log4jを使用するアプリケーションやソフトウェアの開発元などから情報が公開される可能性もあるため、最新の情報は各組織から提供される関連情報をご確認ください。<br />
+<br />
+<p class="headline_blue">更新: 2021年12月13日追記 </p><div class="update_details">Apache Log4j 1系のバージョンについては、第三者が本脆弱性を悪用するためにLog4jの設定ファイルを変更することができれば影響を受けるとの情報が公開されていますが、攻撃を行うためには何らかの方法で事前にシステムに不正にアクセスする必要があり、遠隔からの脆弱性を悪用した攻撃の影響は受けません。<br />
+<br />
+Restrict LDAP access via JNDI #608 Comment<br />
+<a href="https://github.com/apache/logging-log4j2/pull/608#issuecomment-991730650">https://github.com/apache/logging-log4j2/pull/608#issuecomment-991730650</a></div><br />
+<br />
+<br />
+<h4>III. 対策</h4>The Apache Software Foundationから本脆弱性を修正したバージョンが公開されています。速やかな対策の適用実施をご検討ください。次のバージョン以降では、Lookup機能がデフォルトでは無効になりました。<br />
+<br />
+- Apache Log4j 2.15.0<br />
+<br />
+使用するアプリケーションやソフトウェアなどについて関連情報を注視し、本脆弱性の影響を受けることが判明した場合も、速やかにアップデートなどの対応を行うことを推奨します。<br />
+<br />
+また、すでに本脆弱性の悪用を試みる通信が確認されていることから、対策の適用実施とあわせて、不審なファイル及びプロセスの有無や、通信ログ等を確認し、攻撃の有無を確認することを推奨します。<br />
+<br />
+<p class="headline_blue">更新: 2021年12月15日追記 </p><div class="update_details">The Apache Software Foundationは、Apache Log4jのバージョン2.16.0（Java 8以降のユーザー向け）および2.12.2（Java 7のユーザー向け）を公開しました。<br />
+<br />
+特定の構成において不正なJNDI検索パターンを入力値とする場合にサービス運用妨害（DoS）が生じる可能性があることが判明し、Message Lookup機能が削除され、JNDIへのアクセスがデフォルトで無効になりました。この問題にはCVE-2021-45046が採番されています。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.12.2 (Java 7) and Log4j 2.16.0 (Java 8)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.16.0">https://logging.apache.org/log4j/2.x/security.html#log4j-2.16.0</a><br />
+<br />
+任意のコード実行の脆弱性（CVE-2021-44228）への対策に加え、サービス運用妨害攻撃の脆弱性（CVE-2021-45046）などのリスクに対応するため、2.16.0または2.12.2へのアップデートを推奨します。</div><p class="headline_blue">更新: 2021年12月20日追記 </p><div class="update_details">CVE-2021-45046の影響について、一部の環境では任意のコード実行などが可能であるとの情報が公開されています。</div><p class="headline_blue">更新: 2021年12月20日追記 </p><div class="update_details">2021年12月18日（現地時間）、The Apache Software Foundationは、Apache Log4jのバージョン2.17.0（Java 8以降のユーザー向け）を公開しました。<br />
+<br />
+自己参照による制御不能な再帰から保護されていないことに起因し、Log4jの設定によっては影響を受けるサービス運用妨害攻撃の脆弱性（CVE-2021-45105）が修正されています。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.17.0 (Java 8)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0">https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0</a></div><p class="headline_blue">更新: 2021年12月28日追記 </p><div class="update_details">2021年12月21日（現地時間）、The Apache Software Foundationは、Apache Log4jのバージョン2.3.1（Java 6のユーザー向け）及び2.12.3（Java 7のユーザー向け）を公開しました。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.17.0 (Java 8), 2.12.3 (Java 7) and 2.3.1 (Java 6)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0">https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0</a></div><p class="headline_blue">更新: 2022年1月4日追記 </p><div class="update_details">2021年12月28日（現地時間）、The Apache Software Foundationは、Apache Log4jの2.17.1（Java 8以降のユーザー向け）、2.12.4（Java 7のユーザー向け）及び2.3.2（Java 6のユーザー向け）を公開しました。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.17.1 (Java 8), 2.12.4 (Java 7) and 2.3.2 (Java 6)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.1">https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.1</a></div><br />
+<br />
+<h4>IV. 回避策</h4>The Apache Software Foundationから、Log4jのバージョンに応じた回避策に関する情報が公開されています。<br />
+<br />
+<p class="headline_blue">更新: 2021年12月15日追記 </p><div class="update_details">The Apache Software Foundationより、一部の回避策は、特定の手法を用いた攻撃を回避するには不十分であることが判明したと明らかにし、有効な回避策として、JndiLookup.classをクラスパスから削除する回避策の実施を呼びかけています。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.12.2 and Log4j 2.16.0<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html">https://logging.apache.org/log4j/2.x/security.html</a></div><br />
+<br />
+Log4jバージョン2.10及びそれ以降<br />
+- 次のいずれかを実施する<br />
+（1）Log4jを実行するJava仮想マシンを起動時に「log4j2.formatMsgNoLookups」というJVMフラグオプションを「true」に指定する 例: -Dlog4j2.formatMsgNoLookups=true<br />
+（2）環境変数「LOG4J_FORMAT_MSG_NO_LOOKUPS」を「true」に設定する<br />
+<br />
+Log4jバージョン2.10より前<br />
+- JndiLookupクラスをクラスパスから削除する<br />
+<br />
+<br />
+また、本脆弱性を悪用する攻撃の影響を軽減するため、システムから外部への接続を制限するための可能な限りのアクセス制御の見直しや強化もご検討ください。<br />
+<br />
+<br />
+<h4>V. 参考情報</h4><br />
+apache / logging-log4j2<br />
+Restrict LDAP access via JNDI #608<br />
+<a href="https://github.com/apache/logging-log4j2/pull/608">https://github.com/apache/logging-log4j2/pull/608</a><br />
+<br />
+The Apache Software Foundation<br />
+Lookups<br />
+<a href="https://logging.apache.org/log4j/2.x/manual/lookups.html">https://logging.apache.org/log4j/2.x/manual/lookups.html</a><br />
+<br />
+LunaSec<br />
+Log4Shell: RCE 0-day exploit found in log4j2, a popular Java logging package<br />
+<a href="https://www.lunasec.io/docs/blog/log4j-zero-day/">https://www.lunasec.io/docs/blog/log4j-zero-day/</a><br />
+<br />
+SANS ISC InfoSec Forums<br />
+RCE in log4j, Log4Shell, or how things can get bad quickly<br />
+<a href="https://isc.sans.edu/forums/diary/RCE+in+log4j+Log4Shell+or+how+things+can+get+bad+quickly/28120/">https://isc.sans.edu/forums/diary/RCE+in+log4j+Log4Shell+or+how+things+can+get+bad+quickly/28120/</a><br />
+<br />
+BlueTeam CheatSheet * Log4Shell*<br />
+<a href="https://gist.github.com/SwitHak/b66db3a06c2955a9cb71a8718970c592">https://gist.github.com/SwitHak/b66db3a06c2955a9cb71a8718970c592</a><br />
+<br />
+<p class="headline_blue">更新: 2021年12月13日追記 </p><div class="update_details">    Japan Vulnerability Notes JVNVU#96768815<br />
+Apache Log4jにおける任意のコードが実行可能な脆弱性<br />
+<a href="https://jvn.jp/vu/JVNVU96768815/">https://jvn.jp/vu/JVNVU96768815/</a></div><br />
+<br />
+<p class="headline_blue">更新: 2021年12月20日追記 </p><div class="update_details">    JPCERT/CC Eyes<br />
+Apache Log4j2のRCE脆弱性（CVE-2021-44228）を狙う攻撃観測<br />
+<a href="https://blogs.jpcert.or.jp/ja/2021/12/log4j-cve-2021-44228.html">https://blogs.jpcert.or.jp/ja/2021/12/log4j-cve-2021-44228.html</a></div><br />
+<br />
+<p class="headline_blue">更新: 2021年12月28日追記 </p><div class="update_details">    JPCERT/CC CyberNewsFlash<br />
+2021年12月に公表されたLog4jの脆弱性について<br />
+<a href="https://www.jpcert.or.jp/newsflash/2021122401.html">https://www.jpcert.or.jp/newsflash/2021122401.html</a></div><br />
+<br />
+今回の件につきまして提供いただける情報がございましたら、JPCERT/CCまでご連絡ください。<br />
+<br />
+<p class="headline_blue">改訂履歴</p>2021-12-11 初版<br />
+2021-12-13 「II. 対象」、「IV. 回避策」、「V. 参考情報」の一部記載の追記・修正<br />
+2021-12-15 「III. 対策」、「IV. 回避策」の追記<br />
+2021-12-20 「I. 概要」、「III. 対策」、「V. 参考情報」の追記<br />
+2021-12-28 「I. 概要」、「III. 対策」、「V. 参考情報」の追記<br />
+2022-01-04 「I. 概要」、「III. 対策」の追記、2021年12月20日追記内容、2021年12月28日追記内容の修正<br />
+<br />
+<br />
+一般社団法人JPCERTコーディネーションセンター（JPCERT/CC）<br />
+早期警戒グループ<br />
+Email：ew-info@jpcert.or.jp
+</div>
+<p class="pg_top"><a href="#link_pgtop">Topへ</a></p>
+<!-- /content_area -->
+				</article>
+
+<div class="social_links cf">
+	<div class="mail">
+		<a href="mailto:?subject=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7&amp;body=https%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html">
+			<img src="/common/social_links/images/btn_share_mail_jp.png" alt="" />
+		</a>
+	</div>
+	<div class="tweet window">
+		<a href="https://twitter.com/intent/tweet?text=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7%0Ahttps%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html%0A%40jpcert" target="_blank">
+			<img src="/common/social_links/images/btn_share_post_jp.png" alt="" />
+		</a>
+	</div>
+</div>
+<div id="fb" class="feedback feedback_noscript">
+<div class="container_a"><div class="container_b">
+<form name="feedback_form" id="feedback_form">
+	<p class="title">このページは役に立ちましたか？</p>
+	<div class="inner">
+		<p>
+			<input type="radio" name="is_useful" id="is_usefull_yes" value="yes" disabled="disabled" /><label for="is_usefull_yes">はい</label>
+			<input type="radio" name="is_useful" id="is_usefull_no" value="no" disabled="disabled" /><label for="is_usefull_no">いいえ</label>
+		</p>
+		<p class="result">&nbsp;</p>
+	</div>
+	<p class="title">その他、ご意見・ご感想などございましたら、ご記入ください。</p>
+	<div class="inner">
+		<p class="message">こちらはご意見・ご感想用のフォームです。各社製品については、各社へお問い合わせください。</p>
+		<p class="message_red">※本フォームにいただいたコメントへの返信はできません。
+		<a href="/reference.html">返信をご希望の方は「お問合せ」</a>
+		をご利用ください。
+		</p>
+		<div class="container_a"><div class="container_b">
+			<textarea name="free_text" id="free_text" disabled="disabled" cols="30" rows="3"></textarea>
+		</div></div>
+		<p class="send_area">
+			<input class="button" type="image" src="/common/feedback/images/fb_btn_send_jp.jpg" alt="送信" disabled="disabled"/>
+			<span class="en_js_msg">javascriptを有効にすると、ご回答いただけます。</span>
+			<span class="loader" style="display:none;"><img src="/common/feedback/images/fb_loader.gif" alt="処理中..." /></span>
+			<span class="thanks">ありがとうございました。</span>
+			<a href="/form/" class="incident_link">インシデント報告はこちらから</a>
+		</p>
+	</div>
+	<input type="hidden" name="redirect_to" id="redirect_to" value="" />
+	<input type="hidden" name="feedback_host" id="feedback_host" value="//ws.jpcert.or.jp/cgi-bin/" />
+	<input type="hidden" name="uri" id="uri" value="" />
+	<input type="hidden" name="token" id="token" value="" />
+</form>
+</div></div>
+</div>
+
+<div class="page_navigation cf">
+	<a href="javascript:;" class="previous disabled">&lt;&lt;&nbsp;前へ</a>
+	<a href="javascript:;" class="next disabled">次へ&nbsp;&gt;&gt;</a>
+</div>
+
+			</div>
+		</div>
+	</div>
+	
+	<div class="contents_left_body">
+		<div class="page_guide_menu">
+	
+	
+	<p>緊急情報を確認する</p>
+	<ul class="page_guide_menu">
+		<li class="selected"><a href="/at/">注意喚起</a></li>
+		<li ><a href="/tsubame/">インターネット定点観測</a></li>
+		<li><a href="https://jvn.jp/">JVN</a></li>
+		<li ><a href="/vh/top.html">脆弱性対策情報</a></li>
+	</ul>
+	
+	
+	
+	
+	
+	
+</div>
+
+		<div class="recommend_list">
+			<p>おすすめ情報</p>
+			<ul class="list">
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/07/apt-c-60_2026.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「APT-C-60による2026年の攻撃」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/06/tool_analysis_update.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「ツール分析結果シートのアップデート」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/06/tsubame-overflow20260103.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2026年1～3月）」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/05/tsubame-overflow20251012.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2025年10～12月）」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/03/tsubame-overflow20250709.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2025年7～9月）」</a></li>
+
+	<li><a href="/magazine/security/ransom-faq.html" onclick="piwikTracker.trackGoal(3);">侵入型ランサムウェア攻撃を受けたら読むFAQ</a></li>
+
+</ul>
+		</div>
+
+		<ul class="banner_list">
+
+	<!--
+	<li><a class="button" href="/csirt_material/"><img src="/common/banner_images/csirt_off.png" alt="CSIRTマテリアル" /></a></li>
+	-->
+	
+	<!--
+	<li><a class="button" href="/pr/2017/pr170002.html"><img src="/common/banner_images/password_off.png" alt="STOP!!パスワード使い回し!!キャンペーン2017" /></a></li>
+	<li><a class="button" href="/pr/2016/pr160005.html"><img src="/common/banner_images/holiday_off.png" alt="" /></a></li>
+	<li><a class="button" href="/pr/2016/pr160005.html"><img src="/common/banner_images/vacation_off.png" alt="" /></a></li>
+	-->
+
+	
+
+	
+	<li><a class="button" href="/csirt_material/"><img src="/common/banner_images/csirt_off.png" alt="CSIRTマテリアル" /></a></li>
+	
+
+	
+
+	
+
+	
+
+	
+</ul>
+	</div>
+</div>
+
+<footer class="gray_background sh_uoh">
+	<div class="page_link_area contents_area_view cf">
+		<div class="page_link_contaienr cf">
+			<div class="page_link_right_area cf">
+				<div class="page_links">
+					<p class="dt"><a href="/menu_aboutjpcert.html">JPCERT/CCについて</a></p>
+					<div class="cf">
+						<dl class="fl">
+							<dt class="hide">&nbsp;</dt>
+							<dd><a href="/about/">JPCERT/CCとは</a></dd>
+							<dd class="dd_second_class"><a href="/message.html">代表理事挨拶</a></dd>
+							<dd class="dd_second_class"><a href="/profile.html">組織概要</a></dd>
+							<dd class="dd_second_class"><a href="/about/01.html">事業概要</a></dd>
+							<dd><a href="/recruit/">採用情報</a></dd>
+							<dd><a href="/solicitation/">公募・入札情報</a></dd>
+							<dd><a href="/press/pressroom.html">プレスルーム</a></dd>
+							<dd class="dd_second_class"><a href="/press/2026.html">プレスリリース</a></dd>
+							<dd class="dd_second_class"><a href="/press/contact.html">広報へのお問い合わせ</a></dd>
+							<dd class="dd_second_class"><a href="/press/request.html">講演依頼</a></dd>
+							<dd class="dd_second_class"><a href="/press/nominal-support.html">後援申請</a></dd>
+						</dl>
+						<dl class="fl">
+							<dt class="hide">&nbsp;</dt>
+							<dd><a href="/event/">イベント</a></dd>
+							<dd><a href="/kouen/">講演・執筆一覧</a></dd>
+							<dd><a href="/magazine/chronology/">セキュリティ<br />インシデント年表</a></dd>
+							<dd><a href="/twitter.html">X（旧Twitter）一覧</a></dd>
+							<dd><a href="/jpcert-pgp.html">PGP公開鍵</a></dd>
+							<dd><a href="/related/">関連組織</a></dd>
+							<dd><a href="/reference.html">お問い合わせ</a></dd>
+						</dl>
+					</div>
+					<dl class="dl_second_line">
+						<dt><a href="/menu_columnblog.html">コラム＆ブログ</a></dt>
+						<dd><a href="/newsflash/">CyberNewsFlash</a></dd>
+						<dd><a href="https://blogs.jpcert.or.jp/ja/">JPCERT/CC Eyes ～JPCERTコーディネーションセンター公式ブログ～</a></dd>
+					</dl>
+				</div>
+			</div>
+			<div class="page_link_left_area cf">
+				<div class="page_links">
+					<dl>
+						<dt>インシデントとは</dt>
+						<dd><a href="/aboutincident.html">インシデントとは</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_alertsandadvisories.html">緊急情報を確認する</a></dt>
+						<dd><a href="/at/">注意喚起</a></dd>
+						<dd><a href="/tsubame/">インターネット定点観測</a></dd>
+						<dd><a href="https://jvn.jp/">JVN</a></dd>
+						<dd><a href="/vh/top.html">脆弱性対策情報</a></dd>
+					</dl>
+					<dl class="dl_second_line">
+						<dt><a href="/menu_reporttojpcert.html">依頼・相談する</a></dt>
+						<dd><a href="/ir/">インシデント対応とは</a></dd>
+						<dd><a href="/form/">インシデント対応依頼</a></dd>
+						<dd><a href="/ir/consult.html">インシデント相談・情報提供</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_documents.html">公開資料を見る</a></dt>
+						<dd><a href="/wr/">Weekly Report</a></dd>
+						<dd><a href="/qr/index.html">四半期レポート</a></dd>
+						<dd><a href="/tsubame/report/">インターネット定点観測レポート</a></dd>
+						<dd><a href="/report/press.html">ソフトウェア等の<br />脆弱性関連情報に関する届出</a></dd>
+						<dd><a href="/research/">研究・調査・翻訳レポート</a></dd>
+						<dd><a href="/csirt_material/">CSIRTマテリアル</a></dd>
+						<dd><a href="/securecoding/">セキュアコーディング</a></dd>
+						<dd><a href="/ics/">制御システムセキュリティ</a></dd>
+						<dd><a href="/magazine/">ライブラリ</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_receiveinformation.html">情報を受け取る</a></dt>
+						<dd><a href="/cista/">CISTA（シスタ）</a></dd>
+						<dd><a href="/vh/register.html">製品開発者登録</a></dd>
+						<dd><a href="/announce.html">メーリングリスト</a></dd>
+						<dd><a href="/rss/">RSS</a></dd>
+					</dl>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="footer_area">
+		<img class="logo" src="/common/image/footer_logo.svg" width="194" height="45" alt="JPCERT/CC" />
+		<p class="company_info">一般社団法人JPCERTコーディネーションセンター<br />〒103-0023<br />東京都中央区日本橋本町4-4-2 東山ビルディング8階<br />TEL: 03-6271-8901　FAX 03-6271-8908<br />
+		</p>
+		<ul class="links">
+			<li><a href="/guide.html">ご利用にあたって</a></li>
+			<li><a href="/privacy.html">プライバシーポリシー</a></li>
+			<li><a href="/reference.html">お問い合わせ</a></li>
+			<li><a href="/about/about_mobile.html">モバイル向けコンテンツ</a></li>
+		</ul>
+		<address>&copy; 1996-2026 JPCERT/CC</address>
+	</div>
+</footer>
+
+<script type="text/javascript" src="/common/js/prototype.js"></script>
+<script type="text/javascript" src="/common/js/effects.js"></script>
+<script type="text/javascript" src="/common/js/builder.js"></script>
+<script type="text/javascript" src="/common/js/cookie.js"></script>
+<script type="text/javascript" src="/common/slide/slide.js"></script>
+<script type="text/javascript" src="/common/js/common.js"></script>
+<script type="text/javascript" src="/common/social_links/script.js"></script>
+<script type="text/javascript" src="/common/feedback/script.js"></script>
+<script type="text/javascript" src="/common/page_navigation/script.js"></script>
+
+
+</body>
+</html>

--- a/pkg/fetch/jvn/feed/detail/testdata/fixtures/checksum.txt
+++ b/pkg/fetch/jvn/feed/detail/testdata/fixtures/checksum.txt
@@ -42,6 +42,13 @@
         "lastModified": "2023/10/29 09:15:44"
     },
     {
+        "url": "https://jvndb.jvn.jp/ja/feed/detail/jvndb_detail_2021.rdf",
+        "filename": "jvndb_detail_2021.rdf",
+        "sha256": "a7c9e2f1b3d4c5e6a7b8c9d0e1f2031425364758697a8b9cadbecfd0e1f20314",
+        "size": 60000000,
+        "lastModified": "2023/10/29 09:16:12"
+    },
+    {
         "url": "https://jvndb.jvn.jp/ja/feed/vendor/myjvn_vendor_202311.rdf",
         "filename": "myjvn_vendor_202311.rdf",
         "sha256": "59c66815e8f210e2b452578f6ba89edf74fdba866cb530ed83a2c5746b93f429",

--- a/pkg/fetch/jvn/feed/detail/testdata/fixtures/jvndb_detail_2021.rdf
+++ b/pkg/fetch/jvn/feed/detail/testdata/fixtures/jvndb_detail_2021.rdf
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" ?>   
+<VULDEF-Document 
+version="3.2" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xmlns="http://jvn.jp/vuldef/" 
+xmlns:vuldef="http://jvn.jp/vuldef/" 
+xmlns:status="http://jvndb.jvn.jp/myjvn/Status" 
+xmlns:sec="http://jvn.jp/rss/mod_sec/3.0/" 
+xmlns:marking="http://data-marking.mitre.org/Marking-1" 
+xmlns:tlpMarking="http://data-marking.mitre.org/extensions/MarkingStructure#TLP-1" 
+xsi:schemaLocation="http://jvn.jp/vuldef/ https://jvndb.jvn.jp/schema/vuldef_3.2.xsd http://jvn.jp/rss/mod_sec/3.0/ https://jvndb.jvn.jp/schema/mod_sec_3.0.xsd http://data-marking.mitre.org/extensions/MarkingStructure#TLP-1 https://jvndb.jvn.jp/schema/tlp_marking.xsd http://jvndb.jvn.jp/myjvn/Status https://jvndb.jvn.jp/schema/status_3.3.xsd" 
+xml:lang="ja">
+    <Vulinfo>
+      <VulinfoID>JVNDB-2021-005429</VulinfoID>
+      <VulinfoData>
+        <Title>Apache Log4j における任意のコードが実行可能な脆弱性</Title>
+        <VulinfoDescription>
+          <Overview>Log4j には JNDI Lookup 機能による外部入力値の検証不備に起因して任意の Java コードを実行可能な脆弱性が存在します。  The Apache Software Foundation が提供する Log4j は、Java ベースのロギングライブラリです。Log4j には、ログに記載された文字列から一部の値を変数として評価する Lookup 機能が実装されています。 その Lookup 機能の内、JNDI Lookup 機能を悪用することにより、ログに含まれる外部の URL もしくは内部パスから Java のクラス情報をデシリアライズして実行してしまう問題（CWE-20, CVE-2021-44228）が発見されました。 これにより、遠隔の攻撃者が細工した文字列を脆弱なシステムのログに記載させ、結果として任意の Java コードをシステムに実行させることが可能です。 </Overview>
+        </VulinfoDescription>
+        <Affected>
+          <AffectedItem>
+            <Name>Apache Software Foundation</Name>
+            <ProductName>Apache Log4j</ProductName>
+            <Cpe version="2.2">cpe:/a:apache:log4j</Cpe>
+            <VersionNumber>2.13.0 から 2.15.0 より前のバージョン</VersionNumber>
+            <VersionNumber>core 2.0-beta9 から 2.12.1 より前のバージョン</VersionNumber>
+          </AffectedItem>
+          <AffectedItem>
+            <Name>日本電気</Name>
+            <ProductName>ACOS Access Toolkit</ProductName>
+            <Cpe version="2.2">cpe:/a:nec:acos_access_toolkit</Cpe>
+            <VersionNumber/>
+          </AffectedItem>
+        </Affected>
+        <Impact>
+          <Cvss version="2.0">
+            <Severity type="Base">High</Severity>
+            <Base>9.3</Base>
+            <Vector>AV:N/AC:M/Au:N/C:C/I:C/A:C</Vector>
+          </Cvss>
+          <Cvss version="3.0">
+            <Severity type="Base">Critical</Severity>
+            <Base>10</Base>
+            <Vector>CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H</Vector>
+          </Cvss>
+          <ImpactItem>
+            <Description>遠隔の攻撃者により細工された文字列を Log4j がログに記録することにより、システム上で任意の Java コードが実行される可能性があります。</Description>
+          </ImpactItem>
+        </Impact>
+        <Solution>
+          <SolutionItem>
+            <Description>[アップデートする] 開発者により、本脆弱性を修正した以下のバージョンが提供されています。 開発者が提供する情報をもとに、最新版にアップデートしてください。 なお、本アップデートでは、Log4j の Lookup 機能が削除されており、JNDI へのアクセスがデフォルトで無効化されています。   　* Java 8のユーザ向け修正版 　　* Log4j 2.17.1  　* Java 7のユーザ向け修正版 　　* Log4j 2.12.4  　* Java 6のユーザ向け修正 　　* Log4j 2.3.2  開発者は当初、本脆弱性に対する修正版として 2.15.0 をリリースしていましたが、特定の構成において任意のコード実行が行われる可能性があることが判明し、Lookup 機能を削除した上で JNDI 機能そのものをデフォルトで無効化した 2.16.0 および 2.12.2 が改めてリリースされました。この問題に対しては CVE-2021-45046 が採番されています。  2021年12月18日、開発者は Log4j 2.0-alpha1 から 2.16.0 までのバージョンにおいて、再帰的（self-referential）なLookup を行う設定下において、サービス運用（DoS）が行われる脆弱性が新たに発見されたとして、バージョン 2.17.0 をリリースしました。この脆弱性に対しては CVE-2021-45105 が採番されています。  2021年12月21日、開発者は一連の脆弱性を修正したバージョンとして、Java 6 ユーザ向けに 2.3.1 を、Java 7 ユーザ向けに 2.12.3 をリリースしました。  2021年12月28日、開発者は Log4j2 2.0-beta7 から 2.17.0（2.3.2 および 2.12.4 を除く）において、攻撃者がログ出力設定を変更できる場合に限り任意のコード実行が行われる可能性があるとして、Log4j 2.17.1、2.12.4、2.3.2 をリリースしました。この修正では、JNDI のデータソースを Java プロトコルに制限する変更が行われました。この脆弱性に対しては CVE-2021-44832 が採番されています。  [ワークアラウンドを実施する] 以下の回避策を適用することにより、本脆弱性の悪用を防ぐことが可能です。  　* JndiLookup クラスをクラスパスから除外する 　　* 例: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class 　　* この回避策は CVE-2021-45046 に対しても有効です  　* Log4j を実行する Java 仮想マシンを起動する際に log4j2.formatMsgNoLookups を true に設定する（Log4j 2.10 およびそれ以降のバージョンが対象） 　　* 例: -Dlog4j2.formatMsgNoLookups=true 　　* この回避策は CVE-2021-45046 に対して有効ではありません  　* 環境変数 LOG4J_FORMAT_MSG_NO_LOOKUPS を true に設定する（Log4j 2.10 およびそれ以降のバージョンが対象） 　　* この回避策は CVE-2021-45046 に対して有効ではありません  また、本脆弱性の影響を軽減するため、システムから外部への接続を制限するアクセス制御を実施または強化することも有効です。</Description>
+          </SolutionItem>
+        </Solution>
+        <Related>
+          <RelatedItem type="vendor">
+            <Name>Apache</Name>
+            <VulinfoID>Apache Log4j Security Vulnerabilities - Fixed in Log4j 2.15.0</VulinfoID>
+            <URL>https://logging.apache.org/log4j/2.x/security.html</URL>
+          </RelatedItem>
+          <RelatedItem type="vendor">
+            <Name>Hitachi Incdent Response Team</Name>
+            <VulinfoID>HIRT-PUB21001：Apache Log4jの脆弱性</VulinfoID>
+            <URL>https://www.hitachi.co.jp/hirt/publications/hirt-pub21001/</URL>
+          </RelatedItem>
+          <RelatedItem type="vendor">
+            <Name>Hitachi Software Vulnerability Information</Name>
+            <VulinfoID>hitachi-sec-2021-146</VulinfoID>
+            <URL>https://www.hitachi.co.jp/Prod/comp/soft1/global/security/info/vuls/hitachi-sec-2021-146/index.html</URL>
+          </RelatedItem>
+          <RelatedItem type="vendor">
+            <Name>Hitachi Software Vulnerability Information</Name>
+            <VulinfoID>hitachi-sec-2021-147</VulinfoID>
+            <URL>https://www.hitachi.co.jp/Prod/comp/soft1/global/security/info/vuls/hitachi-sec-2021-147/index.html</URL>
+          </RelatedItem>
+          <RelatedItem type="advisory">
+            <Name>JPCERT 緊急報告</Name>
+            <VulinfoID>JPCERT-AT-2021-0050</VulinfoID>
+            <URL>https://www.jpcert.or.jp/at/2021/at210050.html</URL>
+          </RelatedItem>
+        </Related>
+        <History>
+          <HistoryItem>
+            <HistoryNo>1</HistoryNo>
+            <DateTime>2021-12-14T16:37:27+09:00</DateTime>
+            <Description>[2021年12月14日]\n  掲載</Description>
+          </HistoryItem>
+          <HistoryItem>
+            <HistoryNo>2</HistoryNo>
+            <DateTime>2021-12-16T18:10:13+09:00</DateTime>
+            <Description>[2021年12月16日]\n  影響を受けるシステム：内容を更新\n  対策：内容を更新\n  ベンダ情報：トレンドマイクロ (アラート/アドバイザリ：Apache Log4j の脆弱性（CVE-2021-44228）について) を追加\n  共通脆弱性識別子(CVE)：CVE-2021-45046 を追加\n  参考情報：National Vulnerability Database (NVD) (CVE-2021-45046) を追加\n  参考情報：US-CERT Vulnerability Note (VU#930724) を追加</Description>
+          </HistoryItem>
+        </History>
+        <DateFirstPublished>2021-12-14T16:37:27+09:00</DateFirstPublished>
+        <DateLastUpdated>2022-12-15T10:24:36+09:00</DateLastUpdated>
+        <DatePublic>2021-12-13T00:00:00+09:00</DatePublic>
+      </VulinfoData>
+    </Vulinfo>
+    <sec:handling>
+      <marking:Marking>
+        <marking:Marking_Structure xsi:type="tlpMarking:TLPMarkingStructureType" marking_model_name="TLP" marking_model_ref="http://www.us-cert.gov/tlp/" color="WHITE"/>
+      </marking:Marking>
+    </sec:handling>
+    <status:Status version="3.3" method="getVulnDetailInfo" lang="ja" retCd="0" retMax="10" errCd="" errMsg="" totalRes="1" totalResRet="1" firstRes="1" feed="hnd" startItem="1" maxCountItem="1" vulnId="JVNDB-2021-005429"/>
+  </VULDEF-Document>
+

--- a/pkg/fetch/jvn/feed/detail/testdata/golden/2021/JVNDB-2021-005429.json
+++ b/pkg/fetch/jvn/feed/detail/testdata/golden/2021/JVNDB-2021-005429.json
@@ -1,0 +1,115 @@
+{
+	"vulinfoid": "JVNDB-2021-005429",
+	"vulinfodata": {
+		"title": "Apache Log4j における任意のコードが実行可能な脆弱性",
+		"vulinfodescription": {
+			"overview": "Log4j には JNDI Lookup 機能による外部入力値の検証不備に起因して任意の Java コードを実行可能な脆弱性が存在します。  The Apache Software Foundation が提供する Log4j は、Java ベースのロギングライブラリです。Log4j には、ログに記載された文字列から一部の値を変数として評価する Lookup 機能が実装されています。 その Lookup 機能の内、JNDI Lookup 機能を悪用することにより、ログに含まれる外部の URL もしくは内部パスから Java のクラス情報をデシリアライズして実行してしまう問題（CWE-20, CVE-2021-44228）が発見されました。 これにより、遠隔の攻撃者が細工した文字列を脆弱なシステムのログに記載させ、結果として任意の Java コードをシステムに実行させることが可能です。 "
+		},
+		"affected": {
+			"affecteditem": [
+				{
+					"name": "Apache Software Foundation",
+					"productname": "Apache Log4j",
+					"cpe": {
+						"text": "cpe:/a:apache:log4j",
+						"version": "2.2"
+					},
+					"versionnumber": [
+						"2.13.0 から 2.15.0 より前のバージョン",
+						"core 2.0-beta9 から 2.12.1 より前のバージョン"
+					]
+				},
+				{
+					"name": "日本電気",
+					"productname": "ACOS Access Toolkit",
+					"cpe": {
+						"text": "cpe:/a:nec:acos_access_toolkit",
+						"version": "2.2"
+					}
+				}
+			]
+		},
+		"impact": {
+			"cvss": [
+				{
+					"version": "2.0",
+					"severity": {
+						"text": "High",
+						"type": "Base"
+					},
+					"base": "9.3",
+					"vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C"
+				},
+				{
+					"version": "3.0",
+					"severity": {
+						"text": "Critical",
+						"type": "Base"
+					},
+					"base": "10",
+					"vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+				}
+			],
+			"impactitem": {
+				"description": "遠隔の攻撃者により細工された文字列を Log4j がログに記録することにより、システム上で任意の Java コードが実行される可能性があります。"
+			}
+		},
+		"solution": {
+			"solutionitem": {
+				"description": "[アップデートする] 開発者により、本脆弱性を修正した以下のバージョンが提供されています。 開発者が提供する情報をもとに、最新版にアップデートしてください。 なお、本アップデートでは、Log4j の Lookup 機能が削除されており、JNDI へのアクセスがデフォルトで無効化されています。   　* Java 8のユーザ向け修正版 　　* Log4j 2.17.1  　* Java 7のユーザ向け修正版 　　* Log4j 2.12.4  　* Java 6のユーザ向け修正 　　* Log4j 2.3.2  開発者は当初、本脆弱性に対する修正版として 2.15.0 をリリースしていましたが、特定の構成において任意のコード実行が行われる可能性があることが判明し、Lookup 機能を削除した上で JNDI 機能そのものをデフォルトで無効化した 2.16.0 および 2.12.2 が改めてリリースされました。この問題に対しては CVE-2021-45046 が採番されています。  2021年12月18日、開発者は Log4j 2.0-alpha1 から 2.16.0 までのバージョンにおいて、再帰的（self-referential）なLookup を行う設定下において、サービス運用（DoS）が行われる脆弱性が新たに発見されたとして、バージョン 2.17.0 をリリースしました。この脆弱性に対しては CVE-2021-45105 が採番されています。  2021年12月21日、開発者は一連の脆弱性を修正したバージョンとして、Java 6 ユーザ向けに 2.3.1 を、Java 7 ユーザ向けに 2.12.3 をリリースしました。  2021年12月28日、開発者は Log4j2 2.0-beta7 から 2.17.0（2.3.2 および 2.12.4 を除く）において、攻撃者がログ出力設定を変更できる場合に限り任意のコード実行が行われる可能性があるとして、Log4j 2.17.1、2.12.4、2.3.2 をリリースしました。この修正では、JNDI のデータソースを Java プロトコルに制限する変更が行われました。この脆弱性に対しては CVE-2021-44832 が採番されています。  [ワークアラウンドを実施する] 以下の回避策を適用することにより、本脆弱性の悪用を防ぐことが可能です。  　* JndiLookup クラスをクラスパスから除外する 　　* 例: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class 　　* この回避策は CVE-2021-45046 に対しても有効です  　* Log4j を実行する Java 仮想マシンを起動する際に log4j2.formatMsgNoLookups を true に設定する（Log4j 2.10 およびそれ以降のバージョンが対象） 　　* 例: -Dlog4j2.formatMsgNoLookups=true 　　* この回避策は CVE-2021-45046 に対して有効ではありません  　* 環境変数 LOG4J_FORMAT_MSG_NO_LOOKUPS を true に設定する（Log4j 2.10 およびそれ以降のバージョンが対象） 　　* この回避策は CVE-2021-45046 に対して有効ではありません  また、本脆弱性の影響を軽減するため、システムから外部への接続を制限するアクセス制御を実施または強化することも有効です。"
+			}
+		},
+		"related": {
+			"relateditem": [
+				{
+					"type": "vendor",
+					"name": "Apache",
+					"vulinfoid": "Apache Log4j Security Vulnerabilities - Fixed in Log4j 2.15.0",
+					"url": "https://logging.apache.org/log4j/2.x/security.html"
+				},
+				{
+					"type": "vendor",
+					"name": "Hitachi Incdent Response Team",
+					"vulinfoid": "HIRT-PUB21001：Apache Log4jの脆弱性",
+					"url": "https://www.hitachi.co.jp/hirt/publications/hirt-pub21001/"
+				},
+				{
+					"type": "vendor",
+					"name": "Hitachi Software Vulnerability Information",
+					"vulinfoid": "hitachi-sec-2021-146",
+					"url": "https://www.hitachi.co.jp/Prod/comp/soft1/global/security/info/vuls/hitachi-sec-2021-146/index.html"
+				},
+				{
+					"type": "vendor",
+					"name": "Hitachi Software Vulnerability Information",
+					"vulinfoid": "hitachi-sec-2021-147",
+					"url": "https://www.hitachi.co.jp/Prod/comp/soft1/global/security/info/vuls/hitachi-sec-2021-147/index.html"
+				},
+				{
+					"type": "advisory",
+					"name": "JPCERT 緊急報告",
+					"vulinfoid": "JPCERT-AT-2021-0050",
+					"url": "https://www.jpcert.or.jp/at/2021/at210050.html",
+					"fetchedtitle": "Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起"
+				}
+			]
+		},
+		"history": {
+			"historyitem": [
+				{
+					"historyno": "1",
+					"datetime": "2021-12-14T16:37:27+09:00",
+					"description": "[2021年12月14日]\\n  掲載"
+				},
+				{
+					"historyno": "2",
+					"datetime": "2021-12-16T18:10:13+09:00",
+					"description": "[2021年12月16日]\\n  影響を受けるシステム：内容を更新\\n  対策：内容を更新\\n  ベンダ情報：トレンドマイクロ (アラート/アドバイザリ：Apache Log4j の脆弱性（CVE-2021-44228）について) を追加\\n  共通脆弱性識別子(CVE)：CVE-2021-45046 を追加\\n  参考情報：National Vulnerability Database (NVD) (CVE-2021-45046) を追加\\n  参考情報：US-CERT Vulnerability Note (VU#930724) を追加"
+				}
+			]
+		},
+		"datefirstpublished": "2021-12-14T16:37:27+09:00",
+		"datelastupdated": "2022-12-15T10:24:36+09:00",
+		"datepublic": "2021-12-13T00:00:00+09:00"
+	}
+}

--- a/pkg/fetch/jvn/feed/detail/types.go
+++ b/pkg/fetch/jvn/feed/detail/types.go
@@ -93,6 +93,9 @@ type Vulinfo struct {
 				VulinfoID string `xml:"VulinfoID" json:"vulinfoid,omitempty"`
 				URL       string `xml:"URL" json:"url,omitempty"`
 				Title     string `xml:"Title" json:"title,omitempty"`
+				// FetchedTitle holds the HTML <title> of the referenced page,
+				// retrieved separately from the feed for JPCERT-AT references.
+				FetchedTitle string `xml:"-" json:"fetchedtitle,omitempty"`
 			} `xml:"RelatedItem" json:"relateditem,omitempty"`
 		} `xml:"Related" json:"related,omitzero"`
 		History struct {

--- a/pkg/fetch/jvn/feed/rss/rss.go
+++ b/pkg/fetch/jvn/feed/rss/rss.go
@@ -116,12 +116,14 @@ func Fetch(opts ...Option) error {
 		return 0
 	})
 
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry))
+
 	advisories := make(map[string]Item)
 	for _, c := range filtered {
 		slog.Info("Fetch JVNDB RSS Feed", slog.String("feed", c.Filename))
 
 		items, err := func() ([]Item, error) {
-			resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(c.URL)
+			resp, err := client.Get(c.URL)
 			if err != nil {
 				return nil, errors.Wrap(err, "fetch jvndb rss")
 			}
@@ -155,8 +157,33 @@ func Fetch(opts ...Option) error {
 		}
 	}
 
+	// A single JPCERT-AT alert is referenced by many advisories, so cache the
+	// fetched title per URL to avoid refetching.
+	certTitles := make(map[string]string)
+
 	bar := progressbar.Default(int64(len(advisories)))
 	for _, a := range advisories {
+		for i, ref := range a.References {
+			// Trim once so the cache key, fetch target, and error context all use
+			// the same canonical URL. Only JPCERT-AT alert pages ("/at/") carry a
+			// fetchable title; other cited JPCERT reference types (weekly reports,
+			// press releases) are skipped by IsAlertURL.
+			u := strings.TrimSpace(ref.Text)
+			if ref.Source != "JPCERT-AT" || !jvnutil.IsAlertURL(u) {
+				continue
+			}
+			title, ok := certTitles[u]
+			if !ok {
+				t, err := jvnutil.FetchTitle(client, u)
+				if err != nil {
+					return errors.Wrapf(err, "fetch JPCERT-AT title %s", u)
+				}
+				title = t
+				certTitles[u] = title
+			}
+			a.References[i].FetchedTitle = title
+		}
+
 		splitted, err := util.Split(a.Identifier, "-", "-")
 		if err != nil {
 			return errors.Wrapf(err, "unexpected ID format. expected: %q, actual: %q", "JVNDB-yyyy-\\d{6}", a.Identifier)

--- a/pkg/fetch/jvn/feed/rss/rss_test.go
+++ b/pkg/fetch/jvn/feed/rss/rss_test.go
@@ -34,24 +34,46 @@ func TestFetch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch path.Base(r.URL.Path) {
-				case "checksum.txt":
+				switch {
+				case path.Base(r.URL.Path) == "checksum.txt":
 					f, err := os.Open(strings.TrimPrefix(r.URL.Path, "/"))
 					if err != nil {
 						http.NotFound(w, r)
+						return
 					}
 					defer f.Close()
 
 					bs, err := io.ReadAll(f)
 					if err != nil {
 						http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+						return
 					}
 
 					s := strings.NewReplacer("https://jvndb.jvn.jp/ja/rss/years", fmt.Sprintf("http://%s/testdata/fixtures", r.Host), "https://jvndb.jvn.jp/ja/rss", fmt.Sprintf("http://%s/testdata/fixtures", r.Host)).Replace(string(bs))
 
 					http.ServeContent(w, r, "checksum.txt", time.Now(), strings.NewReader(s))
+				case strings.HasPrefix(r.URL.Path, "/at/"):
+					// Real JPCERT-AT alert page saved under testdata/fixtures.
+					http.ServeFile(w, r, filepath.Join("testdata", "fixtures", strings.TrimPrefix(r.URL.Path, "/")))
 				default:
-					http.ServeFile(w, r, strings.TrimPrefix(r.URL.Path, "/"))
+					f, err := os.Open(strings.TrimPrefix(r.URL.Path, "/"))
+					if err != nil {
+						http.NotFound(w, r)
+						return
+					}
+					defer f.Close()
+
+					bs, err := io.ReadAll(f)
+					if err != nil {
+						http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+						return
+					}
+
+					// Rewrite JPCERT-AT reference URLs so they are fetched from this
+					// test server instead of the real host.
+					s := strings.ReplaceAll(string(bs), "https://www.jpcert.or.jp", fmt.Sprintf("http://%s", r.Host))
+
+					http.ServeContent(w, r, path.Base(r.URL.Path), time.Now(), strings.NewReader(s))
 				}
 			}))
 			defer ts.Close()
@@ -88,6 +110,10 @@ func TestFetch(t *testing.T) {
 					if err != nil {
 						return err
 					}
+
+					// The test server rewrites JPCERT-AT reference URLs to its own
+					// host; normalize them back so the golden stays deterministic.
+					got = []byte(strings.ReplaceAll(string(got), ts.URL, "https://www.jpcert.or.jp"))
 
 					if diff := cmp.Diff(want, got); diff != "" {
 						t.Errorf("Fetch(). (-expected +got):\n%s", diff)

--- a/pkg/fetch/jvn/feed/rss/testdata/fixtures/at/2011/at110008.html
+++ b/pkg/fetch/jvn/feed/rss/testdata/fixtures/at/2011/at110008.html
@@ -1,0 +1,665 @@
+<!DOCTYPE html>
+<html lang="ja-jp">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	
+	<title>2011年4月 Microsoft セキュリティ情報 (緊急 9件含) に関する注意喚起</title>
+	<meta name="keywords" content="" />
+	<meta name="description" content="" />
+	<meta property="og:locale" content="ja_JP" />
+	<meta property="og:site_name" content="JPCERT/CC" />
+	<meta property="og:url" content="https://www.jpcert.or.jp/at/2011/at110008.html">
+	<meta property="og:title" content="2011年4月 Microsoft セキュリティ情報 (緊急 9件含) に関する注意喚起">
+	
+	<meta property="og:image" content="https://www.jpcert.or.jp/common/image/ogp_image.jpg">
+	
+	<link rel="alternate" type="application/rss+xml" title="注意喚起、Weekly Report、脆弱性情報（JVN）、JPCERT/CCからのお知らせやイベントの新着情報をまとめて提供" href="/rss/jpcert-all.rdf" />
+	<link rel="alternate" type="application/rss+xml" title="注意喚起と緊急報告、Weekly Report の新着情報" href="/rss/jpcert.rdf" />
+	<link rel="alternate" type="application/rss+xml" title="JPCERT/CCからのお知らせ、イベントの新着情報" href="/rss/whatsnew.rdf" />
+	<link rel="stylesheet" href="/common/css/html5reset-1.6.1.css">
+	<link rel="stylesheet" href="/common/css/common.css">
+	<link rel="stylesheet" href="/common/css/page.css">
+	<link rel="stylesheet" href="/common/css/print.css" media="print" />
+	<link rel="stylesheet" href="/common/slide/slide.css"/>
+	
+</head>
+<body class="category_a">
+
+
+<!-- guidance_sp -->
+<div id="guidance_sp" style="display:none;">
+<div class="title"><img src="/common/guidance/g_guidance_title.png" alt="スマートフォン用で表示" /><a href="/m/at/2011/at110008.html" id="show_sp_site"><img src="/common/guidance/g_button_show.png" alt="" /></a></div>
+<div class="message"><a href="javascript:;" id="check_no_message"><img src="/common/guidance/g_check_off.png" alt="" /><img src="/common/guidance/g_guidance_message.png" alt="" /></a></div>
+</div>
+<!-- /guidance_sp -->
+
+<header class="sh_uoh">
+	<div class="top">
+		<h2><img src="/common/image/h2_image.png" width="330" height="25" alt="サイバーインシデントがなくなるその日まで" /></h2>
+		<ul>
+			<li><a href="/reference.html">お問い合わせ</a></li>
+			<li><a href="/recruit/index.html">採用情報</a></li>
+			<li><a href="/sitemap.html">サイトマップ</a></li>
+			<li><a href="/english/">English</a></li>
+		</ul>
+	</div>
+
+	<div class="main">
+		<h1><a href="/"><img src="/common/image/header_logo.svg" width="198" height="66" alt="JPCERT Coordination Center" /></a></h1>
+
+<!-- googlr search area
+		<div class="search_area">
+			<form id="cse-search-box" action="https://www.google.com/cse">
+				<input value="011276954563619633753:gam5ydxz2ni" name="cx" type="hidden">
+				<input value="UTF-8" name="ie" type="hidden">
+				<input name="q" id="q" value="" type="text" placeholder="検索キーワードを入力" /><input name="sa" id="sa" type="submit" value="検索" />
+			</form>
+		</div>
+-->
+		
+<!-- yahoo custom search area		
+		<div id="yahoo_search_area" class="watermark">
+
+			<form action="https://custom.search.yahoo.co.jp/search" method="get" id="srch">
+				<p id="srchForm">
+					<input type="text" name="p" id="srchInput">
+					<input type="submit" value="検索" id="srchBtn" onclick="document.getElementById('srchInput').focus();">
+					<input type="hidden" id="fr" name="fr" value="cse">
+					<input type="hidden" id="ei" name="ei" value="UTF-8">
+					<input type="hidden" id="csid" name="csid" value="YZgbsqsHFIwmPApo7sIjK_PtheLpmwnBs_eTDxVthQ--">
+				</p>
+				<input type="hidden" name="vs" value="www.jpcert.or.jp" id="yjInsite">
+			</form>
+		</div>
+-->
+		<div id="yahoo_search_new_area" style="width:396px;">
+			<form action="https://search.yahoo.co.jp/search" method="get" style="margin:0;padding:0;">
+			<p style="margin:0;padding:0;">
+				<a href="https://www.yahoo.co.jp/" target="_blank" style="font-size: 10px;">
+					powered by Yahoo! JAPAN
+				</a>
+				<input type="text" name="p" size="28" style="margin:0 3px;width:50%;">
+				<input type="hidden" name="fr" value="ysiw">
+				<input type="hidden" name="ei" value="utf-8">
+				<input type="submit" value="検索" style="margin:0;color:#595757;font-size:10pt;">
+			</p>
+			<ul style="margin:2px 0 0 0;padding:0;font-size:10pt;list-style:none;">
+				<li style="display:inline;font-size:10pt;">
+					<input name="vs" type="radio" value="www.jpcert.or.jp" checked="checked">
+					このサイト内を検索
+				</li>
+				<li style="display:inline;font-size:10pt;">
+					<input name="vs" type="radio" value="">
+					ウェブ全体を検索
+				</li>
+			</ul>
+			</form>
+			<img src="https://custom.search.yahoo.co.jp/images/window/006c75a92ba244c6b4cbe2709aa17d7b.gif" width="1" height="1" style="display:block;position:absolute">
+		</div>
+		<ul class="links">
+			<li class="icon_rss">最新情報を取得 (<a href="/rss/">RSS</a> | <a href="/announce.html">メーリングリスト</a>) </li>
+			<li><a href="https://www.jpcert.or.jp/" class="icon_https">HTTPS</a></li>
+			<li><a href="/m/" class="icon_mobile">モバイル</a></li>
+		</ul>
+		<script type="text/javascript">
+			(function() {
+			var sb = document.getElementById('srchBox');
+			if (sb && sb.className == 'watermark') {
+  			var si = document.getElementById('srchInput');
+  			var f = function() { si.className = 'nomark'; };
+  			var b = function() {
+    			if (si.value == '') {
+      			si.className = '';
+    			}
+  			};
+  			si.onfocus = f;
+  			si.onblur = b;
+  			if (!/[&?]p=[^&]/.test(location.search)) {
+    			b();
+  			} else {
+    			f();
+  			}
+			}
+			})();
+			</script>
+			
+	</div>
+</header>
+
+<nav>
+	<ul class="menu contents_area_view">
+		<li class="category_a "><a href="/aboutincident.html">インシデントとは</a></li>
+		<li class="category_a selected">
+			<a href="/menu_alertsandadvisories.html">緊急情報を確認する</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">緊急情報を確認する</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/at/">注意喚起</a></li>
+							<li><a href="/tsubame/">インターネット定点観測</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="https://jvn.jp/">JVN</a></li>
+							<li><a href="/vh/top.html">脆弱性対策情報</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_reporttojpcert.html">依頼・相談する</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">依頼・相談する</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/ir/">インシデント対応とは</a></li>
+							<li><a href="/form/">インシデント対応依頼</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/ir/consult.html">インシデント相談・情報提供</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_documents.html">公開資料を見る</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">公開資料を見る</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/wr/">Weekly Report</a></li>
+							<li><a href="/qr/index.html">四半期レポート</a></li>
+							<li><a href="/tsubame/report/">インターネット定点観測レポート</a></li>
+							<li><a href="/report/press.html">ソフトウェア等の脆弱性関連情報に関する届出状況</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/research/">研究・調査・翻訳レポート</a></li>
+							<li><a href="/csirt_material/">CSIRTマテリアル</a></li>
+							<li><a href="/securecoding/">セキュアコーディング</a></li>
+							<li><a href="/ics/">制御システムセキュリティ</a></li>
+							<li><a href="/magazine/">ライブラリ</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_receiveinformation.html">情報を受け取る</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">情報を受け取る</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/cista/">CISTA（シスタ）</a></li>
+							<li><a href="/vh/register.html">製品開発者登録</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/announce.html">メーリングリスト</a></li>
+							<li><a href="/rss/">RSS</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_b ">
+			<a href="/menu_columnblog.html">コラム＆ブログ</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">コラム＆ブログ</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/newsflash/">CyberNewsFlash</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="https://blogs.jpcert.or.jp/ja/">JPCERT/CC Eyes～JPCERT/CC公式ブログ～ </a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_b ">
+			<a href="/menu_aboutjpcert.html">JPCERT/CCについて</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">JPCERT/CCについて</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/about/">JPCERT/CCとは</a></li>
+							<li class="level2"><a href="/message.html">代表理事挨拶</a></li>
+							<li class="level2"><a href="/profile.html">組織概要</a></li>
+							<li class="level2"><a href="/about/01.html">事業概要</a></li>
+							<li><a href="/recruit/">採用情報</a></li>
+							<li><a href="/solicitation/">公募・入札情報</a></li>
+							<li><a href="/press/pressroom.html">プレスルーム</a></li>
+							<li class="level2"><a href="/press/2026.html">プレスリリース</a></li>
+							<li class="level2"><a href="/press/contact.html">広報へのお問い合わせ</a></li>
+							<li class="level2"><a href="/press/request.html">講演依頼</a></li>
+							<li class="level2"><a href="/press/nominal-support.html">後援申請</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/event/">イベント</a></li>
+							<li><a href="/kouen/">講演・執筆一覧</a></li>
+							<li><a href="/twitter.html">X（旧Twitter）一覧</a></li>
+							<li><a href="/jpcert-pgp.html">PGP公開鍵</a></li>
+							<li><a href="/related/">関連組織</a></li>
+							<li><a href="/reference.html">お問い合わせ</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+	</ul>
+</nav>
+
+<div class="breadcrumb_list_area contents_area_view sh_uoh cf">
+	<ul class="breadcrumb_list fl">
+		<li><a href="/">HOME</a></li><li><a href="/menu_alertsandadvisories.html">緊急情報を確認する</a></li><li>2011年4月 Microsoft セキュリティ情報 (緊急 9件含) に関する注意喚起</li>
+	</ul>
+	
+	<ul id="page_layout_utility" class="page_layout_utility fr" style="display:none;">
+		<li class="to_normal_layout_group"><a href="javascript:;" class="icon_normal_layout">通常レイアウトに戻す</a></li>
+		<li class="to_normal_layout_group"><a href="javascript:;" class="icon_print">印刷</a></li>
+		<li class="to_print_layout_group"><a href="javascript:;" class="icon_print_layout">印刷用レイアウト</a></li>
+		<li class="to_print_layout_group"><span class="icon_print_disabled">印刷</span></li>
+	</ul>
+	
+</div>
+
+
+<div class="contents_body contents_area_view cf">
+	<div id="link_pgtop" class="contents_right_body">
+		<div class="contents_right_body_wrapper">
+			<div class="page_title_area">
+				<h3>2011年4月 Microsoft セキュリティ情報 (緊急 9件含) に関する注意喚起</h3>
+				<span>最終更新: 2011-04-13</span>
+			</div>
+
+			<div class="contents_container">
+<div class="social_links cf">
+	<div class="mail">
+		<a href="mailto:?subject=2011%E5%B9%B44%E6%9C%88%20Microsoft%20%E3%82%BB%E3%82%AD%E3%83%A5%E3%83%AA%E3%83%86%E3%82%A3%E6%83%85%E5%A0%B1%20(%E7%B7%8A%E6%80%A5%209%E4%BB%B6%E5%90%AB)%20%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7&amp;body=https%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2011%2Fat110008.html">
+			<img src="/common/social_links/images/btn_share_mail_jp.png" alt="" />
+		</a>
+	</div>
+	<div class="tweet window">
+		<a href="https://twitter.com/intent/tweet?text=2011%E5%B9%B44%E6%9C%88%20Microsoft%20%E3%82%BB%E3%82%AD%E3%83%A5%E3%83%AA%E3%83%86%E3%82%A3%E6%83%85%E5%A0%B1%20(%E7%B7%8A%E6%80%A5%209%E4%BB%B6%E5%90%AB)%20%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7%0Ahttps%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2011%2Fat110008.html%0A%40jpcert" target="_blank">
+			<img src="/common/social_links/images/btn_share_post_jp.png" alt="" />
+		</a>
+	</div>
+</div>
+
+				<article class="">
+<!-- content_area -->
+<pre class="at">
+各位
+
+                                                   JPCERT-AT-2011-0008
+                                                             JPCERT/CC
+                                                            2011-04-13
+
+                  &lt;&lt;&lt; JPCERT/CC Alert 2011-04-13 &gt;&gt;&gt;
+
+  2011年4月 Microsoft セキュリティ情報 (緊急 9件含) に関する注意喚起
+
+                March 2011 Microsoft Security Bulletin
+                  (including nine critical patches)
+
+            <a href="https://www.jpcert.or.jp/at/2011/at110008.txt" title="https://www.jpcert.or.jp/at/2011/at110008.txt">https://www.jpcert.or.jp/at/2011/at110008.txt</a>
+
+
+I. 概要
+
+  日本マイクロソフト社から 2011年4月のセキュリティ情報が公開されました。
+本情報には、深刻度が「緊急」のセキュリティ更新プログラムが 9件含まれて
+います。
+  これらの脆弱性を使用された場合、結果として遠隔の第三者によってサービ
+ス不能状態を引き起こされたり、任意のコードを実行されたりする可能性があ
+ります。
+
+  各脆弱性に関する情報の詳細は、以下の URL を参照してください。
+
+    2011 年 4 月のセキュリティ情報
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/ms11-apr.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/ms11-apr.mspx">http://www.microsoft.com/japan/technet/security/bulletin/ms11-apr.mspx</a>
+
+  また、既に公表されている以下の脆弱性については、今回のセキュリティ更
+新プログラムにより問題が修正されます。
+
+    マイクロソフト セキュリティ アドバイザリ (2501696)
+    MHTML の脆弱性により、情報漏えいが起こる
+    <a href="http://www.microsoft.com/japan/technet/security/advisory/2501696.mspx" title="http://www.microsoft.com/japan/technet/security/advisory/2501696.mspx">http://www.microsoft.com/japan/technet/security/advisory/2501696.mspx</a>
+
+    US-CERT Vulnerability Note VU#323172
+    Microsoft Windows browser election message kernel pool overflow
+    <a href="http://www.kb.cert.org/vuls/id/323172" title="http://www.kb.cert.org/vuls/id/323172">http://www.kb.cert.org/vuls/id/323172</a>
+    <a href="https://jvn.jp/cert/JVNVU323172/index.html" title="https://jvn.jp/cert/JVNVU323172/index.html">https://jvn.jp/cert/JVNVU323172/index.html</a>
+
+    US-CERT Vulnerability Note VU#427980
+    Microsoft Internet Explorer 8 use-after-free vulnerability
+    <a href="http://www.kb.cert.org/vuls/id/427980" title="http://www.kb.cert.org/vuls/id/427980">http://www.kb.cert.org/vuls/id/427980</a>
+    <a href="https://jvn.jp/cert/JVNVU427980/index.html" title="https://jvn.jp/cert/JVNVU427980/index.html">https://jvn.jp/cert/JVNVU427980/index.html</a>
+
+    US-CERT Vulnerability Note VU#725596
+    Microsoft WMI Administrative Tools WBEMSingleView.ocx ActiveX control
+    <a href="http://www.kb.cert.org/vuls/id/725596" title="http://www.kb.cert.org/vuls/id/725596">http://www.kb.cert.org/vuls/id/725596</a>
+    <a href="https://jvn.jp/cert/JVNVU725596/index.html" title="https://jvn.jp/cert/JVNVU725596/index.html">https://jvn.jp/cert/JVNVU725596/index.html</a>
+
+
+  [緊急の更新プログラム]
+
+    MS11-018
+    Internet Explorer 用の累積的なセキュリティ更新プログラム (2497640)
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/MS11-018.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/MS11-018.mspx">http://www.microsoft.com/japan/technet/security/bulletin/MS11-018.mspx</a>
+
+    MS11-019
+    SMB クライアントの脆弱性により、リモートでコードが実行される (2511455)
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/MS11-019.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/MS11-019.mspx">http://www.microsoft.com/japan/technet/security/bulletin/MS11-019.mspx</a>
+
+    MS11-020
+    SMB サーバーの脆弱性により、リモートでコードが実行される (2508429)
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/MS11-020.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/MS11-020.mspx">http://www.microsoft.com/japan/technet/security/bulletin/MS11-020.mspx</a>
+
+    MS11-027
+    ActiveX の Kill Bit の累積的なセキュリティ更新プログラム (2508272)
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/MS11-027.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/MS11-027.mspx">http://www.microsoft.com/japan/technet/security/bulletin/MS11-027.mspx</a>
+
+    MS11-028
+    .NET Framework の脆弱性により、リモートでコードが実行される (2484015)
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/MS11-028.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/MS11-028.mspx">http://www.microsoft.com/japan/technet/security/bulletin/MS11-028.mspx</a>
+
+    MS11-029
+    GDI+ の脆弱性により、リモートでコードが実行される (2489979)
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/MS11-029.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/MS11-029.mspx">http://www.microsoft.com/japan/technet/security/bulletin/MS11-029.mspx</a>
+
+    MS11-030
+    DNS 解決の脆弱性により、リモートでコードが実行される(2509553)
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/MS11-030.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/MS11-030.mspx">http://www.microsoft.com/japan/technet/security/bulletin/MS11-030.mspx</a>
+
+    MS11-031
+    JScript および VBScript スクリプト エンジンの脆弱性により、リモートでコードが実行される (2514666)
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/MS11-031.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/MS11-031.mspx">http://www.microsoft.com/japan/technet/security/bulletin/MS11-031.mspx</a>
+
+    MS11-032
+    OpenType Compact Font Format (CFF) ドライバーの脆弱性により、リモートでコードが実行される (2507618)
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/MS11-032.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/MS11-032.mspx">http://www.microsoft.com/japan/technet/security/bulletin/MS11-032.mspx</a>
+
+
+II. 対策
+
+  Microsoft Update、Windows Update などを用いて、セキュリティ更新プロ
+グラムを早急に適用してください。
+
+    Microsoft Update
+    <a href="https://www.update.microsoft.com/" title="https://www.update.microsoft.com/">https://www.update.microsoft.com/</a>
+
+    Windows Update
+    <a href="https://windowsupdate.microsoft.com/" title="https://windowsupdate.microsoft.com/">https://windowsupdate.microsoft.com/</a>
+
+
+III. 参考情報
+
+    2011 年 4 月のセキュリティ情報
+    <a href="http://www.microsoft.com/japan/technet/security/bulletin/ms11-apr.mspx" title="http://www.microsoft.com/japan/technet/security/bulletin/ms11-apr.mspx">http://www.microsoft.com/japan/technet/security/bulletin/ms11-apr.mspx</a>
+
+    US-CERT Technical Cyber Security Alert TA11-102A
+    Microsoft Updates for Multiple Vulnerabilities
+    <a href="http://www.us-cert.gov/cas/techalerts/TA11-102A.html" title="http://www.us-cert.gov/cas/techalerts/TA11-102A.html">http://www.us-cert.gov/cas/techalerts/TA11-102A.html</a>
+
+
+  今回の件につきまして当方まで提供いただける情報がございましたら、ご連
+絡ください。
+
+======================================================================
+一般社団法人 JPCERT コーディネーションセンター (JPCERT/CC)
+MAIL: info@jpcert.or.jp
+TEL: 03-3518-4600 FAX: 03-3518-4602
+<a href="https://www.jpcert.or.jp/" title="https://www.jpcert.or.jp/">https://www.jpcert.or.jp/</a>
+</pre>
+<p class="pg_top"><a href="#link_pgtop">Topへ</a></p>
+<!-- /content_area -->
+				</article>
+
+<div class="social_links cf">
+	<div class="mail">
+		<a href="mailto:?subject=2011%E5%B9%B44%E6%9C%88%20Microsoft%20%E3%82%BB%E3%82%AD%E3%83%A5%E3%83%AA%E3%83%86%E3%82%A3%E6%83%85%E5%A0%B1%20(%E7%B7%8A%E6%80%A5%209%E4%BB%B6%E5%90%AB)%20%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7&amp;body=https%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2011%2Fat110008.html">
+			<img src="/common/social_links/images/btn_share_mail_jp.png" alt="" />
+		</a>
+	</div>
+	<div class="tweet window">
+		<a href="https://twitter.com/intent/tweet?text=2011%E5%B9%B44%E6%9C%88%20Microsoft%20%E3%82%BB%E3%82%AD%E3%83%A5%E3%83%AA%E3%83%86%E3%82%A3%E6%83%85%E5%A0%B1%20(%E7%B7%8A%E6%80%A5%209%E4%BB%B6%E5%90%AB)%20%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7%0Ahttps%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2011%2Fat110008.html%0A%40jpcert" target="_blank">
+			<img src="/common/social_links/images/btn_share_post_jp.png" alt="" />
+		</a>
+	</div>
+</div>
+<div id="fb" class="feedback feedback_noscript">
+<div class="container_a"><div class="container_b">
+<form name="feedback_form" id="feedback_form">
+	<p class="title">このページは役に立ちましたか？</p>
+	<div class="inner">
+		<p>
+			<input type="radio" name="is_useful" id="is_usefull_yes" value="yes" disabled="disabled" /><label for="is_usefull_yes">はい</label>
+			<input type="radio" name="is_useful" id="is_usefull_no" value="no" disabled="disabled" /><label for="is_usefull_no">いいえ</label>
+		</p>
+		<p class="result">&nbsp;</p>
+	</div>
+	<p class="title">その他、ご意見・ご感想などございましたら、ご記入ください。</p>
+	<div class="inner">
+		<p class="message">こちらはご意見・ご感想用のフォームです。各社製品については、各社へお問い合わせください。</p>
+		<p class="message_red">※本フォームにいただいたコメントへの返信はできません。
+		<a href="/reference.html">返信をご希望の方は「お問合せ」</a>
+		をご利用ください。
+		</p>
+		<div class="container_a"><div class="container_b">
+			<textarea name="free_text" id="free_text" disabled="disabled" cols="30" rows="3"></textarea>
+		</div></div>
+		<p class="send_area">
+			<input class="button" type="image" src="/common/feedback/images/fb_btn_send_jp.jpg" alt="送信" disabled="disabled"/>
+			<span class="en_js_msg">javascriptを有効にすると、ご回答いただけます。</span>
+			<span class="loader" style="display:none;"><img src="/common/feedback/images/fb_loader.gif" alt="処理中..." /></span>
+			<span class="thanks">ありがとうございました。</span>
+			<a href="/form/" class="incident_link">インシデント報告はこちらから</a>
+		</p>
+	</div>
+	<input type="hidden" name="redirect_to" id="redirect_to" value="" />
+	<input type="hidden" name="feedback_host" id="feedback_host" value="//ws.jpcert.or.jp/cgi-bin/" />
+	<input type="hidden" name="uri" id="uri" value="" />
+	<input type="hidden" name="token" id="token" value="" />
+</form>
+</div></div>
+</div>
+
+<div class="page_navigation cf">
+	<a href="javascript:;" class="previous disabled">&lt;&lt;&nbsp;前へ</a>
+	<a href="javascript:;" class="next disabled">次へ&nbsp;&gt;&gt;</a>
+</div>
+
+			</div>
+		</div>
+	</div>
+	
+	<div class="contents_left_body">
+		<div class="page_guide_menu">
+	
+	
+	<p>緊急情報を確認する</p>
+	<ul class="page_guide_menu">
+		<li class="selected"><a href="/at/">注意喚起</a></li>
+		<li ><a href="/tsubame/">インターネット定点観測</a></li>
+		<li><a href="https://jvn.jp/">JVN</a></li>
+		<li ><a href="/vh/top.html">脆弱性対策情報</a></li>
+	</ul>
+	
+	
+	
+	
+	
+	
+</div>
+
+		<div class="recommend_list">
+			<p>おすすめ情報</p>
+			<ul class="list">
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/07/apt-c-60_2026.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「APT-C-60による2026年の攻撃」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/06/tool_analysis_update.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「ツール分析結果シートのアップデート」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/06/tsubame-overflow20260103.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2026年1～3月）」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/05/tsubame-overflow20251012.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2025年10～12月）」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/03/tsubame-overflow20250709.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2025年7～9月）」</a></li>
+
+	<li><a href="/magazine/security/ransom-faq.html" onclick="piwikTracker.trackGoal(3);">侵入型ランサムウェア攻撃を受けたら読むFAQ</a></li>
+
+</ul>
+		</div>
+
+		<ul class="banner_list">
+
+	<!--
+	<li><a class="button" href="/csirt_material/"><img src="/common/banner_images/csirt_off.png" alt="CSIRTマテリアル" /></a></li>
+	-->
+	
+	<!--
+	<li><a class="button" href="/pr/2017/pr170002.html"><img src="/common/banner_images/password_off.png" alt="STOP!!パスワード使い回し!!キャンペーン2017" /></a></li>
+	<li><a class="button" href="/pr/2016/pr160005.html"><img src="/common/banner_images/holiday_off.png" alt="" /></a></li>
+	<li><a class="button" href="/pr/2016/pr160005.html"><img src="/common/banner_images/vacation_off.png" alt="" /></a></li>
+	-->
+
+	
+
+	
+	<li><a class="button" href="/csirt_material/"><img src="/common/banner_images/csirt_off.png" alt="CSIRTマテリアル" /></a></li>
+	
+
+	
+
+	
+
+	
+
+	
+</ul>
+	</div>
+</div>
+
+<footer class="gray_background sh_uoh">
+	<div class="page_link_area contents_area_view cf">
+		<div class="page_link_contaienr cf">
+			<div class="page_link_right_area cf">
+				<div class="page_links">
+					<p class="dt"><a href="/menu_aboutjpcert.html">JPCERT/CCについて</a></p>
+					<div class="cf">
+						<dl class="fl">
+							<dt class="hide">&nbsp;</dt>
+							<dd><a href="/about/">JPCERT/CCとは</a></dd>
+							<dd class="dd_second_class"><a href="/message.html">代表理事挨拶</a></dd>
+							<dd class="dd_second_class"><a href="/profile.html">組織概要</a></dd>
+							<dd class="dd_second_class"><a href="/about/01.html">事業概要</a></dd>
+							<dd><a href="/recruit/">採用情報</a></dd>
+							<dd><a href="/solicitation/">公募・入札情報</a></dd>
+							<dd><a href="/press/pressroom.html">プレスルーム</a></dd>
+							<dd class="dd_second_class"><a href="/press/2026.html">プレスリリース</a></dd>
+							<dd class="dd_second_class"><a href="/press/contact.html">広報へのお問い合わせ</a></dd>
+							<dd class="dd_second_class"><a href="/press/request.html">講演依頼</a></dd>
+							<dd class="dd_second_class"><a href="/press/nominal-support.html">後援申請</a></dd>
+						</dl>
+						<dl class="fl">
+							<dt class="hide">&nbsp;</dt>
+							<dd><a href="/event/">イベント</a></dd>
+							<dd><a href="/kouen/">講演・執筆一覧</a></dd>
+							<dd><a href="/magazine/chronology/">セキュリティ<br />インシデント年表</a></dd>
+							<dd><a href="/twitter.html">X（旧Twitter）一覧</a></dd>
+							<dd><a href="/jpcert-pgp.html">PGP公開鍵</a></dd>
+							<dd><a href="/related/">関連組織</a></dd>
+							<dd><a href="/reference.html">お問い合わせ</a></dd>
+						</dl>
+					</div>
+					<dl class="dl_second_line">
+						<dt><a href="/menu_columnblog.html">コラム＆ブログ</a></dt>
+						<dd><a href="/newsflash/">CyberNewsFlash</a></dd>
+						<dd><a href="https://blogs.jpcert.or.jp/ja/">JPCERT/CC Eyes ～JPCERTコーディネーションセンター公式ブログ～</a></dd>
+					</dl>
+				</div>
+			</div>
+			<div class="page_link_left_area cf">
+				<div class="page_links">
+					<dl>
+						<dt>インシデントとは</dt>
+						<dd><a href="/aboutincident.html">インシデントとは</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_alertsandadvisories.html">緊急情報を確認する</a></dt>
+						<dd><a href="/at/">注意喚起</a></dd>
+						<dd><a href="/tsubame/">インターネット定点観測</a></dd>
+						<dd><a href="https://jvn.jp/">JVN</a></dd>
+						<dd><a href="/vh/top.html">脆弱性対策情報</a></dd>
+					</dl>
+					<dl class="dl_second_line">
+						<dt><a href="/menu_reporttojpcert.html">依頼・相談する</a></dt>
+						<dd><a href="/ir/">インシデント対応とは</a></dd>
+						<dd><a href="/form/">インシデント対応依頼</a></dd>
+						<dd><a href="/ir/consult.html">インシデント相談・情報提供</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_documents.html">公開資料を見る</a></dt>
+						<dd><a href="/wr/">Weekly Report</a></dd>
+						<dd><a href="/qr/index.html">四半期レポート</a></dd>
+						<dd><a href="/tsubame/report/">インターネット定点観測レポート</a></dd>
+						<dd><a href="/report/press.html">ソフトウェア等の<br />脆弱性関連情報に関する届出</a></dd>
+						<dd><a href="/research/">研究・調査・翻訳レポート</a></dd>
+						<dd><a href="/csirt_material/">CSIRTマテリアル</a></dd>
+						<dd><a href="/securecoding/">セキュアコーディング</a></dd>
+						<dd><a href="/ics/">制御システムセキュリティ</a></dd>
+						<dd><a href="/magazine/">ライブラリ</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_receiveinformation.html">情報を受け取る</a></dt>
+						<dd><a href="/cista/">CISTA（シスタ）</a></dd>
+						<dd><a href="/vh/register.html">製品開発者登録</a></dd>
+						<dd><a href="/announce.html">メーリングリスト</a></dd>
+						<dd><a href="/rss/">RSS</a></dd>
+					</dl>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="footer_area">
+		<img class="logo" src="/common/image/footer_logo.svg" width="194" height="45" alt="JPCERT/CC" />
+		<p class="company_info">一般社団法人JPCERTコーディネーションセンター<br />〒103-0023<br />東京都中央区日本橋本町4-4-2 東山ビルディング8階<br />TEL: 03-6271-8901　FAX 03-6271-8908<br />
+		</p>
+		<ul class="links">
+			<li><a href="/guide.html">ご利用にあたって</a></li>
+			<li><a href="/privacy.html">プライバシーポリシー</a></li>
+			<li><a href="/reference.html">お問い合わせ</a></li>
+			<li><a href="/about/about_mobile.html">モバイル向けコンテンツ</a></li>
+		</ul>
+		<address>&copy; 1996-2026 JPCERT/CC</address>
+	</div>
+</footer>
+
+<script type="text/javascript" src="/common/js/prototype.js"></script>
+<script type="text/javascript" src="/common/js/effects.js"></script>
+<script type="text/javascript" src="/common/js/builder.js"></script>
+<script type="text/javascript" src="/common/js/cookie.js"></script>
+<script type="text/javascript" src="/common/slide/slide.js"></script>
+<script type="text/javascript" src="/common/js/common.js"></script>
+<script type="text/javascript" src="/common/social_links/script.js"></script>
+<script type="text/javascript" src="/common/feedback/script.js"></script>
+<script type="text/javascript" src="/common/page_navigation/script.js"></script>
+
+
+</body>
+</html>

--- a/pkg/fetch/jvn/feed/rss/testdata/fixtures/at/2021/at210050.html
+++ b/pkg/fetch/jvn/feed/rss/testdata/fixtures/at/2021/at210050.html
@@ -1,0 +1,683 @@
+<!DOCTYPE html>
+<html lang="ja-jp">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	
+	<title>Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起</title>
+	<meta name="keywords" content="" />
+	<meta name="description" content="" />
+	<meta property="og:locale" content="ja_JP" />
+	<meta property="og:site_name" content="JPCERT/CC" />
+	<meta property="og:url" content="https://www.jpcert.or.jp/at/2021/at210050.html">
+	<meta property="og:title" content="Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起">
+	
+	<meta property="og:image" content="https://www.jpcert.or.jp/common/image/ogp_image.jpg">
+	
+	<link rel="alternate" type="application/rss+xml" title="注意喚起、Weekly Report、脆弱性情報（JVN）、JPCERT/CCからのお知らせやイベントの新着情報をまとめて提供" href="/rss/jpcert-all.rdf" />
+	<link rel="alternate" type="application/rss+xml" title="注意喚起と緊急報告、Weekly Report の新着情報" href="/rss/jpcert.rdf" />
+	<link rel="alternate" type="application/rss+xml" title="JPCERT/CCからのお知らせ、イベントの新着情報" href="/rss/whatsnew.rdf" />
+	<link rel="stylesheet" href="/common/css/html5reset-1.6.1.css">
+	<link rel="stylesheet" href="/common/css/common.css">
+	<link rel="stylesheet" href="/common/css/page.css">
+	<link rel="stylesheet" href="/common/css/print.css" media="print" />
+	<link rel="stylesheet" href="/common/slide/slide.css"/>
+	
+</head>
+<body class="category_a">
+
+
+<!-- guidance_sp -->
+<div id="guidance_sp" style="display:none;">
+<div class="title"><img src="/common/guidance/g_guidance_title.png" alt="スマートフォン用で表示" /><a href="/m/at/2021/at210050.html" id="show_sp_site"><img src="/common/guidance/g_button_show.png" alt="" /></a></div>
+<div class="message"><a href="javascript:;" id="check_no_message"><img src="/common/guidance/g_check_off.png" alt="" /><img src="/common/guidance/g_guidance_message.png" alt="" /></a></div>
+</div>
+<!-- /guidance_sp -->
+
+<header class="sh_uoh">
+	<div class="top">
+		<h2><img src="/common/image/h2_image.png" width="330" height="25" alt="サイバーインシデントがなくなるその日まで" /></h2>
+		<ul>
+			<li><a href="/reference.html">お問い合わせ</a></li>
+			<li><a href="/recruit/index.html">採用情報</a></li>
+			<li><a href="/sitemap.html">サイトマップ</a></li>
+			<li><a href="/english/">English</a></li>
+		</ul>
+	</div>
+
+	<div class="main">
+		<h1><a href="/"><img src="/common/image/header_logo.svg" width="198" height="66" alt="JPCERT Coordination Center" /></a></h1>
+
+<!-- googlr search area
+		<div class="search_area">
+			<form id="cse-search-box" action="https://www.google.com/cse">
+				<input value="011276954563619633753:gam5ydxz2ni" name="cx" type="hidden">
+				<input value="UTF-8" name="ie" type="hidden">
+				<input name="q" id="q" value="" type="text" placeholder="検索キーワードを入力" /><input name="sa" id="sa" type="submit" value="検索" />
+			</form>
+		</div>
+-->
+		
+<!-- yahoo custom search area		
+		<div id="yahoo_search_area" class="watermark">
+
+			<form action="https://custom.search.yahoo.co.jp/search" method="get" id="srch">
+				<p id="srchForm">
+					<input type="text" name="p" id="srchInput">
+					<input type="submit" value="検索" id="srchBtn" onclick="document.getElementById('srchInput').focus();">
+					<input type="hidden" id="fr" name="fr" value="cse">
+					<input type="hidden" id="ei" name="ei" value="UTF-8">
+					<input type="hidden" id="csid" name="csid" value="YZgbsqsHFIwmPApo7sIjK_PtheLpmwnBs_eTDxVthQ--">
+				</p>
+				<input type="hidden" name="vs" value="www.jpcert.or.jp" id="yjInsite">
+			</form>
+		</div>
+-->
+		<div id="yahoo_search_new_area" style="width:396px;">
+			<form action="https://search.yahoo.co.jp/search" method="get" style="margin:0;padding:0;">
+			<p style="margin:0;padding:0;">
+				<a href="https://www.yahoo.co.jp/" target="_blank" style="font-size: 10px;">
+					powered by Yahoo! JAPAN
+				</a>
+				<input type="text" name="p" size="28" style="margin:0 3px;width:50%;">
+				<input type="hidden" name="fr" value="ysiw">
+				<input type="hidden" name="ei" value="utf-8">
+				<input type="submit" value="検索" style="margin:0;color:#595757;font-size:10pt;">
+			</p>
+			<ul style="margin:2px 0 0 0;padding:0;font-size:10pt;list-style:none;">
+				<li style="display:inline;font-size:10pt;">
+					<input name="vs" type="radio" value="www.jpcert.or.jp" checked="checked">
+					このサイト内を検索
+				</li>
+				<li style="display:inline;font-size:10pt;">
+					<input name="vs" type="radio" value="">
+					ウェブ全体を検索
+				</li>
+			</ul>
+			</form>
+			<img src="https://custom.search.yahoo.co.jp/images/window/006c75a92ba244c6b4cbe2709aa17d7b.gif" width="1" height="1" style="display:block;position:absolute">
+		</div>
+		<ul class="links">
+			<li class="icon_rss">最新情報を取得 (<a href="/rss/">RSS</a> | <a href="/announce.html">メーリングリスト</a>) </li>
+			<li><a href="https://www.jpcert.or.jp/" class="icon_https">HTTPS</a></li>
+			<li><a href="/m/" class="icon_mobile">モバイル</a></li>
+		</ul>
+		<script type="text/javascript">
+			(function() {
+			var sb = document.getElementById('srchBox');
+			if (sb && sb.className == 'watermark') {
+  			var si = document.getElementById('srchInput');
+  			var f = function() { si.className = 'nomark'; };
+  			var b = function() {
+    			if (si.value == '') {
+      			si.className = '';
+    			}
+  			};
+  			si.onfocus = f;
+  			si.onblur = b;
+  			if (!/[&?]p=[^&]/.test(location.search)) {
+    			b();
+  			} else {
+    			f();
+  			}
+			}
+			})();
+			</script>
+			
+	</div>
+</header>
+
+<nav>
+	<ul class="menu contents_area_view">
+		<li class="category_a "><a href="/aboutincident.html">インシデントとは</a></li>
+		<li class="category_a selected">
+			<a href="/menu_alertsandadvisories.html">緊急情報を確認する</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">緊急情報を確認する</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/at/">注意喚起</a></li>
+							<li><a href="/tsubame/">インターネット定点観測</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="https://jvn.jp/">JVN</a></li>
+							<li><a href="/vh/top.html">脆弱性対策情報</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_reporttojpcert.html">依頼・相談する</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">依頼・相談する</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/ir/">インシデント対応とは</a></li>
+							<li><a href="/form/">インシデント対応依頼</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/ir/consult.html">インシデント相談・情報提供</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_documents.html">公開資料を見る</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">公開資料を見る</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/wr/">Weekly Report</a></li>
+							<li><a href="/qr/index.html">四半期レポート</a></li>
+							<li><a href="/tsubame/report/">インターネット定点観測レポート</a></li>
+							<li><a href="/report/press.html">ソフトウェア等の脆弱性関連情報に関する届出状況</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/research/">研究・調査・翻訳レポート</a></li>
+							<li><a href="/csirt_material/">CSIRTマテリアル</a></li>
+							<li><a href="/securecoding/">セキュアコーディング</a></li>
+							<li><a href="/ics/">制御システムセキュリティ</a></li>
+							<li><a href="/magazine/">ライブラリ</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_receiveinformation.html">情報を受け取る</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">情報を受け取る</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/cista/">CISTA（シスタ）</a></li>
+							<li><a href="/vh/register.html">製品開発者登録</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/announce.html">メーリングリスト</a></li>
+							<li><a href="/rss/">RSS</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_b ">
+			<a href="/menu_columnblog.html">コラム＆ブログ</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">コラム＆ブログ</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/newsflash/">CyberNewsFlash</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="https://blogs.jpcert.or.jp/ja/">JPCERT/CC Eyes～JPCERT/CC公式ブログ～ </a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_b ">
+			<a href="/menu_aboutjpcert.html">JPCERT/CCについて</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">JPCERT/CCについて</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/about/">JPCERT/CCとは</a></li>
+							<li class="level2"><a href="/message.html">代表理事挨拶</a></li>
+							<li class="level2"><a href="/profile.html">組織概要</a></li>
+							<li class="level2"><a href="/about/01.html">事業概要</a></li>
+							<li><a href="/recruit/">採用情報</a></li>
+							<li><a href="/solicitation/">公募・入札情報</a></li>
+							<li><a href="/press/pressroom.html">プレスルーム</a></li>
+							<li class="level2"><a href="/press/2026.html">プレスリリース</a></li>
+							<li class="level2"><a href="/press/contact.html">広報へのお問い合わせ</a></li>
+							<li class="level2"><a href="/press/request.html">講演依頼</a></li>
+							<li class="level2"><a href="/press/nominal-support.html">後援申請</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/event/">イベント</a></li>
+							<li><a href="/kouen/">講演・執筆一覧</a></li>
+							<li><a href="/twitter.html">X（旧Twitter）一覧</a></li>
+							<li><a href="/jpcert-pgp.html">PGP公開鍵</a></li>
+							<li><a href="/related/">関連組織</a></li>
+							<li><a href="/reference.html">お問い合わせ</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+	</ul>
+</nav>
+
+<div class="breadcrumb_list_area contents_area_view sh_uoh cf">
+	<ul class="breadcrumb_list fl">
+		<li><a href="/">HOME</a></li><li><a href="/menu_alertsandadvisories.html">緊急情報を確認する</a></li><li>Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起</li>
+	</ul>
+	
+	<ul id="page_layout_utility" class="page_layout_utility fr" style="display:none;">
+		<li class="to_normal_layout_group"><a href="javascript:;" class="icon_normal_layout">通常レイアウトに戻す</a></li>
+		<li class="to_normal_layout_group"><a href="javascript:;" class="icon_print">印刷</a></li>
+		<li class="to_print_layout_group"><a href="javascript:;" class="icon_print_layout">印刷用レイアウト</a></li>
+		<li class="to_print_layout_group"><span class="icon_print_disabled">印刷</span></li>
+	</ul>
+	
+</div>
+
+
+<div class="contents_body contents_area_view cf">
+	<div id="link_pgtop" class="contents_right_body">
+		<div class="contents_right_body_wrapper">
+			<div class="page_title_area">
+				<h3>Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起</h3>
+				<span>最終更新: 2022-01-04</span>
+			</div>
+
+			<div class="contents_container">
+<div class="social_links cf">
+	<div class="mail">
+		<a href="mailto:?subject=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7&amp;body=https%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html">
+			<img src="/common/social_links/images/btn_share_mail_jp.png" alt="" />
+		</a>
+	</div>
+	<div class="tweet window">
+		<a href="https://twitter.com/intent/tweet?text=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7%0Ahttps%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html%0A%40jpcert" target="_blank">
+			<img src="/common/social_links/images/btn_share_post_jp.png" alt="" />
+		</a>
+	</div>
+</div>
+
+				<article class="">
+<!-- content_area -->
+<div class="at">
+JPCERT-AT-2021-0050<br />
+JPCERT/CC<br />
+2021-12-11（新規）<br />
+2022-01-04（更新）<br />
+<br />
+<br />
+<h4>I. 概要</h4><br />
+<br />
+<p class="headline_blue">更新: 2022年1月4日記載 </p><div class="update_details">現時点で不明な点もあることから、今後の動向次第で下記掲載内容を修正、更新する予定がありますので、関連情報への注視のほか、本注意喚起の更新内容も逐次ご確認ください。<br />
+<br />
+次の更新を行いました。詳細は「III. 対策」を参照してください。<br />
+<br />
+- Apache Log4jのバージョン2.17.1（Java 8以降のユーザー向け）、2.12.4（Java 7のユーザー向け）及び2.3.2（Java 6のユーザー向け）が公開されました<br />
+<br />
+</div><br />
+<br />
+JavaベースのオープンソースのロギングライブラリのApache Log4jには、任意のコード実行の脆弱性（CVE-2021-44228）があります。Apache Log4jが動作するサーバーにおいて、遠隔の第三者が本脆弱性を悪用する細工したデータを送信することで、任意のコードを実行する可能性があります。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.15.0<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html">https://logging.apache.org/log4j/2.x/security.html</a><br />
+<br />
+Apache Log4jにはLookupと呼ばれる機能があり、ログとして記録された文字列から、一部の文字列を変数として置換します。その内、JNDI Lookup機能が悪用されると、遠隔の第三者が細工した文字列を送信し、Log4jがログとして記録することで、Log4jはLookupにより指定された通信先もしくは内部パスからjava classファイルを読み込み実行し、結果として任意のコードが実行される可能性があります。<br />
+<br />
+2021年12月11日現在、JPCERT/CCは、本脆弱性を悪用する実証コードが公開されていること、及び国内にて本脆弱性の悪用を試みる通信を確認しています。Apache Log4jを利用している場合には、The Apache Software Foundationなどが提供する最新の情報を確認し、バージョンアップや回避策の適用などの実施を検討することを推奨します。<br />
+<br />
+また、Apache Log4jを使用するアプリケーションやソフトウェアなどで、今後セキュリティアップデートが公開される可能性があります。関連する情報を注視し、必要な対策や対応の実施をご検討ください。<br />
+<br />
+<br />
+<h4>II. 対象</h4>対象となるバージョンは次のとおりです。<br />
+<br />
+- Apache Log4j-core 2.15.0より前の2系のバージョン<br />
+<br />
+なお、すでにEnd of Lifeを迎えているApache Log4j 1系のバージョンは、Lookup機能が含まれておらず、JMS Appenderが有効でもクラス情報がデシリアライズされないため影響を受けないとの情報を確認しています。<br />
+<br />
+また、影響を受けるバージョンや条件に関する情報が変更あるいは更新される可能性や、Apache Log4jを使用するアプリケーションやソフトウェアの開発元などから情報が公開される可能性もあるため、最新の情報は各組織から提供される関連情報をご確認ください。<br />
+<br />
+<p class="headline_blue">更新: 2021年12月13日追記 </p><div class="update_details">Apache Log4j 1系のバージョンについては、第三者が本脆弱性を悪用するためにLog4jの設定ファイルを変更することができれば影響を受けるとの情報が公開されていますが、攻撃を行うためには何らかの方法で事前にシステムに不正にアクセスする必要があり、遠隔からの脆弱性を悪用した攻撃の影響は受けません。<br />
+<br />
+Restrict LDAP access via JNDI #608 Comment<br />
+<a href="https://github.com/apache/logging-log4j2/pull/608#issuecomment-991730650">https://github.com/apache/logging-log4j2/pull/608#issuecomment-991730650</a></div><br />
+<br />
+<br />
+<h4>III. 対策</h4>The Apache Software Foundationから本脆弱性を修正したバージョンが公開されています。速やかな対策の適用実施をご検討ください。次のバージョン以降では、Lookup機能がデフォルトでは無効になりました。<br />
+<br />
+- Apache Log4j 2.15.0<br />
+<br />
+使用するアプリケーションやソフトウェアなどについて関連情報を注視し、本脆弱性の影響を受けることが判明した場合も、速やかにアップデートなどの対応を行うことを推奨します。<br />
+<br />
+また、すでに本脆弱性の悪用を試みる通信が確認されていることから、対策の適用実施とあわせて、不審なファイル及びプロセスの有無や、通信ログ等を確認し、攻撃の有無を確認することを推奨します。<br />
+<br />
+<p class="headline_blue">更新: 2021年12月15日追記 </p><div class="update_details">The Apache Software Foundationは、Apache Log4jのバージョン2.16.0（Java 8以降のユーザー向け）および2.12.2（Java 7のユーザー向け）を公開しました。<br />
+<br />
+特定の構成において不正なJNDI検索パターンを入力値とする場合にサービス運用妨害（DoS）が生じる可能性があることが判明し、Message Lookup機能が削除され、JNDIへのアクセスがデフォルトで無効になりました。この問題にはCVE-2021-45046が採番されています。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.12.2 (Java 7) and Log4j 2.16.0 (Java 8)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.16.0">https://logging.apache.org/log4j/2.x/security.html#log4j-2.16.0</a><br />
+<br />
+任意のコード実行の脆弱性（CVE-2021-44228）への対策に加え、サービス運用妨害攻撃の脆弱性（CVE-2021-45046）などのリスクに対応するため、2.16.0または2.12.2へのアップデートを推奨します。</div><p class="headline_blue">更新: 2021年12月20日追記 </p><div class="update_details">CVE-2021-45046の影響について、一部の環境では任意のコード実行などが可能であるとの情報が公開されています。</div><p class="headline_blue">更新: 2021年12月20日追記 </p><div class="update_details">2021年12月18日（現地時間）、The Apache Software Foundationは、Apache Log4jのバージョン2.17.0（Java 8以降のユーザー向け）を公開しました。<br />
+<br />
+自己参照による制御不能な再帰から保護されていないことに起因し、Log4jの設定によっては影響を受けるサービス運用妨害攻撃の脆弱性（CVE-2021-45105）が修正されています。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.17.0 (Java 8)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0">https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0</a></div><p class="headline_blue">更新: 2021年12月28日追記 </p><div class="update_details">2021年12月21日（現地時間）、The Apache Software Foundationは、Apache Log4jのバージョン2.3.1（Java 6のユーザー向け）及び2.12.3（Java 7のユーザー向け）を公開しました。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.17.0 (Java 8), 2.12.3 (Java 7) and 2.3.1 (Java 6)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0">https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0</a></div><p class="headline_blue">更新: 2022年1月4日追記 </p><div class="update_details">2021年12月28日（現地時間）、The Apache Software Foundationは、Apache Log4jの2.17.1（Java 8以降のユーザー向け）、2.12.4（Java 7のユーザー向け）及び2.3.2（Java 6のユーザー向け）を公開しました。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.17.1 (Java 8), 2.12.4 (Java 7) and 2.3.2 (Java 6)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.1">https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.1</a></div><br />
+<br />
+<h4>IV. 回避策</h4>The Apache Software Foundationから、Log4jのバージョンに応じた回避策に関する情報が公開されています。<br />
+<br />
+<p class="headline_blue">更新: 2021年12月15日追記 </p><div class="update_details">The Apache Software Foundationより、一部の回避策は、特定の手法を用いた攻撃を回避するには不十分であることが判明したと明らかにし、有効な回避策として、JndiLookup.classをクラスパスから削除する回避策の実施を呼びかけています。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.12.2 and Log4j 2.16.0<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html">https://logging.apache.org/log4j/2.x/security.html</a></div><br />
+<br />
+Log4jバージョン2.10及びそれ以降<br />
+- 次のいずれかを実施する<br />
+（1）Log4jを実行するJava仮想マシンを起動時に「log4j2.formatMsgNoLookups」というJVMフラグオプションを「true」に指定する 例: -Dlog4j2.formatMsgNoLookups=true<br />
+（2）環境変数「LOG4J_FORMAT_MSG_NO_LOOKUPS」を「true」に設定する<br />
+<br />
+Log4jバージョン2.10より前<br />
+- JndiLookupクラスをクラスパスから削除する<br />
+<br />
+<br />
+また、本脆弱性を悪用する攻撃の影響を軽減するため、システムから外部への接続を制限するための可能な限りのアクセス制御の見直しや強化もご検討ください。<br />
+<br />
+<br />
+<h4>V. 参考情報</h4><br />
+apache / logging-log4j2<br />
+Restrict LDAP access via JNDI #608<br />
+<a href="https://github.com/apache/logging-log4j2/pull/608">https://github.com/apache/logging-log4j2/pull/608</a><br />
+<br />
+The Apache Software Foundation<br />
+Lookups<br />
+<a href="https://logging.apache.org/log4j/2.x/manual/lookups.html">https://logging.apache.org/log4j/2.x/manual/lookups.html</a><br />
+<br />
+LunaSec<br />
+Log4Shell: RCE 0-day exploit found in log4j2, a popular Java logging package<br />
+<a href="https://www.lunasec.io/docs/blog/log4j-zero-day/">https://www.lunasec.io/docs/blog/log4j-zero-day/</a><br />
+<br />
+SANS ISC InfoSec Forums<br />
+RCE in log4j, Log4Shell, or how things can get bad quickly<br />
+<a href="https://isc.sans.edu/forums/diary/RCE+in+log4j+Log4Shell+or+how+things+can+get+bad+quickly/28120/">https://isc.sans.edu/forums/diary/RCE+in+log4j+Log4Shell+or+how+things+can+get+bad+quickly/28120/</a><br />
+<br />
+BlueTeam CheatSheet * Log4Shell*<br />
+<a href="https://gist.github.com/SwitHak/b66db3a06c2955a9cb71a8718970c592">https://gist.github.com/SwitHak/b66db3a06c2955a9cb71a8718970c592</a><br />
+<br />
+<p class="headline_blue">更新: 2021年12月13日追記 </p><div class="update_details">    Japan Vulnerability Notes JVNVU#96768815<br />
+Apache Log4jにおける任意のコードが実行可能な脆弱性<br />
+<a href="https://jvn.jp/vu/JVNVU96768815/">https://jvn.jp/vu/JVNVU96768815/</a></div><br />
+<br />
+<p class="headline_blue">更新: 2021年12月20日追記 </p><div class="update_details">    JPCERT/CC Eyes<br />
+Apache Log4j2のRCE脆弱性（CVE-2021-44228）を狙う攻撃観測<br />
+<a href="https://blogs.jpcert.or.jp/ja/2021/12/log4j-cve-2021-44228.html">https://blogs.jpcert.or.jp/ja/2021/12/log4j-cve-2021-44228.html</a></div><br />
+<br />
+<p class="headline_blue">更新: 2021年12月28日追記 </p><div class="update_details">    JPCERT/CC CyberNewsFlash<br />
+2021年12月に公表されたLog4jの脆弱性について<br />
+<a href="https://www.jpcert.or.jp/newsflash/2021122401.html">https://www.jpcert.or.jp/newsflash/2021122401.html</a></div><br />
+<br />
+今回の件につきまして提供いただける情報がございましたら、JPCERT/CCまでご連絡ください。<br />
+<br />
+<p class="headline_blue">改訂履歴</p>2021-12-11 初版<br />
+2021-12-13 「II. 対象」、「IV. 回避策」、「V. 参考情報」の一部記載の追記・修正<br />
+2021-12-15 「III. 対策」、「IV. 回避策」の追記<br />
+2021-12-20 「I. 概要」、「III. 対策」、「V. 参考情報」の追記<br />
+2021-12-28 「I. 概要」、「III. 対策」、「V. 参考情報」の追記<br />
+2022-01-04 「I. 概要」、「III. 対策」の追記、2021年12月20日追記内容、2021年12月28日追記内容の修正<br />
+<br />
+<br />
+一般社団法人JPCERTコーディネーションセンター（JPCERT/CC）<br />
+早期警戒グループ<br />
+Email：ew-info@jpcert.or.jp
+</div>
+<p class="pg_top"><a href="#link_pgtop">Topへ</a></p>
+<!-- /content_area -->
+				</article>
+
+<div class="social_links cf">
+	<div class="mail">
+		<a href="mailto:?subject=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7&amp;body=https%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html">
+			<img src="/common/social_links/images/btn_share_mail_jp.png" alt="" />
+		</a>
+	</div>
+	<div class="tweet window">
+		<a href="https://twitter.com/intent/tweet?text=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7%0Ahttps%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html%0A%40jpcert" target="_blank">
+			<img src="/common/social_links/images/btn_share_post_jp.png" alt="" />
+		</a>
+	</div>
+</div>
+<div id="fb" class="feedback feedback_noscript">
+<div class="container_a"><div class="container_b">
+<form name="feedback_form" id="feedback_form">
+	<p class="title">このページは役に立ちましたか？</p>
+	<div class="inner">
+		<p>
+			<input type="radio" name="is_useful" id="is_usefull_yes" value="yes" disabled="disabled" /><label for="is_usefull_yes">はい</label>
+			<input type="radio" name="is_useful" id="is_usefull_no" value="no" disabled="disabled" /><label for="is_usefull_no">いいえ</label>
+		</p>
+		<p class="result">&nbsp;</p>
+	</div>
+	<p class="title">その他、ご意見・ご感想などございましたら、ご記入ください。</p>
+	<div class="inner">
+		<p class="message">こちらはご意見・ご感想用のフォームです。各社製品については、各社へお問い合わせください。</p>
+		<p class="message_red">※本フォームにいただいたコメントへの返信はできません。
+		<a href="/reference.html">返信をご希望の方は「お問合せ」</a>
+		をご利用ください。
+		</p>
+		<div class="container_a"><div class="container_b">
+			<textarea name="free_text" id="free_text" disabled="disabled" cols="30" rows="3"></textarea>
+		</div></div>
+		<p class="send_area">
+			<input class="button" type="image" src="/common/feedback/images/fb_btn_send_jp.jpg" alt="送信" disabled="disabled"/>
+			<span class="en_js_msg">javascriptを有効にすると、ご回答いただけます。</span>
+			<span class="loader" style="display:none;"><img src="/common/feedback/images/fb_loader.gif" alt="処理中..." /></span>
+			<span class="thanks">ありがとうございました。</span>
+			<a href="/form/" class="incident_link">インシデント報告はこちらから</a>
+		</p>
+	</div>
+	<input type="hidden" name="redirect_to" id="redirect_to" value="" />
+	<input type="hidden" name="feedback_host" id="feedback_host" value="//ws.jpcert.or.jp/cgi-bin/" />
+	<input type="hidden" name="uri" id="uri" value="" />
+	<input type="hidden" name="token" id="token" value="" />
+</form>
+</div></div>
+</div>
+
+<div class="page_navigation cf">
+	<a href="javascript:;" class="previous disabled">&lt;&lt;&nbsp;前へ</a>
+	<a href="javascript:;" class="next disabled">次へ&nbsp;&gt;&gt;</a>
+</div>
+
+			</div>
+		</div>
+	</div>
+	
+	<div class="contents_left_body">
+		<div class="page_guide_menu">
+	
+	
+	<p>緊急情報を確認する</p>
+	<ul class="page_guide_menu">
+		<li class="selected"><a href="/at/">注意喚起</a></li>
+		<li ><a href="/tsubame/">インターネット定点観測</a></li>
+		<li><a href="https://jvn.jp/">JVN</a></li>
+		<li ><a href="/vh/top.html">脆弱性対策情報</a></li>
+	</ul>
+	
+	
+	
+	
+	
+	
+</div>
+
+		<div class="recommend_list">
+			<p>おすすめ情報</p>
+			<ul class="list">
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/07/apt-c-60_2026.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「APT-C-60による2026年の攻撃」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/06/tool_analysis_update.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「ツール分析結果シートのアップデート」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/06/tsubame-overflow20260103.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2026年1～3月）」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/05/tsubame-overflow20251012.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2025年10～12月）」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/03/tsubame-overflow20250709.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2025年7～9月）」</a></li>
+
+	<li><a href="/magazine/security/ransom-faq.html" onclick="piwikTracker.trackGoal(3);">侵入型ランサムウェア攻撃を受けたら読むFAQ</a></li>
+
+</ul>
+		</div>
+
+		<ul class="banner_list">
+
+	<!--
+	<li><a class="button" href="/csirt_material/"><img src="/common/banner_images/csirt_off.png" alt="CSIRTマテリアル" /></a></li>
+	-->
+	
+	<!--
+	<li><a class="button" href="/pr/2017/pr170002.html"><img src="/common/banner_images/password_off.png" alt="STOP!!パスワード使い回し!!キャンペーン2017" /></a></li>
+	<li><a class="button" href="/pr/2016/pr160005.html"><img src="/common/banner_images/holiday_off.png" alt="" /></a></li>
+	<li><a class="button" href="/pr/2016/pr160005.html"><img src="/common/banner_images/vacation_off.png" alt="" /></a></li>
+	-->
+
+	
+
+	
+	<li><a class="button" href="/csirt_material/"><img src="/common/banner_images/csirt_off.png" alt="CSIRTマテリアル" /></a></li>
+	
+
+	
+
+	
+
+	
+
+	
+</ul>
+	</div>
+</div>
+
+<footer class="gray_background sh_uoh">
+	<div class="page_link_area contents_area_view cf">
+		<div class="page_link_contaienr cf">
+			<div class="page_link_right_area cf">
+				<div class="page_links">
+					<p class="dt"><a href="/menu_aboutjpcert.html">JPCERT/CCについて</a></p>
+					<div class="cf">
+						<dl class="fl">
+							<dt class="hide">&nbsp;</dt>
+							<dd><a href="/about/">JPCERT/CCとは</a></dd>
+							<dd class="dd_second_class"><a href="/message.html">代表理事挨拶</a></dd>
+							<dd class="dd_second_class"><a href="/profile.html">組織概要</a></dd>
+							<dd class="dd_second_class"><a href="/about/01.html">事業概要</a></dd>
+							<dd><a href="/recruit/">採用情報</a></dd>
+							<dd><a href="/solicitation/">公募・入札情報</a></dd>
+							<dd><a href="/press/pressroom.html">プレスルーム</a></dd>
+							<dd class="dd_second_class"><a href="/press/2026.html">プレスリリース</a></dd>
+							<dd class="dd_second_class"><a href="/press/contact.html">広報へのお問い合わせ</a></dd>
+							<dd class="dd_second_class"><a href="/press/request.html">講演依頼</a></dd>
+							<dd class="dd_second_class"><a href="/press/nominal-support.html">後援申請</a></dd>
+						</dl>
+						<dl class="fl">
+							<dt class="hide">&nbsp;</dt>
+							<dd><a href="/event/">イベント</a></dd>
+							<dd><a href="/kouen/">講演・執筆一覧</a></dd>
+							<dd><a href="/magazine/chronology/">セキュリティ<br />インシデント年表</a></dd>
+							<dd><a href="/twitter.html">X（旧Twitter）一覧</a></dd>
+							<dd><a href="/jpcert-pgp.html">PGP公開鍵</a></dd>
+							<dd><a href="/related/">関連組織</a></dd>
+							<dd><a href="/reference.html">お問い合わせ</a></dd>
+						</dl>
+					</div>
+					<dl class="dl_second_line">
+						<dt><a href="/menu_columnblog.html">コラム＆ブログ</a></dt>
+						<dd><a href="/newsflash/">CyberNewsFlash</a></dd>
+						<dd><a href="https://blogs.jpcert.or.jp/ja/">JPCERT/CC Eyes ～JPCERTコーディネーションセンター公式ブログ～</a></dd>
+					</dl>
+				</div>
+			</div>
+			<div class="page_link_left_area cf">
+				<div class="page_links">
+					<dl>
+						<dt>インシデントとは</dt>
+						<dd><a href="/aboutincident.html">インシデントとは</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_alertsandadvisories.html">緊急情報を確認する</a></dt>
+						<dd><a href="/at/">注意喚起</a></dd>
+						<dd><a href="/tsubame/">インターネット定点観測</a></dd>
+						<dd><a href="https://jvn.jp/">JVN</a></dd>
+						<dd><a href="/vh/top.html">脆弱性対策情報</a></dd>
+					</dl>
+					<dl class="dl_second_line">
+						<dt><a href="/menu_reporttojpcert.html">依頼・相談する</a></dt>
+						<dd><a href="/ir/">インシデント対応とは</a></dd>
+						<dd><a href="/form/">インシデント対応依頼</a></dd>
+						<dd><a href="/ir/consult.html">インシデント相談・情報提供</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_documents.html">公開資料を見る</a></dt>
+						<dd><a href="/wr/">Weekly Report</a></dd>
+						<dd><a href="/qr/index.html">四半期レポート</a></dd>
+						<dd><a href="/tsubame/report/">インターネット定点観測レポート</a></dd>
+						<dd><a href="/report/press.html">ソフトウェア等の<br />脆弱性関連情報に関する届出</a></dd>
+						<dd><a href="/research/">研究・調査・翻訳レポート</a></dd>
+						<dd><a href="/csirt_material/">CSIRTマテリアル</a></dd>
+						<dd><a href="/securecoding/">セキュアコーディング</a></dd>
+						<dd><a href="/ics/">制御システムセキュリティ</a></dd>
+						<dd><a href="/magazine/">ライブラリ</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_receiveinformation.html">情報を受け取る</a></dt>
+						<dd><a href="/cista/">CISTA（シスタ）</a></dd>
+						<dd><a href="/vh/register.html">製品開発者登録</a></dd>
+						<dd><a href="/announce.html">メーリングリスト</a></dd>
+						<dd><a href="/rss/">RSS</a></dd>
+					</dl>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="footer_area">
+		<img class="logo" src="/common/image/footer_logo.svg" width="194" height="45" alt="JPCERT/CC" />
+		<p class="company_info">一般社団法人JPCERTコーディネーションセンター<br />〒103-0023<br />東京都中央区日本橋本町4-4-2 東山ビルディング8階<br />TEL: 03-6271-8901　FAX 03-6271-8908<br />
+		</p>
+		<ul class="links">
+			<li><a href="/guide.html">ご利用にあたって</a></li>
+			<li><a href="/privacy.html">プライバシーポリシー</a></li>
+			<li><a href="/reference.html">お問い合わせ</a></li>
+			<li><a href="/about/about_mobile.html">モバイル向けコンテンツ</a></li>
+		</ul>
+		<address>&copy; 1996-2026 JPCERT/CC</address>
+	</div>
+</footer>
+
+<script type="text/javascript" src="/common/js/prototype.js"></script>
+<script type="text/javascript" src="/common/js/effects.js"></script>
+<script type="text/javascript" src="/common/js/builder.js"></script>
+<script type="text/javascript" src="/common/js/cookie.js"></script>
+<script type="text/javascript" src="/common/slide/slide.js"></script>
+<script type="text/javascript" src="/common/js/common.js"></script>
+<script type="text/javascript" src="/common/social_links/script.js"></script>
+<script type="text/javascript" src="/common/feedback/script.js"></script>
+<script type="text/javascript" src="/common/page_navigation/script.js"></script>
+
+
+</body>
+</html>

--- a/pkg/fetch/jvn/feed/rss/testdata/fixtures/checksum.txt
+++ b/pkg/fetch/jvn/feed/rss/testdata/fixtures/checksum.txt
@@ -28,6 +28,27 @@
         "lastModified": "2023/10/29 09:01:06"
     },
     {
+        "url": "https://jvndb.jvn.jp/ja/rss/years/jvndb_2021.rdf",
+        "filename": "jvndb_2021.rdf",
+        "sha256": "b6d8f1c0a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbcc",
+        "size": 30000000,
+        "lastModified": "2023/10/29 09:00:41"
+    },
+    {
+        "url": "https://jvndb.jvn.jp/ja/rss/years/jvndb_2011.rdf",
+        "filename": "jvndb_2011.rdf",
+        "sha256": "11cc22dd33ee44ff5566778899aabbccddeeff00112233445566778899aabbcc",
+        "size": 5000000,
+        "lastModified": "2011/05/02 13:25:00"
+    },
+    {
+        "url": "https://jvndb.jvn.jp/ja/rss/years/jvndb_2007.rdf",
+        "filename": "jvndb_2007.rdf",
+        "sha256": "2007aabbccddeeff00112233445566778899aabbccddeeff0011223344556677",
+        "size": 3000000,
+        "lastModified": "2007/04/01 00:00:00"
+    },
+    {
         "url": "https://jvndb.jvn.jp/ja/feed/detail/jvndb_detail_2023.rdf",
         "filename": "jvndb_detail_2023.rdf",
         "sha256": "61aa3296207db6305bc27145c4be4ab486249d124a7eaf56fc0c3b3372327a36",

--- a/pkg/fetch/jvn/feed/rss/testdata/fixtures/jvndb_2007.rdf
+++ b/pkg/fetch/jvn/feed/rss/testdata/fixtures/jvndb_2007.rdf
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:sec="http://jvn.jp/rss/mod_sec/" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xsi:schemaLocation="http://purl.org/rss/1.0/ https://jvndb.jvn.jp/schema/jvnrss_2.0.xsd" xml:lang="ja">
+  <channel rdf:about="https://jvndb.jvn.jp/ja/rss/years/jvndb_2007.rdf">
+    <title>JVNDB RSS Feed - 2007 Years Entry</title>
+    <link>https://jvndb.jvn.jp/</link>
+    <description>JVN iPedia 2007年情報</description>
+    <dc:creator></dc:creator>
+    <dc:date>2007-04-01T00:00:00+09:00</dc:date>
+    <dcterms:modified>2007-04-01T00:00:00+09:00</dcterms:modified>
+    <items>
+      <rdf:Seq>
+        <rdf:li rdf:resource="https://jvndb.jvn.jp/ja/contents/2007/JVNDB-2007-000127.html"/>
+      </rdf:Seq>
+    </items>
+  </channel>
+  <item rdf:about="https://jvndb.jvn.jp/ja/contents/2007/JVNDB-2007-000127.html">
+    <title>トレンドマイクロ ウイルス検索エンジンの UPX ファイル処理にバッファオーバーフローの脆弱性</title>
+    <link>https://jvndb.jvn.jp/ja/contents/2007/JVNDB-2007-000127.html</link>
+    <description>トレンドマイクロのウイルス対策製品で使用されるウイルス検索エンジンVSAPI には、不正な UPX 圧縮実行ファイルを適切に処理できないため、UPX 圧縮実行ファイルをスキャン処理することでバッファオーバーフローが発生する脆弱性が存在します。</description>
+    <sec:identifier>JVNDB-2007-000127</sec:identifier>
+    <sec:references source="JVN" id="JVNVU#276432">http://jvn.jp/cert/JVNVU%23276432/index.html</sec:references>
+    <sec:references source="CVE" id="CVE-2007-0851">http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2007-0851</sec:references>
+    <sec:references source="NVD" id="CVE-2007-0851">http://nvd.nist.gov/nvd.cfm?cvename=CVE-2007-0851</sec:references>
+    <sec:references source="JPCERT-AT" id="JPCERT-PR-2007-0002">http://www.jpcert.or.jp/pr/2007/pr070002.pdf</sec:references>
+    <sec:references source="CERT-VN" id="VU#276432">http://www.kb.cert.org/vuls/id/276432</sec:references>
+    <sec:cpe version="2.2" vendor="トレンドマイクロ" product="Trend Micro Scan Engine">cpe:/a:trendmicro:scan_engine</sec:cpe>
+    <sec:cvss version="2.0" score="5.4" type="Base" severity="Medium" vector="AV:N/AC:H/Au:N/C:N/I:N/A:C"/>
+    <dc:date>2007-04-01T00:00+09:00</dc:date>
+    <dcterms:issued>2007-04-01T00:00+09:00</dcterms:issued>
+    <dcterms:modified>2007-04-01T00:00+09:00</dcterms:modified>
+  </item>
+</rdf:RDF>

--- a/pkg/fetch/jvn/feed/rss/testdata/fixtures/jvndb_2011.rdf
+++ b/pkg/fetch/jvn/feed/rss/testdata/fixtures/jvndb_2011.rdf
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:sec="http://jvn.jp/rss/mod_sec/" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xsi:schemaLocation="http://purl.org/rss/1.0/ https://jvndb.jvn.jp/schema/jvnrss_2.0.xsd" xml:lang="ja">
+  <channel rdf:about="https://jvndb.jvn.jp/ja/rss/years/jvndb_2011.rdf">
+    <title>JVNDB RSS Feed - 2011 Years Entry</title>
+    <link>https://jvndb.jvn.jp/</link>
+    <description>JVN iPedia 2011年情報</description>
+    <dc:creator></dc:creator>
+    <dc:date>2011-05-02T13:25:00+09:00</dc:date>
+    <dcterms:modified>2011-05-02T13:25:00+09:00</dcterms:modified>
+    <items>
+      <rdf:Seq>
+        <rdf:li rdf:resource="https://jvndb.jvn.jp/ja/contents/2011/JVNDB-2011-001013.html"/>
+      </rdf:Seq>
+    </items>
+  </channel>
+  <item rdf:about="https://jvndb.jvn.jp/ja/contents/2011/JVNDB-2011-001013.html">
+    <title>Microsoft Internet Explorer 8 における解放済みメモリを使用する脆弱性</title>
+    <link>https://jvndb.jvn.jp/ja/contents/2011/JVNDB-2011-001013.html</link>
+    <description>Microsoft Internet Explorer 8 の mshtml.dll ライブラリには、解放済みメモリを使用する (use-after-free) 脆弱性が存在します。</description>
+    <sec:identifier>JVNDB-2011-001013</sec:identifier>
+    <sec:references source="JVN" id="JVNVU#427980">http://jvn.jp/cert/JVNVU427980</sec:references>
+    <sec:references source="JVN" id="JVNTA11-102A">http://jvn.jp/cert/JVNTA11-102A</sec:references>
+    <sec:references source="CVE" id="CVE-2011-0346">http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-0346</sec:references>
+    <sec:references source="NVD" id="CVE-2011-0346">http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2011-0346</sec:references>
+    <sec:references source="JPCERT-AT" id="JPCERT-AT-2011-0008">https://www.jpcert.or.jp/at/2011/at110008.txt</sec:references>
+    <sec:references source="CERT-SA" id="SA11-102A">http://www.us-cert.gov/cas/alerts/SA11-102A.html</sec:references>
+    <sec:references source="CERT-VN" id="VU#427980">http://www.kb.cert.org/vuls/id/427980</sec:references>
+    <sec:references source="CERT-TA" id="TA11-102A">http://www.us-cert.gov/cas/techalerts/TA11-102A.html</sec:references>
+    <sec:references source="IPA" id="20110413-ms11-018">http://www.ipa.go.jp/security/ciadr/vul/20110413-ms11-018.html</sec:references>
+    <sec:references source="BID" id="45639">http://www.securityfocus.com/bid/45639</sec:references>
+    <sec:references title="リソース管理の問題(CWE-399)" id="CWE-399">https://jvndb.jvn.jp/ja/cwe/CWE-399.html</sec:references>
+    <sec:cpe version="2.2" vendor="マイクロソフト" product="Microsoft Internet Explorer">cpe:/a:microsoft:internet_explorer</sec:cpe>
+    <sec:cvss version="2.0" score="9.3" type="Base" severity="High" vector="AV:N/AC:M/Au:N/C:C/I:C/A:C"/>
+    <dc:date>2011-05-02T13:25+09:00</dc:date>
+    <dcterms:issued>2011-01-28T15:38+09:00</dcterms:issued>
+    <dcterms:modified>2011-05-02T13:25+09:00</dcterms:modified>
+  </item>
+</rdf:RDF>

--- a/pkg/fetch/jvn/feed/rss/testdata/fixtures/jvndb_2021.rdf
+++ b/pkg/fetch/jvn/feed/rss/testdata/fixtures/jvndb_2021.rdf
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:sec="http://jvn.jp/rss/mod_sec/" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xsi:schemaLocation="http://purl.org/rss/1.0/ https://jvndb.jvn.jp/schema/jvnrss_2.0.xsd" xml:lang="ja">
+  <channel rdf:about="https://jvndb.jvn.jp/ja/rss/years/jvndb_2021.rdf">
+    <title>JVNDB RSS Feed - 2021 Years Entry</title>
+    <link>https://jvndb.jvn.jp/</link>
+    <description>JVN iPedia 2021年情報</description>
+    <dc:creator></dc:creator>
+    <dc:date>2022-12-15T10:24:01+09:00</dc:date>
+    <dcterms:modified>2022-12-15T10:24:01+09:00</dcterms:modified>
+    <items>
+      <rdf:Seq>
+        <rdf:li rdf:resource="https://jvndb.jvn.jp/ja/contents/2021/JVNDB-2021-005429.html"/>
+      </rdf:Seq>
+    </items>
+  </channel>
+  <item rdf:about="https://jvndb.jvn.jp/ja/contents/2021/JVNDB-2021-005429.html">
+    <title>Apache Log4j における任意のコードが実行可能な脆弱性</title>
+    <link>https://jvndb.jvn.jp/ja/contents/2021/JVNDB-2021-005429.html</link>
+    <description>Log4j には JNDI Lookup 機能による外部入力値の検証不備に起因して任意の Java コードを実行可能な脆弱性が存在します。&#13;
+&#13;
+The Apache Software Foundation が提供する Log4j は、Java ベースのロギングライブラリです。Log4j には、ログに記載された文字列から一部の値を変数として評価する Lookup 機能が実装されています。&#13;
+その Lookup 機能の内、JNDI Lookup 機能を悪用することにより、ログに含まれる外部の URL もしくは内部パスから Java のクラス情報をデシリアライズして実行してしまう問題（CWE-20, CVE-2021-44228）が発見されました。&#13;
+これにより、遠隔の攻撃者が細工した文字列を脆弱なシステムのログに記載させ、結果として任意の Java コードをシステムに実行させることが可能です。&#13;
+</description>
+    <sec:identifier>JVNDB-2021-005429</sec:identifier>
+    <sec:references source="JVN" id="JVNVU#96768815">https://jvn.jp/vu/JVNVU96768815/</sec:references>
+    <sec:references source="CVE" id="CVE-2021-44228">https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228</sec:references>
+    <sec:references source="NVD" id="CVE-2021-44228">https://nvd.nist.gov/vuln/detail/CVE-2021-44228</sec:references>
+    <sec:references source="JPCERT-AT" id="JPCERT-AT-2021-0050">https://www.jpcert.or.jp/at/2021/at210050.html</sec:references>
+    <sec:references title="不適切な入力確認(CWE-20)" id="CWE-20">https://jvndb.jvn.jp/ja/cwe/CWE-20.html</sec:references>
+    <sec:cpe version="2.2" vendor="Apache Software Foundation" product="Apache Log4j">cpe:/a:apache:log4j</sec:cpe>
+    <sec:cvss version="2.0" score="9.3" type="Base" severity="High" vector="AV:N/AC:M/Au:N/C:C/I:C/A:C"/>
+    <sec:cvss version="3.0" score="10.0" type="Base" severity="Critical" vector="CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"/>
+    <dc:date>2022-12-15T10:24+09:00</dc:date>
+    <dcterms:issued>2021-12-14T16:37+09:00</dcterms:issued>
+    <dcterms:modified>2022-12-15T10:24+09:00</dcterms:modified>
+  </item>
+</rdf:RDF>

--- a/pkg/fetch/jvn/feed/rss/testdata/golden/2007/JVNDB-2007-000127.json
+++ b/pkg/fetch/jvn/feed/rss/testdata/golden/2007/JVNDB-2007-000127.json
@@ -1,0 +1,54 @@
+{
+	"about": "https://jvndb.jvn.jp/ja/contents/2007/JVNDB-2007-000127.html",
+	"title": "トレンドマイクロ ウイルス検索エンジンの UPX ファイル処理にバッファオーバーフローの脆弱性",
+	"link": "https://jvndb.jvn.jp/ja/contents/2007/JVNDB-2007-000127.html",
+	"description": "トレンドマイクロのウイルス対策製品で使用されるウイルス検索エンジンVSAPI には、不正な UPX 圧縮実行ファイルを適切に処理できないため、UPX 圧縮実行ファイルをスキャン処理することでバッファオーバーフローが発生する脆弱性が存在します。",
+	"identifier": "JVNDB-2007-000127",
+	"references": [
+		{
+			"text": "http://jvn.jp/cert/JVNVU%23276432/index.html",
+			"source": "JVN",
+			"id": "JVNVU#276432"
+		},
+		{
+			"text": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2007-0851",
+			"source": "CVE",
+			"id": "CVE-2007-0851"
+		},
+		{
+			"text": "http://nvd.nist.gov/nvd.cfm?cvename=CVE-2007-0851",
+			"source": "NVD",
+			"id": "CVE-2007-0851"
+		},
+		{
+			"text": "http://www.jpcert.or.jp/pr/2007/pr070002.pdf",
+			"source": "JPCERT-AT",
+			"id": "JPCERT-PR-2007-0002"
+		},
+		{
+			"text": "http://www.kb.cert.org/vuls/id/276432",
+			"source": "CERT-VN",
+			"id": "VU#276432"
+		}
+	],
+	"cpe": [
+		{
+			"text": "cpe:/a:trendmicro:scan_engine",
+			"version": "2.2",
+			"vendor": "トレンドマイクロ",
+			"product": "Trend Micro Scan Engine"
+		}
+	],
+	"cvss": [
+		{
+			"version": "2.0",
+			"score": "5.4",
+			"type": "Base",
+			"severity": "Medium",
+			"vector": "AV:N/AC:H/Au:N/C:N/I:N/A:C"
+		}
+	],
+	"date": "2007-04-01T00:00+09:00",
+	"issued": "2007-04-01T00:00+09:00",
+	"modified": "2007-04-01T00:00+09:00"
+}

--- a/pkg/fetch/jvn/feed/rss/testdata/golden/2011/JVNDB-2011-001013.json
+++ b/pkg/fetch/jvn/feed/rss/testdata/golden/2011/JVNDB-2011-001013.json
@@ -1,0 +1,85 @@
+{
+	"about": "https://jvndb.jvn.jp/ja/contents/2011/JVNDB-2011-001013.html",
+	"title": "Microsoft Internet Explorer 8 における解放済みメモリを使用する脆弱性",
+	"link": "https://jvndb.jvn.jp/ja/contents/2011/JVNDB-2011-001013.html",
+	"description": "Microsoft Internet Explorer 8 の mshtml.dll ライブラリには、解放済みメモリを使用する (use-after-free) 脆弱性が存在します。",
+	"identifier": "JVNDB-2011-001013",
+	"references": [
+		{
+			"text": "http://jvn.jp/cert/JVNVU427980",
+			"source": "JVN",
+			"id": "JVNVU#427980"
+		},
+		{
+			"text": "http://jvn.jp/cert/JVNTA11-102A",
+			"source": "JVN",
+			"id": "JVNTA11-102A"
+		},
+		{
+			"text": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-0346",
+			"source": "CVE",
+			"id": "CVE-2011-0346"
+		},
+		{
+			"text": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2011-0346",
+			"source": "NVD",
+			"id": "CVE-2011-0346"
+		},
+		{
+			"text": "https://www.jpcert.or.jp/at/2011/at110008.txt",
+			"source": "JPCERT-AT",
+			"id": "JPCERT-AT-2011-0008",
+			"fetchedtitle": "2011年4月 Microsoft セキュリティ情報 (緊急 9件含) に関する注意喚起"
+		},
+		{
+			"text": "http://www.us-cert.gov/cas/alerts/SA11-102A.html",
+			"source": "CERT-SA",
+			"id": "SA11-102A"
+		},
+		{
+			"text": "http://www.kb.cert.org/vuls/id/427980",
+			"source": "CERT-VN",
+			"id": "VU#427980"
+		},
+		{
+			"text": "http://www.us-cert.gov/cas/techalerts/TA11-102A.html",
+			"source": "CERT-TA",
+			"id": "TA11-102A"
+		},
+		{
+			"text": "http://www.ipa.go.jp/security/ciadr/vul/20110413-ms11-018.html",
+			"source": "IPA",
+			"id": "20110413-ms11-018"
+		},
+		{
+			"text": "http://www.securityfocus.com/bid/45639",
+			"source": "BID",
+			"id": "45639"
+		},
+		{
+			"text": "https://jvndb.jvn.jp/ja/cwe/CWE-399.html",
+			"id": "CWE-399",
+			"title": "リソース管理の問題(CWE-399)"
+		}
+	],
+	"cpe": [
+		{
+			"text": "cpe:/a:microsoft:internet_explorer",
+			"version": "2.2",
+			"vendor": "マイクロソフト",
+			"product": "Microsoft Internet Explorer"
+		}
+	],
+	"cvss": [
+		{
+			"version": "2.0",
+			"score": "9.3",
+			"type": "Base",
+			"severity": "High",
+			"vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C"
+		}
+	],
+	"date": "2011-05-02T13:25+09:00",
+	"issued": "2011-01-28T15:38+09:00",
+	"modified": "2011-05-02T13:25+09:00"
+}

--- a/pkg/fetch/jvn/feed/rss/testdata/golden/2021/JVNDB-2021-005429.json
+++ b/pkg/fetch/jvn/feed/rss/testdata/golden/2021/JVNDB-2021-005429.json
@@ -1,0 +1,62 @@
+{
+	"about": "https://jvndb.jvn.jp/ja/contents/2021/JVNDB-2021-005429.html",
+	"title": "Apache Log4j における任意のコードが実行可能な脆弱性",
+	"link": "https://jvndb.jvn.jp/ja/contents/2021/JVNDB-2021-005429.html",
+	"description": "Log4j には JNDI Lookup 機能による外部入力値の検証不備に起因して任意の Java コードを実行可能な脆弱性が存在します。\r\n\r\nThe Apache Software Foundation が提供する Log4j は、Java ベースのロギングライブラリです。Log4j には、ログに記載された文字列から一部の値を変数として評価する Lookup 機能が実装されています。\r\nその Lookup 機能の内、JNDI Lookup 機能を悪用することにより、ログに含まれる外部の URL もしくは内部パスから Java のクラス情報をデシリアライズして実行してしまう問題（CWE-20, CVE-2021-44228）が発見されました。\r\nこれにより、遠隔の攻撃者が細工した文字列を脆弱なシステムのログに記載させ、結果として任意の Java コードをシステムに実行させることが可能です。\r\n",
+	"identifier": "JVNDB-2021-005429",
+	"references": [
+		{
+			"text": "https://jvn.jp/vu/JVNVU96768815/",
+			"source": "JVN",
+			"id": "JVNVU#96768815"
+		},
+		{
+			"text": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228",
+			"source": "CVE",
+			"id": "CVE-2021-44228"
+		},
+		{
+			"text": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
+			"source": "NVD",
+			"id": "CVE-2021-44228"
+		},
+		{
+			"text": "https://www.jpcert.or.jp/at/2021/at210050.html",
+			"source": "JPCERT-AT",
+			"id": "JPCERT-AT-2021-0050",
+			"fetchedtitle": "Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起"
+		},
+		{
+			"text": "https://jvndb.jvn.jp/ja/cwe/CWE-20.html",
+			"id": "CWE-20",
+			"title": "不適切な入力確認(CWE-20)"
+		}
+	],
+	"cpe": [
+		{
+			"text": "cpe:/a:apache:log4j",
+			"version": "2.2",
+			"vendor": "Apache Software Foundation",
+			"product": "Apache Log4j"
+		}
+	],
+	"cvss": [
+		{
+			"version": "2.0",
+			"score": "9.3",
+			"type": "Base",
+			"severity": "High",
+			"vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C"
+		},
+		{
+			"version": "3.0",
+			"score": "10.0",
+			"type": "Base",
+			"severity": "Critical",
+			"vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+		}
+	],
+	"date": "2022-12-15T10:24+09:00",
+	"issued": "2021-12-14T16:37+09:00",
+	"modified": "2022-12-15T10:24+09:00"
+}

--- a/pkg/fetch/jvn/feed/rss/types.go
+++ b/pkg/fetch/jvn/feed/rss/types.go
@@ -62,6 +62,9 @@ type Item struct {
 		Source string `xml:"source,attr" json:"source,omitempty"`
 		ID     string `xml:"id,attr" json:"id,omitempty"`
 		Title  string `xml:"title,attr" json:"title,omitempty"`
+		// FetchedTitle holds the HTML <title> of the referenced page, retrieved
+		// separately from the feed for JPCERT-AT references.
+		FetchedTitle string `xml:"-" json:"fetchedtitle,omitempty"`
 	} `xml:"references" json:"references,omitempty"`
 	CPE []struct {
 		Text    string `xml:",chardata" json:"text,omitempty"`

--- a/pkg/fetch/jvn/feed/util/testdata/fixtures/at210050.html
+++ b/pkg/fetch/jvn/feed/util/testdata/fixtures/at210050.html
@@ -1,0 +1,683 @@
+<!DOCTYPE html>
+<html lang="ja-jp">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	
+	<title>Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起</title>
+	<meta name="keywords" content="" />
+	<meta name="description" content="" />
+	<meta property="og:locale" content="ja_JP" />
+	<meta property="og:site_name" content="JPCERT/CC" />
+	<meta property="og:url" content="https://www.jpcert.or.jp/at/2021/at210050.html">
+	<meta property="og:title" content="Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起">
+	
+	<meta property="og:image" content="https://www.jpcert.or.jp/common/image/ogp_image.jpg">
+	
+	<link rel="alternate" type="application/rss+xml" title="注意喚起、Weekly Report、脆弱性情報（JVN）、JPCERT/CCからのお知らせやイベントの新着情報をまとめて提供" href="/rss/jpcert-all.rdf" />
+	<link rel="alternate" type="application/rss+xml" title="注意喚起と緊急報告、Weekly Report の新着情報" href="/rss/jpcert.rdf" />
+	<link rel="alternate" type="application/rss+xml" title="JPCERT/CCからのお知らせ、イベントの新着情報" href="/rss/whatsnew.rdf" />
+	<link rel="stylesheet" href="/common/css/html5reset-1.6.1.css">
+	<link rel="stylesheet" href="/common/css/common.css">
+	<link rel="stylesheet" href="/common/css/page.css">
+	<link rel="stylesheet" href="/common/css/print.css" media="print" />
+	<link rel="stylesheet" href="/common/slide/slide.css"/>
+	
+</head>
+<body class="category_a">
+
+
+<!-- guidance_sp -->
+<div id="guidance_sp" style="display:none;">
+<div class="title"><img src="/common/guidance/g_guidance_title.png" alt="スマートフォン用で表示" /><a href="/m/at/2021/at210050.html" id="show_sp_site"><img src="/common/guidance/g_button_show.png" alt="" /></a></div>
+<div class="message"><a href="javascript:;" id="check_no_message"><img src="/common/guidance/g_check_off.png" alt="" /><img src="/common/guidance/g_guidance_message.png" alt="" /></a></div>
+</div>
+<!-- /guidance_sp -->
+
+<header class="sh_uoh">
+	<div class="top">
+		<h2><img src="/common/image/h2_image.png" width="330" height="25" alt="サイバーインシデントがなくなるその日まで" /></h2>
+		<ul>
+			<li><a href="/reference.html">お問い合わせ</a></li>
+			<li><a href="/recruit/index.html">採用情報</a></li>
+			<li><a href="/sitemap.html">サイトマップ</a></li>
+			<li><a href="/english/">English</a></li>
+		</ul>
+	</div>
+
+	<div class="main">
+		<h1><a href="/"><img src="/common/image/header_logo.svg" width="198" height="66" alt="JPCERT Coordination Center" /></a></h1>
+
+<!-- googlr search area
+		<div class="search_area">
+			<form id="cse-search-box" action="https://www.google.com/cse">
+				<input value="011276954563619633753:gam5ydxz2ni" name="cx" type="hidden">
+				<input value="UTF-8" name="ie" type="hidden">
+				<input name="q" id="q" value="" type="text" placeholder="検索キーワードを入力" /><input name="sa" id="sa" type="submit" value="検索" />
+			</form>
+		</div>
+-->
+		
+<!-- yahoo custom search area		
+		<div id="yahoo_search_area" class="watermark">
+
+			<form action="https://custom.search.yahoo.co.jp/search" method="get" id="srch">
+				<p id="srchForm">
+					<input type="text" name="p" id="srchInput">
+					<input type="submit" value="検索" id="srchBtn" onclick="document.getElementById('srchInput').focus();">
+					<input type="hidden" id="fr" name="fr" value="cse">
+					<input type="hidden" id="ei" name="ei" value="UTF-8">
+					<input type="hidden" id="csid" name="csid" value="YZgbsqsHFIwmPApo7sIjK_PtheLpmwnBs_eTDxVthQ--">
+				</p>
+				<input type="hidden" name="vs" value="www.jpcert.or.jp" id="yjInsite">
+			</form>
+		</div>
+-->
+		<div id="yahoo_search_new_area" style="width:396px;">
+			<form action="https://search.yahoo.co.jp/search" method="get" style="margin:0;padding:0;">
+			<p style="margin:0;padding:0;">
+				<a href="https://www.yahoo.co.jp/" target="_blank" style="font-size: 10px;">
+					powered by Yahoo! JAPAN
+				</a>
+				<input type="text" name="p" size="28" style="margin:0 3px;width:50%;">
+				<input type="hidden" name="fr" value="ysiw">
+				<input type="hidden" name="ei" value="utf-8">
+				<input type="submit" value="検索" style="margin:0;color:#595757;font-size:10pt;">
+			</p>
+			<ul style="margin:2px 0 0 0;padding:0;font-size:10pt;list-style:none;">
+				<li style="display:inline;font-size:10pt;">
+					<input name="vs" type="radio" value="www.jpcert.or.jp" checked="checked">
+					このサイト内を検索
+				</li>
+				<li style="display:inline;font-size:10pt;">
+					<input name="vs" type="radio" value="">
+					ウェブ全体を検索
+				</li>
+			</ul>
+			</form>
+			<img src="https://custom.search.yahoo.co.jp/images/window/006c75a92ba244c6b4cbe2709aa17d7b.gif" width="1" height="1" style="display:block;position:absolute">
+		</div>
+		<ul class="links">
+			<li class="icon_rss">最新情報を取得 (<a href="/rss/">RSS</a> | <a href="/announce.html">メーリングリスト</a>) </li>
+			<li><a href="https://www.jpcert.or.jp/" class="icon_https">HTTPS</a></li>
+			<li><a href="/m/" class="icon_mobile">モバイル</a></li>
+		</ul>
+		<script type="text/javascript">
+			(function() {
+			var sb = document.getElementById('srchBox');
+			if (sb && sb.className == 'watermark') {
+  			var si = document.getElementById('srchInput');
+  			var f = function() { si.className = 'nomark'; };
+  			var b = function() {
+    			if (si.value == '') {
+      			si.className = '';
+    			}
+  			};
+  			si.onfocus = f;
+  			si.onblur = b;
+  			if (!/[&?]p=[^&]/.test(location.search)) {
+    			b();
+  			} else {
+    			f();
+  			}
+			}
+			})();
+			</script>
+			
+	</div>
+</header>
+
+<nav>
+	<ul class="menu contents_area_view">
+		<li class="category_a "><a href="/aboutincident.html">インシデントとは</a></li>
+		<li class="category_a selected">
+			<a href="/menu_alertsandadvisories.html">緊急情報を確認する</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">緊急情報を確認する</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/at/">注意喚起</a></li>
+							<li><a href="/tsubame/">インターネット定点観測</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="https://jvn.jp/">JVN</a></li>
+							<li><a href="/vh/top.html">脆弱性対策情報</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_reporttojpcert.html">依頼・相談する</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">依頼・相談する</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/ir/">インシデント対応とは</a></li>
+							<li><a href="/form/">インシデント対応依頼</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/ir/consult.html">インシデント相談・情報提供</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_documents.html">公開資料を見る</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">公開資料を見る</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/wr/">Weekly Report</a></li>
+							<li><a href="/qr/index.html">四半期レポート</a></li>
+							<li><a href="/tsubame/report/">インターネット定点観測レポート</a></li>
+							<li><a href="/report/press.html">ソフトウェア等の脆弱性関連情報に関する届出状況</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/research/">研究・調査・翻訳レポート</a></li>
+							<li><a href="/csirt_material/">CSIRTマテリアル</a></li>
+							<li><a href="/securecoding/">セキュアコーディング</a></li>
+							<li><a href="/ics/">制御システムセキュリティ</a></li>
+							<li><a href="/magazine/">ライブラリ</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_a ">
+			<a href="/menu_receiveinformation.html">情報を受け取る</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">情報を受け取る</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/cista/">CISTA（シスタ）</a></li>
+							<li><a href="/vh/register.html">製品開発者登録</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/announce.html">メーリングリスト</a></li>
+							<li><a href="/rss/">RSS</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_b ">
+			<a href="/menu_columnblog.html">コラム＆ブログ</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">コラム＆ブログ</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/newsflash/">CyberNewsFlash</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="https://blogs.jpcert.or.jp/ja/">JPCERT/CC Eyes～JPCERT/CC公式ブログ～ </a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+		<li class="category_b ">
+			<a href="/menu_aboutjpcert.html">JPCERT/CCについて</a>
+			<div class="detail_menu contents_area_view">
+				<div class="container cf">
+					<div class="detail_menu_title">JPCERT/CCについて</div>
+					<div class="detail_menu_area cf">
+						<ul class="fl">
+							<li><a href="/about/">JPCERT/CCとは</a></li>
+							<li class="level2"><a href="/message.html">代表理事挨拶</a></li>
+							<li class="level2"><a href="/profile.html">組織概要</a></li>
+							<li class="level2"><a href="/about/01.html">事業概要</a></li>
+							<li><a href="/recruit/">採用情報</a></li>
+							<li><a href="/solicitation/">公募・入札情報</a></li>
+							<li><a href="/press/pressroom.html">プレスルーム</a></li>
+							<li class="level2"><a href="/press/2026.html">プレスリリース</a></li>
+							<li class="level2"><a href="/press/contact.html">広報へのお問い合わせ</a></li>
+							<li class="level2"><a href="/press/request.html">講演依頼</a></li>
+							<li class="level2"><a href="/press/nominal-support.html">後援申請</a></li>
+						</ul>
+						<ul class="fl">
+							<li><a href="/event/">イベント</a></li>
+							<li><a href="/kouen/">講演・執筆一覧</a></li>
+							<li><a href="/twitter.html">X（旧Twitter）一覧</a></li>
+							<li><a href="/jpcert-pgp.html">PGP公開鍵</a></li>
+							<li><a href="/related/">関連組織</a></li>
+							<li><a href="/reference.html">お問い合わせ</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</li>
+	</ul>
+</nav>
+
+<div class="breadcrumb_list_area contents_area_view sh_uoh cf">
+	<ul class="breadcrumb_list fl">
+		<li><a href="/">HOME</a></li><li><a href="/menu_alertsandadvisories.html">緊急情報を確認する</a></li><li>Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起</li>
+	</ul>
+	
+	<ul id="page_layout_utility" class="page_layout_utility fr" style="display:none;">
+		<li class="to_normal_layout_group"><a href="javascript:;" class="icon_normal_layout">通常レイアウトに戻す</a></li>
+		<li class="to_normal_layout_group"><a href="javascript:;" class="icon_print">印刷</a></li>
+		<li class="to_print_layout_group"><a href="javascript:;" class="icon_print_layout">印刷用レイアウト</a></li>
+		<li class="to_print_layout_group"><span class="icon_print_disabled">印刷</span></li>
+	</ul>
+	
+</div>
+
+
+<div class="contents_body contents_area_view cf">
+	<div id="link_pgtop" class="contents_right_body">
+		<div class="contents_right_body_wrapper">
+			<div class="page_title_area">
+				<h3>Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起</h3>
+				<span>最終更新: 2022-01-04</span>
+			</div>
+
+			<div class="contents_container">
+<div class="social_links cf">
+	<div class="mail">
+		<a href="mailto:?subject=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7&amp;body=https%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html">
+			<img src="/common/social_links/images/btn_share_mail_jp.png" alt="" />
+		</a>
+	</div>
+	<div class="tweet window">
+		<a href="https://twitter.com/intent/tweet?text=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7%0Ahttps%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html%0A%40jpcert" target="_blank">
+			<img src="/common/social_links/images/btn_share_post_jp.png" alt="" />
+		</a>
+	</div>
+</div>
+
+				<article class="">
+<!-- content_area -->
+<div class="at">
+JPCERT-AT-2021-0050<br />
+JPCERT/CC<br />
+2021-12-11（新規）<br />
+2022-01-04（更新）<br />
+<br />
+<br />
+<h4>I. 概要</h4><br />
+<br />
+<p class="headline_blue">更新: 2022年1月4日記載 </p><div class="update_details">現時点で不明な点もあることから、今後の動向次第で下記掲載内容を修正、更新する予定がありますので、関連情報への注視のほか、本注意喚起の更新内容も逐次ご確認ください。<br />
+<br />
+次の更新を行いました。詳細は「III. 対策」を参照してください。<br />
+<br />
+- Apache Log4jのバージョン2.17.1（Java 8以降のユーザー向け）、2.12.4（Java 7のユーザー向け）及び2.3.2（Java 6のユーザー向け）が公開されました<br />
+<br />
+</div><br />
+<br />
+JavaベースのオープンソースのロギングライブラリのApache Log4jには、任意のコード実行の脆弱性（CVE-2021-44228）があります。Apache Log4jが動作するサーバーにおいて、遠隔の第三者が本脆弱性を悪用する細工したデータを送信することで、任意のコードを実行する可能性があります。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.15.0<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html">https://logging.apache.org/log4j/2.x/security.html</a><br />
+<br />
+Apache Log4jにはLookupと呼ばれる機能があり、ログとして記録された文字列から、一部の文字列を変数として置換します。その内、JNDI Lookup機能が悪用されると、遠隔の第三者が細工した文字列を送信し、Log4jがログとして記録することで、Log4jはLookupにより指定された通信先もしくは内部パスからjava classファイルを読み込み実行し、結果として任意のコードが実行される可能性があります。<br />
+<br />
+2021年12月11日現在、JPCERT/CCは、本脆弱性を悪用する実証コードが公開されていること、及び国内にて本脆弱性の悪用を試みる通信を確認しています。Apache Log4jを利用している場合には、The Apache Software Foundationなどが提供する最新の情報を確認し、バージョンアップや回避策の適用などの実施を検討することを推奨します。<br />
+<br />
+また、Apache Log4jを使用するアプリケーションやソフトウェアなどで、今後セキュリティアップデートが公開される可能性があります。関連する情報を注視し、必要な対策や対応の実施をご検討ください。<br />
+<br />
+<br />
+<h4>II. 対象</h4>対象となるバージョンは次のとおりです。<br />
+<br />
+- Apache Log4j-core 2.15.0より前の2系のバージョン<br />
+<br />
+なお、すでにEnd of Lifeを迎えているApache Log4j 1系のバージョンは、Lookup機能が含まれておらず、JMS Appenderが有効でもクラス情報がデシリアライズされないため影響を受けないとの情報を確認しています。<br />
+<br />
+また、影響を受けるバージョンや条件に関する情報が変更あるいは更新される可能性や、Apache Log4jを使用するアプリケーションやソフトウェアの開発元などから情報が公開される可能性もあるため、最新の情報は各組織から提供される関連情報をご確認ください。<br />
+<br />
+<p class="headline_blue">更新: 2021年12月13日追記 </p><div class="update_details">Apache Log4j 1系のバージョンについては、第三者が本脆弱性を悪用するためにLog4jの設定ファイルを変更することができれば影響を受けるとの情報が公開されていますが、攻撃を行うためには何らかの方法で事前にシステムに不正にアクセスする必要があり、遠隔からの脆弱性を悪用した攻撃の影響は受けません。<br />
+<br />
+Restrict LDAP access via JNDI #608 Comment<br />
+<a href="https://github.com/apache/logging-log4j2/pull/608#issuecomment-991730650">https://github.com/apache/logging-log4j2/pull/608#issuecomment-991730650</a></div><br />
+<br />
+<br />
+<h4>III. 対策</h4>The Apache Software Foundationから本脆弱性を修正したバージョンが公開されています。速やかな対策の適用実施をご検討ください。次のバージョン以降では、Lookup機能がデフォルトでは無効になりました。<br />
+<br />
+- Apache Log4j 2.15.0<br />
+<br />
+使用するアプリケーションやソフトウェアなどについて関連情報を注視し、本脆弱性の影響を受けることが判明した場合も、速やかにアップデートなどの対応を行うことを推奨します。<br />
+<br />
+また、すでに本脆弱性の悪用を試みる通信が確認されていることから、対策の適用実施とあわせて、不審なファイル及びプロセスの有無や、通信ログ等を確認し、攻撃の有無を確認することを推奨します。<br />
+<br />
+<p class="headline_blue">更新: 2021年12月15日追記 </p><div class="update_details">The Apache Software Foundationは、Apache Log4jのバージョン2.16.0（Java 8以降のユーザー向け）および2.12.2（Java 7のユーザー向け）を公開しました。<br />
+<br />
+特定の構成において不正なJNDI検索パターンを入力値とする場合にサービス運用妨害（DoS）が生じる可能性があることが判明し、Message Lookup機能が削除され、JNDIへのアクセスがデフォルトで無効になりました。この問題にはCVE-2021-45046が採番されています。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.12.2 (Java 7) and Log4j 2.16.0 (Java 8)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.16.0">https://logging.apache.org/log4j/2.x/security.html#log4j-2.16.0</a><br />
+<br />
+任意のコード実行の脆弱性（CVE-2021-44228）への対策に加え、サービス運用妨害攻撃の脆弱性（CVE-2021-45046）などのリスクに対応するため、2.16.0または2.12.2へのアップデートを推奨します。</div><p class="headline_blue">更新: 2021年12月20日追記 </p><div class="update_details">CVE-2021-45046の影響について、一部の環境では任意のコード実行などが可能であるとの情報が公開されています。</div><p class="headline_blue">更新: 2021年12月20日追記 </p><div class="update_details">2021年12月18日（現地時間）、The Apache Software Foundationは、Apache Log4jのバージョン2.17.0（Java 8以降のユーザー向け）を公開しました。<br />
+<br />
+自己参照による制御不能な再帰から保護されていないことに起因し、Log4jの設定によっては影響を受けるサービス運用妨害攻撃の脆弱性（CVE-2021-45105）が修正されています。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.17.0 (Java 8)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0">https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0</a></div><p class="headline_blue">更新: 2021年12月28日追記 </p><div class="update_details">2021年12月21日（現地時間）、The Apache Software Foundationは、Apache Log4jのバージョン2.3.1（Java 6のユーザー向け）及び2.12.3（Java 7のユーザー向け）を公開しました。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.17.0 (Java 8), 2.12.3 (Java 7) and 2.3.1 (Java 6)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0">https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.0</a></div><p class="headline_blue">更新: 2022年1月4日追記 </p><div class="update_details">2021年12月28日（現地時間）、The Apache Software Foundationは、Apache Log4jの2.17.1（Java 8以降のユーザー向け）、2.12.4（Java 7のユーザー向け）及び2.3.2（Java 6のユーザー向け）を公開しました。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.17.1 (Java 8), 2.12.4 (Java 7) and 2.3.2 (Java 6)<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.1">https://logging.apache.org/log4j/2.x/security.html#log4j-2.17.1</a></div><br />
+<br />
+<h4>IV. 回避策</h4>The Apache Software Foundationから、Log4jのバージョンに応じた回避策に関する情報が公開されています。<br />
+<br />
+<p class="headline_blue">更新: 2021年12月15日追記 </p><div class="update_details">The Apache Software Foundationより、一部の回避策は、特定の手法を用いた攻撃を回避するには不十分であることが判明したと明らかにし、有効な回避策として、JndiLookup.classをクラスパスから削除する回避策の実施を呼びかけています。<br />
+<br />
+Apache Log4j Security Vulnerabilities<br />
+Fixed in Log4j 2.12.2 and Log4j 2.16.0<br />
+<a href="https://logging.apache.org/log4j/2.x/security.html">https://logging.apache.org/log4j/2.x/security.html</a></div><br />
+<br />
+Log4jバージョン2.10及びそれ以降<br />
+- 次のいずれかを実施する<br />
+（1）Log4jを実行するJava仮想マシンを起動時に「log4j2.formatMsgNoLookups」というJVMフラグオプションを「true」に指定する 例: -Dlog4j2.formatMsgNoLookups=true<br />
+（2）環境変数「LOG4J_FORMAT_MSG_NO_LOOKUPS」を「true」に設定する<br />
+<br />
+Log4jバージョン2.10より前<br />
+- JndiLookupクラスをクラスパスから削除する<br />
+<br />
+<br />
+また、本脆弱性を悪用する攻撃の影響を軽減するため、システムから外部への接続を制限するための可能な限りのアクセス制御の見直しや強化もご検討ください。<br />
+<br />
+<br />
+<h4>V. 参考情報</h4><br />
+apache / logging-log4j2<br />
+Restrict LDAP access via JNDI #608<br />
+<a href="https://github.com/apache/logging-log4j2/pull/608">https://github.com/apache/logging-log4j2/pull/608</a><br />
+<br />
+The Apache Software Foundation<br />
+Lookups<br />
+<a href="https://logging.apache.org/log4j/2.x/manual/lookups.html">https://logging.apache.org/log4j/2.x/manual/lookups.html</a><br />
+<br />
+LunaSec<br />
+Log4Shell: RCE 0-day exploit found in log4j2, a popular Java logging package<br />
+<a href="https://www.lunasec.io/docs/blog/log4j-zero-day/">https://www.lunasec.io/docs/blog/log4j-zero-day/</a><br />
+<br />
+SANS ISC InfoSec Forums<br />
+RCE in log4j, Log4Shell, or how things can get bad quickly<br />
+<a href="https://isc.sans.edu/forums/diary/RCE+in+log4j+Log4Shell+or+how+things+can+get+bad+quickly/28120/">https://isc.sans.edu/forums/diary/RCE+in+log4j+Log4Shell+or+how+things+can+get+bad+quickly/28120/</a><br />
+<br />
+BlueTeam CheatSheet * Log4Shell*<br />
+<a href="https://gist.github.com/SwitHak/b66db3a06c2955a9cb71a8718970c592">https://gist.github.com/SwitHak/b66db3a06c2955a9cb71a8718970c592</a><br />
+<br />
+<p class="headline_blue">更新: 2021年12月13日追記 </p><div class="update_details">    Japan Vulnerability Notes JVNVU#96768815<br />
+Apache Log4jにおける任意のコードが実行可能な脆弱性<br />
+<a href="https://jvn.jp/vu/JVNVU96768815/">https://jvn.jp/vu/JVNVU96768815/</a></div><br />
+<br />
+<p class="headline_blue">更新: 2021年12月20日追記 </p><div class="update_details">    JPCERT/CC Eyes<br />
+Apache Log4j2のRCE脆弱性（CVE-2021-44228）を狙う攻撃観測<br />
+<a href="https://blogs.jpcert.or.jp/ja/2021/12/log4j-cve-2021-44228.html">https://blogs.jpcert.or.jp/ja/2021/12/log4j-cve-2021-44228.html</a></div><br />
+<br />
+<p class="headline_blue">更新: 2021年12月28日追記 </p><div class="update_details">    JPCERT/CC CyberNewsFlash<br />
+2021年12月に公表されたLog4jの脆弱性について<br />
+<a href="https://www.jpcert.or.jp/newsflash/2021122401.html">https://www.jpcert.or.jp/newsflash/2021122401.html</a></div><br />
+<br />
+今回の件につきまして提供いただける情報がございましたら、JPCERT/CCまでご連絡ください。<br />
+<br />
+<p class="headline_blue">改訂履歴</p>2021-12-11 初版<br />
+2021-12-13 「II. 対象」、「IV. 回避策」、「V. 参考情報」の一部記載の追記・修正<br />
+2021-12-15 「III. 対策」、「IV. 回避策」の追記<br />
+2021-12-20 「I. 概要」、「III. 対策」、「V. 参考情報」の追記<br />
+2021-12-28 「I. 概要」、「III. 対策」、「V. 参考情報」の追記<br />
+2022-01-04 「I. 概要」、「III. 対策」の追記、2021年12月20日追記内容、2021年12月28日追記内容の修正<br />
+<br />
+<br />
+一般社団法人JPCERTコーディネーションセンター（JPCERT/CC）<br />
+早期警戒グループ<br />
+Email：ew-info@jpcert.or.jp
+</div>
+<p class="pg_top"><a href="#link_pgtop">Topへ</a></p>
+<!-- /content_area -->
+				</article>
+
+<div class="social_links cf">
+	<div class="mail">
+		<a href="mailto:?subject=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7&amp;body=https%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html">
+			<img src="/common/social_links/images/btn_share_mail_jp.png" alt="" />
+		</a>
+	</div>
+	<div class="tweet window">
+		<a href="https://twitter.com/intent/tweet?text=Apache%20Log4j%E3%81%AE%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%89%E5%AE%9F%E8%A1%8C%E3%81%AE%E8%84%86%E5%BC%B1%E6%80%A7%EF%BC%88CVE-2021-44228%EF%BC%89%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%B3%A8%E6%84%8F%E5%96%9A%E8%B5%B7%0Ahttps%3A%2F%2Fwww.jpcert.or.jp%2Fat%2F2021%2Fat210050.html%0A%40jpcert" target="_blank">
+			<img src="/common/social_links/images/btn_share_post_jp.png" alt="" />
+		</a>
+	</div>
+</div>
+<div id="fb" class="feedback feedback_noscript">
+<div class="container_a"><div class="container_b">
+<form name="feedback_form" id="feedback_form">
+	<p class="title">このページは役に立ちましたか？</p>
+	<div class="inner">
+		<p>
+			<input type="radio" name="is_useful" id="is_usefull_yes" value="yes" disabled="disabled" /><label for="is_usefull_yes">はい</label>
+			<input type="radio" name="is_useful" id="is_usefull_no" value="no" disabled="disabled" /><label for="is_usefull_no">いいえ</label>
+		</p>
+		<p class="result">&nbsp;</p>
+	</div>
+	<p class="title">その他、ご意見・ご感想などございましたら、ご記入ください。</p>
+	<div class="inner">
+		<p class="message">こちらはご意見・ご感想用のフォームです。各社製品については、各社へお問い合わせください。</p>
+		<p class="message_red">※本フォームにいただいたコメントへの返信はできません。
+		<a href="/reference.html">返信をご希望の方は「お問合せ」</a>
+		をご利用ください。
+		</p>
+		<div class="container_a"><div class="container_b">
+			<textarea name="free_text" id="free_text" disabled="disabled" cols="30" rows="3"></textarea>
+		</div></div>
+		<p class="send_area">
+			<input class="button" type="image" src="/common/feedback/images/fb_btn_send_jp.jpg" alt="送信" disabled="disabled"/>
+			<span class="en_js_msg">javascriptを有効にすると、ご回答いただけます。</span>
+			<span class="loader" style="display:none;"><img src="/common/feedback/images/fb_loader.gif" alt="処理中..." /></span>
+			<span class="thanks">ありがとうございました。</span>
+			<a href="/form/" class="incident_link">インシデント報告はこちらから</a>
+		</p>
+	</div>
+	<input type="hidden" name="redirect_to" id="redirect_to" value="" />
+	<input type="hidden" name="feedback_host" id="feedback_host" value="//ws.jpcert.or.jp/cgi-bin/" />
+	<input type="hidden" name="uri" id="uri" value="" />
+	<input type="hidden" name="token" id="token" value="" />
+</form>
+</div></div>
+</div>
+
+<div class="page_navigation cf">
+	<a href="javascript:;" class="previous disabled">&lt;&lt;&nbsp;前へ</a>
+	<a href="javascript:;" class="next disabled">次へ&nbsp;&gt;&gt;</a>
+</div>
+
+			</div>
+		</div>
+	</div>
+	
+	<div class="contents_left_body">
+		<div class="page_guide_menu">
+	
+	
+	<p>緊急情報を確認する</p>
+	<ul class="page_guide_menu">
+		<li class="selected"><a href="/at/">注意喚起</a></li>
+		<li ><a href="/tsubame/">インターネット定点観測</a></li>
+		<li><a href="https://jvn.jp/">JVN</a></li>
+		<li ><a href="/vh/top.html">脆弱性対策情報</a></li>
+	</ul>
+	
+	
+	
+	
+	
+	
+</div>
+
+		<div class="recommend_list">
+			<p>おすすめ情報</p>
+			<ul class="list">
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/07/apt-c-60_2026.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「APT-C-60による2026年の攻撃」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/06/tool_analysis_update.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「ツール分析結果シートのアップデート」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/06/tsubame-overflow20260103.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2026年1～3月）」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/05/tsubame-overflow20251012.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2025年10～12月）」</a></li>
+
+	<li><a href="https://blogs.jpcert.or.jp/ja/2026/03/tsubame-overflow20250709.html" onclick="piwikTracker.trackGoal(3);">JPCERT/CC Eyes「TSUBAMEレポート Overflow（2025年7～9月）」</a></li>
+
+	<li><a href="/magazine/security/ransom-faq.html" onclick="piwikTracker.trackGoal(3);">侵入型ランサムウェア攻撃を受けたら読むFAQ</a></li>
+
+</ul>
+		</div>
+
+		<ul class="banner_list">
+
+	<!--
+	<li><a class="button" href="/csirt_material/"><img src="/common/banner_images/csirt_off.png" alt="CSIRTマテリアル" /></a></li>
+	-->
+	
+	<!--
+	<li><a class="button" href="/pr/2017/pr170002.html"><img src="/common/banner_images/password_off.png" alt="STOP!!パスワード使い回し!!キャンペーン2017" /></a></li>
+	<li><a class="button" href="/pr/2016/pr160005.html"><img src="/common/banner_images/holiday_off.png" alt="" /></a></li>
+	<li><a class="button" href="/pr/2016/pr160005.html"><img src="/common/banner_images/vacation_off.png" alt="" /></a></li>
+	-->
+
+	
+
+	
+	<li><a class="button" href="/csirt_material/"><img src="/common/banner_images/csirt_off.png" alt="CSIRTマテリアル" /></a></li>
+	
+
+	
+
+	
+
+	
+
+	
+</ul>
+	</div>
+</div>
+
+<footer class="gray_background sh_uoh">
+	<div class="page_link_area contents_area_view cf">
+		<div class="page_link_contaienr cf">
+			<div class="page_link_right_area cf">
+				<div class="page_links">
+					<p class="dt"><a href="/menu_aboutjpcert.html">JPCERT/CCについて</a></p>
+					<div class="cf">
+						<dl class="fl">
+							<dt class="hide">&nbsp;</dt>
+							<dd><a href="/about/">JPCERT/CCとは</a></dd>
+							<dd class="dd_second_class"><a href="/message.html">代表理事挨拶</a></dd>
+							<dd class="dd_second_class"><a href="/profile.html">組織概要</a></dd>
+							<dd class="dd_second_class"><a href="/about/01.html">事業概要</a></dd>
+							<dd><a href="/recruit/">採用情報</a></dd>
+							<dd><a href="/solicitation/">公募・入札情報</a></dd>
+							<dd><a href="/press/pressroom.html">プレスルーム</a></dd>
+							<dd class="dd_second_class"><a href="/press/2026.html">プレスリリース</a></dd>
+							<dd class="dd_second_class"><a href="/press/contact.html">広報へのお問い合わせ</a></dd>
+							<dd class="dd_second_class"><a href="/press/request.html">講演依頼</a></dd>
+							<dd class="dd_second_class"><a href="/press/nominal-support.html">後援申請</a></dd>
+						</dl>
+						<dl class="fl">
+							<dt class="hide">&nbsp;</dt>
+							<dd><a href="/event/">イベント</a></dd>
+							<dd><a href="/kouen/">講演・執筆一覧</a></dd>
+							<dd><a href="/magazine/chronology/">セキュリティ<br />インシデント年表</a></dd>
+							<dd><a href="/twitter.html">X（旧Twitter）一覧</a></dd>
+							<dd><a href="/jpcert-pgp.html">PGP公開鍵</a></dd>
+							<dd><a href="/related/">関連組織</a></dd>
+							<dd><a href="/reference.html">お問い合わせ</a></dd>
+						</dl>
+					</div>
+					<dl class="dl_second_line">
+						<dt><a href="/menu_columnblog.html">コラム＆ブログ</a></dt>
+						<dd><a href="/newsflash/">CyberNewsFlash</a></dd>
+						<dd><a href="https://blogs.jpcert.or.jp/ja/">JPCERT/CC Eyes ～JPCERTコーディネーションセンター公式ブログ～</a></dd>
+					</dl>
+				</div>
+			</div>
+			<div class="page_link_left_area cf">
+				<div class="page_links">
+					<dl>
+						<dt>インシデントとは</dt>
+						<dd><a href="/aboutincident.html">インシデントとは</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_alertsandadvisories.html">緊急情報を確認する</a></dt>
+						<dd><a href="/at/">注意喚起</a></dd>
+						<dd><a href="/tsubame/">インターネット定点観測</a></dd>
+						<dd><a href="https://jvn.jp/">JVN</a></dd>
+						<dd><a href="/vh/top.html">脆弱性対策情報</a></dd>
+					</dl>
+					<dl class="dl_second_line">
+						<dt><a href="/menu_reporttojpcert.html">依頼・相談する</a></dt>
+						<dd><a href="/ir/">インシデント対応とは</a></dd>
+						<dd><a href="/form/">インシデント対応依頼</a></dd>
+						<dd><a href="/ir/consult.html">インシデント相談・情報提供</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_documents.html">公開資料を見る</a></dt>
+						<dd><a href="/wr/">Weekly Report</a></dd>
+						<dd><a href="/qr/index.html">四半期レポート</a></dd>
+						<dd><a href="/tsubame/report/">インターネット定点観測レポート</a></dd>
+						<dd><a href="/report/press.html">ソフトウェア等の<br />脆弱性関連情報に関する届出</a></dd>
+						<dd><a href="/research/">研究・調査・翻訳レポート</a></dd>
+						<dd><a href="/csirt_material/">CSIRTマテリアル</a></dd>
+						<dd><a href="/securecoding/">セキュアコーディング</a></dd>
+						<dd><a href="/ics/">制御システムセキュリティ</a></dd>
+						<dd><a href="/magazine/">ライブラリ</a></dd>
+					</dl>
+				</div>
+				<div class="page_links">
+					<dl>
+						<dt><a href="/menu_receiveinformation.html">情報を受け取る</a></dt>
+						<dd><a href="/cista/">CISTA（シスタ）</a></dd>
+						<dd><a href="/vh/register.html">製品開発者登録</a></dd>
+						<dd><a href="/announce.html">メーリングリスト</a></dd>
+						<dd><a href="/rss/">RSS</a></dd>
+					</dl>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="footer_area">
+		<img class="logo" src="/common/image/footer_logo.svg" width="194" height="45" alt="JPCERT/CC" />
+		<p class="company_info">一般社団法人JPCERTコーディネーションセンター<br />〒103-0023<br />東京都中央区日本橋本町4-4-2 東山ビルディング8階<br />TEL: 03-6271-8901　FAX 03-6271-8908<br />
+		</p>
+		<ul class="links">
+			<li><a href="/guide.html">ご利用にあたって</a></li>
+			<li><a href="/privacy.html">プライバシーポリシー</a></li>
+			<li><a href="/reference.html">お問い合わせ</a></li>
+			<li><a href="/about/about_mobile.html">モバイル向けコンテンツ</a></li>
+		</ul>
+		<address>&copy; 1996-2026 JPCERT/CC</address>
+	</div>
+</footer>
+
+<script type="text/javascript" src="/common/js/prototype.js"></script>
+<script type="text/javascript" src="/common/js/effects.js"></script>
+<script type="text/javascript" src="/common/js/builder.js"></script>
+<script type="text/javascript" src="/common/js/cookie.js"></script>
+<script type="text/javascript" src="/common/slide/slide.js"></script>
+<script type="text/javascript" src="/common/js/common.js"></script>
+<script type="text/javascript" src="/common/social_links/script.js"></script>
+<script type="text/javascript" src="/common/feedback/script.js"></script>
+<script type="text/javascript" src="/common/page_navigation/script.js"></script>
+
+
+</body>
+</html>

--- a/pkg/fetch/jvn/feed/util/testdata/fixtures/no_title.html
+++ b/pkg/fetch/jvn/feed/util/testdata/fixtures/no_title.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <p>この文書には title 要素がありません。</p>
+  </body>
+</html>

--- a/pkg/fetch/jvn/feed/util/util.go
+++ b/pkg/fetch/jvn/feed/util/util.go
@@ -3,11 +3,18 @@ package util
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
+
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
 )
 
 func CheckRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {
@@ -28,4 +35,72 @@ func CheckRetry(ctx context.Context, resp *http.Response, err error) (bool, erro
 	resp.Body = io.NopCloser(bytes.NewBuffer(body))
 
 	return false, nil
+}
+
+// IsAlertURL reports whether rawURL points to a JPCERT-AT alert page — one whose
+// path is "/at/<year>/...". Only alert pages carry a fetchable HTML title; the
+// other JPCERT reference types the JVN feeds cite under source "JPCERT-AT" —
+// weekly reports ("/wr/", plain-text with no .html rendering) and press releases
+// ("/pr/", PDF) — do not, so callers skip them. The URL path is the only reliable
+// discriminator here: the feeds' reference id / VulinfoID fields are inconsistent
+// (often the alert title text or a bare number rather than "JPCERT-AT-yyyy-nnnn").
+//
+// A bare "/at/" prefix is not enough — the feeds also cite vendor advisory URLs
+// with "/at/" as a path segment (e.g. ".../at/portals/..."); requiring a 4-digit
+// year segment excludes them.
+func IsAlertURL(rawURL string) bool {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return false
+	}
+	rest, ok := strings.CutPrefix(u.Path, "/at/")
+	if !ok {
+		return false
+	}
+	year, _, ok := strings.Cut(rest, "/")
+	if !ok {
+		return false
+	}
+	_, err = time.Parse("2006", year)
+	return err == nil
+}
+
+// FetchTitle returns the title of the JPCERT-AT alert page whose feed URL is
+// rawURL. JVN feeds do not carry the title of referenced alert pages, so it is
+// retrieved from the page itself. Older alerts are referenced as PGP-signed
+// ".txt" files that carry no HTML title, so the ".html" rendering of the same
+// alert is fetched instead.
+//
+// A missing or empty title is treated as an error so an unexpected page (e.g. a
+// soft 404) is surfaced rather than silently omitted.
+func FetchTitle(client *utilhttp.Client, rawURL string) (string, error) {
+	u := strings.TrimSpace(rawURL)
+
+	// Only a trailing ".txt" extension is the plain-text alert; never rewrite a
+	// ".txt" that appears elsewhere in the URL (e.g. a path segment or query).
+	if rest, ok := strings.CutSuffix(u, ".txt"); ok {
+		u = fmt.Sprintf("%s.html", rest)
+	}
+
+	resp, err := client.Get(u)
+	if err != nil {
+		return "", errors.Wrap(err, "get")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", errors.Errorf("error response with status code %d", resp.StatusCode)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "parse html")
+	}
+
+	title := strings.TrimSpace(doc.Find("title").First().Text())
+	if title == "" {
+		return "", errors.Errorf("empty or missing title in %s", u)
+	}
+	return title, nil
 }

--- a/pkg/fetch/jvn/feed/util/util_test.go
+++ b/pkg/fetch/jvn/feed/util/util_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -124,6 +126,93 @@ func TestCheckRetry(t *testing.T) {
 			}
 			if rt.reqCount != tt.wantReqCount {
 				t.Errorf("request count, got: %d, want: %d", rt.reqCount, tt.wantReqCount)
+			}
+		})
+	}
+}
+
+func TestIsAlertURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "at alert html", url: "https://www.jpcert.or.jp/at/2021/at210050.html", want: true},
+		{name: "at alert txt", url: "http://www.jpcert.or.jp/at/2004/at040002.txt", want: true},
+		{
+			// A vendor advisory URL that merely contains "/at/" as a path segment
+			// (not the "/at/<year>/" alert structure) must not be treated as one.
+			name: "vendor /at/ path is skipped",
+			url:  "http://assistenzatecnica.telecomitalia.it/at/portals/assistenzatecnica.portal?_nfpb=true",
+			want: false,
+		},
+		{name: "weekly report is skipped", url: "http://www.jpcert.or.jp/wr/2004/wr043001.txt", want: false},
+		{name: "press release is skipped", url: "http://www.jpcert.or.jp/pr/2007/pr070002.pdf", want: false},
+		{name: "non-at path is skipped", url: "https://jvn.jp/vu/JVNVU95841181/index.html", want: false},
+		{name: "empty is skipped", url: "  ", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := jvnutil.IsAlertURL(tt.url); got != tt.want {
+				t.Errorf("IsAlertURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		// path is requested against the test server, which serves the file at
+		// that path under testdata/fixtures.
+		path      string
+		want      string
+		wantError bool
+	}{
+		{
+			name: "happy path",
+			path: "/at210050.html",
+			want: "Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起",
+		},
+		{
+			// Older alerts are referenced as PGP-signed .txt files; the title is
+			// fetched from the .html rendering (here the same fixture).
+			name: "txt is fetched as html",
+			path: "/at210050.txt",
+			want: "Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起",
+		},
+		{
+			// A page without a <title> is treated as an error.
+			name:      "no title element",
+			path:      "/no_title.html",
+			wantError: true,
+		},
+		{
+			// A non-existent file makes ServeFile respond with 404.
+			name:      "not found",
+			path:      "/nonexistent.html",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.ServeFile(w, r, filepath.Join("testdata", "fixtures", strings.TrimPrefix(r.URL.Path, "/")))
+			}))
+			defer ts.Close()
+
+			got, err := jvnutil.FetchTitle(utilhttp.NewClient(utilhttp.WithClientRetryMax(0)), ts.URL+tt.path)
+			switch {
+			case err != nil && !tt.wantError:
+				t.Fatalf("unexpected error: %s", err)
+			case err == nil && tt.wantError:
+				t.Fatal("expected error has not occurred")
+			default:
+				if got != tt.want {
+					t.Errorf("FetchTitle() = %q, want %q", got, tt.want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## What
Fetch the HTML `<title>` of referenced JPCERT-AT alert pages in `fetch jvn-feed-rss` / `fetch jvn-feed-detail`, and store it in a new `fetchedtitle` field on the reference / related-item.

## Why
JVN feeds reference JPCERT-AT alerts but do not carry those alert pages' titles. go-cve-dictionary retrieves them by fetching each JPCERT-AT page and reading its `<title>`; this brings the same information into the vuls-data-update datasets.

## How
- Add `util.FetchTitle(client, url)` — GET the URL and return the trimmed HTML `<title>` (goquery). Older alerts are referenced as a PGP-signed `.txt` file that carries no HTML title, so a trailing `.txt` is fetched as its `.html` rendering. A missing/empty title or a non-200 response aborts the run (fail-fast) so an unexpected page (e.g. a soft 404) is surfaced rather than silently omitted.
- Restrict title fetching to JPCERT-AT **alert** pages via `util.IsAlertURL` — a URL whose path is `/at/<year>/...`. The URL path is the only reliable discriminator: the feeds' reference `id` (rss) and `RelatedItem.VulinfoID` (detail) are inconsistent — often the alert title text or a bare number (`at060009`, `2004-0002`, `wr073001`) rather than `JPCERT-AT-yyyy-nnnn` — so matching on them both **misses real alerts** and is fragile. Matching on the URL path also excludes the non-alert JPCERT reference types the feeds cite under source `JPCERT-AT` — weekly reports (`/wr/`, plain text with no `.html` rendering) and press releases (`/pr/`, PDF) — which have no fetchable HTML title. The rss side additionally pre-filters on `Source == "JPCERT-AT"`.
  - Validated across all JVN feeds (1998–2026): every URL whose path matches `/at/<year>/` is on `www.jpcert.or.jp` (15,191 URLs, zero non-jpcert hosts). A bare `/at/` prefix is insufficient because some vendor advisory URLs contain `/at/` as a path segment (e.g. `.../at/portals/...`), so a 4-digit year segment is required.
- Reuse the feed HTTP client for the extra requests and cache titles per URL within a run (one alert is referenced by many advisories).
- `fetchedtitle` is a derived field kept separate from the feed-provided `title`, added with `xml:"-"` / `json:",omitempty"`.

## Testing
- Golden fetch tests for rss and detail use real data (`JVNDB-2021-005429` / Apache Log4j → `at210050`), with the real alert page served by the test server (its URL rewritten to the test host and normalized back so goldens stay deterministic). The rss goldens also cover a `.txt`-origin alert (`JVNDB-2011-001013` → `at110008.txt`→`.html`) and a skipped non-alert reference (`JVNDB-2007-000127` → a `/pr/` PDF, no `fetchedtitle`).
- `util.IsAlertURL` and `util.FetchTitle` unit tests (table-driven, `httptest.NewServer`): alert `.html`/`.txt`, `/wr/`, `/pr/`, vendor `/at/` path, non-`/at/`, empty; happy path, `.txt`→`.html`, missing-title error, 404 error.
- `GOEXPERIMENT=jsonv2 go test ./pkg/fetch/jvn/... ./pkg/extract/jvn/...` passes; `go build ./...`, `gofmt`, `go vet` clean.
- Ran `fetch jvn-feed-rss` and `fetch jvn-feed-detail` end-to-end against the live JVN feeds — both complete successfully (293k / 292k advisories, ~15k titles each, every title on a `/at/` alert URL). `extract jvn-feed-rss` / `jvn-feed-detail` also run cleanly on the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
