### PR TITLE
fix(extract/types/data): sort both sides in Merge

### DIFF
--- a/pkg/extract/types/data/data.go
+++ b/pkg/extract/types/data/data.go
@@ -56,11 +56,10 @@ func (d *Data) Merge(ds ...Data) {
 	// in canonical (sorted) order first: d is typically freshly built in
 	// construction order, while an element of ds may have round-tripped
 	// through util.Write's Sort. Relying on the two orders coinciding is what
-	// this normalization replaces. The appends below leave d non-canonical
-	// again, so re-sort on the way out — Merge's output should be canonical
-	// without every caller having to remember a follow-up Sort.
+	// this normalization replaces. The appends below may leave d non-canonical
+	// again; that is fine — matching scans linearly and never relies on d's
+	// order, and the result is canonicalized by util.Write's Sort on write.
 	d.Sort()
-	defer d.Sort()
 	for _, e := range ds {
 		if d.ID != e.ID {
 			continue

--- a/pkg/extract/types/data/data.go
+++ b/pkg/extract/types/data/data.go
@@ -52,10 +52,17 @@ func Compare(x, y Data) int {
 }
 
 func (d *Data) Merge(ds ...Data) {
+	// Contents are matched with order-sensitive Compare, so both sides must be
+	// in canonical (sorted) order first: d is typically freshly built in
+	// construction order, while an element of ds may have round-tripped
+	// through util.Write's Sort. Relying on the two orders coinciding is what
+	// this normalization replaces.
+	d.Sort()
 	for _, e := range ds {
 		if d.ID != e.ID {
 			continue
 		}
+		e.Sort()
 
 		as := d.Advisories
 		for _, ea := range e.Advisories {

--- a/pkg/extract/types/data/data.go
+++ b/pkg/extract/types/data/data.go
@@ -56,9 +56,11 @@ func (d *Data) Merge(ds ...Data) {
 	// in canonical (sorted) order first: d is typically freshly built in
 	// construction order, while an element of ds may have round-tripped
 	// through util.Write's Sort. Relying on the two orders coinciding is what
-	// this normalization replaces. The appends below may leave d non-canonical
-	// again; that is fine — matching scans linearly and never relies on d's
-	// order, and the result is canonicalized by util.Write's Sort on write.
+	// this normalization replaces. Note that e.Sort() below reorders the
+	// backing arrays of the caller's ds elements in place — Merge treats its
+	// inputs as owned. The appends below may leave d non-canonical again;
+	// that is fine — matching scans linearly and never relies on d's order,
+	// and the result is canonicalized by util.Write's Sort on write.
 	d.Sort()
 	for _, e := range ds {
 		if d.ID != e.ID {

--- a/pkg/extract/types/data/data.go
+++ b/pkg/extract/types/data/data.go
@@ -56,8 +56,11 @@ func (d *Data) Merge(ds ...Data) {
 	// in canonical (sorted) order first: d is typically freshly built in
 	// construction order, while an element of ds may have round-tripped
 	// through util.Write's Sort. Relying on the two orders coinciding is what
-	// this normalization replaces.
+	// this normalization replaces. The appends below leave d non-canonical
+	// again, so re-sort on the way out — Merge's output should be canonical
+	// without every caller having to remember a follow-up Sort.
 	d.Sort()
+	defer d.Sort()
 	for _, e := range ds {
 		if d.ID != e.ID {
 			continue

--- a/pkg/extract/types/data/data_test.go
+++ b/pkg/extract/types/data/data_test.go
@@ -10,6 +10,8 @@ import (
 	advisoryContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory/content"
 	detectionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection"
 	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
+	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	v31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
 	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
@@ -223,6 +225,94 @@ func TestData_Merge(t *testing.T) {
 						},
 						Segments: []segmentTypes.Segment{
 							{Ecosystem: "ecosystem:2.1"},
+						},
+					},
+				},
+			},
+		},
+		{
+			// Regression case for Merge's Sort normalization: the same advisory
+			// content carries its severities in opposite orders on the two sides
+			// (receiver freshly built in construction order vs merged-in side
+			// round-tripped through util.Write's Sort). Order-sensitive Compare
+			// must still match them as one advisory, not duplicate it.
+			name: "same advisory with severities in reverse order",
+			fields: dataTypes.Data{
+				ID: dataTypes.RootID("id"),
+				Advisories: []advisoryTypes.Advisory{
+					{
+						Content: advisoryContentTypes.Content{
+							ID: advisoryContentTypes.AdvisoryID("ADV-001"),
+							Severity: []severityTypes.Severity{
+								{
+									Type:    severityTypes.SeverityTypeCVSSv31,
+									Source:  "vendor",
+									CVSSv31: &v31Types.CVSSv31{Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", BaseScore: 9.8, BaseSeverity: "CRITICAL"},
+								},
+								{
+									Type:   severityTypes.SeverityTypeVendor,
+									Source: "vendor",
+									Vendor: func() *string { s := "Critical"; return &s }(),
+								},
+							},
+						},
+						Segments: []segmentTypes.Segment{
+							{Ecosystem: "ecosystem:1"},
+						},
+					},
+				},
+			},
+			args: args{
+				ds: []dataTypes.Data{
+					{
+						ID: dataTypes.RootID("id"),
+						Advisories: []advisoryTypes.Advisory{
+							{
+								Content: advisoryContentTypes.Content{
+									ID: advisoryContentTypes.AdvisoryID("ADV-001"),
+									Severity: []severityTypes.Severity{
+										{
+											Type:   severityTypes.SeverityTypeVendor,
+											Source: "vendor",
+											Vendor: func() *string { s := "Critical"; return &s }(),
+										},
+										{
+											Type:    severityTypes.SeverityTypeCVSSv31,
+											Source:  "vendor",
+											CVSSv31: &v31Types.CVSSv31{Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", BaseScore: 9.8, BaseSeverity: "CRITICAL"},
+										},
+									},
+								},
+								Segments: []segmentTypes.Segment{
+									{Ecosystem: "ecosystem:2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: dataTypes.Data{
+				ID: dataTypes.RootID("id"),
+				Advisories: []advisoryTypes.Advisory{
+					{
+						Content: advisoryContentTypes.Content{
+							ID: advisoryContentTypes.AdvisoryID("ADV-001"),
+							Severity: []severityTypes.Severity{
+								{
+									Type:   severityTypes.SeverityTypeVendor,
+									Source: "vendor",
+									Vendor: func() *string { s := "Critical"; return &s }(),
+								},
+								{
+									Type:    severityTypes.SeverityTypeCVSSv31,
+									Source:  "vendor",
+									CVSSv31: &v31Types.CVSSv31{Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", BaseScore: 9.8, BaseSeverity: "CRITICAL"},
+								},
+							},
+						},
+						Segments: []segmentTypes.Segment{
+							{Ecosystem: "ecosystem:1"},
+							{Ecosystem: "ecosystem:2"},
 						},
 					},
 				},

--- a/pkg/extract/types/data/data_test.go
+++ b/pkg/extract/types/data/data_test.go
@@ -252,7 +252,7 @@ func TestData_Merge(t *testing.T) {
 								{
 									Type:   severityTypes.SeverityTypeVendor,
 									Source: "vendor",
-									Vendor: func() *string { s := "Critical"; return &s }(),
+									Vendor: new("Critical"),
 								},
 							},
 						},
@@ -274,7 +274,7 @@ func TestData_Merge(t *testing.T) {
 										{
 											Type:   severityTypes.SeverityTypeVendor,
 											Source: "vendor",
-											Vendor: func() *string { s := "Critical"; return &s }(),
+											Vendor: new("Critical"),
 										},
 										{
 											Type:    severityTypes.SeverityTypeCVSSv31,
@@ -301,7 +301,7 @@ func TestData_Merge(t *testing.T) {
 								{
 									Type:   severityTypes.SeverityTypeVendor,
 									Source: "vendor",
-									Vendor: func() *string { s := "Critical"; return &s }(),
+									Vendor: new("Critical"),
 								},
 								{
 									Type:    severityTypes.SeverityTypeCVSSv31,

--- a/pkg/extract/types/data/data_test.go
+++ b/pkg/extract/types/data/data_test.go
@@ -11,6 +11,7 @@ import (
 	detectionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection"
 	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	v2Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v2"
 	v31Types "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
 	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
@@ -232,11 +233,12 @@ func TestData_Merge(t *testing.T) {
 		},
 		{
 			// Regression case for Merge's Sort normalization: the same advisory
-			// content carries its severities in opposite orders on the two sides
-			// (receiver freshly built in construction order vs merged-in side
-			// round-tripped through util.Write's Sort). Order-sensitive Compare
-			// must still match them as one advisory, not duplicate it.
-			name: "same advisory with severities in reverse order",
+			// content carries its severities in a different non-canonical order
+			// on each side (canonical: vendor, cvss_v2, cvss_v31). The two raw
+			// orders also differ from each other, so the match succeeds only if
+			// BOTH d.Sort() and e.Sort() run — dropping either one makes this
+			// case duplicate the advisory instead of merging it.
+			name: "same advisory with severities in different non-canonical orders",
 			fields: dataTypes.Data{
 				ID: dataTypes.RootID("id"),
 				Advisories: []advisoryTypes.Advisory{
@@ -253,6 +255,11 @@ func TestData_Merge(t *testing.T) {
 									Type:   severityTypes.SeverityTypeVendor,
 									Source: "vendor",
 									Vendor: new("Critical"),
+								},
+								{
+									Type:   severityTypes.SeverityTypeCVSSv2,
+									Source: "vendor",
+									CVSSv2: &v2Types.CVSSv2{Vector: "AV:N/AC:L/Au:N/C:C/I:C/A:C", BaseScore: 10, NVDBaseSeverity: "HIGH"},
 								},
 							},
 						},
@@ -272,14 +279,19 @@ func TestData_Merge(t *testing.T) {
 									ID: advisoryContentTypes.AdvisoryID("ADV-001"),
 									Severity: []severityTypes.Severity{
 										{
-											Type:   severityTypes.SeverityTypeVendor,
+											Type:   severityTypes.SeverityTypeCVSSv2,
 											Source: "vendor",
-											Vendor: new("Critical"),
+											CVSSv2: &v2Types.CVSSv2{Vector: "AV:N/AC:L/Au:N/C:C/I:C/A:C", BaseScore: 10, NVDBaseSeverity: "HIGH"},
 										},
 										{
 											Type:    severityTypes.SeverityTypeCVSSv31,
 											Source:  "vendor",
 											CVSSv31: &v31Types.CVSSv31{Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", BaseScore: 9.8, BaseSeverity: "CRITICAL"},
+										},
+										{
+											Type:   severityTypes.SeverityTypeVendor,
+											Source: "vendor",
+											Vendor: new("Critical"),
 										},
 									},
 								},
@@ -302,6 +314,11 @@ func TestData_Merge(t *testing.T) {
 									Type:   severityTypes.SeverityTypeVendor,
 									Source: "vendor",
 									Vendor: new("Critical"),
+								},
+								{
+									Type:   severityTypes.SeverityTypeCVSSv2,
+									Source: "vendor",
+									CVSSv2: &v2Types.CVSSv2{Vector: "AV:N/AC:L/Au:N/C:C/I:C/A:C", BaseScore: 10, NVDBaseSeverity: "HIGH"},
 								},
 								{
 									Type:    severityTypes.SeverityTypeCVSSv31,


### PR DESCRIPTION
## What

`Data.Merge` now sorts the receiver and each merged-in `Data` before matching advisory/vulnerability contents.

## Why

Merge matches contents with order-sensitive `Compare`, but the receiver is typically freshly built in construction order while the merged-in side has round-tripped through `util.Write`'s `Sort` (e.g. redhat/oval/v1 merging a fresh definition into the previously written per-RHSA file). Matching only works because the two orders happen to coincide — a latent bug that any future change to canonical `Compare` order would silently turn into split/duplicated entries.

Split out of #887 to keep that PR scoped to the enum conversion. ~~#887 depends on this~~ **No longer blocking #887**: it now preserves the canonical order via vocabulary-rank `Compare`, so the coincidence keeps holding. This PR remains worthwhile as independent hardening — Merge should not rely on that coincidence.

## How

Normalize both sides with `Sort()` at the top of `Merge` instead of relying on the coincidence.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` — all green (redhat/oval/v1's golden test exercises the fresh-vs-round-tripped merge path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)