### PR TITLE
fix(extract/microsoft/cvrf): handle 2026-Jul products and placeholder FixedBuild

### DIFF
--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -1307,12 +1307,14 @@ func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criter
 			"Microsoft SQL Server 2022 for x64-based Systems (CU 22)",
 			"Microsoft SQL Server 2022 for x64-based Systems (CU 23)",
 			"Microsoft SQL Server 2022 for x64-based Systems (CU 24)",
+			"Microsoft SQL Server 2022 for x64-based Systems (CU 25)",
 			"Microsoft SQL Server 2022 for x64-based Systems (CU 5)",
 			"Microsoft SQL Server 2022 for x64-based Systems (CU 8)",
 			"Microsoft SQL Server 2022 for x64-based Systems (GDR)",
 			"Microsoft SQL Server 2025 for x64-based Systems (CU2)",
 			"Microsoft SQL Server 2025 for x64-based Systems (CU3)",
 			"Microsoft SQL Server 2025 for x64-based Systems (CU4)",
+			"Microsoft SQL Server 2025 for x64-based Systems (CU6)",
 			"Microsoft SQL Server 2025 for x64-based Systems (GDR)",
 			"SQL Server 2019 for Linux Containers",
 			"SQL Server Integration Services for Visual Studio 2019",
@@ -1386,7 +1388,8 @@ func buildFixedBuildCriterion(cveID, productName, rawFixedBuild string) (*criter
 			"Microsoft Visual Studio 2026 Version 18.3",
 			"Microsoft Visual Studio 2026 Version 18.4",
 			"Microsoft Visual Studio 2026 Version 18.5",
-			"Microsoft Visual Studio 2026 Version 18.6":
+			"Microsoft Visual Studio 2026 Version 18.6",
+			"Microsoft Visual Studio 2026 Version 18.7":
 			if _, err := visualstudioversion.NewVersion(fixedBuild); err != nil {
 				return rangeTypes.RangeTypeUnknown, errors.Wrap(err, "visualstudioversion.NewVersion")
 			}

--- a/pkg/extract/microsoft/cvrf/cvrf.go
+++ b/pkg/extract/microsoft/cvrf/cvrf.go
@@ -2244,6 +2244,11 @@ var fixedBuildOverrides = map[[3]string]string{
 	// 2026-Jun (IE Cumulative, FixedBuild "1.000" is a revision number, not a Windows OS build)
 	{"CVE-2026-45592", "Windows Server 2012 R2", "1.000"}:                            "",
 	{"CVE-2026-45592", "Windows Server 2012 R2 (Server Core installation)", "1.000"}: "",
+	// 2026-Jul (IE Cumulative, FixedBuild "1.000" is a revision number, not a Windows OS build)
+	{"CVE-2026-50480", "Windows Server 2012", "1.000"}:                               "",
+	{"CVE-2026-50480", "Windows Server 2012 (Server Core installation)", "1.000"}:    "",
+	{"CVE-2026-50480", "Windows Server 2012 R2", "1.000"}:                            "",
+	{"CVE-2026-50480", "Windows Server 2012 R2 (Server Core installation)", "1.000"}: "",
 
 	// Windows OS (FixedBuild leaked from a sibling servicing branch: a single Vendor Fix
 	// Remediation grouped products from multiple servicing branches but specified only

--- a/pkg/extract/microsoft/cvrf/cvrf_test.go
+++ b/pkg/extract/microsoft/cvrf/cvrf_test.go
@@ -168,6 +168,96 @@ func TestBuildFixedBuildCriterion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "SQL Server 2022 CU 25",
+			args: args{
+				cveID:         "CVE-2026-47295",
+				productName:   "Microsoft SQL Server 2022 for x64-based Systems (CU 25)",
+				rawFixedBuild: "16.0.4262.2",
+			},
+			want: &criterionTypes.Criterion{
+				Type: criterionTypes.CriterionTypeVersion,
+				Version: &vcTypes.Criterion{
+					Vulnerable: true,
+					FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed},
+					Package: packageTypes.Package{
+						Type:   packageTypes.PackageTypeBinary,
+						Binary: &binaryTypes.Package{Name: "Microsoft SQL Server 2022 for x64-based Systems (CU 25)"},
+					},
+					Affected: &affectedTypes.Affected{
+						Type:  affectedrangeTypes.RangeTypeMicrosoftSQLServer,
+						Range: []affectedrangeTypes.Range{{LessThan: "16.0.4262.2"}},
+						Fixed: []string{"16.0.4262.2"},
+					},
+				},
+			},
+		},
+		{
+			name: "SQL Server 2025 CU6",
+			args: args{
+				cveID:         "CVE-2026-47296",
+				productName:   "Microsoft SQL Server 2025 for x64-based Systems (CU6)",
+				rawFixedBuild: "17.0.4060.2",
+			},
+			want: &criterionTypes.Criterion{
+				Type: criterionTypes.CriterionTypeVersion,
+				Version: &vcTypes.Criterion{
+					Vulnerable: true,
+					FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed},
+					Package: packageTypes.Package{
+						Type:   packageTypes.PackageTypeBinary,
+						Binary: &binaryTypes.Package{Name: "Microsoft SQL Server 2025 for x64-based Systems (CU6)"},
+					},
+					Affected: &affectedTypes.Affected{
+						Type:  affectedrangeTypes.RangeTypeMicrosoftSQLServer,
+						Range: []affectedrangeTypes.Range{{LessThan: "17.0.4060.2"}},
+						Fixed: []string{"17.0.4060.2"},
+					},
+				},
+			},
+		},
+		{
+			name: "Visual Studio 2026 Version 18.7",
+			args: args{
+				cveID:         "CVE-2026-47300",
+				productName:   "Microsoft Visual Studio 2026 Version 18.7",
+				rawFixedBuild: "18.7.4",
+			},
+			want: &criterionTypes.Criterion{
+				Type: criterionTypes.CriterionTypeVersion,
+				Version: &vcTypes.Criterion{
+					Vulnerable: true,
+					FixStatus:  &fixstatusTypes.FixStatus{Class: fixstatusTypes.ClassFixed},
+					Package: packageTypes.Package{
+						Type:   packageTypes.PackageTypeBinary,
+						Binary: &binaryTypes.Package{Name: "Microsoft Visual Studio 2026 Version 18.7"},
+					},
+					Affected: &affectedTypes.Affected{
+						Type:  affectedrangeTypes.RangeTypeMicrosoftVisualStudio,
+						Range: []affectedrangeTypes.Range{{LessThan: "18.7.4"}},
+						Fixed: []string{"18.7.4"},
+					},
+				},
+			},
+		},
+		{
+			name: "CVE-2026-50480 Windows Server 2012 IE Cumulative 1.000 skipped",
+			args: args{
+				cveID:         "CVE-2026-50480",
+				productName:   "Windows Server 2012",
+				rawFixedBuild: "1.000",
+			},
+			want: nil,
+		},
+		{
+			name: "CVE-2026-50480 Windows Server 2012 R2 IE Cumulative 1.000 skipped",
+			args: args{
+				cveID:         "CVE-2026-50480",
+				productName:   "Windows Server 2012 R2",
+				rawFixedBuild: "1.000",
+			},
+			want: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -197,6 +287,26 @@ func TestFixedBuildOverrides(t *testing.T) {
 		{
 			name: "CVE-2026-32077 Windows Server 2012 R2 Server Core",
 			key:  [3]string{"CVE-2026-32077", "Windows Server 2012 R2 (Server Core installation)", "1.000"},
+			want: "",
+		},
+		{
+			name: "CVE-2026-50480 Windows Server 2012",
+			key:  [3]string{"CVE-2026-50480", "Windows Server 2012", "1.000"},
+			want: "",
+		},
+		{
+			name: "CVE-2026-50480 Windows Server 2012 Server Core",
+			key:  [3]string{"CVE-2026-50480", "Windows Server 2012 (Server Core installation)", "1.000"},
+			want: "",
+		},
+		{
+			name: "CVE-2026-50480 Windows Server 2012 R2",
+			key:  [3]string{"CVE-2026-50480", "Windows Server 2012 R2", "1.000"},
+			want: "",
+		},
+		{
+			name: "CVE-2026-50480 Windows Server 2012 R2 Server Core",
+			key:  [3]string{"CVE-2026-50480", "Windows Server 2012 R2 (Server Core installation)", "1.000"},
 			want: "",
 		},
 		// Branch-leaked Windows OS FixedBuild (sibling-servicing-branch leak in


### PR DESCRIPTION
## What
Fix two failure modes in `pkg/extract/microsoft/cvrf/cvrf.go` triggered by the 2026-Jul CVRF batch:

1. **New products** added to `buildFixedBuildCriterion`:
   - `Microsoft SQL Server 2022 for x64-based Systems (CU 25)`
   - `Microsoft SQL Server 2025 for x64-based Systems (CU6)`
   - `Microsoft Visual Studio 2026 Version 18.7`
2. **Placeholder FixedBuild** `"1.000"` for the IE Cumulative update (KB5099415, `CVE-2026-50480`) on Windows Server 2012 / 2012 R2 (and their Server Core variants) added to `fixedBuildOverrides` mapped to `""`, matching the existing IE-Cumulative handling for prior months.

## Why
The `extract microsoft-cvrf` job in `vuls-data-db` failed (exit code 1) on the 2026-Jul batch. Extraction is fail-fast, so it surfaced one error at a time:

```
unexpected FixedBuild format for CVE-2026-47295 (Microsoft SQL Server 2022 for x64-based Systems (CU 25)): "16.0.4262.2"
...
unexpected Windows version format. expected: [...], actual: "1.000"  (CVE-2026-50480)
```

- A product matching a detection prefix (e.g. `"Microsoft SQL Server 20"`) but absent from the switch returns an "unknown product ... please add it" error.
- `"1.000"` is a revision placeholder Microsoft ships for IE Cumulative updates; it is not a Windows OS build and is rejected by `windowsversion.NewVersion`.

Ref: https://github.com/vulsio/vuls-data-db/actions/runs/29382833779

## How
Rather than fixing only the CVEs named in CI, the full 2026-Jul CVRF document was scanned by calling the real `buildFixedBuildCriterion` over every Vendor Fix remediation, enumerating *all* products/values that would error. The scan surfaced exactly these cases; no others remain.

## Testing
- `GOEXPERIMENT=jsonv2 go build ./cmd/vuls-data-update`
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/microsoft/cvrf/ ./pkg/fetch/microsoft/cvrf/`
- End-to-end: fetched the real 2026-Jul CVRF document, wrote it to the raw repo layout via the fetcher's `writeCVRF`, and ran `extract microsoft-cvrf` on it — **exit 0, 1150 CVEs extracted**. Verified CVE-2026-47295 (SQL 2022 CU 25) and CVE-2026-47300 (VS 2026 18.7) emit criteria, and CVE-2026-50480 emits the correct Monthly Rollup builds (6.2.9200.26226 / 6.3.9600.23291) with no `1.000` leaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)