### PR TITLE
feat(extract/jvn): keep JPCERT-AT reference titles in optional url->title map

### DIFF
--- a/pkg/extract/jvn/feed/detail/detail.go
+++ b/pkg/extract/jvn/feed/detail/detail.go
@@ -240,6 +240,17 @@ func extract(fetched fetchTypes.Vulinfo, raws []string) (dataTypes.Data, error) 
 		})
 	}
 
+	// Collect fetched reference titles (HTML <title> of referenced JPCERT-AT
+	// alert pages) into an optional url->title map. Only a subset of related
+	// items carries one, so it is kept in Optional rather than on Reference.
+	referenceTitles := make(map[string]string)
+	for _, item := range fetched.VulinfoData.Related.RelatedItem {
+		if item.URL == "" || item.FetchedTitle == "" {
+			continue
+		}
+		referenceTitles[item.URL] = item.FetchedTitle
+	}
+
 	// Build CPE-based detections (convert CPE 2.2 URI to CPE 2.3 FS format)
 	var criterions []criterionTypes.Criterion
 	for _, item := range fetched.VulinfoData.Affected.AffectedItem {
@@ -318,6 +329,12 @@ func extract(fetched fetchTypes.Vulinfo, raws []string) (dataTypes.Data, error) 
 				References:  refs,
 				Published:   utiltime.Parse([]string{time.RFC3339}, fetched.VulinfoData.DateFirstPublished),
 				Modified:    utiltime.Parse([]string{time.RFC3339}, fetched.VulinfoData.DateLastUpdated),
+				Optional: func() map[string]any {
+					if len(referenceTitles) == 0 {
+						return nil
+					}
+					return map[string]any{"reference_titles": referenceTitles}
+				}(),
 			},
 			Segments: segments,
 		}},

--- a/pkg/extract/jvn/feed/detail/detail.go
+++ b/pkg/extract/jvn/feed/detail/detail.go
@@ -243,10 +243,13 @@ func extract(fetched fetchTypes.Vulinfo, raws []string) (dataTypes.Data, error) 
 	// Collect fetched reference titles (HTML <title> of referenced JPCERT-AT
 	// alert pages) into an optional url->title map. Only a subset of related
 	// items carries one, so it is kept in Optional rather than on Reference.
-	referenceTitles := make(map[string]string)
+	var referenceTitles map[string]string
 	for _, item := range fetched.VulinfoData.Related.RelatedItem {
 		if item.URL == "" || item.FetchedTitle == "" {
 			continue
+		}
+		if referenceTitles == nil {
+			referenceTitles = make(map[string]string)
 		}
 		referenceTitles[item.URL] = item.FetchedTitle
 	}

--- a/pkg/extract/jvn/feed/detail/testdata/fixtures/2021/JVNDB-2021-005429.json
+++ b/pkg/extract/jvn/feed/detail/testdata/fixtures/2021/JVNDB-2021-005429.json
@@ -1,0 +1,115 @@
+{
+	"vulinfoid": "JVNDB-2021-005429",
+	"vulinfodata": {
+		"title": "Apache Log4j における任意のコードが実行可能な脆弱性",
+		"vulinfodescription": {
+			"overview": "Log4j には JNDI Lookup 機能による外部入力値の検証不備に起因して任意の Java コードを実行可能な脆弱性が存在します。  The Apache Software Foundation が提供する Log4j は、Java ベースのロギングライブラリです。Log4j には、ログに記載された文字列から一部の値を変数として評価する Lookup 機能が実装されています。 その Lookup 機能の内、JNDI Lookup 機能を悪用することにより、ログに含まれる外部の URL もしくは内部パスから Java のクラス情報をデシリアライズして実行してしまう問題（CWE-20, CVE-2021-44228）が発見されました。 これにより、遠隔の攻撃者が細工した文字列を脆弱なシステムのログに記載させ、結果として任意の Java コードをシステムに実行させることが可能です。 "
+		},
+		"affected": {
+			"affecteditem": [
+				{
+					"name": "Apache Software Foundation",
+					"productname": "Apache Log4j",
+					"cpe": {
+						"text": "cpe:/a:apache:log4j",
+						"version": "2.2"
+					},
+					"versionnumber": [
+						"2.13.0 から 2.15.0 より前のバージョン",
+						"core 2.0-beta9 から 2.12.1 より前のバージョン"
+					]
+				},
+				{
+					"name": "日本電気",
+					"productname": "ACOS Access Toolkit",
+					"cpe": {
+						"text": "cpe:/a:nec:acos_access_toolkit",
+						"version": "2.2"
+					}
+				}
+			]
+		},
+		"impact": {
+			"cvss": [
+				{
+					"version": "2.0",
+					"severity": {
+						"text": "High",
+						"type": "Base"
+					},
+					"base": "9.3",
+					"vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C"
+				},
+				{
+					"version": "3.0",
+					"severity": {
+						"text": "Critical",
+						"type": "Base"
+					},
+					"base": "10",
+					"vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+				}
+			],
+			"impactitem": {
+				"description": "遠隔の攻撃者により細工された文字列を Log4j がログに記録することにより、システム上で任意の Java コードが実行される可能性があります。"
+			}
+		},
+		"solution": {
+			"solutionitem": {
+				"description": "[アップデートする] 開発者により、本脆弱性を修正した以下のバージョンが提供されています。 開発者が提供する情報をもとに、最新版にアップデートしてください。 なお、本アップデートでは、Log4j の Lookup 機能が削除されており、JNDI へのアクセスがデフォルトで無効化されています。   　* Java 8のユーザ向け修正版 　　* Log4j 2.17.1  　* Java 7のユーザ向け修正版 　　* Log4j 2.12.4  　* Java 6のユーザ向け修正 　　* Log4j 2.3.2  開発者は当初、本脆弱性に対する修正版として 2.15.0 をリリースしていましたが、特定の構成において任意のコード実行が行われる可能性があることが判明し、Lookup 機能を削除した上で JNDI 機能そのものをデフォルトで無効化した 2.16.0 および 2.12.2 が改めてリリースされました。この問題に対しては CVE-2021-45046 が採番されています。  2021年12月18日、開発者は Log4j 2.0-alpha1 から 2.16.0 までのバージョンにおいて、再帰的（self-referential）なLookup を行う設定下において、サービス運用（DoS）が行われる脆弱性が新たに発見されたとして、バージョン 2.17.0 をリリースしました。この脆弱性に対しては CVE-2021-45105 が採番されています。  2021年12月21日、開発者は一連の脆弱性を修正したバージョンとして、Java 6 ユーザ向けに 2.3.1 を、Java 7 ユーザ向けに 2.12.3 をリリースしました。  2021年12月28日、開発者は Log4j2 2.0-beta7 から 2.17.0（2.3.2 および 2.12.4 を除く）において、攻撃者がログ出力設定を変更できる場合に限り任意のコード実行が行われる可能性があるとして、Log4j 2.17.1、2.12.4、2.3.2 をリリースしました。この修正では、JNDI のデータソースを Java プロトコルに制限する変更が行われました。この脆弱性に対しては CVE-2021-44832 が採番されています。  [ワークアラウンドを実施する] 以下の回避策を適用することにより、本脆弱性の悪用を防ぐことが可能です。  　* JndiLookup クラスをクラスパスから除外する 　　* 例: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class 　　* この回避策は CVE-2021-45046 に対しても有効です  　* Log4j を実行する Java 仮想マシンを起動する際に log4j2.formatMsgNoLookups を true に設定する（Log4j 2.10 およびそれ以降のバージョンが対象） 　　* 例: -Dlog4j2.formatMsgNoLookups=true 　　* この回避策は CVE-2021-45046 に対して有効ではありません  　* 環境変数 LOG4J_FORMAT_MSG_NO_LOOKUPS を true に設定する（Log4j 2.10 およびそれ以降のバージョンが対象） 　　* この回避策は CVE-2021-45046 に対して有効ではありません  また、本脆弱性の影響を軽減するため、システムから外部への接続を制限するアクセス制御を実施または強化することも有効です。"
+			}
+		},
+		"related": {
+			"relateditem": [
+				{
+					"type": "vendor",
+					"name": "Apache",
+					"vulinfoid": "Apache Log4j Security Vulnerabilities - Fixed in Log4j 2.15.0",
+					"url": "https://logging.apache.org/log4j/2.x/security.html"
+				},
+				{
+					"type": "vendor",
+					"name": "Hitachi Incdent Response Team",
+					"vulinfoid": "HIRT-PUB21001：Apache Log4jの脆弱性",
+					"url": "https://www.hitachi.co.jp/hirt/publications/hirt-pub21001/"
+				},
+				{
+					"type": "vendor",
+					"name": "Hitachi Software Vulnerability Information",
+					"vulinfoid": "hitachi-sec-2021-146",
+					"url": "https://www.hitachi.co.jp/Prod/comp/soft1/global/security/info/vuls/hitachi-sec-2021-146/index.html"
+				},
+				{
+					"type": "vendor",
+					"name": "Hitachi Software Vulnerability Information",
+					"vulinfoid": "hitachi-sec-2021-147",
+					"url": "https://www.hitachi.co.jp/Prod/comp/soft1/global/security/info/vuls/hitachi-sec-2021-147/index.html"
+				},
+				{
+					"type": "advisory",
+					"name": "JPCERT 緊急報告",
+					"vulinfoid": "JPCERT-AT-2021-0050",
+					"url": "https://www.jpcert.or.jp/at/2021/at210050.html",
+					"fetchedtitle": "Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起"
+				}
+			]
+		},
+		"history": {
+			"historyitem": [
+				{
+					"historyno": "1",
+					"datetime": "2021-12-14T16:37:27+09:00",
+					"description": "[2021年12月14日]\\n  掲載"
+				},
+				{
+					"historyno": "2",
+					"datetime": "2021-12-16T18:10:13+09:00",
+					"description": "[2021年12月16日]\\n  影響を受けるシステム：内容を更新\\n  対策：内容を更新\\n  ベンダ情報：トレンドマイクロ (アラート/アドバイザリ：Apache Log4j の脆弱性（CVE-2021-44228）について) を追加\\n  共通脆弱性識別子(CVE)：CVE-2021-45046 を追加\\n  参考情報：National Vulnerability Database (NVD) (CVE-2021-45046) を追加\\n  参考情報：US-CERT Vulnerability Note (VU#930724) を追加"
+				}
+			]
+		},
+		"datefirstpublished": "2021-12-14T16:37:27+09:00",
+		"datelastupdated": "2022-12-15T10:24:36+09:00",
+		"datepublic": "2021-12-13T00:00:00+09:00"
+	}
+}

--- a/pkg/extract/jvn/feed/detail/testdata/golden/data/2021/JVNDB-2021-005429.json
+++ b/pkg/extract/jvn/feed/detail/testdata/golden/data/2021/JVNDB-2021-005429.json
@@ -1,0 +1,108 @@
+{
+	"id": "JVNDB-2021-005429",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2021-005429",
+				"title": "Apache Log4j における任意のコードが実行可能な脆弱性",
+				"description": "Log4j には JNDI Lookup 機能による外部入力値の検証不備に起因して任意の Java コードを実行可能な脆弱性が存在します。  The Apache Software Foundation が提供する Log4j は、Java ベースのロギングライブラリです。Log4j には、ログに記載された文字列から一部の値を変数として評価する Lookup 機能が実装されています。 その Lookup 機能の内、JNDI Lookup 機能を悪用することにより、ログに含まれる外部の URL もしくは内部パスから Java のクラス情報をデシリアライズして実行してしまう問題（CWE-20, CVE-2021-44228）が発見されました。 これにより、遠隔の攻撃者が細工した文字列を脆弱なシステムのログに記載させ、結果として任意の Java コードをシステムに実行させることが可能です。 ",
+				"severity": [
+					{
+						"type": "cvss_v2",
+						"source": "jvndb.jvn.jp",
+						"cvss_v2": {
+							"vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C",
+							"base_score": 9.3,
+							"nvd_base_severity": "HIGH",
+							"temporal_score": 9.3,
+							"nvd_temporal_severity": "HIGH",
+							"environmental_score": 9.3,
+							"nvd_environmental_severity": "HIGH"
+						}
+					},
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+							"base_score": 10,
+							"base_severity": "CRITICAL",
+							"temporal_score": 10,
+							"temporal_severity": "CRITICAL",
+							"environmental_score": 10,
+							"environmental_severity": "CRITICAL"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://logging.apache.org/log4j/2.x/security.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.hitachi.co.jp/Prod/comp/soft1/global/security/info/vuls/hitachi-sec-2021-146/index.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.hitachi.co.jp/Prod/comp/soft1/global/security/info/vuls/hitachi-sec-2021-147/index.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.hitachi.co.jp/hirt/publications/hirt-pub21001/"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.jpcert.or.jp/at/2021/at210050.html"
+					}
+				],
+				"published": "2021-12-14T16:37:27+09:00",
+				"modified": "2022-12-15T10:24:36+09:00",
+				"optional": {
+					"reference_titles": {
+						"https://www.jpcert.or.jp/at/2021/at210050.html": "Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起"
+					}
+				}
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*"
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:nec:acos_access_toolkit:*:*:*:*:*:*:*:*"
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-detail",
+		"raws": [
+			"fixtures/2021/JVNDB-2021-005429.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/rss/rss.go
+++ b/pkg/extract/jvn/feed/rss/rss.go
@@ -243,6 +243,17 @@ func extract(fetched fetchTypes.Item, raws []string) (dataTypes.Data, error) {
 		})
 	}
 
+	// Collect fetched reference titles (HTML <title> of referenced JPCERT-AT
+	// alert pages) into an optional url->title map. Only a subset of references
+	// carries one, so it is kept in Optional rather than on Reference itself.
+	referenceTitles := make(map[string]string)
+	for _, ref := range fetched.References {
+		if ref.Text == "" || ref.FetchedTitle == "" {
+			continue
+		}
+		referenceTitles[ref.Text] = ref.FetchedTitle
+	}
+
 	// Build CPE-based detections (convert CPE 2.2 URI to CPE 2.3 FS format)
 	var criterions []criterionTypes.Criterion
 	for _, cpe := range fetched.CPE {
@@ -318,6 +329,12 @@ func extract(fetched fetchTypes.Item, raws []string) (dataTypes.Data, error) {
 				References:  refs,
 				Published:   utiltime.Parse([]string{time.RFC3339, "2006-01-02T15:04-07:00"}, fetched.Issued),
 				Modified:    utiltime.Parse([]string{time.RFC3339, "2006-01-02T15:04-07:00"}, fetched.Modified),
+				Optional: func() map[string]any {
+					if len(referenceTitles) == 0 {
+						return nil
+					}
+					return map[string]any{"reference_titles": referenceTitles}
+				}(),
 			},
 			Segments: segments,
 		}},

--- a/pkg/extract/jvn/feed/rss/rss.go
+++ b/pkg/extract/jvn/feed/rss/rss.go
@@ -246,10 +246,13 @@ func extract(fetched fetchTypes.Item, raws []string) (dataTypes.Data, error) {
 	// Collect fetched reference titles (HTML <title> of referenced JPCERT-AT
 	// alert pages) into an optional url->title map. Only a subset of references
 	// carries one, so it is kept in Optional rather than on Reference itself.
-	referenceTitles := make(map[string]string)
+	var referenceTitles map[string]string
 	for _, ref := range fetched.References {
 		if ref.Text == "" || ref.FetchedTitle == "" {
 			continue
+		}
+		if referenceTitles == nil {
+			referenceTitles = make(map[string]string)
 		}
 		referenceTitles[ref.Text] = ref.FetchedTitle
 	}

--- a/pkg/extract/jvn/feed/rss/testdata/fixtures/2011/JVNDB-2011-001013.json
+++ b/pkg/extract/jvn/feed/rss/testdata/fixtures/2011/JVNDB-2011-001013.json
@@ -1,0 +1,85 @@
+{
+	"about": "https://jvndb.jvn.jp/ja/contents/2011/JVNDB-2011-001013.html",
+	"title": "Microsoft Internet Explorer 8 における解放済みメモリを使用する脆弱性",
+	"link": "https://jvndb.jvn.jp/ja/contents/2011/JVNDB-2011-001013.html",
+	"description": "Microsoft Internet Explorer 8 の mshtml.dll ライブラリには、解放済みメモリを使用する (use-after-free) 脆弱性が存在します。",
+	"identifier": "JVNDB-2011-001013",
+	"references": [
+		{
+			"text": "http://jvn.jp/cert/JVNVU427980",
+			"source": "JVN",
+			"id": "JVNVU#427980"
+		},
+		{
+			"text": "http://jvn.jp/cert/JVNTA11-102A",
+			"source": "JVN",
+			"id": "JVNTA11-102A"
+		},
+		{
+			"text": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-0346",
+			"source": "CVE",
+			"id": "CVE-2011-0346"
+		},
+		{
+			"text": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2011-0346",
+			"source": "NVD",
+			"id": "CVE-2011-0346"
+		},
+		{
+			"text": "https://www.jpcert.or.jp/at/2011/at110008.txt",
+			"source": "JPCERT-AT",
+			"id": "JPCERT-AT-2011-0008",
+			"fetchedtitle": "2011年4月 Microsoft セキュリティ情報 (緊急 9件含) に関する注意喚起"
+		},
+		{
+			"text": "http://www.us-cert.gov/cas/alerts/SA11-102A.html",
+			"source": "CERT-SA",
+			"id": "SA11-102A"
+		},
+		{
+			"text": "http://www.kb.cert.org/vuls/id/427980",
+			"source": "CERT-VN",
+			"id": "VU#427980"
+		},
+		{
+			"text": "http://www.us-cert.gov/cas/techalerts/TA11-102A.html",
+			"source": "CERT-TA",
+			"id": "TA11-102A"
+		},
+		{
+			"text": "http://www.ipa.go.jp/security/ciadr/vul/20110413-ms11-018.html",
+			"source": "IPA",
+			"id": "20110413-ms11-018"
+		},
+		{
+			"text": "http://www.securityfocus.com/bid/45639",
+			"source": "BID",
+			"id": "45639"
+		},
+		{
+			"text": "https://jvndb.jvn.jp/ja/cwe/CWE-399.html",
+			"id": "CWE-399",
+			"title": "リソース管理の問題(CWE-399)"
+		}
+	],
+	"cpe": [
+		{
+			"text": "cpe:/a:microsoft:internet_explorer",
+			"version": "2.2",
+			"vendor": "マイクロソフト",
+			"product": "Microsoft Internet Explorer"
+		}
+	],
+	"cvss": [
+		{
+			"version": "2.0",
+			"score": "9.3",
+			"type": "Base",
+			"severity": "High",
+			"vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C"
+		}
+	],
+	"date": "2011-05-02T13:25+09:00",
+	"issued": "2011-01-28T15:38+09:00",
+	"modified": "2011-05-02T13:25+09:00"
+}

--- a/pkg/extract/jvn/feed/rss/testdata/fixtures/2021/JVNDB-2021-005429.json
+++ b/pkg/extract/jvn/feed/rss/testdata/fixtures/2021/JVNDB-2021-005429.json
@@ -1,0 +1,62 @@
+{
+	"about": "https://jvndb.jvn.jp/ja/contents/2021/JVNDB-2021-005429.html",
+	"title": "Apache Log4j における任意のコードが実行可能な脆弱性",
+	"link": "https://jvndb.jvn.jp/ja/contents/2021/JVNDB-2021-005429.html",
+	"description": "Log4j には JNDI Lookup 機能による外部入力値の検証不備に起因して任意の Java コードを実行可能な脆弱性が存在します。\r\n\r\nThe Apache Software Foundation が提供する Log4j は、Java ベースのロギングライブラリです。Log4j には、ログに記載された文字列から一部の値を変数として評価する Lookup 機能が実装されています。\r\nその Lookup 機能の内、JNDI Lookup 機能を悪用することにより、ログに含まれる外部の URL もしくは内部パスから Java のクラス情報をデシリアライズして実行してしまう問題（CWE-20, CVE-2021-44228）が発見されました。\r\nこれにより、遠隔の攻撃者が細工した文字列を脆弱なシステムのログに記載させ、結果として任意の Java コードをシステムに実行させることが可能です。\r\n",
+	"identifier": "JVNDB-2021-005429",
+	"references": [
+		{
+			"text": "https://jvn.jp/vu/JVNVU96768815/",
+			"source": "JVN",
+			"id": "JVNVU#96768815"
+		},
+		{
+			"text": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228",
+			"source": "CVE",
+			"id": "CVE-2021-44228"
+		},
+		{
+			"text": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
+			"source": "NVD",
+			"id": "CVE-2021-44228"
+		},
+		{
+			"text": "https://www.jpcert.or.jp/at/2021/at210050.html",
+			"source": "JPCERT-AT",
+			"id": "JPCERT-AT-2021-0050",
+			"fetchedtitle": "Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起"
+		},
+		{
+			"text": "https://jvndb.jvn.jp/ja/cwe/CWE-20.html",
+			"id": "CWE-20",
+			"title": "不適切な入力確認(CWE-20)"
+		}
+	],
+	"cpe": [
+		{
+			"text": "cpe:/a:apache:log4j",
+			"version": "2.2",
+			"vendor": "Apache Software Foundation",
+			"product": "Apache Log4j"
+		}
+	],
+	"cvss": [
+		{
+			"version": "2.0",
+			"score": "9.3",
+			"type": "Base",
+			"severity": "High",
+			"vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C"
+		},
+		{
+			"version": "3.0",
+			"score": "10.0",
+			"type": "Base",
+			"severity": "Critical",
+			"vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+		}
+	],
+	"date": "2022-12-15T10:24+09:00",
+	"issued": "2021-12-14T16:37+09:00",
+	"modified": "2022-12-15T10:24+09:00"
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-20.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-20.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-20",
+	"name": "不適切な入力確認",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "https://jvndb.jvn.jp/ja/cwe/CWE-20.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss"
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-399.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/cwe/CWE-399.json
@@ -1,0 +1,13 @@
+{
+	"id": "CWE-399",
+	"name": "リソース管理の問題",
+	"references": [
+		{
+			"source": "jvndb.jvn.jp",
+			"url": "https://jvndb.jvn.jp/ja/cwe/CWE-399.html"
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss"
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2011/JVNDB-2011-001013.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2011/JVNDB-2011-001013.json
@@ -1,0 +1,138 @@
+{
+	"id": "JVNDB-2011-001013",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2011-001013",
+				"title": "Microsoft Internet Explorer 8 における解放済みメモリを使用する脆弱性",
+				"description": "Microsoft Internet Explorer 8 の mshtml.dll ライブラリには、解放済みメモリを使用する (use-after-free) 脆弱性が存在します。",
+				"severity": [
+					{
+						"type": "cvss_v2",
+						"source": "jvndb.jvn.jp",
+						"cvss_v2": {
+							"vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C",
+							"base_score": 9.3,
+							"nvd_base_severity": "HIGH",
+							"temporal_score": 9.3,
+							"nvd_temporal_severity": "HIGH",
+							"environmental_score": 9.3,
+							"nvd_environmental_severity": "HIGH"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-399"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-0346"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://jvn.jp/cert/JVNTA11-102A"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://jvn.jp/cert/JVNVU427980"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2011-0346"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://www.ipa.go.jp/security/ciadr/vul/20110413-ms11-018.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://www.kb.cert.org/vuls/id/427980"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://www.securityfocus.com/bid/45639"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://www.us-cert.gov/cas/alerts/SA11-102A.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://www.us-cert.gov/cas/techalerts/TA11-102A.html"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.jpcert.or.jp/at/2011/at110008.txt"
+					}
+				],
+				"published": "2011-01-28T15:38:00+09:00",
+				"modified": "2011-05-02T13:25:00+09:00",
+				"optional": {
+					"reference_titles": {
+						"https://www.jpcert.or.jp/at/2011/at110008.txt": "2011年4月 Microsoft セキュリティ情報 (緊急 9件含) に関する注意喚起"
+					}
+				}
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2011-0346",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-0346"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2011-0346"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:microsoft:internet_explorer:*:*:*:*:*:*:*:*"
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss",
+		"raws": [
+			"fixtures/2011/JVNDB-2011-001013.json"
+		]
+	}
+}

--- a/pkg/extract/jvn/feed/rss/testdata/golden/data/2021/JVNDB-2021-005429.json
+++ b/pkg/extract/jvn/feed/rss/testdata/golden/data/2021/JVNDB-2021-005429.json
@@ -1,0 +1,127 @@
+{
+	"id": "JVNDB-2021-005429",
+	"advisories": [
+		{
+			"content": {
+				"id": "JVNDB-2021-005429",
+				"title": "Apache Log4j における任意のコードが実行可能な脆弱性",
+				"description": "Log4j には JNDI Lookup 機能による外部入力値の検証不備に起因して任意の Java コードを実行可能な脆弱性が存在します。\r\n\r\nThe Apache Software Foundation が提供する Log4j は、Java ベースのロギングライブラリです。Log4j には、ログに記載された文字列から一部の値を変数として評価する Lookup 機能が実装されています。\r\nその Lookup 機能の内、JNDI Lookup 機能を悪用することにより、ログに含まれる外部の URL もしくは内部パスから Java のクラス情報をデシリアライズして実行してしまう問題（CWE-20, CVE-2021-44228）が発見されました。\r\nこれにより、遠隔の攻撃者が細工した文字列を脆弱なシステムのログに記載させ、結果として任意の Java コードをシステムに実行させることが可能です。\r\n",
+				"severity": [
+					{
+						"type": "cvss_v2",
+						"source": "jvndb.jvn.jp",
+						"cvss_v2": {
+							"vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C",
+							"base_score": 9.3,
+							"nvd_base_severity": "HIGH",
+							"temporal_score": 9.3,
+							"nvd_temporal_severity": "HIGH",
+							"environmental_score": 9.3,
+							"nvd_environmental_severity": "HIGH"
+						}
+					},
+					{
+						"type": "cvss_v30",
+						"source": "jvndb.jvn.jp",
+						"cvss_v30": {
+							"vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+							"base_score": 10,
+							"base_severity": "CRITICAL",
+							"temporal_score": 10,
+							"temporal_severity": "CRITICAL",
+							"environmental_score": 10,
+							"environmental_severity": "CRITICAL"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "jvndb.jvn.jp",
+						"cwe": [
+							"CWE-20"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://jvn.jp/vu/JVNVU96768815/"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://www.jpcert.or.jp/at/2021/at210050.html"
+					}
+				],
+				"published": "2021-12-14T16:37:00+09:00",
+				"modified": "2022-12-15T10:24:00+09:00",
+				"optional": {
+					"reference_titles": {
+						"https://www.jpcert.or.jp/at/2021/at210050.html": "Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起"
+					}
+				}
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2021-44228",
+				"references": [
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228"
+					},
+					{
+						"source": "jvndb.jvn.jp",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*"
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "jvn-feed-rss",
+		"raws": [
+			"fixtures/2021/JVNDB-2021-005429.json"
+		]
+	}
+}


### PR DESCRIPTION
## What
Preserve the JPCERT-AT alert-page titles that `fetch jvn-feed-rss` / `jvn-feed-detail` retrieve (`fetchedtitle`) into the extracted JVN data — as a JVN-local **optional `url -> title` map**, not as a field on the shared `reference.Reference`.

## Why
An earlier attempt added `Title`/`Tags` to the shared `reference.Reference` and wired every source (#891). Across sources the embedded data turned out to be low-signal, so that approach was dropped. JVN, however, does carry genuinely useful data: the HTML `<title>` of referenced JPCERT-AT alert pages (already fetched in #883). This keeps that value without touching shared types.

## How
- In the JVN rss/detail extractors, collect `fetchedtitle` into a `map[url]title` and store it under the advisory `Content.Optional` bag as `{"reference_titles": {url: title}}`. Empty → `Optional` stays nil (`omitempty`).
- Mirrors the existing `Optional` pattern (e.g. `mitre/cve/v5`'s `container_types`).
- **No changes to `reference.Reference` or any shared type** — the map lives only in JVN output.

Example output:
```json
"optional": {
  "reference_titles": {
    "https://www.jpcert.or.jp/at/2021/at210050.html":
      "Apache Log4jの任意のコード実行の脆弱性（CVE-2021-44228）に関する注意喚起"
  }
}
```

## Testing
- Added extract fixtures `JVNDB-2011-001013` (`.txt` alert) and `JVNDB-2021-005429` (Log4j) — reusing the real fetch-side output that carries `fetchedtitle` — to exercise the map; goldens regenerated.
- `GOEXPERIMENT=jsonv2 go build ./...`, `go vet`, `gofmt` clean; `go test ./pkg/extract/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)