### PR TITLE
feat!(extract): add reference Title/Tags and wire across extractors

### DIFF
--- a/pkg/extract/alma/errata/errata.go
+++ b/pkg/extract/alma/errata/errata.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
-	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -183,18 +182,27 @@ func extract(fetched errata.Erratum, osver string, raws []string) dataTypes.Data
 					Vendor: &fetched.Severity,
 				}},
 				References: func() []referenceTypes.Reference {
-					m := make(map[referenceTypes.Reference]struct{})
-					m[referenceTypes.Reference{
+					refs := []referenceTypes.Reference{{
 						Source: "errata.almalinux.org",
 						URL:    fmt.Sprintf("https://errata.almalinux.org/%s/%s.html", osver, strings.ReplaceAll(fetched.ID, ":", "-")),
-					}] = struct{}{}
+					}}
 					for _, r := range fetched.References {
-						m[referenceTypes.Reference{
+						refs = append(refs, referenceTypes.Reference{
 							Source: "errata.almalinux.org",
 							URL:    r.Href,
-						}] = struct{}{}
+							Title:  r.ID,
+							Tags: func() []string {
+								if r.Type == "" {
+									return nil
+								}
+								return []string{r.Type}
+							}(),
+						})
 					}
-					return slices.Collect(maps.Keys(m))
+					slices.SortFunc(refs, referenceTypes.Compare)
+					return slices.CompactFunc(refs, func(a, b referenceTypes.Reference) bool {
+						return referenceTypes.Compare(a, b) == 0
+					})
 				}(),
 				Published: new(time.Unix(int64(fetched.IssuedDate), 0)),
 				Modified:  new(time.Unix(int64(fetched.UpdatedDate), 0)),
@@ -214,6 +222,8 @@ func extract(fetched errata.Erratum, osver string, raws []string) dataTypes.Data
 					base.References = append(base.References, referenceTypes.Reference{
 						Source: "errata.almalinux.org",
 						URL:    r.Href,
+						Title:  r.ID,
+						Tags:   []string{r.Type},
 					})
 					m[r.ID] = base
 				}

--- a/pkg/extract/alma/errata/testdata/golden/data/ALSA/2019/ALSA-2019%3A3708.json
+++ b/pkg/extract/alma/errata/testdata/golden/data/ALSA/2019/ALSA-2019%3A3708.json
@@ -20,51 +20,99 @@
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2510"
+						"url": "https://vulners.com/cve/CVE-2019-2510",
+						"title": "CVE-2019-2510",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2537"
+						"url": "https://vulners.com/cve/CVE-2019-2537",
+						"title": "CVE-2019-2537",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2614"
+						"url": "https://vulners.com/cve/CVE-2019-2614",
+						"title": "CVE-2019-2614",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2627"
+						"url": "https://vulners.com/cve/CVE-2019-2627",
+						"title": "CVE-2019-2627",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2628"
+						"url": "https://vulners.com/cve/CVE-2019-2628",
+						"title": "CVE-2019-2628",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2737"
+						"url": "https://vulners.com/cve/CVE-2019-2737",
+						"title": "CVE-2019-2737",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2739"
+						"url": "https://vulners.com/cve/CVE-2019-2739",
+						"title": "CVE-2019-2739",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2740"
+						"url": "https://vulners.com/cve/CVE-2019-2740",
+						"title": "CVE-2019-2740",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2758"
+						"url": "https://vulners.com/cve/CVE-2019-2758",
+						"title": "CVE-2019-2758",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2805"
+						"url": "https://vulners.com/cve/CVE-2019-2805",
+						"title": "CVE-2019-2805",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2020-2922"
+						"url": "https://vulners.com/cve/CVE-2020-2922",
+						"title": "CVE-2020-2922",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2021-2007"
+						"url": "https://vulners.com/cve/CVE-2021-2007",
+						"title": "CVE-2021-2007",
+						"tags": [
+							"cve"
+						]
 					}
 				],
 				"published": "2019-11-06T04:53:43+09:00",
@@ -84,7 +132,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2510"
+						"url": "https://vulners.com/cve/CVE-2019-2510",
+						"title": "CVE-2019-2510",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -100,7 +152,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2537"
+						"url": "https://vulners.com/cve/CVE-2019-2537",
+						"title": "CVE-2019-2537",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -116,7 +172,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2614"
+						"url": "https://vulners.com/cve/CVE-2019-2614",
+						"title": "CVE-2019-2614",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -132,7 +192,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2627"
+						"url": "https://vulners.com/cve/CVE-2019-2627",
+						"title": "CVE-2019-2627",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -148,7 +212,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2628"
+						"url": "https://vulners.com/cve/CVE-2019-2628",
+						"title": "CVE-2019-2628",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -164,7 +232,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2737"
+						"url": "https://vulners.com/cve/CVE-2019-2737",
+						"title": "CVE-2019-2737",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -180,7 +252,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2739"
+						"url": "https://vulners.com/cve/CVE-2019-2739",
+						"title": "CVE-2019-2739",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -196,7 +272,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2740"
+						"url": "https://vulners.com/cve/CVE-2019-2740",
+						"title": "CVE-2019-2740",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -212,7 +292,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2758"
+						"url": "https://vulners.com/cve/CVE-2019-2758",
+						"title": "CVE-2019-2758",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -228,7 +312,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2019-2805"
+						"url": "https://vulners.com/cve/CVE-2019-2805",
+						"title": "CVE-2019-2805",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -244,7 +332,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2020-2922"
+						"url": "https://vulners.com/cve/CVE-2020-2922",
+						"title": "CVE-2020-2922",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},
@@ -260,7 +352,11 @@
 				"references": [
 					{
 						"source": "errata.almalinux.org",
-						"url": "https://vulners.com/cve/CVE-2021-2007"
+						"url": "https://vulners.com/cve/CVE-2021-2007",
+						"title": "CVE-2021-2007",
+						"tags": [
+							"cve"
+						]
 					}
 				]
 			},

--- a/pkg/extract/amazon/amazon.go
+++ b/pkg/extract/amazon/amazon.go
@@ -259,6 +259,13 @@ func extract(fetched amazon.Update, raws []string) dataTypes.Data {
 						rs = append(rs, referenceTypes.Reference{
 							Source: fetched.Author,
 							URL:    r.Href,
+							Title:  r.Title,
+							Tags: func() []string {
+								if r.Type == "" {
+									return nil
+								}
+								return []string{r.Type}
+							}(),
 						})
 					}
 					return rs
@@ -283,6 +290,8 @@ func extract(fetched amazon.Update, raws []string) dataTypes.Data {
 								{
 									Source: fetched.Author,
 									URL:    r.Href,
+									Title:  r.Title,
+									Tags:   []string{r.Type},
 								},
 							},
 						},

--- a/pkg/extract/amazon/testdata/golden/data/1/updates/2011/ALAS-2011-1.json
+++ b/pkg/extract/amazon/testdata/golden/data/1/updates/2011/ALAS-2011-1.json
@@ -16,7 +16,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-3192"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-3192",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -24,7 +27,10 @@
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "https://rhn.redhat.com/errata/RHSA-2011:1245.html"
+						"url": "https://rhn.redhat.com/errata/RHSA-2011:1245.html",
+						"tags": [
+							"redhat"
+						]
 					}
 				],
 				"published": "2011-09-27T22:46:00Z",
@@ -44,7 +50,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-3192"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-3192",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",

--- a/pkg/extract/amazon/testdata/golden/data/2/core/2018/ALAS2-2018-939.json
+++ b/pkg/extract/amazon/testdata/golden/data/2/core/2018/ALAS2-2018-939.json
@@ -16,11 +16,17 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5715"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5715",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5754"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5754",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -44,7 +50,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5715"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5715",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -64,7 +73,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5754"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5754",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",

--- a/pkg/extract/amazon/testdata/golden/data/2/extras/kernel-5.15/2022/ALAS2KERNEL-5.15-2022-001.json
+++ b/pkg/extract/amazon/testdata/golden/data/2/extras/kernel-5.15/2022/ALAS2KERNEL-5.15-2022-001.json
@@ -16,51 +16,87 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1015"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1015",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1016"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1016",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1158"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1158",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1263"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1263",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1353"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1353",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1729"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1729",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23222"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23222",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28893"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28893",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29581"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29581",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29582"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29582",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30594"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30594",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3526"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3526",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -84,7 +120,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1015"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1015",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -104,7 +143,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1016"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1016",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -124,7 +166,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1158"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1158",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -144,7 +189,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1263"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1263",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -164,7 +212,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1353"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1353",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -184,7 +235,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1729"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1729",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -204,7 +258,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23222"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23222",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -224,7 +281,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28893"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28893",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -244,7 +304,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29581"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29581",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -264,7 +327,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29582"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29582",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -284,7 +350,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30594"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-30594",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -304,7 +373,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3526"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3526",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",

--- a/pkg/extract/amazon/testdata/golden/data/2022/core/2021/ALAS2022-2021-001.json
+++ b/pkg/extract/amazon/testdata/golden/data/2022/core/2021/ALAS2022-2021-001.json
@@ -16,19 +16,31 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3778"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3778",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3796"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3796",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3872"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3872",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3875"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3875",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -52,7 +64,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3778"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3778",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -72,7 +87,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3796"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3796",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -92,7 +110,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3872"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3872",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -112,7 +133,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3875"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3875",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",

--- a/pkg/extract/amazon/testdata/golden/data/2023/core/2023/ALAS2023-2023-001.json
+++ b/pkg/extract/amazon/testdata/golden/data/2023/core/2023/ALAS2023-2023-001.json
@@ -16,11 +16,17 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3634"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3634",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24903"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24903",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -44,7 +50,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3634"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3634",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -64,7 +73,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24903"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24903",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",

--- a/pkg/extract/amazon/testdata/golden/data/2023/core/2025/ALAS2023-2025-935.json
+++ b/pkg/extract/amazon/testdata/golden/data/2023/core/2025/ALAS2023-2025-935.json
@@ -16,59 +16,101 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-58092"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-58092",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21893"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21893",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21926"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21926",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21997"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21997",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21999"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21999",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22000"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22000",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22002"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22002",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22005"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22005",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22013"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22013",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22015"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22015",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22017"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22017",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22021"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22021",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22022"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22022",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22023"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22023",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -92,7 +134,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-58092"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-58092",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -112,7 +157,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21893"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21893",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -132,7 +180,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21926"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21926",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -152,7 +203,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21997"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21997",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -172,7 +226,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21999"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-21999",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -192,7 +249,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22000"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22000",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -212,7 +272,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22002"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22002",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -232,7 +295,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22005"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22005",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -252,7 +318,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22013"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22013",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -272,7 +341,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22015"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22015",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -292,7 +364,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22017"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22017",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -312,7 +387,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22021"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22021",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -332,7 +410,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22022"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22022",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -352,7 +433,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22023"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-22023",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",

--- a/pkg/extract/amazon/testdata/golden/data/2023/kernel-livepatch/2023/ALAS2023LIVEPATCH-2023-001.json
+++ b/pkg/extract/amazon/testdata/golden/data/2023/kernel-livepatch/2023/ALAS2023LIVEPATCH-2023-001.json
@@ -16,7 +16,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-26545"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-26545",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",
@@ -40,7 +43,10 @@
 				"references": [
 					{
 						"source": "linux-security@amazon.com",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-26545"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-26545",
+						"tags": [
+							"cve"
+						]
 					},
 					{
 						"source": "linux-security@amazon.com",

--- a/pkg/extract/debian/tracker/salsa/salsa.go
+++ b/pkg/extract/debian/tracker/salsa/salsa.go
@@ -898,7 +898,9 @@ func collectSeverityAndBugRefs(anns []packageAnnotation) (*string, []referenceTy
 					Source: "security-tracker.debian.org",
 					URL:    fmt.Sprintf("https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=%d", *f.Bug),
 				}
-				if !slices.Contains(refs, r) {
+				if !slices.ContainsFunc(refs, func(e referenceTypes.Reference) bool {
+					return referenceTypes.Compare(e, r) == 0
+				}) {
 					refs = append(refs, r)
 				}
 			}

--- a/pkg/extract/jvn/feed/detail/detail.go
+++ b/pkg/extract/jvn/feed/detail/detail.go
@@ -1,6 +1,7 @@
 package detail
 
 import (
+	"cmp"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -237,6 +238,8 @@ func extract(fetched fetchTypes.Vulinfo, raws []string) (dataTypes.Data, error) 
 		refs = append(refs, referenceTypes.Reference{
 			Source: "jvndb.jvn.jp",
 			URL:    item.URL,
+			Title:  cmp.Or(item.FetchedTitle, item.Name),
+			Tags:   []string{item.Type},
 		})
 	}
 
@@ -297,6 +300,8 @@ func extract(fetched fetchTypes.Vulinfo, raws []string) (dataTypes.Data, error) 
 					v.Content.References = append(v.Content.References, referenceTypes.Reference{
 						Source: "jvndb.jvn.jp",
 						URL:    item.URL,
+						Title:  cmp.Or(item.FetchedTitle, item.Name),
+						Tags:   []string{item.Type},
 					})
 					vulnMap[item.VulinfoID] = v
 				}

--- a/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-000001.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-000001.json
@@ -45,15 +45,27 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://cweb.canon.jp/e-support/info/211221xss.html"
+						"url": "https://cweb.canon.jp/e-support/info/211221xss.html",
+						"title": "Canon",
+						"tags": [
+							"vendor"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://jvn.jp/jp/JVN64806328/index.html"
+						"url": "https://jvn.jp/jp/JVN64806328/index.html",
+						"title": "JVN",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					}
 				],
 				"published": "2022-01-19T12:05:15+09:00",
@@ -68,7 +80,11 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					}
 				]
 			}

--- a/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-000002.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-000002.json
@@ -46,27 +46,51 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://ja.wordpress.org/plugins/quiz-master-next/"
+						"url": "https://ja.wordpress.org/plugins/quiz-master-next/",
+						"title": "ExpressTech",
+						"tags": [
+							"vendor"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://jvn.jp/jp/JVN72788165/index.html"
+						"url": "https://jvn.jp/jp/JVN72788165/index.html",
+						"title": "JVN",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://quizandsurveymaster.com/"
+						"url": "https://quizandsurveymaster.com/",
+						"title": "ExpressTech",
+						"tags": [
+							"vendor"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0180"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0180",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0181"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0181",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0182"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0182",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					}
 				],
 				"published": "2022-01-12T12:08:20+09:00",
@@ -86,7 +110,11 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0180"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0180",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					}
 				]
 			},
@@ -102,7 +130,11 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0181"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0181",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					}
 				]
 			},
@@ -118,7 +150,11 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0182"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-0182",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					}
 				]
 			},

--- a/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-017704.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/data/2022/JVNDB-2022-017704.json
@@ -32,23 +32,43 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.16.3"
+						"url": "https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.16.3",
+						"title": "ChangeLog",
+						"tags": [
+							"vendor"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://github.com/torvalds/linux/commit/3ba880a12df5aa4488c18281701b5b1bc3d4531a"
+						"url": "https://github.com/torvalds/linux/commit/3ba880a12df5aa4488c18281701b5b1bc3d4531a",
+						"title": "GitHub",
+						"tags": [
+							"vendor"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23001"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23001",
+						"title": "National Vulnerability Database (NVD)",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23001"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23001",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.kernel.org"
+						"url": "https://www.kernel.org",
+						"title": "Linux Kernel",
+						"tags": [
+							"vendor"
+						]
 					}
 				],
 				"published": "2023-10-16T17:17:41+09:00",
@@ -68,11 +88,19 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23001"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23001",
+						"title": "National Vulnerability Database (NVD)",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23001"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23001",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					}
 				]
 			},

--- a/pkg/extract/jvn/feed/detail/testdata/golden/data/2023/JVNDB-2023-004315.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/data/2023/JVNDB-2023-004315.json
@@ -32,27 +32,51 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://code.google.com/archive/p/oaicat/issues/7"
+						"url": "https://code.google.com/archive/p/oaicat/issues/7",
+						"title": "関連文書",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://github.com/OCLC-Research/oaicat/commit/6cc65501869fa663bcd24a70b63f41f5cfe6b3e1"
+						"url": "https://github.com/OCLC-Research/oaicat/commit/6cc65501869fa663bcd24a70b63f41f5cfe6b3e1",
+						"title": "関連文書",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2013-10019"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2013-10019",
+						"title": "National Vulnerability Database (NVD)",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://oaicat.googlecode.com/files/oaicat-1.5.62.tar.gz"
+						"url": "https://oaicat.googlecode.com/files/oaicat-1.5.62.tar.gz",
+						"title": "関連文書",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://vuldb.com/?id.221489"
+						"url": "https://vuldb.com/?id.221489",
+						"title": "関連文書",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2013-10019"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2013-10019",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					}
 				],
 				"published": "2023-10-27T17:01:51+09:00",
@@ -72,11 +96,19 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2013-10019"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2013-10019",
+						"title": "National Vulnerability Database (NVD)",
+						"tags": [
+							"advisory"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2013-10019"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2013-10019",
+						"title": "Common Vulnerabilities and Exposures (CVE)",
+						"tags": [
+							"advisory"
+						]
 					}
 				]
 			},

--- a/pkg/extract/jvn/feed/rss/rss.go
+++ b/pkg/extract/jvn/feed/rss/rss.go
@@ -1,6 +1,7 @@
 package rss
 
 import (
+	"cmp"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -240,6 +241,8 @@ func extract(fetched fetchTypes.Item, raws []string) (dataTypes.Data, error) {
 		refs = append(refs, referenceTypes.Reference{
 			Source: "jvndb.jvn.jp",
 			URL:    ref.Text,
+			Title:  cmp.Or(ref.FetchedTitle, ref.Title),
+			Tags:   []string{ref.Source},
 		})
 	}
 
@@ -298,6 +301,8 @@ func extract(fetched fetchTypes.Item, raws []string) (dataTypes.Data, error) {
 				v.Content.References = append(v.Content.References, referenceTypes.Reference{
 					Source: "jvndb.jvn.jp",
 					URL:    ref.Text,
+					Title:  cmp.Or(ref.FetchedTitle, ref.Title),
+					Tags:   []string{ref.Source},
 				})
 				vulnMap[ref.ID] = v
 			}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2021/JVNDB-2021-018345.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2021/JVNDB-2021-018345.json
@@ -45,15 +45,24 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22292"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22292",
+						"tags": [
+							"NVD"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://security.samsungmobile.com/securityUpdate.smsb?year=2022&month=2"
+						"url": "https://security.samsungmobile.com/securityUpdate.smsb?year=2022&month=2",
+						"tags": [
+							"関連文書"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-22292"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-22292",
+						"tags": [
+							"CVE"
+						]
 					}
 				],
 				"published": "2023-06-01T11:12:00+09:00",
@@ -73,11 +82,17 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22292"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-22292",
+						"tags": [
+							"NVD"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-22292"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-22292",
+						"tags": [
+							"CVE"
+						]
 					}
 				]
 			},

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-000001.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-000001.json
@@ -45,11 +45,17 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://jvn.jp/jp/JVN64806328/index.html"
+						"url": "https://jvn.jp/jp/JVN64806328/index.html",
+						"tags": [
+							"JVN"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877",
+						"tags": [
+							"CVE"
+						]
 					}
 				],
 				"published": "2022-01-19T12:05:00+09:00",
@@ -64,7 +70,10 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2021-20877",
+						"tags": [
+							"CVE"
+						]
 					}
 				]
 			}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-017708.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-017708.json
@@ -32,11 +32,17 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23006"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23006",
+						"tags": [
+							"NVD"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23006"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23006",
+						"tags": [
+							"CVE"
+						]
 					}
 				],
 				"published": "2023-10-16T17:18:00+09:00",
@@ -56,11 +62,17 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23006"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-23006",
+						"tags": [
+							"NVD"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23006"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-23006",
+						"tags": [
+							"CVE"
+						]
 					}
 				]
 			},

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-020469.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2022/JVNDB-2022-020469.json
@@ -32,11 +32,17 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46723"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46723",
+						"tags": [
+							"NVD"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46723"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46723",
+						"tags": [
+							"CVE"
+						]
 					}
 				],
 				"published": "2023-11-02T11:30:00+09:00",
@@ -56,11 +62,17 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46723"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-46723",
+						"tags": [
+							"NVD"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46723"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46723",
+						"tags": [
+							"CVE"
+						]
 					}
 				]
 			},

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-000001.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-000001.json
@@ -45,15 +45,24 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://jvn.jp/jp/JVN16765254/index.html"
+						"url": "https://jvn.jp/jp/JVN16765254/index.html",
+						"tags": [
+							"JVN"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46648"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46648",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-47318"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-47318",
+						"tags": [
+							"CVE"
+						]
 					}
 				],
 				"published": "2023-01-05T12:02:00+09:00",
@@ -73,7 +82,10 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46648"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-46648",
+						"tags": [
+							"CVE"
+						]
 					}
 				]
 			},
@@ -89,7 +101,10 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-47318"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-47318",
+						"tags": [
+							"CVE"
+						]
 					}
 				]
 			},

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-002068.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-002068.json
@@ -32,15 +32,24 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://labs.nettitude.com/blog/cve-2022-25026-cve-2022-25027-vulnerabilities-in-rocket-trufusion-enterprise/"
+						"url": "https://labs.nettitude.com/blog/cve-2022-25026-cve-2022-25027-vulnerabilities-in-rocket-trufusion-enterprise/",
+						"tags": [
+							"関連文書"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25027"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25027",
+						"tags": [
+							"NVD"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-25027"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-25027",
+						"tags": [
+							"CVE"
+						]
 					}
 				],
 				"published": "2023-06-08T16:22:00+09:00",
@@ -60,11 +69,17 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25027"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-25027",
+						"tags": [
+							"NVD"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-25027"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-25027",
+						"tags": [
+							"CVE"
+						]
 					}
 				]
 			},

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-004814.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2023/JVNDB-2023-004814.json
@@ -32,15 +32,24 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0078"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0078",
+						"tags": [
+							"NVD"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://wpscan.com/vulnerability/e667854f-56f8-4dbe-9573-6652a8aacc2c"
+						"url": "https://wpscan.com/vulnerability/e667854f-56f8-4dbe-9573-6652a8aacc2c",
+						"tags": [
+							"関連文書"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-0078"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-0078",
+						"tags": [
+							"CVE"
+						]
 					}
 				],
 				"published": "2023-11-02T11:57:00+09:00",
@@ -60,11 +69,17 @@
 				"references": [
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0078"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-0078",
+						"tags": [
+							"NVD"
+						]
 					},
 					{
 						"source": "jvndb.jvn.jp",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-0078"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-0078",
+						"tags": [
+							"CVE"
+						]
 					}
 				]
 			},

--- a/pkg/extract/mitre/attack/attack.go
+++ b/pkg/extract/mitre/attack/attack.go
@@ -1250,6 +1250,7 @@ func toReferences(ers []attack.ExternalReference) []referenceTypes.Reference {
 		out = append(out, referenceTypes.Reference{
 			Source: er.SourceName,
 			URL:    *er.URL,
+			Title:  deref(er.Description),
 		})
 	}
 	if len(out) == 0 {

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1021.005.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1021.005.json
@@ -36,51 +36,63 @@
 	"references": [
 		{
 			"source": "Apple Unified Log Analysis Remote Login and Screen Sharing",
-			"url": "https://sarah-edwards-xzkc.squarespace.com/blog/2020/4/30/analysis-of-apple-unified-logs-quarantine-edition-entry-6-working-from-home-remote-logins"
+			"url": "https://sarah-edwards-xzkc.squarespace.com/blog/2020/4/30/analysis-of-apple-unified-logs-quarantine-edition-entry-6-working-from-home-remote-logins",
+			"title": "Sarah Edwards. (2020, April 30). Analysis of Apple Unified Logs: Quarantine Edition [Entry 6] – Working From Home? Remote Logins. Retrieved August 19, 2021."
 		},
 		{
 			"source": "Attacking VNC Servers PentestLab",
-			"url": "https://pentestlab.blog/2012/10/30/attacking-vnc-servers/"
+			"url": "https://pentestlab.blog/2012/10/30/attacking-vnc-servers/",
+			"title": "Administrator, Penetration Testing Lab. (2012, October 30). Attacking VNC Servers. Retrieved October 6, 2021."
 		},
 		{
 			"source": "Gnome Remote Desktop grd-settings",
-			"url": "https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/blob/9aa9181e/src/grd-settings.c#L207"
+			"url": "https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/blob/9aa9181e/src/grd-settings.c#L207",
+			"title": "Pascal Nowack. (n.d.). Retrieved September 21, 2021."
 		},
 		{
 			"source": "Gnome Remote Desktop gschema",
-			"url": "https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/blob/9aa9181e/src/org.gnome.desktop.remote-desktop.gschema.xml.in"
+			"url": "https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/blob/9aa9181e/src/org.gnome.desktop.remote-desktop.gschema.xml.in",
+			"title": "Pascal Nowack. (n.d.). Retrieved September 21, 2021."
 		},
 		{
 			"source": "Havana authentication bug",
-			"url": "http://lists.openstack.org/pipermail/openstack/2013-December/004138.html"
+			"url": "http://lists.openstack.org/pipermail/openstack/2013-December/004138.html",
+			"title": "Jay Pipes. (2013, December 23). Security Breach! Tenant A is seeing the VNC Consoles of Tenant B!. Retrieved October 6, 2021."
 		},
 		{
 			"source": "Hijacking VNC",
-			"url": "https://int0x33.medium.com/day-70-hijacking-vnc-enum-brute-access-and-crack-d3d18a4601cc"
+			"url": "https://int0x33.medium.com/day-70-hijacking-vnc-enum-brute-access-and-crack-d3d18a4601cc",
+			"title": "Z3RO. (2019, March 10). Day 70: Hijacking VNC (Enum, Brute, Access and Crack). Retrieved September 20, 2021."
 		},
 		{
 			"source": "MacOS VNC software for Remote Desktop",
-			"url": "https://support.apple.com/guide/remote-desktop/set-up-a-computer-running-vnc-software-apdbed09830/mac"
+			"url": "https://support.apple.com/guide/remote-desktop/set-up-a-computer-running-vnc-software-apdbed09830/mac",
+			"title": "Apple Support. (n.d.). Set up a computer running VNC software for Remote Desktop. Retrieved August 18, 2021."
 		},
 		{
 			"source": "Offensive Security VNC Authentication Check",
-			"url": "https://www.offensive-security.com/metasploit-unleashed/vnc-authentication/"
+			"url": "https://www.offensive-security.com/metasploit-unleashed/vnc-authentication/",
+			"title": "Offensive Security. (n.d.). VNC Authentication. Retrieved October 6, 2021."
 		},
 		{
 			"source": "The Remote Framebuffer Protocol",
-			"url": "https://datatracker.ietf.org/doc/html/rfc6143#section-7.2.2"
+			"url": "https://datatracker.ietf.org/doc/html/rfc6143#section-7.2.2",
+			"title": "T. Richardson, J. Levine, RealVNC Ltd.. (2011, March). The Remote Framebuffer Protocol. Retrieved September 20, 2021."
 		},
 		{
 			"source": "VNC Authentication",
-			"url": "https://help.realvnc.com/hc/en-us/articles/360002250097-Setting-up-System-Authentication"
+			"url": "https://help.realvnc.com/hc/en-us/articles/360002250097-Setting-up-System-Authentication",
+			"title": "Tegan. (2019, August 15). Setting up System Authentication. Retrieved September 20, 2021."
 		},
 		{
 			"source": "VNC Vulnerabilities",
-			"url": "https://www.bleepingcomputer.com/news/security/dozens-of-vnc-vulnerabilities-found-in-linux-windows-solutions/"
+			"url": "https://www.bleepingcomputer.com/news/security/dozens-of-vnc-vulnerabilities-found-in-linux-windows-solutions/",
+			"title": "Sergiu Gatlan. (2019, November 22). Dozens of VNC Vulnerabilities Found in Linux, Windows Solutions. Retrieved September 20, 2021."
 		},
 		{
 			"source": "macOS root VNC login without authentication",
-			"url": "https://www.tenable.com/blog/detecting-macos-high-sierra-root-account-without-authentication"
+			"url": "https://www.tenable.com/blog/detecting-macos-high-sierra-root-account-without-authentication",
+			"title": "Nick Miles. (2017, November 30). Detecting macOS High Sierra root account without authentication. Retrieved September 20, 2021."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1047.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1047.json
@@ -47,15 +47,18 @@
 	"references": [
 		{
 			"source": "FireEye WMI 2015",
-			"url": "https://www.fireeye.com/content/dam/fireeye-www/global/en/current-threats/pdfs/wp-windows-management-instrumentation.pdf"
+			"url": "https://www.fireeye.com/content/dam/fireeye-www/global/en/current-threats/pdfs/wp-windows-management-instrumentation.pdf",
+			"title": "Ballenthin, W., et al. (2015). Windows Management Instrumentation (WMI) Offense, Defense, and Forensics. Retrieved March 30, 2016."
 		},
 		{
 			"source": "FireEye WMI SANS 2015",
-			"url": "https://www.fireeye.com/content/dam/fireeye-www/services/pdfs/sans-dfir-2015.pdf"
+			"url": "https://www.fireeye.com/content/dam/fireeye-www/services/pdfs/sans-dfir-2015.pdf",
+			"title": "Devon Kerr. (2015). There's Something About WMI. Retrieved May 4, 2020."
 		},
 		{
 			"source": "MSDN WMI",
-			"url": "https://msdn.microsoft.com/en-us/library/aa394582.aspx"
+			"url": "https://msdn.microsoft.com/en-us/library/aa394582.aspx",
+			"title": "Microsoft. (n.d.). Windows Management Instrumentation. Retrieved April 27, 2016."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1053.005.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1053.005.json
@@ -49,39 +49,48 @@
 	"references": [
 		{
 			"source": "Defending Against Scheduled Task Attacks in Windows Environments",
-			"url": "https://blog.qualys.com/vulnerabilities-threat-research/2022/06/20/defending-against-scheduled-task-attacks-in-windows-environments"
+			"url": "https://blog.qualys.com/vulnerabilities-threat-research/2022/06/20/defending-against-scheduled-task-attacks-in-windows-environments",
+			"title": "Harshal Tupsamudre. (2022, June 20). Defending Against Scheduled Tasks. Retrieved July 5, 2022."
 		},
 		{
 			"source": "Microsoft Scheduled Task Events Win10",
-			"url": "https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/audit-other-object-access-events"
+			"url": "https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/audit-other-object-access-events",
+			"title": "Microsoft. (2017, May 28). Audit Other Object Access Events. Retrieved June 27, 2019."
 		},
 		{
 			"source": "ProofPoint Serpent",
-			"url": "https://www.proofpoint.com/us/blog/threat-insight/serpent-no-swiping-new-backdoor-targets-french-entities-unique-attack-chain"
+			"url": "https://www.proofpoint.com/us/blog/threat-insight/serpent-no-swiping-new-backdoor-targets-french-entities-unique-attack-chain",
+			"title": "Campbell, B. et al. (2022, March 21). Serpent, No Swiping! New Backdoor Targets French Entities with Unique Attack Chain. Retrieved April 11, 2022."
 		},
 		{
 			"source": "SigmaHQ",
-			"url": "https://github.com/SigmaHQ/sigma/blob/master/rules/windows/registry/registry_delete/registry_delete_schtasks_hide_task_via_sd_value_removal.yml"
+			"url": "https://github.com/SigmaHQ/sigma/blob/master/rules/windows/registry/registry_delete/registry_delete_schtasks_hide_task_via_sd_value_removal.yml",
+			"title": "Sittikorn S. (2022, April 15). Removal Of SD Value to Hide Schedule Task - Registry. Retrieved June 1, 2022."
 		},
 		{
 			"source": "Tarrask scheduled task",
-			"url": "https://www.microsoft.com/security/blog/2022/04/12/tarrask-malware-uses-scheduled-tasks-for-defense-evasion/"
+			"url": "https://www.microsoft.com/security/blog/2022/04/12/tarrask-malware-uses-scheduled-tasks-for-defense-evasion/",
+			"title": "Microsoft Threat Intelligence Team & Detection and Response Team . (2022, April 12). Tarrask malware uses scheduled tasks for defense evasion. Retrieved June 1, 2022."
 		},
 		{
 			"source": "TechNet Autoruns",
-			"url": "https://technet.microsoft.com/en-us/sysinternals/bb963902"
+			"url": "https://technet.microsoft.com/en-us/sysinternals/bb963902",
+			"title": "Russinovich, M. (2016, January 4). Autoruns for Windows v13.51. Retrieved June 6, 2016."
 		},
 		{
 			"source": "TechNet Forum Scheduled Task Operational Setting",
-			"url": "https://social.technet.microsoft.com/Forums/en-US/e5bca729-52e7-4fcb-ba12-3225c564674c/scheduled-tasks-history-retention-settings?forum=winserver8gen"
+			"url": "https://social.technet.microsoft.com/Forums/en-US/e5bca729-52e7-4fcb-ba12-3225c564674c/scheduled-tasks-history-retention-settings?forum=winserver8gen",
+			"title": "Satyajit321. (2015, November 3). Scheduled Tasks History Retention settings. Retrieved December 12, 2017."
 		},
 		{
 			"source": "TechNet Scheduled Task Events",
-			"url": "https://technet.microsoft.com/library/dd315590.aspx"
+			"url": "https://technet.microsoft.com/library/dd315590.aspx",
+			"title": "Microsoft. (n.d.). General Task Registration. Retrieved December 12, 2017."
 		},
 		{
 			"source": "Twitter Leoloobeek Scheduled Task",
-			"url": "https://twitter.com/leoloobeek/status/939248813465853953"
+			"url": "https://twitter.com/leoloobeek/status/939248813465853953",
+			"title": "Loobeek, L. (2017, December 8). leoloobeek Status. Retrieved December 12, 2017."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1055.011.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1055.011.json
@@ -40,31 +40,38 @@
 	"references": [
 		{
 			"source": "Elastic Process Injection July 2017",
-			"url": "https://www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process"
+			"url": "https://www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process",
+			"title": "Hosseini, A. (2017, July 18). Ten Process Injection Techniques: A Technical Survey Of Common And Trending Process Injection Techniques. Retrieved December 7, 2017."
 		},
 		{
 			"source": "MalwareTech Power Loader Aug 2013",
-			"url": "https://www.malwaretech.com/2013/08/powerloader-injection-something-truly.html"
+			"url": "https://www.malwaretech.com/2013/08/powerloader-injection-something-truly.html",
+			"title": "MalwareTech. (2013, August 13). PowerLoader Injection – Something truly amazing. Retrieved December 16, 2017."
 		},
 		{
 			"source": "Microsoft GetWindowLong function",
-			"url": "https://msdn.microsoft.com/library/windows/desktop/ms633584.aspx"
+			"url": "https://msdn.microsoft.com/library/windows/desktop/ms633584.aspx",
+			"title": "Microsoft. (n.d.). GetWindowLong function. Retrieved December 16, 2017."
 		},
 		{
 			"source": "Microsoft SendNotifyMessage function",
-			"url": "https://msdn.microsoft.com/library/windows/desktop/ms644953.aspx"
+			"url": "https://msdn.microsoft.com/library/windows/desktop/ms644953.aspx",
+			"title": "Microsoft. (n.d.). SendNotifyMessage function. Retrieved December 16, 2017."
 		},
 		{
 			"source": "Microsoft SetWindowLong function",
-			"url": "https://msdn.microsoft.com/library/windows/desktop/ms633591.aspx"
+			"url": "https://msdn.microsoft.com/library/windows/desktop/ms633591.aspx",
+			"title": "Microsoft. (n.d.). SetWindowLong function. Retrieved December 16, 2017."
 		},
 		{
 			"source": "Microsoft Window Classes",
-			"url": "https://msdn.microsoft.com/library/windows/desktop/ms633574.aspx"
+			"url": "https://msdn.microsoft.com/library/windows/desktop/ms633574.aspx",
+			"title": "Microsoft. (n.d.). About Window Classes. Retrieved December 16, 2017."
 		},
 		{
 			"source": "WeLiveSecurity Gapz and Redyms Mar 2013",
-			"url": "https://www.welivesecurity.com/2013/03/19/gapz-and-redyms-droppers-based-on-power-loader-code/"
+			"url": "https://www.welivesecurity.com/2013/03/19/gapz-and-redyms-droppers-based-on-power-loader-code/",
+			"title": "Matrosov, A. (2013, March 19). Gapz and Redyms droppers based on Power Loader code. Retrieved December 16, 2017."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1113.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1113.json
@@ -35,11 +35,13 @@
 	"references": [
 		{
 			"source": "Antiquated Mac Malware",
-			"url": "https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/"
+			"url": "https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/",
+			"title": "Thomas Reed. (2017, January 18). New Mac backdoor using antiquated code. Retrieved July 5, 2017."
 		},
 		{
 			"source": "CopyFromScreen .NET",
-			"url": "https://docs.microsoft.com/en-us/dotnet/api/system.drawing.graphics.copyfromscreen?view=netframework-4.8"
+			"url": "https://docs.microsoft.com/en-us/dotnet/api/system.drawing.graphics.copyfromscreen?view=netframework-4.8",
+			"title": "Microsoft. (n.d.). Graphics.CopyFromScreen Method. Retrieved March 24, 2020."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1134.003.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1134.003.json
@@ -49,7 +49,8 @@
 	"references": [
 		{
 			"source": "Microsoft Command-line Logging",
-			"url": "https://technet.microsoft.com/en-us/windows-server-docs/identity/ad-ds/manage/component-updates/command-line-process-auditing"
+			"url": "https://technet.microsoft.com/en-us/windows-server-docs/identity/ad-ds/manage/component-updates/command-line-process-auditing",
+			"title": "Mathers, B. (2017, March 7). Command line process auditing. Retrieved April 21, 2017."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1137.005.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1137.005.json
@@ -39,19 +39,23 @@
 	"references": [
 		{
 			"source": "Microsoft Detect Outlook Forms",
-			"url": "https://docs.microsoft.com/en-us/office365/securitycompliance/detect-and-remediate-outlook-rules-forms-attack"
+			"url": "https://docs.microsoft.com/en-us/office365/securitycompliance/detect-and-remediate-outlook-rules-forms-attack",
+			"title": "Fox, C., Vangel, D. (2018, April 22). Detect and Remediate Outlook Rules and Custom Forms Injections Attacks in Office 365. Retrieved February 4, 2019."
 		},
 		{
 			"source": "Pfammatter - Hidden Inbox Rules",
-			"url": "https://blog.compass-security.com/2018/09/hidden-inbox-rules-in-microsoft-exchange/"
+			"url": "https://blog.compass-security.com/2018/09/hidden-inbox-rules-in-microsoft-exchange/",
+			"title": "Damian Pfammatter. (2018, September 17). Hidden Inbox Rules in Microsoft Exchange. Retrieved October 12, 2021."
 		},
 		{
 			"source": "SensePost NotRuler",
-			"url": "https://github.com/sensepost/notruler"
+			"url": "https://github.com/sensepost/notruler",
+			"title": "SensePost. (2017, September 21). NotRuler - The opposite of Ruler, provides blue teams with the ability to detect Ruler usage against Exchange. Retrieved February 4, 2019."
 		},
 		{
 			"source": "SilentBreak Outlook Rules",
-			"url": "https://silentbreaksecurity.com/malicious-outlook-rules/"
+			"url": "https://silentbreaksecurity.com/malicious-outlook-rules/",
+			"title": "Landers, N. (2015, December 4). Malicious Outlook Rules. Retrieved February 4, 2019."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1140.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1140.json
@@ -42,15 +42,18 @@
 	"references": [
 		{
 			"source": "Carbon Black Obfuscation Sept 2016",
-			"url": "https://www.carbonblack.com/2016/09/23/security-advisory-variants-well-known-adware-families-discovered-include-sophisticated-obfuscation-techniques-previously-associated-nation-state-attacks/"
+			"url": "https://www.carbonblack.com/2016/09/23/security-advisory-variants-well-known-adware-families-discovered-include-sophisticated-obfuscation-techniques-previously-associated-nation-state-attacks/",
+			"title": "Tedesco, B. (2016, September 23). Security Alert Summary. Retrieved February 12, 2018."
 		},
 		{
 			"source": "Malwarebytes Targeted Attack against Saudi Arabia",
-			"url": "https://blog.malwarebytes.com/cybercrime/social-engineering-cybercrime/2017/03/new-targeted-attack-saudi-arabia-government/"
+			"url": "https://blog.malwarebytes.com/cybercrime/social-engineering-cybercrime/2017/03/new-targeted-attack-saudi-arabia-government/",
+			"title": "Malwarebytes Labs. (2017, March 27). New targeted attack against Saudi Arabia Government. Retrieved July 3, 2017."
 		},
 		{
 			"source": "Volexity PowerDuke November 2016",
-			"url": "https://www.volexity.com/blog/2016/11/09/powerduke-post-election-spear-phishing-campaigns-targeting-think-tanks-and-ngos/"
+			"url": "https://www.volexity.com/blog/2016/11/09/powerduke-post-election-spear-phishing-campaigns-targeting-think-tanks-and-ngos/",
+			"title": "Adair, S.. (2016, November 9). PowerDuke: Widespread Post-Election Spear Phishing Campaigns Targeting Think Tanks and NGOs. Retrieved January 11, 2017."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1156.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1156.json
@@ -30,7 +30,8 @@
 	"references": [
 		{
 			"source": "intezer-kaiji-malware",
-			"url": "https://www.intezer.com/blog/research/kaiji-new-chinese-linux-malware-turning-to-golang/"
+			"url": "https://www.intezer.com/blog/research/kaiji-new-chinese-linux-malware-turning-to-golang/",
+			"title": "Paul Litvak. (2020, May 4). Kaiji: New Chinese Linux malware turning to Golang. Retrieved December 17, 2020."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1190.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1190.json
@@ -38,39 +38,48 @@
 	"references": [
 		{
 			"source": "CIS Multiple SMB Vulnerabilities",
-			"url": "https://www.cisecurity.org/advisory/multiple-vulnerabilities-in-microsoft-windows-smb-server-could-allow-for-remote-code-execution/"
+			"url": "https://www.cisecurity.org/advisory/multiple-vulnerabilities-in-microsoft-windows-smb-server-could-allow-for-remote-code-execution/",
+			"title": "CIS. (2017, May 15). Multiple Vulnerabilities in Microsoft Windows SMB Server Could Allow for Remote Code Execution. Retrieved April 3, 2018."
 		},
 		{
 			"source": "CWE top 25",
-			"url": "https://cwe.mitre.org/top25/index.html"
+			"url": "https://cwe.mitre.org/top25/index.html",
+			"title": "Christey, S., Brown, M., Kirby, D., Martin, B., Paller, A.. (2011, September 13). 2011 CWE/SANS Top 25 Most Dangerous Software Errors. Retrieved April 10, 2019."
 		},
 		{
 			"source": "Cisco Blog Legacy Device Attacks",
-			"url": "https://community.cisco.com/t5/security-blogs/attackers-continue-to-target-legacy-devices/ba-p/4169954"
+			"url": "https://community.cisco.com/t5/security-blogs/attackers-continue-to-target-legacy-devices/ba-p/4169954",
+			"title": "Omar Santos. (2020, October 19). Attackers Continue to Target Legacy Devices. Retrieved October 20, 2020."
 		},
 		{
 			"source": "Mandiant Fortinet Zero Day",
-			"url": "https://www.mandiant.com/resources/blog/fortinet-malware-ecosystem"
+			"url": "https://www.mandiant.com/resources/blog/fortinet-malware-ecosystem",
+			"title": "Marvi, A. et al.. (2023, March 16). Fortinet Zero-Day and Custom Malware Used by Suspected Chinese Actor in Espionage Operation. Retrieved March 22, 2023."
 		},
 		{
 			"source": "NVD CVE-2014-7169",
-			"url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7169"
+			"url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7169",
+			"title": "National Vulnerability Database. (2017, September 24). CVE-2014-7169 Detail. Retrieved April 3, 2018."
 		},
 		{
 			"source": "NVD CVE-2016-6662",
-			"url": "https://nvd.nist.gov/vuln/detail/CVE-2016-6662"
+			"url": "https://nvd.nist.gov/vuln/detail/CVE-2016-6662",
+			"title": "National Vulnerability Database. (2017, February 2). CVE-2016-6662 Detail. Retrieved April 3, 2018."
 		},
 		{
 			"source": "OWASP Top 10",
-			"url": "https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project"
+			"url": "https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project",
+			"title": "OWASP. (2018, February 23). OWASP Top Ten Project. Retrieved April 3, 2018."
 		},
 		{
 			"source": "US-CERT TA18-106A Network Infrastructure Devices 2018",
-			"url": "https://us-cert.cisa.gov/ncas/alerts/TA18-106A"
+			"url": "https://us-cert.cisa.gov/ncas/alerts/TA18-106A",
+			"title": "US-CERT. (2018, April 20). Russian State-Sponsored Cyber Actors Targeting Network Infrastructure Devices. Retrieved October 19, 2020."
 		},
 		{
 			"source": "Wired Russia Cyberwar",
-			"url": "https://www.wired.com/story/russia-ukraine-cyberattacks-mandiant/"
+			"url": "https://www.wired.com/story/russia-ukraine-cyberattacks-mandiant/",
+			"title": "Greenberg, A. (2022, November 10). Russia’s New Cyberwarfare in Ukraine Is Fast, Dirty, and Relentless. Retrieved March 22, 2023."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1195.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1195.json
@@ -69,31 +69,38 @@
 	"references": [
 		{
 			"source": "Avast CCleaner3 2018",
-			"url": "https://blog.avast.com/new-investigations-in-ccleaner-incident-point-to-a-possible-third-stage-that-had-keylogger-capacities"
+			"url": "https://blog.avast.com/new-investigations-in-ccleaner-incident-point-to-a-possible-third-stage-that-had-keylogger-capacities",
+			"title": "Avast Threat Intelligence Team. (2018, March 8). New investigations into the CCleaner incident point to a possible third stage that had keylogger capacities. Retrieved March 15, 2018."
 		},
 		{
 			"source": "Command Five SK 2011",
-			"url": "https://www.commandfive.com/papers/C5_APT_SKHack.pdf"
+			"url": "https://www.commandfive.com/papers/C5_APT_SKHack.pdf",
+			"title": "Command Five Pty Ltd. (2011, September). SK Hack by an Advanced Persistent Threat. Retrieved April 6, 2018."
 		},
 		{
 			"source": "IBM Storwize",
-			"url": "https://www-01.ibm.com/support/docview.wss?uid=ssg1S1010146&myns=s028&mynp=OCSTHGUJ&mynp=OCSTLM5A&mynp=OCSTLM6B&mynp=OCHW206&mync=E&cm_sp=s028-_-OCSTHGUJ-OCSTLM5A-OCSTLM6B-OCHW206-_-E"
+			"url": "https://www-01.ibm.com/support/docview.wss?uid=ssg1S1010146&myns=s028&mynp=OCSTHGUJ&mynp=OCSTLM5A&mynp=OCSTLM6B&mynp=OCHW206&mync=E&cm_sp=s028-_-OCSTHGUJ-OCSTLM5A-OCSTLM6B-OCHW206-_-E",
+			"title": "IBM Support. (2017, April 26). Storwize USB Initialization Tool may contain malicious code. Retrieved May 28, 2019."
 		},
 		{
 			"source": "Microsoft Dofoil 2018",
-			"url": "https://cloudblogs.microsoft.com/microsoftsecure/2018/03/07/behavior-monitoring-combined-with-machine-learning-spoils-a-massive-dofoil-coin-mining-campaign/"
+			"url": "https://cloudblogs.microsoft.com/microsoftsecure/2018/03/07/behavior-monitoring-combined-with-machine-learning-spoils-a-massive-dofoil-coin-mining-campaign/",
+			"title": "Windows Defender Research. (2018, March 7). Behavior monitoring combined with machine learning spoils a massive Dofoil coin mining campaign. Retrieved March 20, 2018."
 		},
 		{
 			"source": "Schneider Electric USB Malware",
-			"url": "https://www.se.com/ww/en/download/document/SESN-2018-236-01/"
+			"url": "https://www.se.com/ww/en/download/document/SESN-2018-236-01/",
+			"title": "Schneider Electric. (2018, August 24). Security Notification – USB Removable Media Provided With Conext Combox and Conext Battery Monitor. Retrieved May 28, 2019."
 		},
 		{
 			"source": "Symantec Elderwood Sept 2012",
-			"url": "https://web.archive.org/web/20190717233006/http://www.symantec.com/content/en/us/enterprise/media/security_response/whitepapers/the-elderwood-project.pdf"
+			"url": "https://web.archive.org/web/20190717233006/http://www.symantec.com/content/en/us/enterprise/media/security_response/whitepapers/the-elderwood-project.pdf",
+			"title": "O'Gorman, G., and McDonald, G.. (2012, September 6). The Elderwood Project. Retrieved February 15, 2018."
 		},
 		{
 			"source": "Trendmicro NPM Compromise",
-			"url": "https://www.trendmicro.com/vinfo/dk/security/news/cybercrime-and-digital-threats/hacker-infects-node-js-package-to-steal-from-bitcoin-wallets"
+			"url": "https://www.trendmicro.com/vinfo/dk/security/news/cybercrime-and-digital-threats/hacker-infects-node-js-package-to-steal-from-bitcoin-wallets",
+			"title": "Trendmicro. (2018, November 29). Hacker Infects Node.js Package to Steal from Bitcoin Wallets. Retrieved April 10, 2019."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1205.002.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1205.002.json
@@ -43,19 +43,23 @@
 	"references": [
 		{
 			"source": "Leonardo Turla Penquin May 2020",
-			"url": "https://www.leonardo.com/documents/20142/10868623/Malware+Technical+Insight+_Turla+%E2%80%9CPenquin_x64%E2%80%9D.pdf"
+			"url": "https://www.leonardo.com/documents/20142/10868623/Malware+Technical+Insight+_Turla+%E2%80%9CPenquin_x64%E2%80%9D.pdf",
+			"title": "Leonardo. (2020, May 29). MALWARE TECHNICAL INSIGHT TURLA “Penquin_x64”. Retrieved March 11, 2021."
 		},
 		{
 			"source": "crowdstrike bpf socket filters",
-			"url": "https://www.crowdstrike.com/blog/how-to-hunt-for-decisivearchitect-and-justforfun-implant/"
+			"url": "https://www.crowdstrike.com/blog/how-to-hunt-for-decisivearchitect-and-justforfun-implant/",
+			"title": "Jamie Harries. (2022, May 25). Hunting a Global Telecommunications Threat: DecisiveArchitect and Its Custom Implant JustForFun. Retrieved October 18, 2022."
 		},
 		{
 			"source": "exatrack bpf filters passive backdoors",
-			"url": "https://exatrack.com/public/Tricephalic_Hellkeeper.pdf"
+			"url": "https://exatrack.com/public/Tricephalic_Hellkeeper.pdf",
+			"title": "ExaTrack. (2022, May 11). Tricephalic Hellkeeper: a tale of a passive backdoor. Retrieved October 18, 2022."
 		},
 		{
 			"source": "haking9 libpcap network sniffing",
-			"url": "http://recursos.aldabaknocking.com/libpcapHakin9LuisMartinGarcia.pdf"
+			"url": "http://recursos.aldabaknocking.com/libpcapHakin9LuisMartinGarcia.pdf",
+			"title": "Luis Martin Garcia. (2008, February 1). Hakin9 Issue 2/2008 Vol 3 No.2 VoIP Abuse: Storming SIP Security. Retrieved October 18, 2022."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1219.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1219.json
@@ -49,15 +49,18 @@
 	"references": [
 		{
 			"source": "CrowdStrike 2015 Global Threat Report",
-			"url": "https://go.crowdstrike.com/rs/281-OBQ-266/images/15GlobalThreatReport.pdf"
+			"url": "https://go.crowdstrike.com/rs/281-OBQ-266/images/15GlobalThreatReport.pdf",
+			"title": "CrowdStrike Intelligence. (2016). 2015 Global Threat Report. Retrieved April 11, 2018."
 		},
 		{
 			"source": "CrySyS Blog TeamSpy",
-			"url": "https://blog.crysys.hu/2013/03/teamspy/"
+			"url": "https://blog.crysys.hu/2013/03/teamspy/",
+			"title": "CrySyS Lab. (2013, March 20). TeamSpy – Obshie manevri. Ispolzovat’ tolko s razreshenija S-a. Retrieved April 11, 2018."
 		},
 		{
 			"source": "Symantec Living off the Land",
-			"url": "https://www.symantec.com/content/dam/symantec/docs/security-center/white-papers/istr-living-off-the-land-and-fileless-attack-techniques-en.pdf"
+			"url": "https://www.symantec.com/content/dam/symantec/docs/security-center/white-papers/istr-living-off-the-land-and-fileless-attack-techniques-en.pdf",
+			"title": "Wueest, C., Anand, H. (2017, July). Living off the land and fileless attack techniques. Retrieved April 10, 2018."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1558.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1558.json
@@ -41,63 +41,78 @@
 	"references": [
 		{
 			"source": "ADSecurity Detecting Forged Tickets",
-			"url": "https://adsecurity.org/?p=1515"
+			"url": "https://adsecurity.org/?p=1515",
+			"title": "Metcalf, S. (2015, May 03). Detecting Forged Kerberos Ticket (Golden Ticket & Silver Ticket) Use in Active Directory. Retrieved December 23, 2015."
 		},
 		{
 			"source": "ADSecurity Kerberos Ring Decoder",
-			"url": "https://adsecurity.org/?p=227"
+			"url": "https://adsecurity.org/?p=227",
+			"title": "Sean Metcalf. (2014, September 12). Kerberos, Active Directory’s Secret Decoder Ring. Retrieved February 27, 2020."
 		},
 		{
 			"source": "AdSecurity Cracking Kerberos Dec 2015",
-			"url": "https://adsecurity.org/?p=2293"
+			"url": "https://adsecurity.org/?p=2293",
+			"title": "Metcalf, S. (2015, December 31). Cracking Kerberos TGS Tickets Using Kerberoast – Exploiting Kerberos to Compromise the Active Directory Domain. Retrieved March 22, 2018."
 		},
 		{
 			"source": "Brining MimiKatz to Unix",
-			"url": "https://labs.portcullis.co.uk/download/eu-18-Wadhwa-Brown-Where-2-worlds-collide-Bringing-Mimikatz-et-al-to-UNIX.pdf"
+			"url": "https://labs.portcullis.co.uk/download/eu-18-Wadhwa-Brown-Where-2-worlds-collide-Bringing-Mimikatz-et-al-to-UNIX.pdf",
+			"title": "Tim Wadhwa-Brown. (2018, November). Where 2 worlds collide Bringing Mimikatz et al to UNIX. Retrieved October 13, 2021."
 		},
 		{
 			"source": "CERT-EU Golden Ticket Protection",
-			"url": "https://cert.europa.eu/static/WhitePapers/UPDATED%20-%20CERT-EU_Security_Whitepaper_2014-007_Kerberos_Golden_Ticket_Protection_v1_4.pdf"
+			"url": "https://cert.europa.eu/static/WhitePapers/UPDATED%20-%20CERT-EU_Security_Whitepaper_2014-007_Kerberos_Golden_Ticket_Protection_v1_4.pdf",
+			"title": "Abolins, D., Boldea, C., Socha, K., Soria-Machado, M. (2016, April 26). Kerberos Golden Ticket Protection. Retrieved July 13, 2017."
 		},
 		{
 			"source": "Kekeo",
-			"url": "https://github.com/gentilkiwi/kekeo"
+			"url": "https://github.com/gentilkiwi/kekeo",
+			"title": "Benjamin Delpy. (n.d.). Kekeo. Retrieved October 4, 2021."
 		},
 		{
 			"source": "Linux Kerberos Tickets",
-			"url": "https://www.fireeye.com/blog/threat-research/2020/04/kerberos-tickets-on-linux-red-teams.html"
+			"url": "https://www.fireeye.com/blog/threat-research/2020/04/kerberos-tickets-on-linux-red-teams.html",
+			"title": "Trevor Haskell. (2020, April 1). Kerberos Tickets on Linux Red Teams. Retrieved October 4, 2021."
 		},
 		{
 			"source": "MIT ccache",
-			"url": "https://web.mit.edu/kerberos/krb5-1.12/doc/basic/ccache_def.html"
+			"url": "https://web.mit.edu/kerberos/krb5-1.12/doc/basic/ccache_def.html",
+			"title": "Massachusetts Institute of Technology. (n.d.). MIT Kerberos Documentation: Credential Cache. Retrieved October 4, 2021."
 		},
 		{
 			"source": "Medium Detecting Attempts to Steal Passwords from Memory",
-			"url": "https://medium.com/threatpunter/detecting-attempts-to-steal-passwords-from-memory-558f16dce4ea"
+			"url": "https://medium.com/threatpunter/detecting-attempts-to-steal-passwords-from-memory-558f16dce4ea",
+			"title": "French, D. (2018, October 2). Detecting Attempts to Steal Passwords from Memory. Retrieved October 11, 2019."
 		},
 		{
 			"source": "Microsoft Detecting Kerberoasting Feb 2018",
-			"url": "https://blogs.technet.microsoft.com/motiba/2018/02/23/detecting-kerberoasting-activity-using-azure-security-center/"
+			"url": "https://blogs.technet.microsoft.com/motiba/2018/02/23/detecting-kerberoasting-activity-using-azure-security-center/",
+			"title": "Bani, M. (2018, February 23). Detecting Kerberoasting activity using Azure Security Center. Retrieved March 23, 2018."
 		},
 		{
 			"source": "Microsoft Kerberos Golden Ticket",
-			"url": "https://gallery.technet.microsoft.com/scriptcenter/Kerberos-Golden-Ticket-b4814285"
+			"url": "https://gallery.technet.microsoft.com/scriptcenter/Kerberos-Golden-Ticket-b4814285",
+			"title": "Microsoft. (2015, March 24). Kerberos Golden Ticket Check (Updated). Retrieved February 27, 2020."
 		},
 		{
 			"source": "Microsoft Klist",
-			"url": "https://docs.microsoft.com/windows-server/administration/windows-commands/klist"
+			"url": "https://docs.microsoft.com/windows-server/administration/windows-commands/klist",
+			"title": "Microsoft. (2021, March 3). klist. Retrieved October 14, 2021."
 		},
 		{
 			"source": "SpectorOps Bifrost Kerberos macOS 2019",
-			"url": "https://posts.specterops.io/when-kirbi-walks-the-bifrost-4c727807744f"
+			"url": "https://posts.specterops.io/when-kirbi-walks-the-bifrost-4c727807744f",
+			"title": "Cody Thomas. (2019, November 14). When Kirbi walks the Bifrost. Retrieved October 6, 2021."
 		},
 		{
 			"source": "Stealthbits Detect PtT 2019",
-			"url": "https://blog.stealthbits.com/detect-pass-the-ticket-attacks"
+			"url": "https://blog.stealthbits.com/detect-pass-the-ticket-attacks",
+			"title": "Jeff Warren. (2019, February 19). How to Detect Pass-the-Ticket Attacks. Retrieved February 27, 2020."
 		},
 		{
 			"source": "macOS kerberos framework MIT",
-			"url": "http://web.mit.edu/macdev/KfM/Common/Documentation/preferences.html"
+			"url": "http://web.mit.edu/macdev/KfM/Common/Documentation/preferences.html",
+			"title": "Massachusetts Institute of Technology. (2007, October 27). Kerberos for Macintosh Preferences Documentation. Retrieved October 6, 2021."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1560.001.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1560.001.json
@@ -36,23 +36,28 @@
 	"references": [
 		{
 			"source": "7zip Homepage",
-			"url": "https://www.7-zip.org/"
+			"url": "https://www.7-zip.org/",
+			"title": "I. Pavlov. (2019). 7-Zip. Retrieved February 20, 2020."
 		},
 		{
 			"source": "Wikipedia File Header Signatures",
-			"url": "https://en.wikipedia.org/wiki/List_of_file_signatures"
+			"url": "https://en.wikipedia.org/wiki/List_of_file_signatures",
+			"title": "Wikipedia. (2016, March 31). List of file signatures. Retrieved April 22, 2016."
 		},
 		{
 			"source": "WinRAR Homepage",
-			"url": "https://www.rarlab.com/"
+			"url": "https://www.rarlab.com/",
+			"title": "A. Roshal. (2020). RARLAB. Retrieved February 20, 2020."
 		},
 		{
 			"source": "WinZip Homepage",
-			"url": "https://www.winzip.com/win/en/"
+			"url": "https://www.winzip.com/win/en/",
+			"title": "Corel Corporation. (2020). WinZip. Retrieved February 20, 2020."
 		},
 		{
 			"source": "diantz.exe_lolbas",
-			"url": "https://lolbas-project.github.io/lolbas/Binaries/Diantz/"
+			"url": "https://lolbas-project.github.io/lolbas/Binaries/Diantz/",
+			"title": "Living Off The Land Binaries, Scripts and Libraries (LOLBAS). (n.d.). Diantz.exe. Retrieved October 25, 2021."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1562.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1562.json
@@ -65,7 +65,8 @@
 	"references": [
 		{
 			"source": "Emotet shutdown",
-			"url": "https://thedfirreport.com/2022/11/28/emotet-strikes-again-lnk-file-leads-to-domain-wide-ransomware/"
+			"url": "https://thedfirreport.com/2022/11/28/emotet-strikes-again-lnk-file-leads-to-domain-wide-ransomware/",
+			"title": "The DFIR Report. (2022, November 8). Emotet Strikes Again – LNK File Leads to Domain Wide Ransomware. Retrieved March 6, 2023."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1586.002.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1586.002.json
@@ -29,11 +29,13 @@
 	"references": [
 		{
 			"source": "AnonHBGary",
-			"url": "https://arstechnica.com/tech-policy/2011/02/anonymous-speaks-the-inside-story-of-the-hbgary-hack/"
+			"url": "https://arstechnica.com/tech-policy/2011/02/anonymous-speaks-the-inside-story-of-the-hbgary-hack/",
+			"title": "Bright, P. (2011, February 15). Anonymous speaks: the inside story of the HBGary hack. Retrieved March 9, 2017."
 		},
 		{
 			"source": "Microsoft DEV-0537",
-			"url": "https://www.microsoft.com/security/blog/2022/03/22/dev-0537-criminal-actor-targeting-organizations-for-data-exfiltration-and-destruction/"
+			"url": "https://www.microsoft.com/security/blog/2022/03/22/dev-0537-criminal-actor-targeting-organizations-for-data-exfiltration-and-destruction/",
+			"title": "Microsoft. (2022, March 22). DEV-0537 criminal actor targeting organizations for data exfiltration and destruction. Retrieved March 23, 2022."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1586.003.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1586.003.json
@@ -29,11 +29,13 @@
 	"references": [
 		{
 			"source": "Awake Security C2 Cloud",
-			"url": "https://awakesecurity.com/blog/threat-hunting-series-detecting-command-control-in-the-cloud/"
+			"url": "https://awakesecurity.com/blog/threat-hunting-series-detecting-command-control-in-the-cloud/",
+			"title": "Gary Golomb and Tory Kei. (n.d.). Threat Hunting Series: Detecting Command & Control in the Cloud. Retrieved May 27, 2022."
 		},
 		{
 			"source": "MSTIC Nobelium Oct 2021",
-			"url": "https://www.microsoft.com/security/blog/2021/10/25/nobelium-targeting-delegated-administrative-privileges-to-facilitate-broader-attacks/"
+			"url": "https://www.microsoft.com/security/blog/2021/10/25/nobelium-targeting-delegated-administrative-privileges-to-facilitate-broader-attacks/",
+			"title": "Microsoft Threat Intelligence Center. (2021, October 25). NOBELIUM targeting delegated administrative privileges to facilitate broader attacks. Retrieved March 25, 2022."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1608.001.json
+++ b/pkg/extract/mitre/attack/testdata/golden/attack/technique/T1608.001.json
@@ -32,11 +32,13 @@
 	"references": [
 		{
 			"source": "Talos IPFS 2022",
-			"url": "https://blog.talosintelligence.com/ipfs-abuse/"
+			"url": "https://blog.talosintelligence.com/ipfs-abuse/",
+			"title": "Edmund Brumaghin. (2022, November 9). Threat Spotlight: Cyber Criminal Adoption of IPFS for Phishing, Malware Campaigns. Retrieved March 8, 2023."
 		},
 		{
 			"source": "Volexity Ocean Lotus November 2020",
-			"url": "https://www.volexity.com/blog/2020/11/06/oceanlotus-extending-cyber-espionage-operations-through-fake-websites/"
+			"url": "https://www.volexity.com/blog/2020/11/06/oceanlotus-extending-cyber-espionage-operations-through-fake-websites/",
+			"title": "Adair, S. and Lancaster, T. (2020, November 6). OceanLotus: Extending Cyber Espionage Operations Through Fake Websites. Retrieved November 20, 2020."
 		},
 		{
 			"source": "mitre-attack",

--- a/pkg/extract/mitre/capec/capec.go
+++ b/pkg/extract/mitre/capec/capec.go
@@ -240,6 +240,10 @@ func convert(e capecEntry, entries map[string]capecEntry) (capecTypes.CAPEC, err
 	relatedAttacks := make([]string, 0, len(c.ExternalReferences))
 	refs := make([]referenceTypes.Reference, 0, len(c.ExternalReferences))
 	for _, r := range c.ExternalReferences {
+		var title string
+		if r.Description != nil {
+			title = *r.Description
+		}
 		switch strings.ToLower(r.SourceName) {
 		case "cwe":
 			if r.ExternalID != nil {
@@ -257,6 +261,7 @@ func convert(e capecEntry, entries map[string]capecEntry) (capecTypes.CAPEC, err
 				refs = append(refs, referenceTypes.Reference{
 					Source: "capec.mitre.org",
 					URL:    *r.URL,
+					Title:  title,
 				})
 			}
 		default:
@@ -264,6 +269,7 @@ func convert(e capecEntry, entries map[string]capecEntry) (capecTypes.CAPEC, err
 				refs = append(refs, referenceTypes.Reference{
 					Source: "capec.mitre.org",
 					URL:    *r.URL,
+					Title:  title,
 				})
 			}
 		}

--- a/pkg/extract/mitre/capec/testdata/golden/capec/CAPEC-10.json
+++ b/pkg/extract/mitre/capec/testdata/golden/capec/CAPEC-10.json
@@ -69,7 +69,8 @@
 	"references": [
 		{
 			"source": "capec.mitre.org",
-			"url": "http://sharefuzz.sourceforge.net"
+			"url": "http://sharefuzz.sourceforge.net",
+			"title": "Sharefuzz"
 		},
 		{
 			"source": "capec.mitre.org",
@@ -77,7 +78,8 @@
 		},
 		{
 			"source": "capec.mitre.org",
-			"url": "https://owasp.org/www-community/attacks/Buffer_Overflow_via_Environment_Variables"
+			"url": "https://owasp.org/www-community/attacks/Buffer_Overflow_via_Environment_Variables",
+			"title": "Buffer Overflow via Environment Variables"
 		}
 	],
 	"data_source": {

--- a/pkg/extract/mitre/capec/testdata/golden/capec/CAPEC-510.json
+++ b/pkg/extract/mitre/capec/testdata/golden/capec/CAPEC-510.json
@@ -29,7 +29,8 @@
 	"references": [
 		{
 			"source": "capec.mitre.org",
-			"url": "http://www.adallom.com/blog/a-new-zeus-variant-targeting-salesforce-com-accounts-research-and-analysis/"
+			"url": "http://www.adallom.com/blog/a-new-zeus-variant-targeting-salesforce-com-accounts-research-and-analysis/",
+			"title": "Ami Luttwak, A new Zeus variant targeting Salesforce.com – Research and Analysis, Adallom, Inc."
 		},
 		{
 			"source": "capec.mitre.org",

--- a/pkg/extract/mitre/capec/testdata/golden/capec/CAPEC-653.json
+++ b/pkg/extract/mitre/capec/testdata/golden/capec/CAPEC-653.json
@@ -63,11 +63,13 @@
 	"references": [
 		{
 			"source": "capec.mitre.org",
-			"url": "https://arstechnica.com/information-technology/2020/04/unpatched-zoom-bug-lets-attackers-steal-windows-credentials-with-no-warning/"
+			"url": "https://arstechnica.com/information-technology/2020/04/unpatched-zoom-bug-lets-attackers-steal-windows-credentials-with-no-warning/",
+			"title": "Dan Goodin, Attackers can use Zoom to steal users’ Windows credentials with no warning, 2020--04---01, Ars Technica"
 		},
 		{
 			"source": "capec.mitre.org",
-			"url": "https://blog.stealthbits.com/how-attackers-are-stealing-your-credentials-with-mimikatz/"
+			"url": "https://blog.stealthbits.com/how-attackers-are-stealing-your-credentials-with-mimikatz/",
+			"title": "Jeff Warren, How Attackers are Stealing Your Credentials with Mimikatz, 2017--07---11, STEALTHbits Technologies, Inc."
 		},
 		{
 			"source": "capec.mitre.org",

--- a/pkg/extract/mitre/capec/testdata/golden/capec/CAPEC-70.json
+++ b/pkg/extract/mitre/capec/testdata/golden/capec/CAPEC-70.json
@@ -58,19 +58,23 @@
 		},
 		{
 			"source": "capec.mitre.org",
-			"url": "https://msrc-blog.microsoft.com/2019/08/05/corporate-iot-a-path-to-intrusion"
+			"url": "https://msrc-blog.microsoft.com/2019/08/05/corporate-iot-a-path-to-intrusion",
+			"title": "Corporate IoT – a path to intrusion, 2019--10---05, Microsoft Security Response Center (MSRC)"
 		},
 		{
 			"source": "capec.mitre.org",
-			"url": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.html"
+			"url": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account.html",
+			"title": "OWASP Web Security Testing Guide, The Open Web Application Security Project (OWASP)"
 		},
 		{
 			"source": "capec.mitre.org",
-			"url": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.html"
+			"url": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/02-Testing_for_Default_Credentials.html",
+			"title": "OWASP Web Security Testing Guide, The Open Web Application Security Project (OWASP)"
 		},
 		{
 			"source": "capec.mitre.org",
-			"url": "https://www.us-cert.gov/ncas/alerts/TA13-175A"
+			"url": "https://www.us-cert.gov/ncas/alerts/TA13-175A",
+			"title": "Risks of Default Passwords on the Internet, 2016--10---07, Cybersecurity and Infrastructure Security Agency (CISA)"
 		}
 	],
 	"data_source": {

--- a/pkg/extract/mitre/cve/v5/testdata/golden/data/2024/CVE-2024-39565.json
+++ b/pkg/extract/mitre/cve/v5/testdata/golden/data/2024/CVE-2024-39565.json
@@ -73,15 +73,24 @@
 				"references": [
 					{
 						"source": "juniper",
-						"url": "https://support.juniper.net/support/downloads/?p=283"
+						"url": "https://support.juniper.net/support/downloads/?p=283",
+						"tags": [
+							"signature"
+						]
 					},
 					{
 						"source": "juniper",
-						"url": "https://supportportal.juniper.net/JSA83023"
+						"url": "https://supportportal.juniper.net/JSA83023",
+						"tags": [
+							"vendor-advisory"
+						]
 					},
 					{
 						"source": "juniper",
-						"url": "https://www.first.org/cvss/calculator/v4-0#CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:P/AU:Y/R:I/V:C/RE:L/U:Amber"
+						"url": "https://www.first.org/cvss/calculator/v4-0#CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:P/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:P/AU:Y/R:I/V:C/RE:L/U:Amber",
+						"tags": [
+							"related"
+						]
 					}
 				],
 				"published": "2024-07-10T22:55:27.516Z",

--- a/pkg/extract/mitre/cve/v5/testdata/golden/data/2024/CVE-2024-4232.json
+++ b/pkg/extract/mitre/cve/v5/testdata/golden/data/2024/CVE-2024-4232.json
@@ -69,7 +69,10 @@
 				"references": [
 					{
 						"source": "CERT-In",
-						"url": "https://www.cert-in.org.in/s2cMainServlet?pageid=PUBVLNOTES01&VLCODE=CIVN-2024-0158"
+						"url": "https://www.cert-in.org.in/s2cMainServlet?pageid=PUBVLNOTES01&VLCODE=CIVN-2024-0158",
+						"tags": [
+							"third-party-advisory"
+						]
 					}
 				],
 				"published": "2024-05-10T13:32:08.224Z",

--- a/pkg/extract/mitre/cve/v5/testdata/golden/data/2024/CVE-2024-6958.json
+++ b/pkg/extract/mitre/cve/v5/testdata/golden/data/2024/CVE-2024-6958.json
@@ -67,19 +67,36 @@
 				"references": [
 					{
 						"source": "VulDB",
-						"url": "https://github.com/DeepMountains/Mirage/blob/main/CVE6-4.md"
+						"url": "https://github.com/DeepMountains/Mirage/blob/main/CVE6-4.md",
+						"tags": [
+							"exploit"
+						]
 					},
 					{
 						"source": "VulDB",
-						"url": "https://vuldb.com/?ctiid.272080"
+						"url": "https://vuldb.com/?ctiid.272080",
+						"title": "VDB-272080 | CTI Indicators (IOB, IOC, TTP, IOA)",
+						"tags": [
+							"permissions-required",
+							"signature"
+						]
 					},
 					{
 						"source": "VulDB",
-						"url": "https://vuldb.com/?id.272080"
+						"url": "https://vuldb.com/?id.272080",
+						"title": "VDB-272080 | itsourcecode University Management System Avatar File st_update.php unrestricted upload",
+						"tags": [
+							"technical-description",
+							"vdb-entry"
+						]
 					},
 					{
 						"source": "VulDB",
-						"url": "https://vuldb.com/?submit.377756"
+						"url": "https://vuldb.com/?submit.377756",
+						"title": "Submit #377756 | itsourcecode University Management System 1.0 File Upload",
+						"tags": [
+							"third-party-advisory"
+						]
 					}
 				],
 				"published": "2024-07-21T15:00:04.983Z",

--- a/pkg/extract/mitre/cve/v5/v5.go
+++ b/pkg/extract/mitre/cve/v5/v5.go
@@ -328,10 +328,15 @@ func extract(fetched v5.CVE, raws []string) (dataTypes.Data, error) {
 						var refs []referenceTypes.Reference
 						for source, rs := range m {
 							for _, r := range rs {
-								refs = append(refs, referenceTypes.Reference{
+								ref := referenceTypes.Reference{
 									Source: source,
 									URL:    r.URL,
-								})
+									Tags:   r.Tags,
+								}
+								if r.Name != nil {
+									ref.Title = *r.Name
+								}
+								refs = append(refs, ref)
 							}
 						}
 						return refs

--- a/pkg/extract/mitre/cwe/cwe.go
+++ b/pkg/extract/mitre/cwe/cwe.go
@@ -549,6 +549,7 @@ func extractReferences(id string, refs []cwe.Reference) []referenceTypes.Referen
 		out = append(out, referenceTypes.Reference{
 			Source: "cwe.mitre.org",
 			URL:    r.URL,
+			Title:  r.Title,
 		})
 	}
 	return out

--- a/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1007.json
+++ b/pkg/extract/mitre/cwe/testdata/golden/cwe/CWE-1007.json
@@ -111,7 +111,8 @@
 	"references": [
 		{
 			"source": "cwe.mitre.org",
-			"url": "http://ro.ecu.edu.au/cgi/viewcontent.cgi?article=1174&context=ecuworks2012"
+			"url": "http://ro.ecu.edu.au/cgi/viewcontent.cgi?article=1174&context=ecuworks2012",
+			"title": "The 2011 IDN Homograph Attack Mitigation Survey"
 		},
 		{
 			"source": "cwe.mitre.org",
@@ -119,7 +120,8 @@
 		},
 		{
 			"source": "cwe.mitre.org",
-			"url": "https://www.microsoftpressstore.com/store/writing-secure-code-9780735617223"
+			"url": "https://www.microsoftpressstore.com/store/writing-secure-code-9780735617223",
+			"title": "Writing Secure Code"
 		}
 	],
 	"data_source": {

--- a/pkg/extract/nvd/api/cve/cve.go
+++ b/pkg/extract/nvd/api/cve/cve.go
@@ -321,6 +321,7 @@ func (e extractor) buildData(fetched cveTypes.CVE) (dataTypes.Data, error) {
 							refs = append(refs, referenceTypes.Reference{
 								Source: r.Source,
 								URL:    r.URL,
+								Tags:   r.Tags,
 							})
 						}
 						return refs

--- a/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2018/CVE-2018-1202.json
+++ b/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2018/CVE-2018-1202.json
@@ -48,19 +48,36 @@
 					},
 					{
 						"source": "security_alert@emc.com",
-						"url": "http://seclists.org/fulldisclosure/2018/Mar/50"
+						"url": "http://seclists.org/fulldisclosure/2018/Mar/50",
+						"tags": [
+							"Mailing List",
+							"Third Party Advisory"
+						]
 					},
 					{
 						"source": "security_alert@emc.com",
-						"url": "http://www.securityfocus.com/bid/103033"
+						"url": "http://www.securityfocus.com/bid/103033",
+						"tags": [
+							"Third Party Advisory",
+							"VDB Entry"
+						]
 					},
 					{
 						"source": "security_alert@emc.com",
-						"url": "https://www.coresecurity.com/advisories/dell-emc-isilon-onefs-multiple-vulnerabilities"
+						"url": "https://www.coresecurity.com/advisories/dell-emc-isilon-onefs-multiple-vulnerabilities",
+						"tags": [
+							"Exploit",
+							"Third Party Advisory"
+						]
 					},
 					{
 						"source": "security_alert@emc.com",
-						"url": "https://www.exploit-db.com/exploits/44039/"
+						"url": "https://www.exploit-db.com/exploits/44039/",
+						"tags": [
+							"Exploit",
+							"Third Party Advisory",
+							"VDB Entry"
+						]
 					}
 				],
 				"published": "2018-03-26T18:29:01.19Z",

--- a/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2022/CVE-2022-26582.json
+++ b/pkg/extract/nvd/api/cve/testdata/golden/happy/data/2022/CVE-2022-26582.json
@@ -52,7 +52,10 @@
 				"references": [
 					{
 						"source": "cve@mitre.org",
-						"url": "https://cyshield.com/e077d6c3-adff-49a1-afc3-71e10140f95c"
+						"url": "https://cyshield.com/e077d6c3-adff-49a1-afc3-71e10140f95c",
+						"tags": [
+							"Third Party Advisory"
+						]
 					},
 					{
 						"source": "cve@mitre.org",

--- a/pkg/extract/nvd/api/cve/testdata/golden/with-and/data/2024/CVE-2024-0158.json
+++ b/pkg/extract/nvd/api/cve/testdata/golden/with-and/data/2024/CVE-2024-0158.json
@@ -48,7 +48,10 @@
 					},
 					{
 						"source": "security_alert@emc.com",
-						"url": "https://www.dell.com/support/kbdoc/en-in/000220141/dsa-2024-030-security-update-for-dell-client-bios-for-an-improper-input-validation-vulnerability"
+						"url": "https://www.dell.com/support/kbdoc/en-in/000220141/dsa-2024-030-security-update-for-dell-client-bios-for-an-improper-input-validation-vulnerability",
+						"tags": [
+							"Vendor Advisory"
+						]
 					}
 				],
 				"published": "2024-07-02T07:15:02.37Z",

--- a/pkg/extract/nvd/api/cve/testdata/golden/with-cpematch/data/2024/CVE-2024-20253.json
+++ b/pkg/extract/nvd/api/cve/testdata/golden/with-cpematch/data/2024/CVE-2024-20253.json
@@ -54,7 +54,11 @@
 					},
 					{
 						"source": "ykramarz@cisco.com",
-						"url": "https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-cucm-rce-bWNzQcUm"
+						"url": "https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-cucm-rce-bWNzQcUm",
+						"tags": [
+							"Issue Tracking",
+							"Vendor Advisory"
+						]
 					}
 				],
 				"published": "2024-01-26T18:15:10.97Z",

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/and-vulnerable-mixed/data/2024/CVE-2024-2049.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/and-vulnerable-mixed/data/2024/CVE-2024-2049.json
@@ -48,7 +48,10 @@
 					},
 					{
 						"source": "secure@citrix.com",
-						"url": "https://support.citrix.com/article/CTX617071/citrix-sdwan-security-bulletin-for-cve20242049"
+						"url": "https://support.citrix.com/article/CTX617071/citrix-sdwan-security-bulletin-for-cve20242049",
+						"tags": [
+							"Broken Link"
+						]
 					}
 				],
 				"published": "2024-03-12T13:15:49.807Z",

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/exact-match/data/2024/CVE-2024-0028.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/exact-match/data/2024/CVE-2024-0028.json
@@ -35,7 +35,10 @@
 					},
 					{
 						"source": "security@android.com",
-						"url": "https://source.android.com/security/bulletin/android-16"
+						"url": "https://source.android.com/security/bulletin/android-16",
+						"tags": [
+							"Vendor Advisory"
+						]
 					}
 				],
 				"published": "2025-09-05T17:15:33.27Z",

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/non-semver-range/data/2024/CVE-2024-20282.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/non-semver-range/data/2024/CVE-2024-20282.json
@@ -50,7 +50,10 @@
 				"references": [
 					{
 						"source": "af854a3a-2127-422b-91ae-364da2661108",
-						"url": "https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ndru-pesc-kZ2PQLZH"
+						"url": "https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ndru-pesc-kZ2PQLZH",
+						"tags": [
+							"Vendor Advisory"
+						]
 					},
 					{
 						"source": "nvd.nist.gov",
@@ -58,7 +61,10 @@
 					},
 					{
 						"source": "psirt@cisco.com",
-						"url": "https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ndru-pesc-kZ2PQLZH"
+						"url": "https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ndru-pesc-kZ2PQLZH",
+						"tags": [
+							"Vendor Advisory"
+						]
 					}
 				],
 				"published": "2024-04-03T17:15:47.95Z",

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/reference-tags/data/2024/CVE-2024-0028.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/reference-tags/data/2024/CVE-2024-0028.json
@@ -43,11 +43,19 @@
 				"references": [
 					{
 						"source": "cve@mitre.org",
-						"url": "https://example.com/advisory/workaround"
+						"url": "https://example.com/advisory/workaround",
+						"tags": [
+							"Mitigation",
+							"Vendor Advisory"
+						]
 					},
 					{
 						"source": "cve@mitre.org",
-						"url": "https://example.com/exploit/poc"
+						"url": "https://example.com/exploit/poc",
+						"tags": [
+							"Exploit",
+							"Third Party Advisory"
+						]
 					},
 					{
 						"source": "nvd.nist.gov",
@@ -55,7 +63,10 @@
 					},
 					{
 						"source": "security@android.com",
-						"url": "https://source.android.com/security/bulletin/android-16"
+						"url": "https://source.android.com/security/bulletin/android-16",
+						"tags": [
+							"Vendor Advisory"
+						]
 					}
 				],
 				"published": "2025-09-05T17:15:33.27Z",

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/semver-range-mixed/data/2021/CVE-2021-1569.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/semver-range-mixed/data/2021/CVE-2021-1569.json
@@ -63,7 +63,10 @@
 				"references": [
 					{
 						"source": "af854a3a-2127-422b-91ae-364da2661108",
-						"url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-jabber-GuC5mLwG"
+						"url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-jabber-GuC5mLwG",
+						"tags": [
+							"Vendor Advisory"
+						]
 					},
 					{
 						"source": "nvd.nist.gov",
@@ -71,7 +74,10 @@
 					},
 					{
 						"source": "psirt@cisco.com",
-						"url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-jabber-GuC5mLwG"
+						"url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-jabber-GuC5mLwG",
+						"tags": [
+							"Vendor Advisory"
+						]
 					}
 				],
 				"published": "2021-06-16T18:15:09.077Z",

--- a/pkg/extract/nvd/feed/cve/v2/testdata/golden/semver-range/data/2024/CVE-2024-0008.json
+++ b/pkg/extract/nvd/feed/cve/v2/testdata/golden/semver-range/data/2024/CVE-2024-0008.json
@@ -50,7 +50,10 @@
 				"references": [
 					{
 						"source": "af854a3a-2127-422b-91ae-364da2661108",
-						"url": "https://security.paloaltonetworks.com/CVE-2024-0008"
+						"url": "https://security.paloaltonetworks.com/CVE-2024-0008",
+						"tags": [
+							"Vendor Advisory"
+						]
 					},
 					{
 						"source": "nvd.nist.gov",
@@ -58,7 +61,10 @@
 					},
 					{
 						"source": "psirt@paloaltonetworks.com",
-						"url": "https://security.paloaltonetworks.com/CVE-2024-0008"
+						"url": "https://security.paloaltonetworks.com/CVE-2024-0008",
+						"tags": [
+							"Vendor Advisory"
+						]
 					}
 				],
 				"published": "2024-02-14T18:15:47.31Z",

--- a/pkg/extract/nvd/feed/cve/v2/v2.go
+++ b/pkg/extract/nvd/feed/cve/v2/v2.go
@@ -386,6 +386,7 @@ func (e extractor) buildData(fetched cveTypes.CVE) (dataTypes.Data, error) {
 							refs = append(refs, referenceTypes.Reference{
 								Source: r.Source,
 								URL:    r.URL,
+								Tags:   r.Tags,
 							})
 						}
 						return refs

--- a/pkg/extract/oracle/linux/linux.go
+++ b/pkg/extract/oracle/linux/linux.go
@@ -265,6 +265,7 @@ func (e extractor) extract(def linux.Definition) (dataTypes.Data, error) {
 						refs = append(refs, referenceTypes.Reference{
 							Source: "linux.oracle.com/security",
 							URL:    r.RefURL,
+							Title:  r.RefID,
 						})
 					}
 					return refs

--- a/pkg/extract/oracle/linux/testdata/golden/happy/data/2007/ELSA-2007-0057.json
+++ b/pkg/extract/oracle/linux/testdata/golden/happy/data/2007/ELSA-2007-0057.json
@@ -16,15 +16,18 @@
 				"references": [
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/cve/CVE-2007-0493.html"
+						"url": "https://linux.oracle.com/cve/CVE-2007-0493.html",
+						"title": "CVE-2007-0493"
 					},
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/cve/CVE-2007-0494.html"
+						"url": "https://linux.oracle.com/cve/CVE-2007-0494.html",
+						"title": "CVE-2007-0494"
 					},
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/errata/ELSA-2007-0057.html"
+						"url": "https://linux.oracle.com/errata/ELSA-2007-0057.html",
+						"title": "ELSA-2007-0057"
 					}
 				],
 				"published": "2007-06-26T00:00:00Z"

--- a/pkg/extract/oracle/linux/testdata/golden/happy/data/2023/ELSA-2023-12342.json
+++ b/pkg/extract/oracle/linux/testdata/golden/happy/data/2023/ELSA-2023-12342.json
@@ -16,15 +16,18 @@
 				"references": [
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/cve/CVE-2022-4144.html"
+						"url": "https://linux.oracle.com/cve/CVE-2022-4144.html",
+						"title": "CVE-2022-4144"
 					},
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/cve/CVE-2023-0664.html"
+						"url": "https://linux.oracle.com/cve/CVE-2023-0664.html",
+						"title": "CVE-2023-0664"
 					},
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/errata/ELSA-2023-12342.html"
+						"url": "https://linux.oracle.com/errata/ELSA-2023-12342.html",
+						"title": "ELSA-2023-12342"
 					}
 				],
 				"published": "2023-05-15T00:00:00Z"

--- a/pkg/extract/oracle/linux/testdata/golden/majormixed/data/2024/ELSA-2024-1828.json
+++ b/pkg/extract/oracle/linux/testdata/golden/majormixed/data/2024/ELSA-2024-1828.json
@@ -16,19 +16,23 @@
 				"references": [
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/cve/CVE-2024-21011.html"
+						"url": "https://linux.oracle.com/cve/CVE-2024-21011.html",
+						"title": "CVE-2024-21011"
 					},
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/cve/CVE-2024-21012.html"
+						"url": "https://linux.oracle.com/cve/CVE-2024-21012.html",
+						"title": "CVE-2024-21012"
 					},
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/cve/CVE-2024-21068.html"
+						"url": "https://linux.oracle.com/cve/CVE-2024-21068.html",
+						"title": "CVE-2024-21068"
 					},
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/errata/ELSA-2024-1828.html"
+						"url": "https://linux.oracle.com/errata/ELSA-2024-1828.html",
+						"title": "ELSA-2024-1828"
 					}
 				],
 				"published": "2024-04-23T00:00:00Z"

--- a/pkg/extract/oracle/linux/testdata/golden/modularitylabel-stream-reversed/data/2024/ELSA-2024-4197.json
+++ b/pkg/extract/oracle/linux/testdata/golden/modularitylabel-stream-reversed/data/2024/ELSA-2024-4197.json
@@ -16,11 +16,13 @@
 				"references": [
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/cve/CVE-2023-38709.html"
+						"url": "https://linux.oracle.com/cve/CVE-2023-38709.html",
+						"title": "CVE-2023-38709"
 					},
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/errata/ELSA-2024-4197.html"
+						"url": "https://linux.oracle.com/errata/ELSA-2024-4197.html",
+						"title": "ELSA-2024-4197"
 					}
 				],
 				"published": "2024-07-01T00:00:00Z"

--- a/pkg/extract/oracle/linux/testdata/golden/modularitylabel/data/2024/ELSA-2024-4197.json
+++ b/pkg/extract/oracle/linux/testdata/golden/modularitylabel/data/2024/ELSA-2024-4197.json
@@ -16,11 +16,13 @@
 				"references": [
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/cve/CVE-2023-38709.html"
+						"url": "https://linux.oracle.com/cve/CVE-2023-38709.html",
+						"title": "CVE-2023-38709"
 					},
 					{
 						"source": "linux.oracle.com/security",
-						"url": "https://linux.oracle.com/errata/ELSA-2024-4197.html"
+						"url": "https://linux.oracle.com/errata/ELSA-2024-4197.html",
+						"title": "ELSA-2024-4197"
 					}
 				],
 				"published": "2024-07-01T00:00:00Z"

--- a/pkg/extract/paloalto/json/json.go
+++ b/pkg/extract/paloalto/json/json.go
@@ -332,10 +332,15 @@ func cwes(fetched paloaltoJSON.CVE) []cweTypes.CWE {
 func references(fetched paloaltoJSON.CVE) []referenceTypes.Reference {
 	refs := make([]referenceTypes.Reference, 0, len(fetched.Containers.CNA.References))
 	for _, r := range fetched.Containers.CNA.References {
-		refs = append(refs, referenceTypes.Reference{
+		ref := referenceTypes.Reference{
 			Source: "security.paloaltonetworks.com",
 			URL:    r.URL,
-		})
+			Tags:   r.Tags,
+		}
+		if r.Name != nil {
+			ref.Title = *r.Name
+		}
+		refs = append(refs, ref)
 	}
 	return refs
 }

--- a/pkg/extract/paloalto/json/testdata/golden/data/2016/CVE-2016-5195.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2016/CVE-2016-5195.json
@@ -56,7 +56,10 @@
 				"references": [
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://security.paloaltonetworks.com/CVE-2016-5195"
+						"url": "https://security.paloaltonetworks.com/CVE-2016-5195",
+						"tags": [
+							"x_refsource_CONFIRM"
+						]
 					}
 				],
 				"published": "2017-02-21T19:30:00Z"

--- a/pkg/extract/paloalto/json/testdata/golden/data/2020/CVE-2020-1968.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2020/CVE-2020-1968.json
@@ -45,11 +45,17 @@
 				"references": [
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2020-1968"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2020-1968",
+						"tags": [
+							"x_refsource_CONFIRM"
+						]
 					},
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://security.paloaltonetworks.com/CVE-2020-1968"
+						"url": "https://security.paloaltonetworks.com/CVE-2020-1968",
+						"tags": [
+							"x_refsource_CONFIRM"
+						]
 					}
 				],
 				"published": "2021-10-13T16:00:00Z",

--- a/pkg/extract/paloalto/json/testdata/golden/data/2024/CVE-2024-0012.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2024/CVE-2024-0012.json
@@ -52,7 +52,10 @@
 				"references": [
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://security.paloaltonetworks.com/CVE-2024-0012"
+						"url": "https://security.paloaltonetworks.com/CVE-2024-0012",
+						"tags": [
+							"vendor-advisory"
+						]
 					}
 				],
 				"published": "2024-11-18T14:20:00Z"

--- a/pkg/extract/paloalto/json/testdata/golden/data/2024/CVE-2024-3393.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2024/CVE-2024-3393.json
@@ -40,7 +40,10 @@
 				"references": [
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://security.paloaltonetworks.com/CVE-2024-3393"
+						"url": "https://security.paloaltonetworks.com/CVE-2024-3393",
+						"tags": [
+							"vendor-advisory"
+						]
 					}
 				],
 				"published": "2024-12-27T02:30:00Z"

--- a/pkg/extract/paloalto/json/testdata/golden/data/2024/CVE-2024-3400.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2024/CVE-2024-3400.json
@@ -41,19 +41,31 @@
 				"references": [
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://security.paloaltonetworks.com/CVE-2024-3400"
+						"url": "https://security.paloaltonetworks.com/CVE-2024-3400",
+						"tags": [
+							"x_refsource_CONFIRM"
+						]
 					},
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://unit42.paloaltonetworks.com/cve-2024-3400/"
+						"url": "https://unit42.paloaltonetworks.com/cve-2024-3400/",
+						"tags": [
+							"x_refsource_CONFIRM"
+						]
 					},
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://www.paloaltonetworks.com/blog/2024/04/more-on-the-pan-os-cve/"
+						"url": "https://www.paloaltonetworks.com/blog/2024/04/more-on-the-pan-os-cve/",
+						"tags": [
+							"x_refsource_CONFIRM"
+						]
 					},
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://www.volexity.com/blog/2024/04/12/zero-day-exploitation-of-unauthenticated-remote-code-execution-vulnerability-in-globalprotect-cve-2024-3400/"
+						"url": "https://www.volexity.com/blog/2024/04/12/zero-day-exploitation-of-unauthenticated-remote-code-execution-vulnerability-in-globalprotect-cve-2024-3400/",
+						"tags": [
+							"x_refsource_CONFIRM"
+						]
 					}
 				],
 				"published": "2024-04-12T06:55:00Z",

--- a/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-0114.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-0114.json
@@ -40,7 +40,10 @@
 				"references": [
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://security.paloaltonetworks.com/CVE-2025-0114"
+						"url": "https://security.paloaltonetworks.com/CVE-2025-0114",
+						"tags": [
+							"vendor-advisory"
+						]
 					}
 				],
 				"published": "2025-03-12T16:00:00Z"

--- a/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-4619.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-4619.json
@@ -40,7 +40,10 @@
 				"references": [
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://security.paloaltonetworks.com/CVE-2025-4619"
+						"url": "https://security.paloaltonetworks.com/CVE-2025-4619",
+						"tags": [
+							"vendor-advisory"
+						]
 					}
 				],
 				"published": "2025-11-12T17:00:00Z"

--- a/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-99999.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2025/CVE-2025-99999.json
@@ -40,7 +40,10 @@
 				"references": [
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://security.paloaltonetworks.com/CVE-2025-99999"
+						"url": "https://security.paloaltonetworks.com/CVE-2025-99999",
+						"tags": [
+							"vendor-advisory"
+						]
 					}
 				],
 				"published": "2025-03-12T16:00:00Z"

--- a/pkg/extract/paloalto/json/testdata/golden/data/2025/PAN-SA-2025-0007.json
+++ b/pkg/extract/paloalto/json/testdata/golden/data/2025/PAN-SA-2025-0007.json
@@ -32,7 +32,10 @@
 				"references": [
 					{
 						"source": "security.paloaltonetworks.com",
-						"url": "https://security.paloaltonetworks.com/PAN-SA-2025-0007"
+						"url": "https://security.paloaltonetworks.com/PAN-SA-2025-0007",
+						"tags": [
+							"vendor-advisory"
+						]
 					}
 				],
 				"published": "2025-03-12T16:00:00Z"

--- a/pkg/extract/redhat/csaf/csaf.go
+++ b/pkg/extract/redhat/csaf/csaf.go
@@ -219,6 +219,7 @@ func (e extractor) extract(adv csaf.CSAF, c2r map[string][]string) (dataTypes.Da
 				rs = append(rs, referenceTypes.Reference{
 					Source: "secalert@redhat.com",
 					URL:    r.URL,
+					Title:  r.Summary,
 				})
 			}
 			return rs
@@ -771,6 +772,7 @@ func walkVulnerabilities(vulns []csaf.Vulnerability, pids []csaf.ProductID) (map
 					rs = append(rs, referenceTypes.Reference{
 						Source: "secalert@redhat.com",
 						URL:    r.URL,
+						Title:  r.Summary,
 					})
 				}
 				return rs

--- a/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2023/RHSA-2023%3A6939.json
+++ b/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2023/RHSA-2023%3A6939.json
@@ -16,191 +16,238 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.9_release_notes/index"
+						"url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.9_release_notes/index",
+						"title": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.9_release_notes/index"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2023:6939"
+						"url": "https://access.redhat.com/errata/RHSA-2023:6939",
+						"title": "https://access.redhat.com/errata/RHSA-2023:6939"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/updates/classification/#moderate"
+						"url": "https://access.redhat.com/security/updates/classification/#moderate",
+						"title": "https://access.redhat.com/security/updates/classification/#moderate"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2066138"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2066138",
+						"title": "2066138"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2144541"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2144541",
+						"title": "2144541"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2163037"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2163037",
+						"title": "2163037"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2165744"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2165744",
+						"title": "2165744"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2166195"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2166195",
+						"title": "2166195"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173082"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173082",
+						"title": "2173082"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2174485"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2174485",
+						"title": "2174485"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2175721"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2175721",
+						"title": "2175721"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2175794"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2175794",
+						"title": "2175794"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178358"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178358",
+						"title": "2178358"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178488"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178488",
+						"title": "2178488"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178492"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178492",
+						"title": "2178492"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2179449"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2179449",
+						"title": "2179449"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2179465"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2179465",
+						"title": "2179465"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2180104"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2180104",
+						"title": "2180104"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2180118"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2180118",
+						"title": "2180118"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2181521"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2181521",
+						"title": "2181521"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182052"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182052",
+						"title": "2182052"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182883"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182883",
+						"title": "2182883"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182884"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182884",
+						"title": "2182884"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182894"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182894",
+						"title": "2182894"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2183041"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2183041",
+						"title": "2183041"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2183596"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2183596",
+						"title": "2183596"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184481"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184481",
+						"title": "2184481"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184482"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184482",
+						"title": "2184482"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184483"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184483",
+						"title": "2184483"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184484"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184484",
+						"title": "2184484"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2188524"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2188524",
+						"title": "2188524"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2189578"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2189578",
+						"title": "2189578"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2192977"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2192977",
+						"title": "2192977"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196026"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196026",
+						"title": "2196026"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196027"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196027",
+						"title": "2196027"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196029"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196029",
+						"title": "2196029"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2216700"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2216700",
+						"title": "2216700"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2218315"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2218315",
+						"title": "2218315"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2220931"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2220931",
+						"title": "2220931"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2222167"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2222167",
+						"title": "2222167"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2228689"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2228689",
+						"title": "2228689"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2229746"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2229746",
+						"title": "2229746"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2232127"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2232127",
+						"title": "2232127"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2233218"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2233218",
+						"title": "2233218"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/RHEL-3126"
+						"url": "https://issues.redhat.com/browse/RHEL-3126",
+						"title": "RHEL-3126"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/RHEL-3149"
+						"url": "https://issues.redhat.com/browse/RHEL-3149",
+						"title": "RHEL-3149"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://security.access.redhat.com/data/csaf/v2/advisories/2023/rhsa-2023_6939.json"
+						"url": "https://security.access.redhat.com/data/csaf/v2/advisories/2023/rhsa-2023_6939.json",
+						"title": "Canonical URL"
 					}
 				],
 				"published": "2023-11-14T16:03:32Z",
@@ -251,35 +298,43 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-3064"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-3064",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2163037"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2163037",
+						"title": "RHBZ#2163037"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/advisories/GHSA-6q6q-88xp-6f2r"
+						"url": "https://github.com/advisories/GHSA-6q6q-88xp-6f2r",
+						"title": "https://github.com/advisories/GHSA-6q6q-88xp-6f2r"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/go-yaml/yaml/commit/f221b8435cfb71e54062f6c6e99e9ade30b124d5"
+						"url": "https://github.com/go-yaml/yaml/commit/f221b8435cfb71e54062f6c6e99e9ade30b124d5",
+						"title": "https://github.com/go-yaml/yaml/commit/f221b8435cfb71e54062f6c6e99e9ade30b124d5"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/go-yaml/yaml/releases/tag/v2.2.4"
+						"url": "https://github.com/go-yaml/yaml/releases/tag/v2.2.4",
+						"title": "https://github.com/go-yaml/yaml/releases/tag/v2.2.4"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3064"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3064",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2022-3064"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pkg.go.dev/vuln/GO-2022-0956"
+						"url": "https://pkg.go.dev/vuln/GO-2022-0956",
+						"title": "https://pkg.go.dev/vuln/GO-2022-0956"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-3064"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-3064",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2022-3064"
 					}
 				],
 				"published": "2022-08-29T00:00:00Z"
@@ -327,47 +382,58 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-41723"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-41723",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178358"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178358",
+						"title": "RHBZ#2178358"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/advisories/GHSA-vvpx-j8f3-3w6h"
+						"url": "https://github.com/advisories/GHSA-vvpx-j8f3-3w6h",
+						"title": "https://github.com/advisories/GHSA-vvpx-j8f3-3w6h"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/cl/468135"
+						"url": "https://go.dev/cl/468135",
+						"title": "https://go.dev/cl/468135"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/cl/468295"
+						"url": "https://go.dev/cl/468295",
+						"title": "https://go.dev/cl/468295"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/issue/57855"
+						"url": "https://go.dev/issue/57855",
+						"title": "https://go.dev/issue/57855"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E"
+						"url": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E",
+						"title": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41723"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41723",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2022-41723"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pkg.go.dev/vuln/GO-2023-1571"
+						"url": "https://pkg.go.dev/vuln/GO-2023-1571",
+						"title": "https://pkg.go.dev/vuln/GO-2023-1571"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://vuln.go.dev/ID/GO-2023-1571.json"
+						"url": "https://vuln.go.dev/ID/GO-2023-1571.json",
+						"title": "https://vuln.go.dev/ID/GO-2023-1571.json"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-41723"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-41723",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2022-41723"
 					}
 				],
 				"published": "2023-02-17T14:00:00Z"
@@ -415,35 +481,43 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-41724"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-41724",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178492"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178492",
+						"title": "RHBZ#2178492"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/cl/468125"
+						"url": "https://go.dev/cl/468125",
+						"title": "https://go.dev/cl/468125"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/issue/58001"
+						"url": "https://go.dev/issue/58001",
+						"title": "https://go.dev/issue/58001"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E"
+						"url": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E",
+						"title": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41724"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41724",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2022-41724"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pkg.go.dev/vuln/GO-2023-1570"
+						"url": "https://pkg.go.dev/vuln/GO-2023-1570",
+						"title": "https://pkg.go.dev/vuln/GO-2023-1570"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-41724"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-41724",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2022-41724"
 					}
 				],
 				"published": "2023-02-15T00:00:00Z"
@@ -491,35 +565,43 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-41725"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-41725",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178488"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2178488",
+						"title": "RHBZ#2178488"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/cl/468124"
+						"url": "https://go.dev/cl/468124",
+						"title": "https://go.dev/cl/468124"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/issue/58006"
+						"url": "https://go.dev/issue/58006",
+						"title": "https://go.dev/issue/58006"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E"
+						"url": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E",
+						"title": "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41725"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-41725",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2022-41725"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pkg.go.dev/vuln/GO-2023-1569"
+						"url": "https://pkg.go.dev/vuln/GO-2023-1569",
+						"title": "https://pkg.go.dev/vuln/GO-2023-1569"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2022-41725"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2022-41725",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2022-41725"
 					}
 				],
 				"published": "2023-02-15T00:00:00Z"
@@ -567,27 +649,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24534"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24534",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184483"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184483",
+						"title": "RHBZ#2184483"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/issue/58975"
+						"url": "https://go.dev/issue/58975",
+						"title": "https://go.dev/issue/58975"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8"
+						"url": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8",
+						"title": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24534"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24534",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24534"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24534"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24534",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24534"
 					}
 				],
 				"published": "2023-04-04T00:00:00Z"
@@ -641,27 +729,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24536"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24536",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184482"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184482",
+						"title": "RHBZ#2184482"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/issue/59153"
+						"url": "https://go.dev/issue/59153",
+						"title": "https://go.dev/issue/59153"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8"
+						"url": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8",
+						"title": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24536"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24536",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24536"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24536"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24536",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24536"
 					}
 				],
 				"published": "2023-04-04T00:00:00Z"
@@ -709,27 +803,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24537"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24537",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184484"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184484",
+						"title": "RHBZ#2184484"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/golang/go/issues/59180"
+						"url": "https://github.com/golang/go/issues/59180",
+						"title": "https://github.com/golang/go/issues/59180"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8"
+						"url": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8",
+						"title": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24537"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24537",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24537"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24537"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24537",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24537"
 					}
 				],
 				"published": "2023-04-04T00:00:00Z"
@@ -783,27 +883,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24538"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24538",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184481"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2184481",
+						"title": "RHBZ#2184481"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/golang/go/issues/59234"
+						"url": "https://github.com/golang/go/issues/59234",
+						"title": "https://github.com/golang/go/issues/59234"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8"
+						"url": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8",
+						"title": "https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24538"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24538",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24538"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24538"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24538",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24538"
 					}
 				],
 				"published": "2023-04-04T00:00:00Z"
@@ -857,27 +963,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24539"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24539",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196026"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196026",
+						"title": "RHBZ#2196026"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/golang/go/issues/59720"
+						"url": "https://github.com/golang/go/issues/59720",
+						"title": "https://github.com/golang/go/issues/59720"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU"
+						"url": "https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU",
+						"title": "https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24539"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24539",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24539"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24539"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24539",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24539"
 					}
 				],
 				"published": "2023-04-20T00:00:00Z"
@@ -931,27 +1043,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24540"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24540",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196027"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196027",
+						"title": "RHBZ#2196027"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/issue/59721"
+						"url": "https://go.dev/issue/59721",
+						"title": "https://go.dev/issue/59721"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU"
+						"url": "https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU",
+						"title": "https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24540"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24540",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24540"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24540"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24540",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24540"
 					}
 				],
 				"published": "2023-04-20T00:00:00Z"
@@ -999,39 +1117,48 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-25173"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-25173",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2174485"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2174485",
+						"title": "RHBZ#2174485"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/containerd/containerd/commit/133f6bb6cd827ce35a5fb279c1ead12b9d21460a"
+						"url": "https://github.com/containerd/containerd/commit/133f6bb6cd827ce35a5fb279c1ead12b9d21460a",
+						"title": "https://github.com/containerd/containerd/commit/133f6bb6cd827ce35a5fb279c1ead12b9d21460a"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/containerd/containerd/releases/tag/v1.5.18"
+						"url": "https://github.com/containerd/containerd/releases/tag/v1.5.18",
+						"title": "https://github.com/containerd/containerd/releases/tag/v1.5.18"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/containerd/containerd/releases/tag/v1.6.18"
+						"url": "https://github.com/containerd/containerd/releases/tag/v1.6.18",
+						"title": "https://github.com/containerd/containerd/releases/tag/v1.6.18"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/containerd/containerd/security/advisories/GHSA-hmfx-3pcx-653p"
+						"url": "https://github.com/containerd/containerd/security/advisories/GHSA-hmfx-3pcx-653p",
+						"title": "https://github.com/containerd/containerd/security/advisories/GHSA-hmfx-3pcx-653p"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25173"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25173",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-25173"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.benthamsgaze.org/2022/08/22/vulnerability-in-linux-containers-investigation-and-mitigation/"
+						"url": "https://www.benthamsgaze.org/2022/08/22/vulnerability-in-linux-containers-investigation-and-mitigation/",
+						"title": "https://www.benthamsgaze.org/2022/08/22/vulnerability-in-linux-containers-investigation-and-mitigation/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-25173"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-25173",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-25173"
 					}
 				],
 				"published": "2023-02-15T00:00:00Z"
@@ -1085,27 +1212,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-25809"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-25809",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182884"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182884",
+						"title": "RHBZ#2182884"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/opencontainers/runc/commit/0d62b950e60f6980b54fe3bafd9a9c608dc1df17"
+						"url": "https://github.com/opencontainers/runc/commit/0d62b950e60f6980b54fe3bafd9a9c608dc1df17",
+						"title": "https://github.com/opencontainers/runc/commit/0d62b950e60f6980b54fe3bafd9a9c608dc1df17"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/opencontainers/runc/security/advisories/GHSA-m8cg-xc2p-r3fc"
+						"url": "https://github.com/opencontainers/runc/security/advisories/GHSA-m8cg-xc2p-r3fc",
+						"title": "https://github.com/opencontainers/runc/security/advisories/GHSA-m8cg-xc2p-r3fc"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25809"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25809",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-25809"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-25809"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-25809",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-25809"
 					}
 				],
 				"published": "2023-03-29T00:00:00Z"
@@ -1153,31 +1286,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-27561"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-27561",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2175721"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2175721",
+						"title": "RHBZ#2175721"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gist.github.com/LiveOverflow/c937820b688922eb127fb760ce06dab9"
+						"url": "https://gist.github.com/LiveOverflow/c937820b688922eb127fb760ce06dab9",
+						"title": "https://gist.github.com/LiveOverflow/c937820b688922eb127fb760ce06dab9"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/opencontainers/runc/issues/2197#issuecomment-1437617334"
+						"url": "https://github.com/opencontainers/runc/issues/2197#issuecomment-1437617334",
+						"title": "https://github.com/opencontainers/runc/issues/2197#issuecomment-1437617334"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/opencontainers/runc/issues/3751"
+						"url": "https://github.com/opencontainers/runc/issues/3751",
+						"title": "https://github.com/opencontainers/runc/issues/3751"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27561"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27561",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-27561"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-27561"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-27561",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-27561"
 					}
 				],
 				"published": "2023-02-20T00:00:00Z"
@@ -1231,23 +1371,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-28642"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-28642",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182883"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2182883",
+						"title": "RHBZ#2182883"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/advisories/GHSA-g2j6-57v7-gm8c"
+						"url": "https://github.com/advisories/GHSA-g2j6-57v7-gm8c",
+						"title": "https://github.com/advisories/GHSA-g2j6-57v7-gm8c"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28642"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28642",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-28642"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-28642"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-28642",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-28642"
 					}
 				],
 				"published": "2023-03-29T00:00:00Z"
@@ -1301,27 +1446,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-29400"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-29400",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196029"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2196029",
+						"title": "RHBZ#2196029"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/issue/59722"
+						"url": "https://go.dev/issue/59722",
+						"title": "https://go.dev/issue/59722"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU"
+						"url": "https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU",
+						"title": "https://groups.google.com/g/golang-announce/c/MEb0UyuSMsU"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-29400"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-29400",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-29400"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-29400"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-29400",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-29400"
 					}
 				],
 				"published": "2023-04-20T00:00:00Z"
@@ -1369,23 +1520,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-29406"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-29406",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2222167"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2222167",
+						"title": "RHBZ#2222167"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/golang-announce/c/2q13H6LEEx0"
+						"url": "https://groups.google.com/g/golang-announce/c/2q13H6LEEx0",
+						"title": "https://groups.google.com/g/golang-announce/c/2q13H6LEEx0"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-29406"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-29406",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-29406"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-29406"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-29406",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-29406"
 					}
 				],
 				"published": "2023-07-11T00:00:00Z"
@@ -1433,31 +1589,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-3978"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-3978",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2228689"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2228689",
+						"title": "RHBZ#2228689"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/cl/514896"
+						"url": "https://go.dev/cl/514896",
+						"title": "https://go.dev/cl/514896"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://go.dev/issue/61615"
+						"url": "https://go.dev/issue/61615",
+						"title": "https://go.dev/issue/61615"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-3978"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-3978",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-3978"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pkg.go.dev/vuln/GO-2023-1988"
+						"url": "https://pkg.go.dev/vuln/GO-2023-1988",
+						"title": "https://pkg.go.dev/vuln/GO-2023-1988"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-3978"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-3978",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-3978"
 					}
 				],
 				"published": "2023-08-02T00:00:00Z"

--- a/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2023/RHSA-2023%3A7207.json
+++ b/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2023/RHSA-2023%3A7207.json
@@ -16,23 +16,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2023:7207"
+						"url": "https://access.redhat.com/errata/RHSA-2023:7207",
+						"title": "https://access.redhat.com/errata/RHSA-2023:7207"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/updates/classification/#moderate"
+						"url": "https://access.redhat.com/security/updates/classification/#moderate",
+						"title": "https://access.redhat.com/security/updates/classification/#moderate"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2209497"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2209497",
+						"title": "2209497"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2235527"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2235527",
+						"title": "2235527"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://security.access.redhat.com/data/csaf/v2/advisories/2023/rhsa-2023_7207.json"
+						"url": "https://security.access.redhat.com/data/csaf/v2/advisories/2023/rhsa-2023_7207.json",
+						"title": "Canonical URL"
 					}
 				],
 				"published": "2023-11-14T17:00:58Z",
@@ -83,27 +88,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2020-22217"
+						"url": "https://access.redhat.com/security/cve/CVE-2020-22217",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2235527"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2235527",
+						"title": "RHBZ#2235527"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/c-ares/c-ares/issues/333"
+						"url": "https://github.com/c-ares/c-ares/issues/333",
+						"title": "https://github.com/c-ares/c-ares/issues/333"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/c-ares/c-ares/pull/332"
+						"url": "https://github.com/c-ares/c-ares/pull/332",
+						"title": "https://github.com/c-ares/c-ares/pull/332"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2020-22217"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2020-22217",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2020-22217"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2020-22217"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2020-22217",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2020-22217"
 					}
 				],
 				"published": "2023-08-22T00:00:00Z"
@@ -143,23 +154,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-31130"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-31130",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2209497"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2209497",
+						"title": "RHBZ#2209497"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/c-ares/c-ares/security/advisories/GHSA-x6mf-cxr9-8q6v"
+						"url": "https://github.com/c-ares/c-ares/security/advisories/GHSA-x6mf-cxr9-8q6v",
+						"title": "https://github.com/c-ares/c-ares/security/advisories/GHSA-x6mf-cxr9-8q6v"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-31130"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-31130",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-31130"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-31130"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-31130",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-31130"
 					}
 				],
 				"published": "2023-05-22T00:00:00Z"

--- a/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2023/RHSA-2023%3A7218.json
+++ b/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2023/RHSA-2023%3A7218.json
@@ -16,23 +16,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2023:7218"
+						"url": "https://access.redhat.com/errata/RHSA-2023:7218",
+						"title": "https://access.redhat.com/errata/RHSA-2023:7218"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/updates/classification/#important"
+						"url": "https://access.redhat.com/security/updates/classification/#important",
+						"title": "https://access.redhat.com/security/updates/classification/#important"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/vulnerabilities/RHSB-2023-003"
+						"url": "https://access.redhat.com/security/vulnerabilities/RHSB-2023-003",
+						"title": "https://access.redhat.com/security/vulnerabilities/RHSB-2023-003"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2242803"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2242803",
+						"title": "2242803"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://security.access.redhat.com/data/csaf/v2/advisories/2023/rhsa-2023_7218.json"
+						"url": "https://security.access.redhat.com/data/csaf/v2/advisories/2023/rhsa-2023_7218.json",
+						"title": "Canonical URL"
 					}
 				],
 				"published": "2023-11-15T01:02:10Z",

--- a/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2023/RHSA-2023%3A7700.json
+++ b/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2023/RHSA-2023%3A7700.json
@@ -16,79 +16,98 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/articles/4966181"
+						"url": "https://access.redhat.com/articles/4966181",
+						"title": "https://access.redhat.com/articles/4966181"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/documentation/en-us/red_hat_build_of_quarkus/2.13/"
+						"url": "https://access.redhat.com/documentation/en-us/red_hat_build_of_quarkus/2.13/",
+						"title": "https://access.redhat.com/documentation/en-us/red_hat_build_of_quarkus/2.13/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2023:7700"
+						"url": "https://access.redhat.com/errata/RHSA-2023:7700",
+						"title": "https://access.redhat.com/errata/RHSA-2023:7700"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/updates/classification/#important"
+						"url": "https://access.redhat.com/security/updates/classification/#important",
+						"title": "https://access.redhat.com/security/updates/classification/#important"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2215229"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2215229",
+						"title": "2215229"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2215393"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2215393",
+						"title": "2215393"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2215394"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2215394",
+						"title": "2215394"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2215445"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2215445",
+						"title": "2215445"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2216888"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2216888",
+						"title": "2216888"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240036"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240036",
+						"title": "2240036"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2241722"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2241722",
+						"title": "2241722"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2242521"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2242521",
+						"title": "2242521"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2246370"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2246370",
+						"title": "2246370"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2253113"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2253113",
+						"title": "2253113"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/QUARKUS-3781"
+						"url": "https://issues.redhat.com/browse/QUARKUS-3781",
+						"title": "QUARKUS-3781"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/QUARKUS-3782"
+						"url": "https://issues.redhat.com/browse/QUARKUS-3782",
+						"title": "QUARKUS-3782"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/QUARKUS-3785"
+						"url": "https://issues.redhat.com/browse/QUARKUS-3785",
+						"title": "QUARKUS-3785"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/QUARKUS-3787"
+						"url": "https://issues.redhat.com/browse/QUARKUS-3787",
+						"title": "QUARKUS-3787"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://security.access.redhat.com/data/csaf/v2/advisories/2023/rhsa-2023_7700.json"
+						"url": "https://security.access.redhat.com/data/csaf/v2/advisories/2023/rhsa-2023_7700.json",
+						"title": "Canonical URL"
 					}
 				],
 				"published": "2023-12-07T14:26:37Z",

--- a/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2025/RHSA-2025%3A2399.json
+++ b/pkg/extract/redhat/csaf/testdata/golden/data/RHSA/2025/RHSA-2025%3A2399.json
@@ -16,95 +16,118 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/documentation/en-us/red_hat_satellite/6.16/html/updating_red_hat_satellite/index"
+						"url": "https://access.redhat.com/documentation/en-us/red_hat_satellite/6.16/html/updating_red_hat_satellite/index",
+						"title": "https://access.redhat.com/documentation/en-us/red_hat_satellite/6.16/html/updating_red_hat_satellite/index"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2025:2399"
+						"url": "https://access.redhat.com/errata/RHSA-2025:2399",
+						"title": "https://access.redhat.com/errata/RHSA-2025:2399"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/updates/classification/#moderate"
+						"url": "https://access.redhat.com/security/updates/classification/#moderate",
+						"title": "https://access.redhat.com/security/updates/classification/#moderate"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2333856"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2333856",
+						"title": "2333856"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2337996"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2337996",
+						"title": "2337996"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30027"
+						"url": "https://issues.redhat.com/browse/SAT-30027",
+						"title": "SAT-30027"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30099"
+						"url": "https://issues.redhat.com/browse/SAT-30099",
+						"title": "SAT-30099"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30256"
+						"url": "https://issues.redhat.com/browse/SAT-30256",
+						"title": "SAT-30256"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30283"
+						"url": "https://issues.redhat.com/browse/SAT-30283",
+						"title": "SAT-30283"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30293"
+						"url": "https://issues.redhat.com/browse/SAT-30293",
+						"title": "SAT-30293"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30294"
+						"url": "https://issues.redhat.com/browse/SAT-30294",
+						"title": "SAT-30294"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30918"
+						"url": "https://issues.redhat.com/browse/SAT-30918",
+						"title": "SAT-30918"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30934"
+						"url": "https://issues.redhat.com/browse/SAT-30934",
+						"title": "SAT-30934"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30936"
+						"url": "https://issues.redhat.com/browse/SAT-30936",
+						"title": "SAT-30936"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30937"
+						"url": "https://issues.redhat.com/browse/SAT-30937",
+						"title": "SAT-30937"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30938"
+						"url": "https://issues.redhat.com/browse/SAT-30938",
+						"title": "SAT-30938"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30939"
+						"url": "https://issues.redhat.com/browse/SAT-30939",
+						"title": "SAT-30939"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30940"
+						"url": "https://issues.redhat.com/browse/SAT-30940",
+						"title": "SAT-30940"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30941"
+						"url": "https://issues.redhat.com/browse/SAT-30941",
+						"title": "SAT-30941"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30942"
+						"url": "https://issues.redhat.com/browse/SAT-30942",
+						"title": "SAT-30942"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30954"
+						"url": "https://issues.redhat.com/browse/SAT-30954",
+						"title": "SAT-30954"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://issues.redhat.com/browse/SAT-30955"
+						"url": "https://issues.redhat.com/browse/SAT-30955",
+						"title": "SAT-30955"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://security.access.redhat.com/data/csaf/v2/advisories/2025/rhsa-2025_2399.json"
+						"url": "https://security.access.redhat.com/data/csaf/v2/advisories/2025/rhsa-2025_2399.json",
+						"title": "Canonical URL"
 					}
 				],
 				"published": "2025-03-05T14:29:44Z",
@@ -199,23 +222,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-35195"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-35195",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2282114"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2282114",
+						"title": "RHBZ#2282114"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/psf/requests/security/advisories/GHSA-9wx4-h78v-vm56"
+						"url": "https://github.com/psf/requests/security/advisories/GHSA-9wx4-h78v-vm56",
+						"title": "https://github.com/psf/requests/security/advisories/GHSA-9wx4-h78v-vm56"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-35195"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-35195",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-35195"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-35195"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-35195",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-35195"
 					}
 				],
 				"published": "2024-05-20T00:00:00Z"
@@ -283,31 +311,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56326"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56326",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2333856"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2333856",
+						"title": "RHBZ#2333856"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/pallets/jinja/commit/48b0687e05a5466a91cd5812d604fa37ad0943b4"
+						"url": "https://github.com/pallets/jinja/commit/48b0687e05a5466a91cd5812d604fa37ad0943b4",
+						"title": "https://github.com/pallets/jinja/commit/48b0687e05a5466a91cd5812d604fa37ad0943b4"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/pallets/jinja/releases/tag/3.1.5"
+						"url": "https://github.com/pallets/jinja/releases/tag/3.1.5",
+						"title": "https://github.com/pallets/jinja/releases/tag/3.1.5"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h"
+						"url": "https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h",
+						"title": "https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56326"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56326",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56326"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56326"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56326",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56326"
 					}
 				],
 				"published": "2024-12-23T15:43:49.4Z"
@@ -375,35 +410,43 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "http://www.openwall.com/lists/oss-security/2025/01/14/2"
+						"url": "http://www.openwall.com/lists/oss-security/2025/01/14/2",
+						"title": "http://www.openwall.com/lists/oss-security/2025/01/14/2"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56374"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56374",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2337996"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2337996",
+						"title": "RHBZ#2337996"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://docs.djangoproject.com/en/dev/releases/security/"
+						"url": "https://docs.djangoproject.com/en/dev/releases/security/",
+						"title": "https://docs.djangoproject.com/en/dev/releases/security/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://groups.google.com/g/django-announce"
+						"url": "https://groups.google.com/g/django-announce",
+						"title": "https://groups.google.com/g/django-announce"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56374"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56374",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56374"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56374"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56374",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56374"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.djangoproject.com/weblog/2025/jan/14/security-releases/"
+						"url": "https://www.djangoproject.com/weblog/2025/jan/14/security-releases/",
+						"title": "https://www.djangoproject.com/weblog/2025/jan/14/security-releases/"
 					}
 				],
 				"published": "2025-01-14T00:00:00Z"

--- a/pkg/extract/redhat/cve/cve.go
+++ b/pkg/extract/redhat/cve/cve.go
@@ -258,6 +258,7 @@ func buildReferences(fetched cve.CVE) []referenceTypes.Reference {
 		refs = append(refs, referenceTypes.Reference{
 			Source: "secalert@redhat.com",
 			URL:    fetched.Bugzilla.URL,
+			Title:  fetched.Bugzilla.Description,
 		})
 	}
 

--- a/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-48161.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-48161.json
@@ -37,7 +37,8 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2251025"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2251025",
+						"title": "giflib: Heap-Buffer Overflow during Image Saving in DumpScreen2RGB Function"
 					},
 					{
 						"source": "secalert@redhat.com",

--- a/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6204.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6204.json
@@ -37,7 +37,8 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250896"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250896",
+						"title": "Mozilla: Out-of-bound memory access in WebGL2 blitFramebuffer"
 					},
 					{
 						"source": "secalert@redhat.com",

--- a/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6205.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6205.json
@@ -37,7 +37,8 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250897"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250897",
+						"title": "Mozilla: Use-after-free in MessagePort::Entangled"
 					},
 					{
 						"source": "secalert@redhat.com",

--- a/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6206.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6206.json
@@ -37,7 +37,8 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250898"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250898",
+						"title": "Mozilla: Clickjacking permission prompts using the fullscreen transition"
 					},
 					{
 						"source": "secalert@redhat.com",

--- a/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6207.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2023/CVE-2023-6207.json
@@ -37,7 +37,8 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250899"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250899",
+						"title": "Mozilla: Use-after-free in ReadableByteStreamQueueEntry::Buffer"
 					},
 					{
 						"source": "secalert@redhat.com",

--- a/pkg/extract/redhat/cve/testdata/golden/data/2024/CVE-2024-6923.json
+++ b/pkg/extract/redhat/cve/testdata/golden/data/2024/CVE-2024-6923.json
@@ -35,7 +35,8 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "cpython: python: email module doesn't properly quotes newlines in email headers, allowing header injection"
 					},
 					{
 						"source": "secalert@redhat.com",

--- a/pkg/extract/redhat/oval/v1/testdata/golden/data/RHBA/2019/RHBA-2019%3A4268.json
+++ b/pkg/extract/redhat/oval/v1/testdata/golden/data/RHBA/2019/RHBA-2019%3A4268.json
@@ -16,23 +16,37 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHBA-2019:4268"
+						"url": "https://access.redhat.com/errata/RHBA-2019:4268",
+						"title": "RHBA-2019:4268",
+						"tags": [
+							"RHSA"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2019-10195"
+						"url": "https://access.redhat.com/security/cve/CVE-2019-10195",
+						"title": "CVE-2019-10195",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2019-14867"
+						"url": "https://access.redhat.com/security/cve/CVE-2019-14867",
+						"title": "CVE-2019-14867",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1726223"
+						"url": "https://bugzilla.redhat.com/1726223",
+						"title": "CVE-2019-10195 ipa: Batch API logging user passwords to /var/log/httpd/error_log"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1766920"
+						"url": "https://bugzilla.redhat.com/1766920",
+						"title": "CVE-2019-14867 ipa: Denial of service in IPA server due to wrong use of ber_scanf()"
 					}
 				],
 				"published": "2019-12-17T00:00:00Z",
@@ -85,7 +99,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1726223"
+						"url": "https://bugzilla.redhat.com/1726223",
+						"title": "CVE-2019-10195 ipa: Batch API logging user passwords to /var/log/httpd/error_log"
 					}
 				],
 				"published": "2019-11-26T00:00:00Z"
@@ -135,7 +150,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1766920"
+						"url": "https://bugzilla.redhat.com/1766920",
+						"title": "CVE-2019-14867 ipa: Denial of service in IPA server due to wrong use of ber_scanf()"
 					}
 				],
 				"published": "2019-08-26T00:00:00Z"

--- a/pkg/extract/redhat/oval/v1/testdata/golden/data/RHSA/2019/RHSA-2019%3A0597.json
+++ b/pkg/extract/redhat/oval/v1/testdata/golden/data/RHSA/2019/RHSA-2019%3A0597.json
@@ -16,15 +16,24 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2019:0597"
+						"url": "https://access.redhat.com/errata/RHSA-2019:0597",
+						"title": "RHSA-2019:0597",
+						"tags": [
+							"RHSA"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2019-0816"
+						"url": "https://access.redhat.com/security/cve/CVE-2019-0816",
+						"title": "CVE-2019-0816",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1680165"
+						"url": "https://bugzilla.redhat.com/1680165",
+						"title": "CVE-2019-0816 cloud-init: extra ssh keys added to authorized_keys on the Azure platform"
 					}
 				],
 				"published": "2019-03-18T00:00:00Z",
@@ -77,7 +86,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1680165"
+						"url": "https://bugzilla.redhat.com/1680165",
+						"title": "CVE-2019-0816 cloud-init: extra ssh keys added to authorized_keys on the Azure platform"
 					}
 				],
 				"published": "2019-03-05T00:00:00Z"

--- a/pkg/extract/redhat/oval/v1/testdata/golden/data/RHSA/2019/RHSA-2019%3A0679.json
+++ b/pkg/extract/redhat/oval/v1/testdata/golden/data/RHSA/2019/RHSA-2019%3A0679.json
@@ -16,39 +16,63 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2019:0679"
+						"url": "https://access.redhat.com/errata/RHSA-2019:0679",
+						"title": "RHSA-2019:0679",
+						"tags": [
+							"RHSA"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2019-3855"
+						"url": "https://access.redhat.com/security/cve/CVE-2019-3855",
+						"title": "CVE-2019-3855",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2019-3856"
+						"url": "https://access.redhat.com/security/cve/CVE-2019-3856",
+						"title": "CVE-2019-3856",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2019-3857"
+						"url": "https://access.redhat.com/security/cve/CVE-2019-3857",
+						"title": "CVE-2019-3857",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2019-3863"
+						"url": "https://access.redhat.com/security/cve/CVE-2019-3863",
+						"title": "CVE-2019-3863",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1687303"
+						"url": "https://bugzilla.redhat.com/1687303",
+						"title": "CVE-2019-3855 libssh2: Integer overflow in transport read resulting in out of bounds write"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1687304"
+						"url": "https://bugzilla.redhat.com/1687304",
+						"title": "CVE-2019-3856 libssh2: Integer overflow in keyboard interactive handling resulting in out of bounds write"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1687305"
+						"url": "https://bugzilla.redhat.com/1687305",
+						"title": "CVE-2019-3857 libssh2: Integer overflow in SSH packet processing channel resulting in out of bounds write"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1687313"
+						"url": "https://bugzilla.redhat.com/1687313",
+						"title": "CVE-2019-3863 libssh2: Integer overflow in user authenticate keyboard interactive allows out-of-bounds writes"
 					}
 				],
 				"published": "2019-03-28T00:00:00Z",
@@ -101,7 +125,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1687303"
+						"url": "https://bugzilla.redhat.com/1687303",
+						"title": "CVE-2019-3855 libssh2: Integer overflow in transport read resulting in out of bounds write"
 					}
 				],
 				"published": "2019-03-13T00:00:00Z"
@@ -151,7 +176,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1687304"
+						"url": "https://bugzilla.redhat.com/1687304",
+						"title": "CVE-2019-3856 libssh2: Integer overflow in keyboard interactive handling resulting in out of bounds write"
 					}
 				],
 				"published": "2019-03-13T00:00:00Z"
@@ -201,7 +227,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1687305"
+						"url": "https://bugzilla.redhat.com/1687305",
+						"title": "CVE-2019-3857 libssh2: Integer overflow in SSH packet processing channel resulting in out of bounds write"
 					}
 				],
 				"published": "2019-03-13T00:00:00Z"
@@ -251,7 +278,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1687313"
+						"url": "https://bugzilla.redhat.com/1687313",
+						"title": "CVE-2019-3863 libssh2: Integer overflow in user authenticate keyboard interactive allows out-of-bounds writes"
 					}
 				],
 				"published": "2019-03-13T00:00:00Z"

--- a/pkg/extract/redhat/oval/v1/testdata/golden/data/RHSA/2019/RHSA-2019%3A0983.json
+++ b/pkg/extract/redhat/oval/v1/testdata/golden/data/RHSA/2019/RHSA-2019%3A0983.json
@@ -16,15 +16,24 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2019:0983"
+						"url": "https://access.redhat.com/errata/RHSA-2019:0983",
+						"title": "RHSA-2019:0983",
+						"tags": [
+							"RHSA"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2019-5953"
+						"url": "https://access.redhat.com/security/cve/CVE-2019-5953",
+						"title": "CVE-2019-5953",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1695679"
+						"url": "https://bugzilla.redhat.com/1695679",
+						"title": "CVE-2019-5953 wget: do_conversion() heap-based buffer overflow vulnerability"
 					}
 				],
 				"published": "2019-05-07T00:00:00Z",
@@ -77,7 +86,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1695679"
+						"url": "https://bugzilla.redhat.com/1695679",
+						"title": "CVE-2019-5953 wget: do_conversion() heap-based buffer overflow vulnerability"
 					}
 				],
 				"published": "2019-04-03T00:00:00Z"

--- a/pkg/extract/redhat/oval/v1/testdata/golden/data/RHSA/2019/RHSA-2019%3A1619.json
+++ b/pkg/extract/redhat/oval/v1/testdata/golden/data/RHSA/2019/RHSA-2019%3A1619.json
@@ -16,15 +16,24 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2019:1619"
+						"url": "https://access.redhat.com/errata/RHSA-2019:1619",
+						"title": "RHSA-2019:1619",
+						"tags": [
+							"RHSA"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2019-12735"
+						"url": "https://access.redhat.com/security/cve/CVE-2019-12735",
+						"title": "CVE-2019-12735",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1718308"
+						"url": "https://bugzilla.redhat.com/1718308",
+						"title": "CVE-2019-12735 vim/neovim: ':source!' command allows arbitrary command execution via modelines"
 					}
 				],
 				"published": "2019-06-27T00:00:00Z",
@@ -89,7 +98,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1718308"
+						"url": "https://bugzilla.redhat.com/1718308",
+						"title": "CVE-2019-12735 vim/neovim: ':source!' command allows arbitrary command execution via modelines"
 					}
 				],
 				"published": "2019-06-05T00:00:00Z"

--- a/pkg/extract/redhat/oval/v1/testdata/golden/data/RHSA/2019/RHSA-2019%3A2854.json
+++ b/pkg/extract/redhat/oval/v1/testdata/golden/data/RHSA/2019/RHSA-2019%3A2854.json
@@ -16,15 +16,24 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2019:2854"
+						"url": "https://access.redhat.com/errata/RHSA-2019:2854",
+						"title": "RHSA-2019:2854",
+						"tags": [
+							"RHSA"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2019-14835"
+						"url": "https://access.redhat.com/security/cve/CVE-2019-14835",
+						"title": "CVE-2019-14835",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1750727"
+						"url": "https://bugzilla.redhat.com/1750727",
+						"title": "CVE-2019-14835 kernel: vhost-net: guest to host kernel escape during migration"
 					}
 				],
 				"published": "2019-09-21T00:00:00Z",
@@ -77,7 +86,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/1750727"
+						"url": "https://bugzilla.redhat.com/1750727",
+						"title": "CVE-2019-14835 kernel: vhost-net: guest to host kernel escape during migration"
 					}
 				],
 				"published": "2019-09-17T00:00:00Z"

--- a/pkg/extract/redhat/oval/v1/v1.go
+++ b/pkg/extract/redhat/oval/v1/v1.go
@@ -325,6 +325,7 @@ func (e extractor) extract(name string, def v1.Definition, c2r map[string][]stri
 				content.References = append(content.References, referenceTypes.Reference{
 					Source: "secalert@redhat.com",
 					URL:    b.Href,
+					Title:  b.Text,
 				})
 				m[lhs] = content
 			}
@@ -360,12 +361,20 @@ func (e extractor) extract(name string, def v1.Definition, c2r map[string][]stri
 						refs = append(refs, referenceTypes.Reference{
 							Source: "secalert@redhat.com",
 							URL:    r.RefURL,
+							Title:  r.RefID,
+							Tags: func() []string {
+								if r.Source != "" {
+									return []string{r.Source}
+								}
+								return nil
+							}(),
 						})
 					}
 					for _, b := range def.Metadata.Advisory.Bugzilla {
 						refs = append(refs, referenceTypes.Reference{
 							Source: "secalert@redhat.com",
 							URL:    b.Href,
+							Title:  b.Text,
 						})
 					}
 					return refs

--- a/pkg/extract/redhat/oval/v2/testdata/golden/data/RHSA/2022/RHSA-2022%3A4765.json
+++ b/pkg/extract/redhat/oval/v2/testdata/golden/data/RHSA/2022/RHSA-2022%3A4765.json
@@ -16,23 +16,37 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2022:4765"
+						"url": "https://access.redhat.com/errata/RHSA-2022:4765",
+						"title": "RHSA-2022:4765",
+						"tags": [
+							"RHSA"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-1529"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-1529",
+						"title": "CVE-2022-1529",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-1802"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-1802",
+						"title": "CVE-2022-1802",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2089217"
+						"url": "https://bugzilla.redhat.com/2089217",
+						"title": "CVE-2022-1802 Mozilla: Prototype pollution in Top-Level Await implementation"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2089218"
+						"url": "https://bugzilla.redhat.com/2089218",
+						"title": "CVE-2022-1529 Mozilla: Untrusted input used in JavaScript object indexing, leading to prototype pollution"
 					}
 				],
 				"published": "2022-05-27T00:00:00Z",
@@ -85,7 +99,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2089218"
+						"url": "https://bugzilla.redhat.com/2089218",
+						"title": "CVE-2022-1529 Mozilla: Untrusted input used in JavaScript object indexing, leading to prototype pollution"
 					}
 				],
 				"published": "2022-05-20T00:00:00Z"
@@ -135,7 +150,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2089217"
+						"url": "https://bugzilla.redhat.com/2089217",
+						"title": "CVE-2022-1802 Mozilla: Prototype pollution in Top-Level Await implementation"
 					}
 				],
 				"published": "2022-05-20T00:00:00Z"

--- a/pkg/extract/redhat/oval/v2/testdata/golden/data/RHSA/2022/RHSA-2022%3A4772.json
+++ b/pkg/extract/redhat/oval/v2/testdata/golden/data/RHSA/2022/RHSA-2022%3A4772.json
@@ -16,23 +16,37 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2022:4772"
+						"url": "https://access.redhat.com/errata/RHSA-2022:4772",
+						"title": "RHSA-2022:4772",
+						"tags": [
+							"RHSA"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-1529"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-1529",
+						"title": "CVE-2022-1529",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-1802"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-1802",
+						"title": "CVE-2022-1802",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2089217"
+						"url": "https://bugzilla.redhat.com/2089217",
+						"title": "CVE-2022-1802 Mozilla: Prototype pollution in Top-Level Await implementation"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2089218"
+						"url": "https://bugzilla.redhat.com/2089218",
+						"title": "CVE-2022-1529 Mozilla: Untrusted input used in JavaScript object indexing, leading to prototype pollution"
 					}
 				],
 				"published": "2022-05-27T00:00:00Z",
@@ -85,7 +99,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2089218"
+						"url": "https://bugzilla.redhat.com/2089218",
+						"title": "CVE-2022-1529 Mozilla: Untrusted input used in JavaScript object indexing, leading to prototype pollution"
 					}
 				],
 				"published": "2022-05-20T00:00:00Z"
@@ -135,7 +150,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2089217"
+						"url": "https://bugzilla.redhat.com/2089217",
+						"title": "CVE-2022-1802 Mozilla: Prototype pollution in Top-Level Await implementation"
 					}
 				],
 				"published": "2022-05-20T00:00:00Z"

--- a/pkg/extract/redhat/oval/v2/testdata/golden/data/RHSA/2022/RHSA-2022%3A5214.json
+++ b/pkg/extract/redhat/oval/v2/testdata/golden/data/RHSA/2022/RHSA-2022%3A5214.json
@@ -16,39 +16,63 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2022:5214"
+						"url": "https://access.redhat.com/errata/RHSA-2022:5214",
+						"title": "RHSA-2022:5214",
+						"tags": [
+							"RHSA"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-1012"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-1012",
+						"title": "CVE-2022-1012",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-1966"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-1966",
+						"title": "CVE-2022-1966",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-27666"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-27666",
+						"title": "CVE-2022-27666",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-32250"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-32250",
+						"title": "CVE-2022-32250",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2061633"
+						"url": "https://bugzilla.redhat.com/2061633",
+						"title": "kernel: buffer overflow in IPsec ESP transformation code"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2064604"
+						"url": "https://bugzilla.redhat.com/2064604",
+						"title": "kernel: Small table perturb size in the TCP source port generation algorithm can lead to information leak"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2092427"
+						"url": "https://bugzilla.redhat.com/2092427",
+						"title": "kernel: a use-after-free write in the netfilter subsystem can lead to privilege escalation to root"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2093146"
+						"url": "https://bugzilla.redhat.com/2093146",
+						"title": "kernel: netfilter: nf_tables: incorrect NFT_STATEFUL_EXPR check leads to a use-after-free (write)"
 					}
 				],
 				"published": "2022-06-28T00:00:00Z",

--- a/pkg/extract/redhat/oval/v2/testdata/golden/data/RHSA/2022/RHSA-2022%3A6750.json
+++ b/pkg/extract/redhat/oval/v2/testdata/golden/data/RHSA/2022/RHSA-2022%3A6750.json
@@ -16,15 +16,24 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/errata/RHSA-2022:6750"
+						"url": "https://access.redhat.com/errata/RHSA-2022:6750",
+						"title": "RHSA-2022:6750",
+						"tags": [
+							"RHSA"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2022-3100"
+						"url": "https://access.redhat.com/security/cve/CVE-2022-3100",
+						"title": "CVE-2022-3100",
+						"tags": [
+							"CVE"
+						]
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2125404"
+						"url": "https://bugzilla.redhat.com/2125404",
+						"title": "CVE-2022-3100 openstack-barbican: access policy bypass via query string injection"
 					}
 				],
 				"published": "2022-09-29T00:00:00Z",
@@ -77,7 +86,8 @@
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/2125404"
+						"url": "https://bugzilla.redhat.com/2125404",
+						"title": "CVE-2022-3100 openstack-barbican: access policy bypass via query string injection"
 					}
 				]
 			},

--- a/pkg/extract/redhat/oval/v2/v2.go
+++ b/pkg/extract/redhat/oval/v2/v2.go
@@ -418,6 +418,7 @@ func (e extractor) extract(major, stream string, def v2.Definition, c2r map[stri
 				content.References = append(content.References, referenceTypes.Reference{
 					Source: "secalert@redhat.com",
 					URL:    b.Href,
+					Title:  b.Text,
 				})
 				m[lhs] = content
 			}
@@ -457,12 +458,20 @@ func (e extractor) extract(major, stream string, def v2.Definition, c2r map[stri
 							refs = append(refs, referenceTypes.Reference{
 								Source: "secalert@redhat.com",
 								URL:    r.RefURL,
+								Title:  r.RefID,
+								Tags: func() []string {
+									if r.Source != "" {
+										return []string{r.Source}
+									}
+									return nil
+								}(),
 							})
 						}
 						for _, b := range def.Metadata.Advisory.Bugzilla {
 							refs = append(refs, referenceTypes.Reference{
 								Source: "secalert@redhat.com",
 								URL:    b.Href,
+								Title:  b.Text,
 							})
 						}
 						return refs

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2023/CVE-2023-24329.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2023/CVE-2023-24329.json
@@ -507,23 +507,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -572,23 +577,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -637,23 +647,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -702,23 +717,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -767,23 +787,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -832,23 +857,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -897,23 +927,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -962,23 +997,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1027,23 +1067,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1092,23 +1137,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1157,23 +1207,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1222,23 +1277,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1287,23 +1347,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1352,23 +1417,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1417,23 +1487,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1482,23 +1557,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1547,23 +1627,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1612,23 +1697,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1677,23 +1767,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1742,23 +1837,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1807,23 +1907,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1872,23 +1977,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -1937,23 +2047,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -2002,23 +2117,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -2067,23 +2187,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -2132,23 +2257,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -2197,23 +2327,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -2262,23 +2397,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",
@@ -2327,23 +2467,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-24329"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-24329",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2173917",
+						"title": "RHBZ#2173917"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-24329"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://pointernull.com/security/python-url-parse-problem.html"
+						"url": "https://pointernull.com/security/python-url-parse-problem.html",
+						"title": "https://pointernull.com/security/python-url-parse-problem.html"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-24329",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-24329"
 					}
 				],
 				"published": "2023-02-17T00:00:00Z",

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2023/CVE-2023-6212.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2023/CVE-2023-6212.json
@@ -399,27 +399,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -468,27 +474,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -537,27 +549,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -606,27 +624,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -675,27 +699,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -744,27 +774,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -813,27 +849,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -882,27 +924,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -951,27 +999,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1020,27 +1074,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1089,27 +1149,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1158,27 +1224,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1227,27 +1299,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1296,27 +1374,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1365,27 +1449,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1434,27 +1524,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1503,27 +1599,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1572,27 +1674,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1641,27 +1749,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1710,27 +1824,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",
@@ -1779,27 +1899,33 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6212"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6212",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250902",
+						"title": "RHBZ#2250902"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6212",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-50/#CVE-2023-6212"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
+						"url": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212",
+						"title": "https://www.mozilla.org/en-US/security/advisories/mfsa2023-52/#CVE-2023-6212"
 					}
 				],
 				"published": "2023-11-21T00:00:00Z",

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2023/CVE-2023-6228.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2023/CVE-2023-6228.json
@@ -75,19 +75,23 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240995"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240995",
+						"title": "RHBZ#2240995"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",
@@ -136,19 +140,23 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240995"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240995",
+						"title": "RHBZ#2240995"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",
@@ -197,19 +205,23 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240995"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240995",
+						"title": "RHBZ#2240995"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",
@@ -258,19 +270,23 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240995"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240995",
+						"title": "RHBZ#2240995"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",
@@ -319,19 +335,23 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240995"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2240995",
+						"title": "RHBZ#2240995"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2023/CVE-2023-6238.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2023/CVE-2023-6238.json
@@ -43,19 +43,23 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6238"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6238",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250834"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250834",
+						"title": "RHBZ#2250834"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
 					}
 				],
 				"published": "2023-10-13T00:00:00Z",
@@ -110,19 +114,23 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6238"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6238",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250834"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250834",
+						"title": "RHBZ#2250834"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
 					}
 				],
 				"published": "2023-10-13T00:00:00Z",
@@ -177,19 +185,23 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6238"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6238",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250834"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250834",
+						"title": "RHBZ#2250834"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
 					}
 				],
 				"published": "2023-10-13T00:00:00Z",
@@ -244,19 +256,23 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6238"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6238",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250834"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2250834",
+						"title": "RHBZ#2250834"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
 					}
 				],
 				"published": "2023-10-13T00:00:00Z",

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2024/CVE-2024-56171.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2024/CVE-2024-56171.json
@@ -219,23 +219,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -284,23 +289,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -349,23 +359,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -414,23 +429,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -479,23 +499,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -544,23 +569,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -609,23 +639,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -674,23 +709,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -739,23 +779,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -804,23 +849,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -869,23 +919,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",
@@ -934,23 +989,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-56171"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-56171",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2346416",
+						"title": "RHBZ#2346416"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
+						"url": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828",
+						"title": "https://gitlab.gnome.org/GNOME/libxml2/-/issues/828"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-56171"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-56171",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-56171"
 					}
 				],
 				"published": "2024-01-01T00:00:00Z",

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2024/CVE-2024-6923.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2024/CVE-2024-6923.json
@@ -247,31 +247,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -312,31 +319,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -383,31 +397,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -454,31 +475,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -525,31 +553,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -596,31 +631,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -667,31 +709,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -738,31 +787,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -809,31 +865,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -880,31 +943,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -951,31 +1021,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1022,31 +1099,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1093,31 +1177,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1164,31 +1255,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1235,31 +1333,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1306,31 +1411,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1377,31 +1489,38 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2302255",
+						"title": "RHBZ#2302255"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/issues/121650"
+						"url": "https://github.com/python/cpython/issues/121650",
+						"title": "https://github.com/python/cpython/issues/121650"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://github.com/python/cpython/pull/122233"
+						"url": "https://github.com/python/cpython/pull/122233",
+						"title": "https://github.com/python/cpython/pull/122233"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
+						"url": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/",
+						"title": "https://mail.python.org/archives/list/security-announce@python.org/thread/QH3BUOE2DYQBWP7NAQ7UNHPPOELKISRW/"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2026/CVE-2026-11611.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2026/CVE-2026-11611.json
@@ -37,23 +37,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+						"url": "https://access.redhat.com/security/cve/CVE-2026-11611",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424",
+						"title": "RHBZ#2485424"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600",
+						"title": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
 					}
 				],
 				"published": "2026-04-16T00:00:00Z",
@@ -108,23 +113,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+						"url": "https://access.redhat.com/security/cve/CVE-2026-11611",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424",
+						"title": "RHBZ#2485424"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600",
+						"title": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
 					}
 				],
 				"published": "2026-04-16T00:00:00Z",
@@ -179,23 +189,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+						"url": "https://access.redhat.com/security/cve/CVE-2026-11611",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424",
+						"title": "RHBZ#2485424"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600",
+						"title": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
 					}
 				],
 				"published": "2026-04-16T00:00:00Z",
@@ -250,23 +265,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+						"url": "https://access.redhat.com/security/cve/CVE-2026-11611",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424",
+						"title": "RHBZ#2485424"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600",
+						"title": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
 					}
 				],
 				"published": "2026-04-16T00:00:00Z",
@@ -321,23 +341,28 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2026-11611"
+						"url": "https://access.redhat.com/security/cve/CVE-2026-11611",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2485424",
+						"title": "RHBZ#2485424"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611",
+						"title": "https://nvd.nist.gov/vuln/detail/CVE-2026-11611"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
+						"url": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600",
+						"title": "https://redhat.atlassian.net/browse/PSIRTSUPT-7600"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11611",
+						"title": "https://www.cve.org/CVERecord?id=CVE-2026-11611"
 					}
 				],
 				"published": "2026-04-16T00:00:00Z",

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2026/CVE-2026-7323.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2026/CVE-2026-7323.json
@@ -16,7 +16,8 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2026-7323"
+						"url": "https://access.redhat.com/security/cve/CVE-2026-7323",
+						"title": "Canonical URL"
 					}
 				],
 				"published": "2026-01-19T00:00:00Z",

--- a/pkg/extract/redhat/vex/v1/v1.go
+++ b/pkg/extract/redhat/vex/v1/v1.go
@@ -809,6 +809,7 @@ func walkVulnerabilities(vulns []v1.Vulnerability, pids []v1.ProductID) (map[v1.
 				rs = append(rs, referenceTypes.Reference{
 					Source: "secalert@redhat.com",
 					URL:    r.URL,
+					Title:  r.Summary,
 				})
 			}
 			return rs

--- a/pkg/extract/redhat/vex/v2/testdata/golden/data/2007/CVE-2007-6015.json
+++ b/pkg/extract/redhat/vex/v2/testdata/golden/data/2007/CVE-2007-6015.json
@@ -90,15 +90,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2007-6015"
+						"url": "https://access.redhat.com/security/cve/CVE-2007-6015",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2007-6015"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2007-6015",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2007-6015"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2007-6015",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2007-12-10T15:00:00Z",
@@ -126,15 +129,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2007-6015"
+						"url": "https://access.redhat.com/security/cve/CVE-2007-6015",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2007-6015"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2007-6015",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2007-6015"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2007-6015",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2007-12-10T15:00:00Z",
@@ -162,15 +168,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2007-6015"
+						"url": "https://access.redhat.com/security/cve/CVE-2007-6015",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2007-6015"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2007-6015",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2007-6015"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2007-6015",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2007-12-10T15:00:00Z",

--- a/pkg/extract/redhat/vex/v2/testdata/golden/data/2017/CVE-2017-20146.json
+++ b/pkg/extract/redhat/vex/v2/testdata/golden/data/2017/CVE-2017-20146.json
@@ -37,15 +37,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2017-20146"
+						"url": "https://access.redhat.com/security/cve/CVE-2017-20146",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2017-20146"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2017-20146",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2017-20146"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2017-20146",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2022-12-27T00:00:00Z",
@@ -94,15 +97,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2017-20146"
+						"url": "https://access.redhat.com/security/cve/CVE-2017-20146",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2017-20146"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2017-20146",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2017-20146"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2017-20146",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2022-12-27T00:00:00Z",

--- a/pkg/extract/redhat/vex/v2/testdata/golden/data/2023/CVE-2023-6228.json
+++ b/pkg/extract/redhat/vex/v2/testdata/golden/data/2023/CVE-2023-6228.json
@@ -75,15 +75,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",
@@ -132,15 +135,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",
@@ -189,15 +195,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",
@@ -246,15 +255,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",
@@ -303,15 +315,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",
@@ -360,15 +375,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",
@@ -417,15 +435,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6228"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6228",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6228",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6228",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-09-07T00:00:00Z",

--- a/pkg/extract/redhat/vex/v2/testdata/golden/data/2023/CVE-2023-6238.json
+++ b/pkg/extract/redhat/vex/v2/testdata/golden/data/2023/CVE-2023-6238.json
@@ -37,15 +37,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6238"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6238",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-10-13T00:00:00Z",
@@ -94,15 +97,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6238"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6238",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-10-13T00:00:00Z",
@@ -151,15 +157,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6238"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6238",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-10-13T00:00:00Z",
@@ -208,15 +217,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6238"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6238",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-10-13T00:00:00Z",
@@ -271,15 +283,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2023-6238"
+						"url": "https://access.redhat.com/security/cve/CVE-2023-6238",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6238",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-6238",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2023-10-13T00:00:00Z",

--- a/pkg/extract/redhat/vex/v2/testdata/golden/data/2024/CVE-2024-0056.json
+++ b/pkg/extract/redhat/vex/v2/testdata/golden/data/2024/CVE-2024-0056.json
@@ -165,15 +165,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-0056"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-0056",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-01-09T00:00:00Z",
@@ -222,15 +225,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-0056"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-0056",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-01-09T00:00:00Z",
@@ -279,15 +285,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-0056"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-0056",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-01-09T00:00:00Z",
@@ -336,15 +345,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-0056"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-0056",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-01-09T00:00:00Z",
@@ -393,15 +405,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-0056"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-0056",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-01-09T00:00:00Z",
@@ -450,15 +465,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-0056"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-0056",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-01-09T00:00:00Z",
@@ -507,15 +525,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-0056"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-0056",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0056",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-0056",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-01-09T00:00:00Z",

--- a/pkg/extract/redhat/vex/v2/testdata/golden/data/2024/CVE-2024-6923.json
+++ b/pkg/extract/redhat/vex/v2/testdata/golden/data/2024/CVE-2024-6923.json
@@ -247,15 +247,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -296,15 +299,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -345,15 +351,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -394,15 +403,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -443,15 +455,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -492,15 +507,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -541,15 +559,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -590,15 +611,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -639,15 +663,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -688,15 +715,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -737,15 +767,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -786,15 +819,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -835,15 +871,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -884,15 +923,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -939,15 +981,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -994,15 +1039,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1049,15 +1097,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1104,15 +1155,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1159,15 +1213,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1214,15 +1271,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",
@@ -1269,15 +1329,18 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2024-6923"
+						"url": "https://access.redhat.com/security/cve/CVE-2024-6923",
+						"title": "Canonical URL"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6923",
+						"title": "nvd.nist.gov"
 					},
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923"
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-6923",
+						"title": "www.cve.org"
 					}
 				],
 				"published": "2024-08-01T00:00:00Z",

--- a/pkg/extract/redhat/vex/v2/testdata/golden/data/2026/CVE-2026-7323.json
+++ b/pkg/extract/redhat/vex/v2/testdata/golden/data/2026/CVE-2026-7323.json
@@ -16,7 +16,8 @@
 				"references": [
 					{
 						"source": "secalert@redhat.com",
-						"url": "https://access.redhat.com/security/cve/CVE-2026-7323"
+						"url": "https://access.redhat.com/security/cve/CVE-2026-7323",
+						"title": "Canonical URL"
 					}
 				],
 				"published": "2026-01-19T00:00:00Z",

--- a/pkg/extract/redhat/vex/v2/v2.go
+++ b/pkg/extract/redhat/vex/v2/v2.go
@@ -716,6 +716,7 @@ func walkVulnerabilities(vulns []v2.Vulnerability, pids []v2.ProductID) (map[v2.
 				rs = append(rs, referenceTypes.Reference{
 					Source: "secalert@redhat.com",
 					URL:    r.URL,
+					Title:  r.Summary,
 				})
 			}
 			return rs

--- a/pkg/extract/rocky/errata/errata.go
+++ b/pkg/extract/rocky/errata/errata.go
@@ -358,6 +358,7 @@ func extract(fetched errata.Advisory, raws []string) (dataTypes.Data, error) {
 						rs = append(rs, referenceTypes.Reference{
 							Source: "errata.rockylinux.org",
 							URL:    fix.Source,
+							Title:  fix.Description,
 						})
 					}
 					return rs

--- a/pkg/extract/rocky/errata/testdata/golden/data/RLSA/2023/RLSA-2023%3A2652.json
+++ b/pkg/extract/rocky/errata/testdata/golden/data/RLSA/2023/RLSA-2023%3A2652.json
@@ -24,15 +24,18 @@
 					},
 					{
 						"source": "errata.rockylinux.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2180697"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2180697",
+						"title": "* Command 'pcs config checkpoint diff' does not show configuration differences between checkpoints"
 					},
 					{
 						"source": "errata.rockylinux.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2180704"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2180704",
+						"title": "* Need a way to add a scsi fencing device to a cluster without requiring a restart of all cluster resources"
 					},
 					{
 						"source": "errata.rockylinux.org",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2183180"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2183180",
+						"title": "* [WebUI] fence levels prevent loading of cluster status"
 					},
 					{
 						"source": "errata.rockylinux.org",

--- a/pkg/extract/rocky/osv/osv.go
+++ b/pkg/extract/rocky/osv/osv.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -279,9 +280,18 @@ func extract(fetched osv.OSV, raws []string) (dataTypes.Data, error) {
 		}
 
 		refs, err := func() ([]referenceTypes.Reference, error) {
-			us := make(map[string]struct{})
+			var rs []referenceTypes.Reference
 			for _, r := range fetched.References {
-				us[r.URL] = struct{}{}
+				rs = append(rs, referenceTypes.Reference{
+					URL:    r.URL,
+					Source: "osv.dev/Rocky-Linux",
+					Tags: func() []string {
+						if r.Type == "" {
+							return nil
+						}
+						return []string{r.Type}
+					}(),
+				})
 			}
 
 			dbs, err := parseDatabaseSpecific(fetched.DatabaseSpecific)
@@ -289,7 +299,10 @@ func extract(fetched osv.OSV, raws []string) (dataTypes.Data, error) {
 				return nil, errors.Wrap(err, "get database specific source")
 			}
 			if dbs.Source != "" {
-				us[dbs.Source] = struct{}{}
+				rs = append(rs, referenceTypes.Reference{
+					URL:    dbs.Source,
+					Source: "osv.dev/Rocky-Linux",
+				})
 			}
 
 			for _, a := range fetched.Affected {
@@ -298,18 +311,17 @@ func extract(fetched osv.OSV, raws []string) (dataTypes.Data, error) {
 					return nil, errors.Wrap(err, "get database specific source")
 				}
 				if dbs.Source != "" {
-					us[dbs.Source] = struct{}{}
+					rs = append(rs, referenceTypes.Reference{
+						URL:    dbs.Source,
+						Source: "osv.dev/Rocky-Linux",
+					})
 				}
 			}
 
-			rs := make([]referenceTypes.Reference, 0, len(us))
-			for u := range us {
-				rs = append(rs, referenceTypes.Reference{
-					URL:    u,
-					Source: "osv.dev/Rocky-Linux",
-				})
-			}
-			return rs, nil
+			slices.SortFunc(rs, referenceTypes.Compare)
+			return slices.CompactFunc(rs, func(a, b referenceTypes.Reference) bool {
+				return referenceTypes.Compare(a, b) == 0
+			}), nil
 		}()
 		if err != nil {
 			return advisoryTypes.Advisory{}, errors.Wrap(err, "create references")

--- a/pkg/extract/rocky/osv/testdata/golden/data/RLSA/2023/RLSA-2023%3A0005.json
+++ b/pkg/extract/rocky/osv/testdata/golden/data/RLSA/2023/RLSA-2023%3A0005.json
@@ -24,11 +24,17 @@
 				"references": [
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142707"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2142707",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://errata.rockylinux.org/RLSA-2023:0005"
+						"url": "https://errata.rockylinux.org/RLSA-2023:0005",
+						"tags": [
+							"ADVISORY"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",

--- a/pkg/extract/rocky/osv/testdata/golden/data/RLSA/2024/RLSA-2024%3A8121.json
+++ b/pkg/extract/rocky/osv/testdata/golden/data/RLSA/2024/RLSA-2024%3A8121.json
@@ -9,23 +9,38 @@
 				"references": [
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2251025"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2251025",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2318524"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2318524",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2318530"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2318530",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2318534"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2318534",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://errata.rockylinux.org/RLSA-2024:8121"
+						"url": "https://errata.rockylinux.org/RLSA-2024:8121",
+						"tags": [
+							"ADVISORY"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",

--- a/pkg/extract/rocky/osv/testdata/golden/data/RLSA/2025/RLSA-2025%3A8056.json
+++ b/pkg/extract/rocky/osv/testdata/golden/data/RLSA/2025/RLSA-2025%3A8056.json
@@ -24,19 +24,31 @@
 				"references": [
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2297490"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2297490",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2309801"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2309801",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2348609"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2348609",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://errata.rockylinux.org/RLSA-2025:8056"
+						"url": "https://errata.rockylinux.org/RLSA-2025:8056",
+						"tags": [
+							"ADVISORY"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",

--- a/pkg/extract/rocky/osv/testdata/golden/data/RLSA/2025/RLSA-2025%3A9318.json
+++ b/pkg/extract/rocky/osv/testdata/golden/data/RLSA/2025/RLSA-2025%3A9318.json
@@ -24,15 +24,24 @@
 				"references": [
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=1767483"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=1767483",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2368956"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2368956",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://errata.rockylinux.org/RLSA-2025:9318"
+						"url": "https://errata.rockylinux.org/RLSA-2025:9318",
+						"tags": [
+							"ADVISORY"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",

--- a/pkg/extract/rocky/osv/testdata/golden/data/RXSA/2023/RXSA-2023%3A0101.json
+++ b/pkg/extract/rocky/osv/testdata/golden/data/RXSA/2023/RXSA-2023%3A0101.json
@@ -24,15 +24,24 @@
 				"references": [
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2067482"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2067482",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2147572"
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2147572",
+						"tags": [
+							"REPORT"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",
-						"url": "https://errata.rockylinux.org/RXSA-2023:0101"
+						"url": "https://errata.rockylinux.org/RXSA-2023:0101",
+						"tags": [
+							"ADVISORY"
+						]
 					},
 					{
 						"source": "osv.dev/Rocky-Linux",

--- a/pkg/extract/suse/oval/oval.go
+++ b/pkg/extract/suse/oval/oval.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
-	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -454,7 +453,7 @@ func buildAdvisoryAndVulnerability(def oval.Definition) ([]advisoryContentTypes.
 		})
 	}
 
-	refs := make(map[referenceTypes.Reference]struct{})
+	var refs []referenceTypes.Reference
 
 	for _, cve := range def.Metadata.Advisory.Cve {
 		source, err := func() (string, error) {
@@ -472,10 +471,11 @@ func buildAdvisoryAndVulnerability(def oval.Definition) ([]advisoryContentTypes.
 			return nil, vulnerabilityContentTypes.Content{}, errors.Wrap(err, "determine CVE source")
 		}
 
-		refs[referenceTypes.Reference{
+		refs = append(refs, referenceTypes.Reference{
 			Source: source,
 			URL:    strings.TrimSuffix(strings.TrimSpace(cve.Href), "/"),
-		}] = struct{}{}
+			Title:  strings.TrimSpace(cve.Text),
+		})
 
 		ss, err := buildSeverities(source, cve)
 		if err != nil {
@@ -489,25 +489,28 @@ func buildAdvisoryAndVulnerability(def oval.Definition) ([]advisoryContentTypes.
 		if !strings.HasPrefix(b.Text, "SUSE bug ") {
 			return nil, vulnerabilityContentTypes.Content{}, errors.Errorf("unexpected bugzilla text. expected prefix: %q, actual: %q", "SUSE bug ", b.Text)
 		}
-		refs[referenceTypes.Reference{
+		refs = append(refs, referenceTypes.Reference{
 			Source: "SUSE",
 			URL:    strings.TrimSpace(b.Href),
-		}] = struct{}{}
+			Title:  strings.TrimSpace(b.Text),
+		})
 	}
 
 	var advs []advisoryContentTypes.Content
 	for _, r := range def.Metadata.Reference {
 		switch r.Source {
 		case "SUSE CVE":
-			refs[referenceTypes.Reference{
+			refs = append(refs, referenceTypes.Reference{
 				Source: "SUSE",
 				URL:    strings.TrimSuffix(strings.TrimSpace(r.RefURL), "/"),
-			}] = struct{}{}
+				Title:  r.RefID,
+			})
 		case "CVE":
-			refs[referenceTypes.Reference{
+			refs = append(refs, referenceTypes.Reference{
 				Source: "CVE",
 				URL:    strings.TrimSuffix(strings.TrimSpace(r.RefURL), "/"),
-			}] = struct{}{}
+				Title:  r.RefID,
+			})
 		case "SUSE-SU":
 			if r.RefID == "" {
 				if r.RefURL == "" {
@@ -523,6 +526,7 @@ func buildAdvisoryAndVulnerability(def oval.Definition) ([]advisoryContentTypes.
 					{
 						Source: "SUSE",
 						URL:    strings.TrimSpace(r.RefURL),
+						Title:  r.RefID,
 					},
 				},
 			})
@@ -531,7 +535,10 @@ func buildAdvisoryAndVulnerability(def oval.Definition) ([]advisoryContentTypes.
 		}
 	}
 
-	v.References = slices.Collect(maps.Keys(refs))
+	slices.SortFunc(refs, referenceTypes.Compare)
+	v.References = slices.CompactFunc(refs, func(a, b referenceTypes.Reference) bool {
+		return referenceTypes.Compare(a, b) == 0
+	})
 	return advs, v, nil
 }
 

--- a/pkg/extract/suse/oval/testdata/golden/data/1999/CVE-1999-0077.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/1999/CVE-1999-0077.json
@@ -16,19 +16,28 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0077"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0077",
+						"title": "Mitre CVE-1999-0077"
 					},
 					{
 						"source": "NVD",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-1999-0077"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-1999-0077",
+						"title": "CVE-1999-0077 at NVD"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/954946"
+						"url": "https://bugzilla.suse.com/954946",
+						"title": "SUSE bug 954946"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-1999-0077"
+						"url": "https://www.suse.com/security/cve/CVE-1999-0077",
+						"title": "CVE-1999-0077 at SUSE"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-1999-0077",
+						"title": "SUSE CVE-1999-0077"
 					}
 				],
 				"published": "2024-10-18T00:00:00Z",

--- a/pkg/extract/suse/oval/testdata/golden/data/1999/CVE-1999-0524.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/1999/CVE-1999-0524.json
@@ -16,23 +16,33 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0524"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0524",
+						"title": "Mitre CVE-1999-0524"
 					},
 					{
 						"source": "NVD",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-1999-0524"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-1999-0524",
+						"title": "CVE-1999-0524 at NVD"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/351997"
+						"url": "https://bugzilla.suse.com/351997",
+						"title": "SUSE bug 351997"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/992991"
+						"url": "https://bugzilla.suse.com/992991",
+						"title": "SUSE bug 992991"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-1999-0524"
+						"url": "https://www.suse.com/security/cve/CVE-1999-0524",
+						"title": "CVE-1999-0524 at SUSE"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-1999-0524",
+						"title": "SUSE CVE-1999-0524"
 					}
 				],
 				"published": "2022-05-20T00:00:00Z",

--- a/pkg/extract/suse/oval/testdata/golden/data/2001/CVE-2001-1267.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2001/CVE-2001-1267.json
@@ -8,7 +8,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/opensuse-security-announce/2007-09/msg00003.html"
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2007-09/msg00003.html",
+						"title": "SUSE-SR:2007:019"
 					}
 				]
 			},
@@ -40,23 +41,33 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2001-1267"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2001-1267",
+						"title": "Mitre CVE-2001-1267"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/299738"
+						"url": "https://bugzilla.suse.com/299738",
+						"title": "SUSE bug 299738"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/299745"
+						"url": "https://bugzilla.suse.com/299745",
+						"title": "SUSE bug 299745"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/299747"
+						"url": "https://bugzilla.suse.com/299747",
+						"title": "SUSE bug 299747"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-2001-1267"
+						"url": "https://www.suse.com/security/cve/CVE-2001-1267",
+						"title": "CVE-2001-1267"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-2001-1267",
+						"title": "SUSE CVE-2001-1267"
 					}
 				],
 				"published": "2021-10-02T00:00:00Z",
@@ -76,7 +87,8 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2001-1267"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2001-1267",
+						"title": "CVE-2001-1267"
 					}
 				]
 			},

--- a/pkg/extract/suse/oval/testdata/golden/data/2002/CVE-2002-2443.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2002/CVE-2002-2443.json
@@ -9,7 +9,8 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2002-2443"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2002-2443",
+						"title": "CVE-2002-2443"
 					}
 				]
 			},

--- a/pkg/extract/suse/oval/testdata/golden/data/2005/CVE-2005-1038.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2005/CVE-2005-1038.json
@@ -9,7 +9,8 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2005-1038"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2005-1038",
+						"title": "CVE-2005-1038"
 					}
 				]
 			},

--- a/pkg/extract/suse/oval/testdata/golden/data/2006/CVE-2006-20001.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2006/CVE-2006-20001.json
@@ -8,7 +8,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-February/013732.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-February/013732.html",
+						"title": "SUSE-CU-2023:330-1"
 					}
 				]
 			},
@@ -25,7 +26,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-February/013782.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-February/013782.html",
+						"title": "SUSE-CU-2023:348-1"
 					}
 				]
 			},
@@ -42,7 +44,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-January/013558.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-January/013558.html",
+						"title": "SUSE-SU-2023:0183-1"
 					}
 				]
 			},
@@ -59,7 +62,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-January/013556.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-January/013556.html",
+						"title": "SUSE-SU-2023:0185-1"
 					}
 				]
 			},
@@ -76,7 +80,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-February/013648.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-February/013648.html",
+						"title": "SUSE-SU-2023:0294-1"
 					}
 				]
 			},
@@ -93,7 +98,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-February/013700.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-February/013700.html",
+						"title": "SUSE-SU-2023:0321-1"
 					}
 				]
 			},
@@ -110,7 +116,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-updates/2023-February/027580.html"
+						"url": "https://lists.suse.com/pipermail/sle-updates/2023-February/027580.html",
+						"title": "SUSE-SU-2023:0322-1"
 					}
 				]
 			},
@@ -173,23 +180,33 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2006-20001"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2006-20001",
+						"title": "Mitre CVE-2006-20001"
 					},
 					{
 						"source": "NVD",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2006-20001"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2006-20001",
+						"title": "CVE-2006-20001 at NVD"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1207247"
+						"url": "https://bugzilla.suse.com/1207247",
+						"title": "SUSE bug 1207247"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1217021"
+						"url": "https://bugzilla.suse.com/1217021",
+						"title": "SUSE bug 1217021"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-2006-20001"
+						"url": "https://www.suse.com/security/cve/CVE-2006-20001",
+						"title": "CVE-2006-20001 at SUSE"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-2006-20001",
+						"title": "SUSE CVE-2006-20001"
 					}
 				],
 				"published": "2023-01-19T00:00:00Z",

--- a/pkg/extract/suse/oval/testdata/golden/data/2009/CVE-2009-3547.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2009/CVE-2009-3547.json
@@ -8,7 +8,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00005.html"
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00005.html",
+						"title": "SUSE-SA:2009:054"
 					}
 				]
 			},
@@ -25,7 +26,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00006.html"
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00006.html",
+						"title": "SUSE-SA:2009:055"
 					}
 				]
 			},
@@ -42,7 +44,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00007.html"
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-11/msg00007.html",
+						"title": "SUSE-SA:2009:056"
 					}
 				]
 			},
@@ -59,7 +62,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-12/msg00001.html"
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2009-12/msg00001.html",
+						"title": "SUSE-SA:2009:060"
 					}
 				]
 			},
@@ -76,7 +80,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/opensuse-security-announce/2010-01/msg00000.html"
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2010-01/msg00000.html",
+						"title": "SUSE-SA:2010:001"
 					}
 				]
 			},
@@ -93,7 +98,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/opensuse-security-announce/2010-02/msg00005.html"
+						"url": "https://lists.opensuse.org/opensuse-security-announce/2010-02/msg00005.html",
+						"title": "SUSE-SA:2010:012"
 					}
 				]
 			},
@@ -125,15 +131,23 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3547"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3547",
+						"title": "Mitre CVE-2009-3547"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/550001"
+						"url": "https://bugzilla.suse.com/550001",
+						"title": "SUSE bug 550001"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-2009-3547"
+						"url": "https://www.suse.com/security/cve/CVE-2009-3547",
+						"title": "CVE-2009-3547"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-2009-3547",
+						"title": "SUSE CVE-2009-3547"
 					}
 				],
 				"published": "2022-05-20T00:00:00Z",

--- a/pkg/extract/suse/oval/testdata/golden/data/2010/CVE-2010-2322.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2010/CVE-2010-2322.json
@@ -8,7 +8,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2021-August/009264.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2021-August/009264.html",
+						"title": "SUSE-SU-2021:2635-1"
 					}
 				]
 			},
@@ -25,7 +26,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/AJWN7K3ZWIZYG5QW25KKFIGISFYTG2R3/"
+						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/AJWN7K3ZWIZYG5QW25KKFIGISFYTG2R3/",
+						"title": "openSUSE-SU-2021:1107-1"
 					}
 				]
 			},
@@ -42,7 +44,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/OHWHBBR2CBRHE7HR6PAPJLGHP3QCHYHS/"
+						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/OHWHBBR2CBRHE7HR6PAPJLGHP3QCHYHS/",
+						"title": "openSUSE-SU-2021:2565-1"
 					}
 				]
 			},
@@ -87,15 +90,23 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-2322"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-2322",
+						"title": "Mitre CVE-2010-2322"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1188517"
+						"url": "https://bugzilla.suse.com/1188517",
+						"title": "SUSE bug 1188517"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-2010-2322"
+						"url": "https://www.suse.com/security/cve/CVE-2010-2322",
+						"title": "CVE-2010-2322"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-2010-2322",
+						"title": "SUSE CVE-2010-2322"
 					}
 				],
 				"published": "2021-08-10T00:00:00Z",

--- a/pkg/extract/suse/oval/testdata/golden/data/2012/CVE-2012-5252.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2012/CVE-2012-5252.json
@@ -9,7 +9,8 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name= CVE-2012-5252"
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name= CVE-2012-5252",
+						"title": " CVE-2012-5252"
 					}
 				]
 			},

--- a/pkg/extract/suse/oval/testdata/golden/data/2015/CVE-2015-20107.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2015/CVE-2015-20107.json
@@ -8,7 +8,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-June/011362.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-June/011362.html",
+						"title": "SUSE-CU-2022:1385-1"
 					}
 				]
 			},
@@ -25,7 +26,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011460.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011460.html",
+						"title": "SUSE-CU-2022:1435-1"
 					}
 				]
 			},
@@ -42,7 +44,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011506.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011506.html",
+						"title": "SUSE-CU-2022:1460-1"
 					}
 				]
 			},
@@ -59,7 +62,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011523.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011523.html",
+						"title": "SUSE-CU-2022:1477-1"
 					}
 				]
 			},
@@ -76,7 +80,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011533.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011533.html",
+						"title": "SUSE-CU-2022:1492-1"
 					}
 				]
 			},
@@ -93,7 +98,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011536.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011536.html",
+						"title": "SUSE-CU-2022:1498-1"
 					}
 				]
 			},
@@ -110,7 +116,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011624.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011624.html",
+						"title": "SUSE-CU-2022:1616-1"
 					}
 				]
 			},
@@ -127,7 +134,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-August/011745.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-August/011745.html",
+						"title": "SUSE-CU-2022:1736-1"
 					}
 				]
 			},
@@ -144,7 +152,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-August/011795.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-August/011795.html",
+						"title": "SUSE-CU-2022:1765-1"
 					}
 				]
 			},
@@ -161,7 +170,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-August/011814.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-August/011814.html",
+						"title": "SUSE-CU-2022:1771-1"
 					}
 				]
 			},
@@ -178,7 +188,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-August/011821.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-August/011821.html",
+						"title": "SUSE-CU-2022:1780-1"
 					}
 				]
 			},
@@ -195,7 +206,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-August/011936.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-August/011936.html",
+						"title": "SUSE-CU-2022:1852-1"
 					}
 				]
 			},
@@ -212,7 +224,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-September/012141.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-September/012141.html",
+						"title": "SUSE-CU-2022:2082-1"
 					}
 				]
 			},
@@ -229,7 +242,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-September/012187.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-September/012187.html",
+						"title": "SUSE-CU-2022:2123-1"
 					}
 				]
 			},
@@ -246,7 +260,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-September/012188.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-September/012188.html",
+						"title": "SUSE-CU-2022:2125-1"
 					}
 				]
 			},
@@ -263,7 +278,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-September/012189.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-September/012189.html",
+						"title": "SUSE-CU-2022:2126-1"
 					}
 				]
 			},
@@ -280,7 +296,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-September/012196.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-September/012196.html",
+						"title": "SUSE-CU-2022:2149-1"
 					}
 				]
 			},
@@ -297,7 +314,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-February/013693.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-February/013693.html",
+						"title": "SUSE-CU-2023:322-1"
 					}
 				]
 			},
@@ -314,7 +332,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-March/014080.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-March/014080.html",
+						"title": "SUSE-CU-2023:694-1"
 					}
 				]
 			},
@@ -331,7 +350,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011574.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011574.html",
+						"title": "SUSE-IU-2022:814-1"
 					}
 				]
 			},
@@ -348,7 +368,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011575.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011575.html",
+						"title": "SUSE-IU-2022:817-1"
 					}
 				]
 			},
@@ -365,7 +386,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011573.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011573.html",
+						"title": "SUSE-IU-2022:836-1"
 					}
 				]
 			},
@@ -382,7 +404,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011592.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011592.html",
+						"title": "SUSE-IU-2022:853-1"
 					}
 				]
 			},
@@ -399,7 +422,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011593.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011593.html",
+						"title": "SUSE-IU-2022:859-1"
 					}
 				]
 			},
@@ -416,7 +440,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011591.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011591.html",
+						"title": "SUSE-IU-2022:878-1"
 					}
 				]
 			},
@@ -433,7 +458,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011604.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011604.html",
+						"title": "SUSE-IU-2022:894-1"
 					}
 				]
 			},
@@ -450,7 +476,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011605.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011605.html",
+						"title": "SUSE-IU-2022:903-1"
 					}
 				]
 			},
@@ -467,7 +494,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011606.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011606.html",
+						"title": "SUSE-IU-2022:904-1"
 					}
 				]
 			},
@@ -484,7 +512,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011618.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011618.html",
+						"title": "SUSE-IU-2022:953-1"
 					}
 				]
 			},
@@ -501,7 +530,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011619.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011619.html",
+						"title": "SUSE-IU-2022:954-1"
 					}
 				]
 			},
@@ -518,7 +548,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011620.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011620.html",
+						"title": "SUSE-IU-2022:955-1"
 					}
 				]
 			},
@@ -535,7 +566,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-June/011323.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-June/011323.html",
+						"title": "SUSE-SU-2022:2147-1"
 					}
 				]
 			},
@@ -552,7 +584,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-June/011339.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-June/011339.html",
+						"title": "SUSE-SU-2022:2166-1"
 					}
 				]
 			},
@@ -569,7 +602,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-June/011348.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-June/011348.html",
+						"title": "SUSE-SU-2022:2174-1"
 					}
 				]
 			},
@@ -586,7 +620,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011383.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011383.html",
+						"title": "SUSE-SU-2022:2248-1"
 					}
 				]
 			},
@@ -603,7 +638,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011384.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011384.html",
+						"title": "SUSE-SU-2022:2249-1"
 					}
 				]
 			},
@@ -620,7 +656,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011425.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011425.html",
+						"title": "SUSE-SU-2022:2291-1"
 					}
 				]
 			},
@@ -637,7 +674,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011485.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011485.html",
+						"title": "SUSE-SU-2022:2344-1"
 					}
 				]
 			},
@@ -654,7 +692,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011496.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011496.html",
+						"title": "SUSE-SU-2022:2351-1"
 					}
 				]
 			},
@@ -671,7 +710,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011505.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011505.html",
+						"title": "SUSE-SU-2022:2357-1"
 					}
 				]
 			},
@@ -688,7 +728,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/26DEFHSQZHFG2QZLJD7AX3TDPAXVFWZR/"
+						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/26DEFHSQZHFG2QZLJD7AX3TDPAXVFWZR/",
+						"title": "SUSE-SU-2022:2357-2"
 					}
 				]
 			},
@@ -705,7 +746,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-March/014021.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-March/014021.html",
+						"title": "SUSE-SU-2023:0707-1"
 					}
 				]
 			},
@@ -722,7 +764,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-March/014044.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2023-March/014044.html",
+						"title": "SUSE-SU-2023:0748-1"
 					}
 				]
 			},
@@ -767,35 +810,48 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-20107"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-20107",
+						"title": "Mitre CVE-2015-20107"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1198511"
+						"url": "https://bugzilla.suse.com/1198511",
+						"title": "SUSE bug 1198511"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1200507"
+						"url": "https://bugzilla.suse.com/1200507",
+						"title": "SUSE bug 1200507"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1201777"
+						"url": "https://bugzilla.suse.com/1201777",
+						"title": "SUSE bug 1201777"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1201791"
+						"url": "https://bugzilla.suse.com/1201791",
+						"title": "SUSE bug 1201791"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1205068"
+						"url": "https://bugzilla.suse.com/1205068",
+						"title": "SUSE bug 1205068"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1208337"
+						"url": "https://bugzilla.suse.com/1208337",
+						"title": "SUSE bug 1208337"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-2015-20107"
+						"url": "https://www.suse.com/security/cve/CVE-2015-20107",
+						"title": "CVE-2015-20107"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-2015-20107",
+						"title": "SUSE CVE-2015-20107"
 					}
 				],
 				"published": "2022-08-07T00:00:00Z",

--- a/pkg/extract/suse/oval/testdata/golden/data/2021/CVE-2021-3507.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2021/CVE-2021-3507.json
@@ -8,7 +8,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-October/012710.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-October/012710.html",
+						"title": "SUSE-SU-2022:3768-1"
 					}
 				]
 			},
@@ -53,15 +54,23 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3507"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3507",
+						"title": "Mitre CVE-2021-3507"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1185000"
+						"url": "https://bugzilla.suse.com/1185000",
+						"title": "SUSE bug 1185000"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-2021-3507"
+						"url": "https://www.suse.com/security/cve/CVE-2021-3507",
+						"title": "CVE-2021-3507"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-2021-3507",
+						"title": "SUSE CVE-2021-3507"
 					}
 				],
 				"published": "2022-10-27T00:00:00Z",

--- a/pkg/extract/suse/oval/testdata/golden/data/2022/CVE-2022-0330.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2022/CVE-2022-0330.json
@@ -8,7 +8,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-updates/2022-February/021863.html"
+						"url": "https://lists.suse.com/pipermail/sle-updates/2022-February/021863.html",
+						"title": "SUSE-IU-2022:282-1"
 					}
 				]
 			},
@@ -25,7 +26,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010313.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010313.html",
+						"title": "SUSE-IU-2022:283-1"
 					}
 				]
 			},
@@ -42,7 +44,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010324.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010324.html",
+						"title": "SUSE-IU-2022:284-1"
 					}
 				]
 			},
@@ -59,7 +62,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011574.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011574.html",
+						"title": "SUSE-IU-2022:814-1"
 					}
 				]
 			},
@@ -76,7 +80,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011575.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011575.html",
+						"title": "SUSE-IU-2022:817-1"
 					}
 				]
 			},
@@ -93,7 +98,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011573.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011573.html",
+						"title": "SUSE-IU-2022:836-1"
 					}
 				]
 			},
@@ -110,7 +116,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011592.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011592.html",
+						"title": "SUSE-IU-2022:853-1"
 					}
 				]
 			},
@@ -127,7 +134,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011593.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011593.html",
+						"title": "SUSE-IU-2022:859-1"
 					}
 				]
 			},
@@ -144,7 +152,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011591.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-July/011591.html",
+						"title": "SUSE-IU-2022:878-1"
 					}
 				]
 			},
@@ -161,7 +170,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010210.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010210.html",
+						"title": "SUSE-SU-2022:0362-1"
 					}
 				]
 			},
@@ -178,7 +188,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-updates/2022-February/021670.html"
+						"url": "https://lists.suse.com/pipermail/sle-updates/2022-February/021670.html",
+						"title": "SUSE-SU-2022:0363-1"
 					}
 				]
 			},
@@ -195,7 +206,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010215.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010215.html",
+						"title": "SUSE-SU-2022:0364-1"
 					}
 				]
 			},
@@ -212,7 +224,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010211.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010211.html",
+						"title": "SUSE-SU-2022:0365-1"
 					}
 				]
 			},
@@ -229,7 +242,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010213.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010213.html",
+						"title": "SUSE-SU-2022:0367-1"
 					}
 				]
 			},
@@ -246,7 +260,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010216.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010216.html",
+						"title": "SUSE-SU-2022:0370-1"
 					}
 				]
 			},
@@ -263,7 +278,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010217.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010217.html",
+						"title": "SUSE-SU-2022:0371-1"
 					}
 				]
 			},
@@ -280,7 +296,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-updates/2022-February/021678.html"
+						"url": "https://lists.suse.com/pipermail/sle-updates/2022-February/021678.html",
+						"title": "SUSE-SU-2022:0372-1"
 					}
 				]
 			},
@@ -297,7 +314,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010246.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010246.html",
+						"title": "SUSE-SU-2022:0477-1"
 					}
 				]
 			},
@@ -314,7 +332,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010282.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010282.html",
+						"title": "SUSE-SU-2022:0543-1"
 					}
 				]
 			},
@@ -331,7 +350,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010284.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010284.html",
+						"title": "SUSE-SU-2022:0544-1"
 					}
 				]
 			},
@@ -348,7 +368,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010290.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010290.html",
+						"title": "SUSE-SU-2022:0555-1"
 					}
 				]
 			},
@@ -365,7 +386,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010966.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010966.html",
+						"title": "SUSE-SU-2022:1569-1"
 					}
 				]
 			},
@@ -382,7 +404,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010969.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010969.html",
+						"title": "SUSE-SU-2022:1575-1"
 					}
 				]
 			},
@@ -399,7 +422,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010975.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010975.html",
+						"title": "SUSE-SU-2022:1580-1"
 					}
 				]
 			},
@@ -416,7 +440,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010984.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010984.html",
+						"title": "SUSE-SU-2022:1589-1"
 					}
 				]
 			},
@@ -433,7 +458,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010976.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010976.html",
+						"title": "SUSE-SU-2022:1591-1"
 					}
 				]
 			},
@@ -450,7 +476,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010983.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010983.html",
+						"title": "SUSE-SU-2022:1605-1"
 					}
 				]
 			},
@@ -467,7 +494,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010990.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010990.html",
+						"title": "SUSE-SU-2022:1637-1"
 					}
 				]
 			},
@@ -484,7 +512,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010991.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2022-May/010991.html",
+						"title": "SUSE-SU-2022:1640-1"
 					}
 				]
 			},
@@ -501,7 +530,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/K4ZJSATCJ2GMGCX6RSG2TU2YU4DDOMVQ/"
+						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/K4ZJSATCJ2GMGCX6RSG2TU2YU4DDOMVQ/",
+						"title": "openSUSE-SU-2022:0363-1"
 					}
 				]
 			},
@@ -518,7 +548,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/CFUCZRWH2IP7FOHVYO3TO3G5PFWQXLP6/"
+						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/CFUCZRWH2IP7FOHVYO3TO3G5PFWQXLP6/",
+						"title": "openSUSE-SU-2022:0366-1"
 					}
 				]
 			},
@@ -535,7 +566,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/ASMTCFCDULHGAOBQUFJH4PHVCQSTF7S6/"
+						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/ASMTCFCDULHGAOBQUFJH4PHVCQSTF7S6/",
+						"title": "openSUSE-SU-2022:0370-1"
 					}
 				]
 			},
@@ -598,23 +630,33 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0330"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0330",
+						"title": "Mitre CVE-2022-0330"
 					},
 					{
 						"source": "NVD",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-0330"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2022-0330",
+						"title": "CVE-2022-0330 at NVD"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1194880"
+						"url": "https://bugzilla.suse.com/1194880",
+						"title": "SUSE bug 1194880"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1195950"
+						"url": "https://bugzilla.suse.com/1195950",
+						"title": "SUSE bug 1195950"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-2022-0330"
+						"url": "https://www.suse.com/security/cve/CVE-2022-0330",
+						"title": "CVE-2022-0330 at SUSE"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-2022-0330",
+						"title": "SUSE CVE-2022-0330"
 					}
 				],
 				"published": "2022-05-20T00:00:00Z",

--- a/pkg/extract/suse/oval/testdata/golden/data/2024/CVE-2024-49955.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2024/CVE-2024-49955.json
@@ -8,7 +8,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-November/019816.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-November/019816.html",
+						"title": "SUSE-SU-2024:3983-1"
 					}
 				]
 			},
@@ -25,7 +26,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-November/019815.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-November/019815.html",
+						"title": "SUSE-SU-2024:3984-1"
 					}
 				]
 			},
@@ -42,7 +44,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-November/019814.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-November/019814.html",
+						"title": "SUSE-SU-2024:3985-1"
 					}
 				]
 			},
@@ -59,7 +62,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-November/019813.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-November/019813.html",
+						"title": "SUSE-SU-2024:3986-1"
 					}
 				]
 			},
@@ -76,7 +80,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-December/019999.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-December/019999.html",
+						"title": "SUSE-SU-2024:4318-1"
 					}
 				]
 			},
@@ -93,7 +98,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-December/020019.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-December/020019.html",
+						"title": "SUSE-SU-2024:4364-1"
 					}
 				]
 			},
@@ -110,7 +116,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-December/020032.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2024-December/020032.html",
+						"title": "SUSE-SU-2024:4387-1"
 					}
 				]
 			},
@@ -127,7 +134,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2025-June/021187.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2025-June/021187.html",
+						"title": "SUSE-SU-2025:20163-1"
 					}
 				]
 			},
@@ -144,7 +152,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2025-June/021175.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2025-June/021175.html",
+						"title": "SUSE-SU-2025:20164-1"
 					}
 				]
 			},
@@ -161,7 +170,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2025-June/021078.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2025-June/021078.html",
+						"title": "SUSE-SU-2025:20246-1"
 					}
 				]
 			},
@@ -178,7 +188,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.suse.com/pipermail/sle-security-updates/2025-June/021076.html"
+						"url": "https://lists.suse.com/pipermail/sle-security-updates/2025-June/021076.html",
+						"title": "SUSE-SU-2025:20247-1"
 					}
 				]
 			},
@@ -195,7 +206,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/2NO44GTYBSPPWKFDREFWHITK4XKTNVLP/"
+						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/2NO44GTYBSPPWKFDREFWHITK4XKTNVLP/",
+						"title": "openSUSE-SU-2024:14500-1"
 					}
 				]
 			},
@@ -212,7 +224,8 @@
 				"references": [
 					{
 						"source": "SUSE",
-						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/T7LN2FDZYBYZRLX5LOA3REDAXV7VKGW4/"
+						"url": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/T7LN2FDZYBYZRLX5LOA3REDAXV7VKGW4/",
+						"title": "openSUSE-SU-2025:14705-1"
 					}
 				]
 			},
@@ -275,19 +288,28 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-49955"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-49955",
+						"title": "Mitre CVE-2024-49955"
 					},
 					{
 						"source": "NVD",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-49955"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-49955",
+						"title": "CVE-2024-49955 at NVD"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1232154"
+						"url": "https://bugzilla.suse.com/1232154",
+						"title": "SUSE bug 1232154"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-2024-49955"
+						"url": "https://www.suse.com/security/cve/CVE-2024-49955",
+						"title": "CVE-2024-49955 at SUSE"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-2024-49955",
+						"title": "SUSE CVE-2024-49955"
 					}
 				],
 				"published": "2025-06-04T00:00:00Z",

--- a/pkg/extract/suse/oval/testdata/golden/data/2026/CVE-2026-24869.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/2026/CVE-2026-24869.json
@@ -16,19 +16,28 @@
 				"references": [
 					{
 						"source": "CVE",
-						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-24869"
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-24869",
+						"title": "Mitre CVE-2026-24869"
 					},
 					{
 						"source": "NVD",
-						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24869"
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24869",
+						"title": "CVE-2026-24869 at NVD"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://bugzilla.suse.com/1257363"
+						"url": "https://bugzilla.suse.com/1257363",
+						"title": "SUSE bug 1257363"
 					},
 					{
 						"source": "SUSE",
-						"url": "https://www.suse.com/security/cve/CVE-2026-24869"
+						"url": "https://www.suse.com/security/cve/CVE-2026-24869",
+						"title": "CVE-2026-24869 at SUSE"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-2026-24869",
+						"title": "SUSE CVE-2026-24869"
 					}
 				],
 				"published": "2026-01-28T00:00:00Z",

--- a/pkg/extract/types/attack/attack.go
+++ b/pkg/extract/types/attack/attack.go
@@ -73,6 +73,9 @@ func (a *Attack) Sort() {
 	a.AttackDataSource.Sort()
 	a.DataComponent.Sort()
 	a.Analytic.Sort()
+	for i := range a.References {
+		(&a.References[i]).Sort()
+	}
 	slices.SortFunc(a.References, referenceTypes.Compare)
 	a.DataSource.Sort()
 }

--- a/pkg/extract/types/attack/procedure/procedure.go
+++ b/pkg/extract/types/attack/procedure/procedure.go
@@ -23,6 +23,9 @@ type Procedure struct {
 }
 
 func (p *Procedure) Sort() {
+	for i := range p.References {
+		(&p.References[i]).Sort()
+	}
 	slices.SortFunc(p.References, referenceTypes.Compare)
 }
 

--- a/pkg/extract/types/attack/relatedref/relatedref.go
+++ b/pkg/extract/types/attack/relatedref/relatedref.go
@@ -31,6 +31,9 @@ type RelatedRef struct {
 }
 
 func (r *RelatedRef) Sort() {
+	for i := range r.References {
+		(&r.References[i]).Sort()
+	}
 	slices.SortFunc(r.References, referenceTypes.Compare)
 }
 

--- a/pkg/extract/types/attack/techniqueused/techniqueused.go
+++ b/pkg/extract/types/attack/techniqueused/techniqueused.go
@@ -14,6 +14,9 @@ type TechniqueUsed struct {
 }
 
 func (t *TechniqueUsed) Sort() {
+	for i := range t.References {
+		(&t.References[i]).Sort()
+	}
 	slices.SortFunc(t.References, referenceTypes.Compare)
 }
 

--- a/pkg/extract/types/capec/capec.go
+++ b/pkg/extract/types/capec/capec.go
@@ -61,6 +61,9 @@ func (c *CAPEC) Sort() {
 		slices.Sort(c.Consequences[k])
 	}
 	slices.SortFunc(c.Mitigations, mitigationTypes.Compare)
+	for i := range c.References {
+		(&c.References[i]).Sort()
+	}
 	slices.SortFunc(c.References, referenceTypes.Compare)
 	c.DataSource.Sort()
 }

--- a/pkg/extract/types/cwe/cwe.go
+++ b/pkg/extract/types/cwe/cwe.go
@@ -33,6 +33,9 @@ func (c *CWE) Sort() {
 	c.Weakness.Sort()
 	c.Category.Sort()
 	c.View.Sort()
+	for i := range c.References {
+		(&c.References[i]).Sort()
+	}
 	slices.SortFunc(c.References, referenceTypes.Compare)
 	c.DataSource.Sort()
 }

--- a/pkg/extract/types/data/advisory/content/content.go
+++ b/pkg/extract/types/data/advisory/content/content.go
@@ -51,6 +51,9 @@ func (c *Content) Sort() {
 		c.KEV.Sort()
 	}
 
+	for i := range c.References {
+		(&c.References[i]).Sort()
+	}
 	slices.SortFunc(c.References, referenceTypes.Compare)
 }
 

--- a/pkg/extract/types/data/metasploit/metasploit.go
+++ b/pkg/extract/types/data/metasploit/metasploit.go
@@ -28,6 +28,9 @@ func (m *Metasploit) Sort() {
 	slices.Sort(m.Aliases)
 	slices.Sort(m.Author)
 	slices.Sort(m.Targets)
+	for i := range m.References {
+		(&m.References[i]).Sort()
+	}
 	slices.SortFunc(m.References, referenceTypes.Compare)
 }
 

--- a/pkg/extract/types/data/reference/reference.go
+++ b/pkg/extract/types/data/reference/reference.go
@@ -1,15 +1,26 @@
 package reference
 
-import "cmp"
+import (
+	"cmp"
+	"slices"
+)
 
 type Reference struct {
-	Source string `json:"source,omitempty"`
-	URL    string `json:"url,omitempty"`
+	Source string   `json:"source,omitempty"`
+	URL    string   `json:"url,omitempty"`
+	Title  string   `json:"title,omitempty"`
+	Tags   []string `json:"tags,omitempty"`
+}
+
+func (r *Reference) Sort() {
+	slices.Sort(r.Tags)
 }
 
 func Compare(x, y Reference) int {
 	return cmp.Or(
 		cmp.Compare(x.Source, y.Source),
 		cmp.Compare(x.URL, y.URL),
+		cmp.Compare(x.Title, y.Title),
+		slices.CompareFunc(x.Tags, y.Tags, cmp.Compare),
 	)
 }

--- a/pkg/extract/types/data/vulnerability/content/content.go
+++ b/pkg/extract/types/data/vulnerability/content/content.go
@@ -71,6 +71,9 @@ func (c *Content) Sort() {
 	}
 	slices.SortFunc(c.SSVC, ssvcTypes.Compare)
 
+	for i := range c.References {
+		(&c.References[i]).Sort()
+	}
 	slices.SortFunc(c.References, referenceTypes.Compare)
 }
 

--- a/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
+++ b/pkg/extract/vulncheck/nist-nvd2/nist-nvd2.go
@@ -438,6 +438,7 @@ func (e extractor) buildData(fetched nistnvd2Types.CVE) (dataTypes.Data, error) 
 							refs = append(refs, referenceTypes.Reference{
 								Source: r.Source,
 								URL:    r.URL,
+								Tags:   r.Tags,
 							})
 						}
 						return refs

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/and-operator/data/2024/CVE-2024-25741.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/and-operator/data/2024/CVE-2024-25741.json
@@ -37,7 +37,12 @@
 				"references": [
 					{
 						"source": "cve@mitre.org",
-						"url": "https://www.spinics.net/lists/linux-usb/msg252167.html"
+						"url": "https://www.spinics.net/lists/linux-usb/msg252167.html",
+						"tags": [
+							"Exploit",
+							"Mailing List",
+							"Third Party Advisory"
+						]
 					},
 					{
 						"source": "vulncheck.com",

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/exact-match/data/2024/CVE-2024-25741.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/exact-match/data/2024/CVE-2024-25741.json
@@ -64,11 +64,21 @@
 					},
 					{
 						"source": "af854a3a-2127-422b-91ae-364da2661108",
-						"url": "https://www.spinics.net/lists/linux-usb/msg252167.html"
+						"url": "https://www.spinics.net/lists/linux-usb/msg252167.html",
+						"tags": [
+							"Exploit",
+							"Mailing List",
+							"Third Party Advisory"
+						]
 					},
 					{
 						"source": "cve@mitre.org",
-						"url": "https://www.spinics.net/lists/linux-usb/msg252167.html"
+						"url": "https://www.spinics.net/lists/linux-usb/msg252167.html",
+						"tags": [
+							"Exploit",
+							"Mailing List",
+							"Third Party Advisory"
+						]
 					},
 					{
 						"source": "vulncheck.com",

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/happy/data/2024/CVE-2024-0001.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/happy/data/2024/CVE-2024-0001.json
@@ -50,7 +50,10 @@
 				"references": [
 					{
 						"source": "psirt@purestorage.com",
-						"url": "https://purestorage.com/security"
+						"url": "https://purestorage.com/security",
+						"tags": [
+							"Vendor Advisory"
+						]
 					},
 					{
 						"source": "vulncheck.com",

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/non-semver-range/data/2024/CVE-2024-5400.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/non-semver-range/data/2024/CVE-2024-5400.json
@@ -31,11 +31,17 @@
 				"references": [
 					{
 						"source": "af854a3a-2127-422b-91ae-364da2661108",
-						"url": "https://www.twcert.org.tw/tw/cp-132-7819-9661a-1.html"
+						"url": "https://www.twcert.org.tw/tw/cp-132-7819-9661a-1.html",
+						"tags": [
+							"Vendor Advisory"
+						]
 					},
 					{
 						"source": "twcert@cert.org.tw",
-						"url": "https://www.twcert.org.tw/tw/cp-132-7819-9661a-1.html"
+						"url": "https://www.twcert.org.tw/tw/cp-132-7819-9661a-1.html",
+						"tags": [
+							"Vendor Advisory"
+						]
 					},
 					{
 						"source": "vulncheck.com",

--- a/pkg/extract/vulncheck/nist-nvd2/testdata/golden/vuln-cpes/data/2018/CVE-2018-2611.json
+++ b/pkg/extract/vulncheck/nist-nvd2/testdata/golden/vuln-cpes/data/2018/CVE-2018-2611.json
@@ -44,27 +44,51 @@
 				"references": [
 					{
 						"source": "af854a3a-2127-422b-91ae-364da2661108",
-						"url": "http://www.oracle.com/technetwork/security-advisory/cpujan2018-3236628.html"
+						"url": "http://www.oracle.com/technetwork/security-advisory/cpujan2018-3236628.html",
+						"tags": [
+							"Patch",
+							"Vendor Advisory"
+						]
 					},
 					{
 						"source": "af854a3a-2127-422b-91ae-364da2661108",
-						"url": "http://www.securityfocus.com/bid/102587"
+						"url": "http://www.securityfocus.com/bid/102587",
+						"tags": [
+							"Third Party Advisory",
+							"VDB Entry"
+						]
 					},
 					{
 						"source": "af854a3a-2127-422b-91ae-364da2661108",
-						"url": "http://www.securitytracker.com/id/1040215"
+						"url": "http://www.securitytracker.com/id/1040215",
+						"tags": [
+							"Third Party Advisory",
+							"VDB Entry"
+						]
 					},
 					{
 						"source": "secalert_us@oracle.com",
-						"url": "http://www.oracle.com/technetwork/security-advisory/cpujan2018-3236628.html"
+						"url": "http://www.oracle.com/technetwork/security-advisory/cpujan2018-3236628.html",
+						"tags": [
+							"Patch",
+							"Vendor Advisory"
+						]
 					},
 					{
 						"source": "secalert_us@oracle.com",
-						"url": "http://www.securityfocus.com/bid/102587"
+						"url": "http://www.securityfocus.com/bid/102587",
+						"tags": [
+							"Third Party Advisory",
+							"VDB Entry"
+						]
 					},
 					{
 						"source": "secalert_us@oracle.com",
-						"url": "http://www.securitytracker.com/id/1040215"
+						"url": "http://www.securitytracker.com/id/1040215",
+						"tags": [
+							"Third Party Advisory",
+							"VDB Entry"
+						]
 					},
 					{
 						"source": "vulncheck.com",


### PR DESCRIPTION
## What
Add optional `Title` (referenced-document title) and `Tags` (NVD-style reference tags) fields to `reference.Reference` (`pkg/extract/types/data/reference`), and populate them across extractors from source data that was previously dropped.

## Why
Extractors discard per-reference title/category data that exists in the upstream feeds (e.g. NVD reference tags, JVN JPCERT-AT titles, Red Hat Bugzilla summaries). This surfaces that information in the canonical datasets.

## How
- `reference.Reference` gains `Title string` / `Tags []string` (both `omitempty`). `Sort()` sorts `Tags`; `Compare` now also orders by `Title` and `Tags`.
- **Non-comparable side effect**: adding a slice field makes `Reference` non-comparable. Dedup sites that used it as a map key / `slices.Contains` were switched to `reference.Compare`-based dedup (`alma/errata`, `suse/oval`, `debian/tracker/salsa`). The 9 reference-holder types now recurse into per-element `Sort()`.
- Wiring:
  - **Title+Tags**: `paloalto/json`, `mitre/cve/v5`, `amazon`, `alma/errata`, `rocky/osv`, `redhat/oval v1/v2`, `jvn/feed rss+detail`
  - **Tags only**: `nvd/api/cve`, `nvd/feed/cve/v2`, `vulncheck/nist-nvd2`
  - **Title only**: `redhat/cve`, `redhat/csaf`, `redhat/vex v1/v2`, `mitre/cwe`, `mitre/capec`, `mitre/attack`, `suse/oval`, `oracle/linux`, `rocky/errata`
- Deliberate omissions (after reviewing real data):
  - `Category` (`self`/`external`) **not** mapped to Tags for Red Hat CSAF/VEX — too low-signal.
  - `fortinet/cvrf` Title omitted — source `Description` is HTML-wrapped/URL-duplicating.
  - `fortinet/csaf` deferred — references are flattened to `[]string` before construction; preserving Category/Summary needs a de-flatten refactor (separate PR).

## Testing
- `GOEXPERIMENT=jsonv2 go build ./...`, `go vet`, `gofmt` clean.
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/...` passes; golden files regenerated for every wired source.

## ⚠️ Coordination
`pkg/extract/types/data` is imported by `vuls2` and `filter-vuls-data-extracted-redhat`. The JSON/wire format stays backward compatible (new fields are `omitempty`), but `reference.Reference` becoming **non-comparable** is a source-level break for any consumer using it as a map key or with comparable-constrained generics — hence the `feat!` marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)