### PR TITLE
fix(fetch/alma+rocky/updateinfo): handle uppercase filenames and uncompressed modules

### DIFF
--- a/pkg/fetch/alma/updateinfo/export_test.go
+++ b/pkg/fetch/alma/updateinfo/export_test.go
@@ -1,3 +1,6 @@
 package updateinfo
 
-var ToDir = toDir
+var (
+	ToDir      = toDir
+	Decompress = decompress
+)

--- a/pkg/fetch/alma/updateinfo/updateinfo.go
+++ b/pkg/fetch/alma/updateinfo/updateinfo.go
@@ -420,47 +420,9 @@ func (o options) fetchUpdateinfo(client *utilhttp.Client, u string) error {
 		return errors.Wrap(err, "to dir")
 	}
 
-	buf := new(bytes.Buffer)
-	switch {
-	case strings.HasSuffix(u, ".xml"):
-		if _, err := buf.ReadFrom(resp.Body); err != nil {
-			return errors.Wrap(err, "read xml")
-		}
-	case strings.HasSuffix(u, ".gz"):
-		r, err := gzip.NewReader(resp.Body)
-		if err != nil {
-			return errors.Wrap(err, "create gzip reader")
-		}
-		defer r.Close()
-
-		if _, err := buf.ReadFrom(r); err != nil {
-			return errors.Wrap(err, "read gzip")
-		}
-	case strings.HasSuffix(u, ".xz"):
-		r, err := xz.NewReader(resp.Body)
-		if err != nil {
-			return errors.Wrap(err, "create xz reader")
-		}
-
-		if _, err := buf.ReadFrom(r); err != nil {
-			return errors.Wrap(err, "read xz")
-		}
-	case strings.HasSuffix(u, ".bz2"):
-		if _, err := buf.ReadFrom(bzip2.NewReader(resp.Body)); err != nil {
-			return errors.Wrap(err, "read bzip2")
-		}
-	case strings.HasSuffix(u, ".zst"):
-		r, err := zstd.NewReader(resp.Body)
-		if err != nil {
-			return errors.Wrap(err, "create zstd reader")
-		}
-		defer r.Close()
-
-		if _, err := buf.ReadFrom(r); err != nil {
-			return errors.Wrap(err, "read zstd")
-		}
-	default:
-		return errors.Errorf("unexpected updateinfo fileformat. expected: %q, actual: %q", []string{".xml", ".xml.gz", ".xml.xz", ".xml.bz2", ".xml.zst"}, u)
+	buf, err := decompress(u, resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "decompress")
 	}
 
 	var ui updateinfo
@@ -506,13 +468,12 @@ func (o options) fetchModules(client *utilhttp.Client, u string) error {
 		return errors.Wrap(err, "to dir")
 	}
 
-	gr, err := gzip.NewReader(resp.Body)
+	buf, err := decompress(u, resp.Body)
 	if err != nil {
-		return errors.Wrap(err, "create gzip reader")
+		return errors.Wrap(err, "decompress")
 	}
-	defer gr.Close()
 
-	scanner := bufio.NewScanner(gr)
+	scanner := bufio.NewScanner(buf)
 	var sb strings.Builder
 	for scanner.Scan() {
 		switch s := scanner.Text(); s {
@@ -553,6 +514,59 @@ func (o options) fetchModules(client *utilhttp.Client, u string) error {
 	return nil
 }
 
+// decompress reads the (optionally compressed) body of a repodata file into a
+// buffer, selecting the decoder from the URL suffix. AlmaLinux usually ships
+// updateinfo/modules as *.gz, but some (vault) repositories serve uncompressed
+// *.yaml, and mirrors may re-compress with other algorithms, so both callers
+// share this format handling.
+func decompress(u string, r io.Reader) (*bytes.Buffer, error) {
+	buf := new(bytes.Buffer)
+	// Match the suffix case-insensitively for robustness against upper-cased
+	// repodata filenames.
+	switch lu := strings.ToLower(u); {
+	case strings.HasSuffix(lu, ".xml"), strings.HasSuffix(lu, ".yaml"):
+		if _, err := buf.ReadFrom(r); err != nil {
+			return nil, errors.Wrap(err, "read")
+		}
+	case strings.HasSuffix(lu, ".gz"):
+		gr, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "create gzip reader")
+		}
+		defer gr.Close()
+
+		if _, err := buf.ReadFrom(gr); err != nil {
+			return nil, errors.Wrap(err, "read gzip")
+		}
+	case strings.HasSuffix(lu, ".xz"):
+		xr, err := xz.NewReader(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "create xz reader")
+		}
+
+		if _, err := buf.ReadFrom(xr); err != nil {
+			return nil, errors.Wrap(err, "read xz")
+		}
+	case strings.HasSuffix(lu, ".bz2"):
+		if _, err := buf.ReadFrom(bzip2.NewReader(r)); err != nil {
+			return nil, errors.Wrap(err, "read bzip2")
+		}
+	case strings.HasSuffix(lu, ".zst"):
+		zr, err := zstd.NewReader(r)
+		if err != nil {
+			return nil, errors.Wrap(err, "create zstd reader")
+		}
+		defer zr.Close()
+
+		if _, err := buf.ReadFrom(zr); err != nil {
+			return nil, errors.Wrap(err, "read zstd")
+		}
+	default:
+		return nil, errors.Errorf("unexpected fileformat. expected: %q, actual: %q", []string{".xml", ".yaml", ".gz", ".xz", ".bz2", ".zst"}, u)
+	}
+	return buf, nil
+}
+
 // toDir maps a repodata file URL to the on-disk directory that mirrors its
 // source path, replacing the trailing "repodata/<file>" with "updateinfo" or
 // "modules". The full source prefix (tree/version/repository/arch/variant) is
@@ -582,7 +596,9 @@ func toDir(u, baseURL string) (string, error) {
 		}
 	}
 
-	switch name := ss[len(ss)-1]; {
+	// Classify case-insensitively: some repositories publish upper-cased
+	// repodata filenames (e.g. <hash>-UPDATEINFO.xml.gz).
+	switch name := strings.ToLower(ss[len(ss)-1]); {
 	case strings.Contains(name, "updateinfo.xml"):
 		ps = append(ps, "updateinfo")
 	case strings.Contains(name, "-modules.yaml"):

--- a/pkg/fetch/alma/updateinfo/updateinfo_test.go
+++ b/pkg/fetch/alma/updateinfo/updateinfo_test.go
@@ -1,6 +1,8 @@
 package updateinfo_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -163,6 +165,15 @@ func Test_toDir(t *testing.T) {
 			want: "almalinux/9/BaseOS/x86_64/kickstart/updateinfo",
 		},
 		{
+			// Guard against upper-cased repodata filenames some repositories publish.
+			name: "uppercase updateinfo filename",
+			args: args{
+				u:       "https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/repodata/abc-UPDATEINFO.xml.gz",
+				baseURL: "https://repo.almalinux.org/",
+			},
+			want: "almalinux/9/BaseOS/x86_64/os/updateinfo",
+		},
+		{
 			name: "unexpected host",
 			args: args{
 				u:       "https://example.com/almalinux/9/BaseOS/x86_64/os/repodata/updateinfo.xml.gz",
@@ -196,6 +207,76 @@ func Test_toDir(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("toDir() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_decompress(t *testing.T) {
+	gz := func(t *testing.T, b []byte) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		w := gzip.NewWriter(&buf)
+		if _, err := w.Write(b); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+	payload := []byte("document: modulemd\nversion: 2\n")
+	tests := []struct {
+		name    string
+		u       string
+		body    func(*testing.T) []byte
+		want    string
+		wantErr bool
+	}{
+		{
+			// Some (vault) repositories serve uncompressed modules.yaml.
+			name: "uncompressed yaml",
+			u:    "https://example.com/repodata/abc-modules.yaml",
+			body: func(_ *testing.T) []byte { return payload },
+			want: string(payload),
+		},
+		{
+			name: "uncompressed xml",
+			u:    "https://example.com/repodata/abc-updateinfo.xml",
+			body: func(_ *testing.T) []byte { return payload },
+			want: string(payload),
+		},
+		{
+			name: "gzip",
+			u:    "https://example.com/repodata/abc-updateinfo.xml.gz",
+			body: func(t *testing.T) []byte { return gz(t, payload) },
+			want: string(payload),
+		},
+		{
+			// Upper-cased filename must still be recognized as gzip.
+			name: "uppercase gzip filename",
+			u:    "https://example.com/repodata/abc-UPDATEINFO.XML.GZ",
+			body: func(t *testing.T) []byte { return gz(t, payload) },
+			want: string(payload),
+		},
+		{
+			name:    "unexpected format",
+			u:       "https://example.com/repodata/abc.rpm",
+			body:    func(_ *testing.T) []byte { return payload },
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := updateinfo.Decompress(tt.u, bytes.NewReader(tt.body(t)))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("decompress() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.String() != tt.want {
+				t.Errorf("decompress() = %q, want %q", got.String(), tt.want)
 			}
 		})
 	}

--- a/pkg/fetch/rocky/updateinfo/export_test.go
+++ b/pkg/fetch/rocky/updateinfo/export_test.go
@@ -1,3 +1,6 @@
 package updateinfo
 
-var ToDir = toDir
+var (
+	ToDir      = toDir
+	Decompress = decompress
+)

--- a/pkg/fetch/rocky/updateinfo/updateinfo.go
+++ b/pkg/fetch/rocky/updateinfo/updateinfo.go
@@ -462,12 +462,14 @@ func (o options) fetchModules(client *utilhttp.Client, u string) error {
 // with other algorithms, so both callers share this format handling.
 func decompress(u string, r io.Reader) (*bytes.Buffer, error) {
 	buf := new(bytes.Buffer)
-	switch {
-	case strings.HasSuffix(u, ".xml"), strings.HasSuffix(u, ".yaml"):
+	// Match the suffix case-insensitively: some Rocky repositories publish
+	// upper-cased repodata filenames (e.g. <hash>-UPDATEINFO.xml.gz).
+	switch lu := strings.ToLower(u); {
+	case strings.HasSuffix(lu, ".xml"), strings.HasSuffix(lu, ".yaml"):
 		if _, err := buf.ReadFrom(r); err != nil {
 			return nil, errors.Wrap(err, "read")
 		}
-	case strings.HasSuffix(u, ".gz"):
+	case strings.HasSuffix(lu, ".gz"):
 		gr, err := gzip.NewReader(r)
 		if err != nil {
 			return nil, errors.Wrap(err, "create gzip reader")
@@ -477,7 +479,7 @@ func decompress(u string, r io.Reader) (*bytes.Buffer, error) {
 		if _, err := buf.ReadFrom(gr); err != nil {
 			return nil, errors.Wrap(err, "read gzip")
 		}
-	case strings.HasSuffix(u, ".xz"):
+	case strings.HasSuffix(lu, ".xz"):
 		xr, err := xz.NewReader(r)
 		if err != nil {
 			return nil, errors.Wrap(err, "create xz reader")
@@ -486,11 +488,11 @@ func decompress(u string, r io.Reader) (*bytes.Buffer, error) {
 		if _, err := buf.ReadFrom(xr); err != nil {
 			return nil, errors.Wrap(err, "read xz")
 		}
-	case strings.HasSuffix(u, ".bz2"):
+	case strings.HasSuffix(lu, ".bz2"):
 		if _, err := buf.ReadFrom(bzip2.NewReader(r)); err != nil {
 			return nil, errors.Wrap(err, "read bzip2")
 		}
-	case strings.HasSuffix(u, ".zst"):
+	case strings.HasSuffix(lu, ".zst"):
 		zr, err := zstd.NewReader(r)
 		if err != nil {
 			return nil, errors.Wrap(err, "create zstd reader")
@@ -535,7 +537,9 @@ func toDir(u, baseURL string) (string, error) {
 		}
 	}
 
-	switch name := ss[len(ss)-1]; {
+	// Classify case-insensitively: some Rocky repositories publish upper-cased
+	// repodata filenames (e.g. <hash>-UPDATEINFO.xml.gz in a few SIG repos).
+	switch name := strings.ToLower(ss[len(ss)-1]); {
 	case strings.Contains(name, "updateinfo.xml"):
 		ps = append(ps, "updateinfo")
 	case strings.Contains(name, "-modules.yaml"):

--- a/pkg/fetch/rocky/updateinfo/updateinfo_test.go
+++ b/pkg/fetch/rocky/updateinfo/updateinfo_test.go
@@ -1,6 +1,8 @@
 package updateinfo_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
@@ -143,6 +145,15 @@ func Test_toDir(t *testing.T) {
 			want: "pub/rocky/9/BaseOS/x86_64/kickstart/updateinfo",
 		},
 		{
+			// A few Rocky SIG repositories publish upper-cased updateinfo filenames.
+			name: "uppercase updateinfo filename (sig repo)",
+			args: args{
+				u:       "https://dl.rockylinux.org/pub/sig/8/cloud/aarch64/cloud-kernel/repodata/bb99f09e-2129-409f-a7f2-46f8727b0685-UPDATEINFO.xml.gz",
+				baseURL: "https://dl.rockylinux.org/",
+			},
+			want: "pub/sig/8/cloud/aarch64/cloud-kernel/updateinfo",
+		},
+		{
 			name: "unexpected host",
 			args: args{
 				u:       "https://example.com/pub/rocky/9/BaseOS/x86_64/os/repodata/updateinfo.xml.gz",
@@ -176,6 +187,76 @@ func Test_toDir(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("toDir() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_decompress(t *testing.T) {
+	gz := func(t *testing.T, b []byte) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		w := gzip.NewWriter(&buf)
+		if _, err := w.Write(b); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+	payload := []byte("document: modulemd\nversion: 2\n")
+	tests := []struct {
+		name    string
+		u       string
+		body    func(*testing.T) []byte
+		want    string
+		wantErr bool
+	}{
+		{
+			// Some (vault) repositories serve uncompressed modules.yaml.
+			name: "uncompressed yaml",
+			u:    "https://example.com/repodata/abc-modules.yaml",
+			body: func(_ *testing.T) []byte { return payload },
+			want: string(payload),
+		},
+		{
+			name: "uncompressed xml",
+			u:    "https://example.com/repodata/abc-updateinfo.xml",
+			body: func(_ *testing.T) []byte { return payload },
+			want: string(payload),
+		},
+		{
+			name: "gzip",
+			u:    "https://example.com/repodata/abc-updateinfo.xml.gz",
+			body: func(t *testing.T) []byte { return gz(t, payload) },
+			want: string(payload),
+		},
+		{
+			// Upper-cased filename must still be recognized as gzip.
+			name: "uppercase gzip filename",
+			u:    "https://example.com/repodata/abc-UPDATEINFO.XML.GZ",
+			body: func(t *testing.T) []byte { return gz(t, payload) },
+			want: string(payload),
+		},
+		{
+			name:    "unexpected format",
+			u:       "https://example.com/repodata/abc.rpm",
+			body:    func(_ *testing.T) []byte { return payload },
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := updateinfo.Decompress(tt.u, bytes.NewReader(tt.body(t)))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("decompress() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.String() != tt.want {
+				t.Errorf("decompress() = %q, want %q", got.String(), tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What
Fix two crashes that broke the scheduled `Fetch All` run in `vuls-data-db`
(both `alma-updateinfo` and `rocky-updateinfo` jobs failed):
[run 29922926776](https://github.com/vulsio/vuls-data-db/actions/runs/29922926776).

## Why
Both fetchers made assumptions about repodata filenames that do not hold across
all AlmaLinux / Rocky repositories:

1. **Uncompressed `modules.yaml` (alma).**
   `repo.almalinux.org/vault/8.5/AppStream/ppc64le/os/repodata/<hash>-modules.yaml`
   is served **uncompressed**, but `fetchModules` always wrapped the body in
   `gzip.NewReader` → `create gzip reader` error, aborting the whole run.

2. **Upper-cased `UPDATEINFO.xml.gz` (rocky, and latent in alma).**
   `dl.rockylinux.org/pub/sig/8/cloud/aarch64/cloud-kernel/repodata/<hash>-UPDATEINFO.xml.gz`
   has an upper-cased filename. `toDir` classified updateinfo-vs-modules with a
   case-sensitive `strings.Contains(name, "updateinfo.xml")`, so it fell through
   to the error branch and aborted the run. `<data type=...>` in `repomd.xml` is
   still lower-case, so `fetchRepomd` picks the file up — only the on-disk path
   mapping and decompression choke on the casing.

A single failing repo aborts the entire fetch (errgroup), so these took down all
7032 / 3147 repositories.

## How
- **alma**: introduce a shared `decompress(u, r)` helper (as rocky already has)
  that selects the decoder from the URL suffix — `.xml`/`.yaml` (uncompressed),
  `.gz`/`.xz`/`.bz2`/`.zst` — and route both `fetchUpdateinfo` and `fetchModules`
  through it. This handles the uncompressed `modules.yaml` case.
- **both**: match the suffix / classify the filename **case-insensitively**
  (`strings.ToLower`) in `toDir` and `decompress`, handling `UPDATEINFO.xml.gz`.

## Testing
- `GOEXPERIMENT=jsonv2 go build ./...`, `go test ./pkg/fetch/{alma,rocky}/updateinfo/...`, `golangci-lint run` — all green.
- New `Test_toDir` case using the **exact** failing rocky URL
  (`...-UPDATEINFO.xml.gz`) now maps to `.../updateinfo` instead of erroring; same
  case added for alma.
- New `Test_decompress` covering uncompressed `.yaml` (the alma failure), `.gz`,
  an upper-cased `.GZ` filename, and an unexpected format — for both packages.
- The two failing URLs were re-verified live (`HTTP 200`, upper-cased href /
  uncompressed body) while diagnosing.

## Note on rollout
The `vuls-data-db` pipeline runs `vuls-data-update` from `@main`, so this fix
needs to reach `main` (via the usual `nightly` → `main` promotion) before the
scheduled `Fetch All` recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)