### PR TITLE
feat(fetch/nvd/api/cvehistory): add CVE change history fetcher

### DIFF
--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -117,6 +117,7 @@ import (
 	nvdAPICPE "github.com/MaineK00n/vuls-data-update/pkg/fetch/nvd/api/cpe"
 	nvdAPICPEMatch "github.com/MaineK00n/vuls-data-update/pkg/fetch/nvd/api/cpematch"
 	nvdAPICVE "github.com/MaineK00n/vuls-data-update/pkg/fetch/nvd/api/cve"
+	nvdAPICVEHistory "github.com/MaineK00n/vuls-data-update/pkg/fetch/nvd/api/cvehistory"
 	nvdFeedCPEv1 "github.com/MaineK00n/vuls-data-update/pkg/fetch/nvd/feed/cpe/v1"
 	nvdFeedCPEv2 "github.com/MaineK00n/vuls-data-update/pkg/fetch/nvd/feed/cpe/v2"
 	nvdFeedCPEMATCHv1 "github.com/MaineK00n/vuls-data-update/pkg/fetch/nvd/feed/cpematch/v1"
@@ -260,7 +261,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdNpmGHSA(), newCmdNpmGLSA(), newCmdNpmOSV(), newCmdNpmDB(),
 		newCmdNucleiAPI(), newCmdNucleiRepository(),
 		newCmdNugetGHSA(), newCmdNugetGLSA(), newCmdNugetOSV(),
-		newCmdNVDAPICVE(), newCmdNVDAPICPE(), newCmdNVDAPICPEMatch(), newCmdNVDFeedCVEv1(), newCmdNVDFeedCPEv1(), newCmdNVDFeedCPEMATCHv1(), newCmdNVDFeedCVEv2(), newCmdNVDFeedCPEv2(), newCmdNVDFeedCPEMATCHv2(),
+		newCmdNVDAPICVE(), newCmdNVDAPICVEHistory(), newCmdNVDAPICPE(), newCmdNVDAPICPEMatch(), newCmdNVDFeedCVEv1(), newCmdNVDFeedCPEv1(), newCmdNVDFeedCPEMATCHv1(), newCmdNVDFeedCVEv2(), newCmdNVDFeedCPEv2(), newCmdNVDFeedCPEMATCHv2(),
 		newCmdOcamlOSV(),
 		newCmdOpenEulerCVRF(), newCmdOpenEulerCSAF(), newCmdOpenEulerOSV(),
 		newCmdOracleLinux(), newCmdOracleOLAM(), newCmdOracleOpenStack(), newCmdOracleVM(),
@@ -3513,6 +3514,76 @@ func newCmdNVDAPICVE() *cobra.Command {
 	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "sleep duration between consecutive requests")
 	cmd.Flags().TimeVarP(&options.lastModStartDate, "last-mod-start-date", "", options.lastModStartDate, []string{time.DateOnly, time.DateTime, time.RFC3339, "2006-01-02T15:04:05.000-07:00"}, "return only the CVEs that were last modified during the specified period")
 	cmd.Flags().TimeVarP(&options.lastModEndDate, "last-mod-end-date", "", options.lastModEndDate, []string{time.DateOnly, time.DateTime, time.RFC3339, "2006-01-02T15:04:05.000-07:00"}, "return only the CVEs that were last modified during the specified period")
+	cmd.Flags().StringVarP(&options.apiKey, "api-key", "", options.apiKey, "API Key to increase rate limit")
+
+	return cmd
+}
+
+func newCmdNVDAPICVEHistory() *cobra.Command {
+	options := &struct {
+		base
+		retryWaitMin    time.Duration
+		retryWaitMax    time.Duration
+		concurrency     int
+		wait            time.Duration
+		changeStartDate time.Time
+		changeEndDate   time.Time
+		apiKey          string
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "nvd", "api", "cvehistory"),
+			retry: 20,
+		},
+		retryWaitMin:    6 * time.Second,
+		retryWaitMax:    30 * time.Second,
+		concurrency:     1,
+		wait:            6 * time.Second,
+		changeStartDate: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
+		changeEndDate:   time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "nvd-api-cvehistory",
+		Short: "Fetch NVD API CVE Change History data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch nvd-api-cvehistory
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := nvdAPICVEHistory.Fetch(
+				nvdAPICVEHistory.WithDir(options.dir),
+				nvdAPICVEHistory.WithRetry(options.retry), nvdAPICVEHistory.WithRetryWaitMin(options.retryWaitMin), nvdAPICVEHistory.WithRetryWaitMax(options.retryWaitMax),
+				nvdAPICVEHistory.WithConcurrency(options.concurrency), nvdAPICVEHistory.WithWait(options.wait),
+				nvdAPICVEHistory.WithChangeStartDate(func() *time.Time {
+					if options.changeStartDate.IsZero() {
+						return nil
+					}
+					return &options.changeStartDate
+				}()),
+				nvdAPICVEHistory.WithChangeEndDate(func() *time.Time {
+					if options.changeEndDate.IsZero() {
+						return nil
+					}
+					return &options.changeEndDate
+				}()),
+				nvdAPICVEHistory.WithAPIKey(options.apiKey),
+			); err != nil {
+				return errors.Wrap(err, "failed to fetch nvd api cvehistory")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
+	cmd.Flags().DurationVarP(&options.retryWaitMin, "retry-wait-min", "", options.retryWaitMin, "number of minimum time to retry wait")
+	cmd.Flags().DurationVarP(&options.retryWaitMax, "retry-wait-max", "", options.retryWaitMax, "number of maximum time to retry wait")
+	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent API requests")
+	// Rate limit without API key: 5 requests in a rolling 30 second window, and
+	// with API key: 50 requests in a rolling 30 second window.
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "sleep duration between consecutive requests")
+	cmd.Flags().TimeVarP(&options.changeStartDate, "change-start-date", "", options.changeStartDate, []string{time.DateOnly, time.DateTime, time.RFC3339, "2006-01-02T15:04:05.000-07:00"}, "return only the CVE change events that occurred during the specified period")
+	cmd.Flags().TimeVarP(&options.changeEndDate, "change-end-date", "", options.changeEndDate, []string{time.DateOnly, time.DateTime, time.RFC3339, "2006-01-02T15:04:05.000-07:00"}, "return only the CVE change events that occurred during the specified period")
 	cmd.Flags().StringVarP(&options.apiKey, "api-key", "", options.apiKey, "API Key to increase rate limit")
 
 	return cmd

--- a/pkg/fetch/nvd/api/cpe/cpe.go
+++ b/pkg/fetch/nvd/api/cpe/cpe.go
@@ -183,7 +183,7 @@ func Fetch(opts ...Option) error {
 
 	slog.Info("Fetch NVD CPE API", slog.String("dir", options.dir))
 
-	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(time.Duration(options.retryWaitMin)*time.Second), utilhttp.WithClientRetryWaitMax(time.Duration(options.retryWaitMax)*time.Second), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
+	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(options.retryWaitMin), utilhttp.WithClientRetryWaitMax(options.retryWaitMax), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
 
 	h := make(http.Header)
 	if options.apiKey != "" {

--- a/pkg/fetch/nvd/api/cpematch/cpematch.go
+++ b/pkg/fetch/nvd/api/cpematch/cpematch.go
@@ -183,7 +183,7 @@ func Fetch(opts ...Option) error {
 
 	slog.Info("Fetch NVD CPE match API", slog.String("dir", options.dir))
 
-	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(time.Duration(options.retryWaitMin)*time.Second), utilhttp.WithClientRetryWaitMax(time.Duration(options.retryWaitMax)*time.Second), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
+	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(options.retryWaitMin), utilhttp.WithClientRetryWaitMax(options.retryWaitMax), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
 
 	h := make(http.Header)
 	if options.apiKey != "" {

--- a/pkg/fetch/nvd/api/cve/cve.go
+++ b/pkg/fetch/nvd/api/cve/cve.go
@@ -180,7 +180,7 @@ func Fetch(opts ...Option) error {
 
 	slog.Info("Fetch NVD CVE API", slog.String("dir", options.dir))
 
-	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(time.Duration(options.retryWaitMin)*time.Second), utilhttp.WithClientRetryWaitMax(time.Duration(options.retryWaitMax)*time.Second), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
+	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(options.retryWaitMin), utilhttp.WithClientRetryWaitMax(options.retryWaitMax), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
 
 	h := make(http.Header)
 	if options.apiKey != "" {

--- a/pkg/fetch/nvd/api/cvehistory/cvehistory.go
+++ b/pkg/fetch/nvd/api/cvehistory/cvehistory.go
@@ -1,0 +1,314 @@
+package cvehistory
+
+import (
+	"encoding/json/v2"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	nvdutil "github.com/MaineK00n/vuls-data-update/pkg/fetch/nvd/api/util"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+const (
+	// API reference page: https://nvd.nist.gov/developers/vulnerabilities
+	apiURL = "https://services.nvd.nist.gov/rest/json/cvehistory/2.0"
+
+	// resultsPerPage must be <= 5,000, this implementation almost uses the max value
+	resultsPerPageMax = 5_000
+)
+
+type options struct {
+	baseURL         string
+	dir             string
+	retry           int
+	retryWaitMin    time.Duration
+	retryWaitMax    time.Duration
+	concurrency     int
+	wait            time.Duration
+	changeStartDate *time.Time
+	changeEndDate   *time.Time
+	apiKey          string
+
+	// test purpose only
+	resultsPerPage int
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type baseURLOption string
+
+func (u baseURLOption) apply(opts *options) {
+	opts.baseURL = string(u)
+}
+
+func WithBaseURL(url string) Option {
+	return baseURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type retryWaitMinOption time.Duration
+
+func (w retryWaitMinOption) apply(opts *options) {
+	opts.retryWaitMin = time.Duration(w)
+}
+
+func WithRetryWaitMin(wait time.Duration) Option {
+	return retryWaitMinOption(wait)
+}
+
+type retryWaitMaxOption time.Duration
+
+func (w retryWaitMaxOption) apply(opts *options) {
+	opts.retryWaitMax = time.Duration(w)
+}
+
+func WithRetryWaitMax(wait time.Duration) Option {
+	return retryWaitMaxOption(wait)
+}
+
+type concurrencyOption int
+
+func (c concurrencyOption) apply(opts *options) {
+	opts.concurrency = int(c)
+}
+
+func WithConcurrency(concurrency int) Option {
+	return concurrencyOption(concurrency)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+type changeStartDateOption struct {
+	Date *time.Time
+}
+
+func (d changeStartDateOption) apply(opts *options) {
+	opts.changeStartDate = d.Date
+}
+
+func WithChangeStartDate(changeStartDate *time.Time) Option {
+	return changeStartDateOption{Date: changeStartDate}
+}
+
+type changeEndDateOption struct {
+	Date *time.Time
+}
+
+func (d changeEndDateOption) apply(opts *options) {
+	opts.changeEndDate = d.Date
+}
+
+func WithChangeEndDate(changeEndDate *time.Time) Option {
+	return changeEndDateOption{Date: changeEndDate}
+}
+
+type apiKeyOption string
+
+func (a apiKeyOption) apply(opts *options) {
+	opts.apiKey = string(a)
+}
+
+func WithAPIKey(apiKey string) Option {
+	return apiKeyOption(apiKey)
+}
+
+type resultsPerPageOption int
+
+func (r resultsPerPageOption) apply(opts *options) {
+	opts.resultsPerPage = int(r)
+}
+
+func WithResultsPerPage(resultsPerPage int) Option {
+	return resultsPerPageOption(resultsPerPage)
+}
+
+func Fetch(opts ...Option) error {
+	options := &options{
+		baseURL:        apiURL,
+		apiKey:         "",
+		dir:            filepath.Join(util.CacheDir(), "fetch", "nvd", "api", "cvehistory"),
+		retry:          20,
+		retryWaitMin:   6 * time.Second,
+		retryWaitMax:   30 * time.Second,
+		concurrency:    1,
+		wait:           6 * time.Second,
+		resultsPerPage: resultsPerPageMax,
+	}
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Fetch NVD CVE History API", slog.String("dir", options.dir))
+
+	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(time.Duration(options.retryWaitMin)*time.Second), utilhttp.WithClientRetryWaitMax(time.Duration(options.retryWaitMax)*time.Second), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
+
+	h := make(http.Header)
+	if options.apiKey != "" {
+		h.Add("apiKey", options.apiKey)
+	}
+	headerOption := utilhttp.WithRequestHeader(h)
+
+	// Preliminary API call to get totalResults.
+	// Use 1 as resultsPerPage to save time.
+	u, err := fullURL(options.baseURL, 0, 1, options.changeStartDate, options.changeEndDate)
+	if err != nil {
+		return errors.Wrap(err, "full URL")
+	}
+
+	resp, err := c.Get(u, headerOption)
+	if err != nil {
+		return errors.Wrap(err, "preliminary API call")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return errors.Errorf("error response with status code %d", resp.StatusCode)
+	}
+
+	var preliminary api20
+	if err := json.UnmarshalRead(resp.Body, &preliminary); err != nil {
+		return errors.Wrap(err, "decode json")
+	}
+
+	totalResults := preliminary.TotalResults
+	preciselyPaged := (totalResults % options.resultsPerPage) == 0
+	pages := totalResults / options.resultsPerPage
+	if !preciselyPaged {
+		pages++
+	}
+
+	// Actual API calls
+	us := make([]string, 0, pages)
+	for startIndex := 0; startIndex < totalResults; startIndex += options.resultsPerPage {
+		url, err := fullURL(options.baseURL, startIndex, options.resultsPerPage, options.changeStartDate, options.changeEndDate)
+		if err != nil {
+			return errors.Wrap(err, "full URL")
+		}
+		us = append(us, url)
+	}
+
+	if err := c.PipelineGet(us, options.concurrency, options.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d", resp.StatusCode)
+		}
+
+		var response api20
+		if err := json.UnmarshalRead(resp.Body, &response); err != nil {
+			return errors.Wrap(err, "decode json")
+		}
+
+		// Sanity check:
+		// NVD's API document does not say that response item counts are equal to
+		// request's resultsPerPage (in non-final pages).
+		// If we don't check the counts, we may have incomplete results.
+		actualResults := len(response.CVEChanges)
+		finalStartIndex := options.resultsPerPage * (pages - 1)
+		if response.StartIndex == finalStartIndex && !preciselyPaged {
+			// Allow the last page have more than expected results,
+			// because item may be added in the middle of command execution.
+			expectedResults := totalResults % options.resultsPerPage
+			if actualResults < expectedResults {
+				return errors.Errorf("unexpected results at last page, startIndex: %d, expected: %d actual: %d", response.StartIndex, expectedResults, actualResults)
+			}
+		} else {
+			// Non-final page or fully-populated final page, should have max count.
+			if actualResults != options.resultsPerPage {
+				return errors.Errorf("unexpected results at startIndex: %d, expected: %d actual: %d", response.StartIndex, options.resultsPerPage, actualResults)
+			}
+		}
+
+		// A CVE has multiple change events, and they are spread over the pages.
+		// Store each change event in its own file, so that no page has to wait
+		// for the others.
+		for _, ch := range response.CVEChanges {
+			splitted, err := util.Split(ch.Change.CVEID, "-", "-")
+			if err != nil {
+				return errors.Wrapf(err, "unexpected ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", ch.Change.CVEID)
+			}
+			if _, err := time.Parse("2006", splitted[1]); err != nil {
+				return errors.Wrapf(err, "unexpected ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", ch.Change.CVEID)
+			}
+
+			if err := util.Write(filepath.Join(options.dir, splitted[1], ch.Change.CVEID, fmt.Sprintf("%s.json", ch.Change.CVEChangeID)), ch.Change); err != nil {
+				return errors.Wrapf(err, "write %s", filepath.Join(options.dir, splitted[1], ch.Change.CVEID, fmt.Sprintf("%s.json", ch.Change.CVEChangeID)))
+			}
+		}
+		return nil
+	}, headerOption); err != nil {
+		return errors.Wrap(err, "pipeline get")
+	}
+
+	return nil
+}
+
+func fullURL(baseURL string, startIndex, resultsPerPage int, changeStartDate, changeEndDate *time.Time) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", errors.Wrapf(err, "parse base URL: %s", baseURL)
+	}
+	q := u.Query()
+	q.Set("startIndex", strconv.Itoa(startIndex))
+	q.Set("resultsPerPage", strconv.Itoa(resultsPerPage))
+	if changeStartDate != nil || changeEndDate != nil {
+		if changeStartDate == nil || changeEndDate == nil {
+			return "", errors.New("Both changeStartDate and changeEndDate are required when either is present")
+		}
+		if (*changeEndDate).Before(*changeStartDate) {
+			return "", errors.New("end date is before start date")
+		}
+		if (*changeEndDate).Sub(*changeStartDate) > 120*24*time.Hour {
+			return "", errors.New("Date range cannot exceed 120 days")
+		}
+		q.Set("changeStartDate", changeStartDate.Format("2006-01-02T15:04:05.000-07:00"))
+		q.Set("changeEndDate", changeEndDate.Format("2006-01-02T15:04:05.000-07:00"))
+	}
+	u.RawQuery = strings.ReplaceAll(q.Encode(), "%3A", ":")
+	return u.String(), nil
+}

--- a/pkg/fetch/nvd/api/cvehistory/cvehistory.go
+++ b/pkg/fetch/nvd/api/cvehistory/cvehistory.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +26,13 @@ const (
 
 	// resultsPerPage must be <= 5,000, this implementation almost uses the max value
 	resultsPerPageMax = 5_000
+)
+
+// Patterns defined by the API schema
+// https://csrc.nist.gov/schema/nvd/api/2.0/cve_history_api_json_2.0.schema
+var (
+	cveIDPattern       = regexp.MustCompile(`^CVE-([0-9]{4})-[0-9]{4,}$`)
+	cveChangeIDPattern = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
 )
 
 type options struct {
@@ -183,7 +191,7 @@ func Fetch(opts ...Option) error {
 
 	slog.Info("Fetch NVD CVE History API", slog.String("dir", options.dir))
 
-	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(time.Duration(options.retryWaitMin)*time.Second), utilhttp.WithClientRetryWaitMax(time.Duration(options.retryWaitMax)*time.Second), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
+	c := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry), utilhttp.WithClientRetryWaitMin(options.retryWaitMin), utilhttp.WithClientRetryWaitMax(options.retryWaitMax), utilhttp.WithClientCheckRetry(nvdutil.CheckRetry), utilhttp.WithClientBackoff(nvdutil.Backoff))
 
 	h := make(http.Header)
 	if options.apiKey != "" {
@@ -268,16 +276,18 @@ func Fetch(opts ...Option) error {
 		// Store each change event in its own file, so that no page has to wait
 		// for the others.
 		for _, ch := range response.CVEChanges {
-			splitted, err := util.Split(ch.Change.CVEID, "-", "-")
-			if err != nil {
-				return errors.Wrapf(err, "unexpected ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", ch.Change.CVEID)
+			// Both IDs come from the API response and are used as path elements,
+			// so accept only the formats the schema defines.
+			m := cveIDPattern.FindStringSubmatch(ch.Change.CVEID)
+			if m == nil {
+				return errors.Errorf("unexpected ID format. expected: %q, actual: %q", cveIDPattern.String(), ch.Change.CVEID)
 			}
-			if _, err := time.Parse("2006", splitted[1]); err != nil {
-				return errors.Wrapf(err, "unexpected ID format. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}", ch.Change.CVEID)
+			if !cveChangeIDPattern.MatchString(ch.Change.CVEChangeID) {
+				return errors.Errorf("unexpected change ID format. expected: %q, actual: %q", cveChangeIDPattern.String(), ch.Change.CVEChangeID)
 			}
 
-			if err := util.Write(filepath.Join(options.dir, splitted[1], ch.Change.CVEID, fmt.Sprintf("%s.json", ch.Change.CVEChangeID)), ch.Change); err != nil {
-				return errors.Wrapf(err, "write %s", filepath.Join(options.dir, splitted[1], ch.Change.CVEID, fmt.Sprintf("%s.json", ch.Change.CVEChangeID)))
+			if err := util.Write(filepath.Join(options.dir, m[1], ch.Change.CVEID, fmt.Sprintf("%s.json", ch.Change.CVEChangeID)), ch.Change); err != nil {
+				return errors.Wrapf(err, "write %s", filepath.Join(options.dir, m[1], ch.Change.CVEID, fmt.Sprintf("%s.json", ch.Change.CVEChangeID)))
 			}
 		}
 		return nil

--- a/pkg/fetch/nvd/api/cvehistory/cvehistory_test.go
+++ b/pkg/fetch/nvd/api/cvehistory/cvehistory_test.go
@@ -1,0 +1,226 @@
+package cvehistory_test
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/nvd/api/cvehistory"
+)
+
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []cvehistory.Option
+		fixturePrefix string
+		expectedCount int
+		hasError      bool
+	}{
+		{
+			name:          "empty",
+			fixturePrefix: "empty",
+			expectedCount: 0,
+		},
+		{
+			name:          "1 item",
+			fixturePrefix: "1_item",
+			expectedCount: 1,
+		},
+		{
+			// oldValue and newValue are not always a string
+			name:          "detail values in array and object",
+			fixturePrefix: "nonstring_values",
+			expectedCount: 1,
+		},
+		{
+			name:          "Precisely single page",
+			fixturePrefix: "3_items",
+			expectedCount: 3,
+		},
+		{
+			// Change events of a CVE are spread over the pages.
+			name:          "Multiple pages",
+			fixturePrefix: "3_pages",
+			expectedCount: 8,
+		},
+		{
+			// The totalResults is 7 initially, but increases to 8 after 2nd page.
+			name:          "Total count increase in the middle of command execution",
+			fixturePrefix: "increase",
+			expectedCount: 8,
+		},
+		{
+			name:          "With API Key",
+			args:          []cvehistory.Option{cvehistory.WithAPIKey("foobar")},
+			fixturePrefix: "3_pages",
+			expectedCount: 8,
+		},
+		{
+			name: "specify start and end change date",
+			args: []cvehistory.Option{
+				cvehistory.WithChangeStartDate(new(time.Date(2024, time.July, 1, 0, 0, 0, 0, time.UTC))),
+				cvehistory.WithChangeEndDate(new(time.Date(2024, time.October, 1, 0, 0, 0, 0, time.UTC))),
+			},
+			fixturePrefix: "changedate",
+			expectedCount: 3,
+		},
+		{
+			name: "date range exceeds 120 days",
+			args: []cvehistory.Option{
+				cvehistory.WithChangeStartDate(new(time.Date(2024, time.July, 1, 0, 0, 0, 0, time.UTC))),
+				cvehistory.WithChangeEndDate(new(time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC))),
+			},
+			fixturePrefix: "changedate",
+			hasError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				startIndex := "0"
+				if value := r.URL.Query().Get("startIndex"); value != "" {
+					startIndex = value
+				}
+				resultsPerPage := "5000"
+				if value := r.URL.Query().Get("resultsPerPage"); value != "" {
+					resultsPerPage = value
+				}
+
+				switch {
+				case r.URL.Query().Has("changeStartDate") && r.URL.Query().Has("changeEndDate"):
+					f, err := os.Open(filepath.Join("testdata", "fixtures", tt.fixturePrefix, fmt.Sprintf("%s-%s.json", startIndex, resultsPerPage)))
+					if err != nil {
+						http.Error(w, fmt.Sprintf("Internal Server Error. err: %s", err), http.StatusInternalServerError)
+					}
+					defer f.Close()
+
+					var base struct {
+						ResultsPerPage int    `json:"resultsPerPage"`
+						StartIndex     int    `json:"startIndex"`
+						TotalResults   int    `json:"totalResults"`
+						Format         string `json:"format"`
+						Version        string `json:"version"`
+						Timestamp      string `json:"timestamp"`
+						CVEChanges     []struct {
+							Change cvehistory.Change `json:"change"`
+						} `json:"cveChanges"`
+					}
+					if err := json.UnmarshalRead(f, &base); err != nil {
+						http.Error(w, fmt.Sprintf("Internal Server Error. err: %s", err), http.StatusInternalServerError)
+					}
+
+					s, err := time.Parse("2006-01-02T15:04:05.000-07:00", strings.ReplaceAll(r.URL.Query().Get("changeStartDate"), "%2B", "+"))
+					if err != nil {
+						http.Error(w, fmt.Sprintf("Internal Server Error. err: %s", err), http.StatusInternalServerError)
+					}
+					e, err := time.Parse("2006-01-02T15:04:05.000-07:00", strings.ReplaceAll(r.URL.Query().Get("changeEndDate"), "%2B", "+"))
+					if err != nil {
+						http.Error(w, fmt.Sprintf("Internal Server Error. err: %s", err), http.StatusInternalServerError)
+					}
+
+					var filtered []struct {
+						Change cvehistory.Change `json:"change"`
+					}
+					for _, c := range base.CVEChanges {
+						t, err := time.Parse("2006-01-02T15:04:05.000", c.Change.Created)
+						if err != nil {
+							http.Error(w, fmt.Sprintf("Internal Server Error. err: %s", err), http.StatusInternalServerError)
+						}
+
+						if (t.Equal(s) || t.After(s)) && (t.Equal(e) || t.Before(e)) {
+							filtered = append(filtered, c)
+						}
+					}
+
+					base.TotalResults = len(filtered)
+					end := min(base.StartIndex+base.ResultsPerPage, base.TotalResults)
+					base.CVEChanges = filtered[base.StartIndex:end]
+
+					bs, err := json.Marshal(base)
+					if err != nil {
+						http.Error(w, fmt.Sprintf("Internal Server Error. err: %s", err), http.StatusInternalServerError)
+					}
+
+					i, err := f.Stat()
+					if err != nil {
+						http.Error(w, fmt.Sprintf("Internal Server Error. err: %s", err), http.StatusInternalServerError)
+					}
+
+					http.ServeContent(w, r, filepath.Join("testdata", "fixtures", tt.fixturePrefix, fmt.Sprintf("%s-%s.json", startIndex, resultsPerPage)), i.ModTime(), bytes.NewReader(bs))
+				default:
+					http.ServeFile(w, r, filepath.Join("testdata", "fixtures", tt.fixturePrefix, fmt.Sprintf("%s-%s.json", startIndex, resultsPerPage)))
+				}
+			}))
+			defer ts.Close()
+
+			u, err := url.JoinPath(ts.URL, "/rest/json/cvehistory/2.0")
+			if err != nil {
+				t.Error("unexpected error:", err)
+			}
+
+			dir := t.TempDir()
+			err = cvehistory.Fetch(append(tt.args, cvehistory.WithBaseURL(u), cvehistory.WithDir(dir), cvehistory.WithRetry(0), cvehistory.WithConcurrency(3), cvehistory.WithWait(0), cvehistory.WithResultsPerPage(3))...)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			default:
+				if tt.hasError {
+					return
+				}
+
+				actualCount := 0
+				if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+					if err != nil {
+						return err
+					}
+
+					if d.IsDir() {
+						return nil
+					}
+
+					rel, err := filepath.Rel(dir, path)
+					if err != nil {
+						return err
+					}
+
+					want, err := os.ReadFile(filepath.Join("testdata", "golden", tt.fixturePrefix, rel))
+					if err != nil {
+						return err
+					}
+
+					got, err := os.ReadFile(path)
+					if err != nil {
+						return err
+					}
+
+					if diff := cmp.Diff(want, got); diff != "" {
+						t.Errorf("Fetch(). %s (-expected +got):\n%s", rel, diff)
+					}
+
+					actualCount++
+					return nil
+				}); err != nil {
+					t.Error("walk error:", err)
+				}
+
+				if actualCount != tt.expectedCount {
+					t.Errorf("unexpected #files, expected: %d, actual: %d", actualCount, tt.expectedCount)
+				}
+			}
+		})
+	}
+}

--- a/pkg/fetch/nvd/api/cvehistory/cvehistory_test.go
+++ b/pkg/fetch/nvd/api/cvehistory/cvehistory_test.go
@@ -76,6 +76,12 @@ func TestFetch(t *testing.T) {
 			expectedCount: 3,
 		},
 		{
+			// Both IDs are used as path elements, so a malformed one must not be written
+			name:          "malformed cveChangeId",
+			fixturePrefix: "invalid_id",
+			hasError:      true,
+		},
+		{
 			name: "date range exceeds 120 days",
 			args: []cvehistory.Option{
 				cvehistory.WithChangeStartDate(new(time.Date(2024, time.July, 1, 0, 0, 0, 0, time.UTC))),

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/1_item/0-1.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/1_item/0-1.json
@@ -1,0 +1,20 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 1,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2022-23815",
+        "eventName": "Reanalysis",
+        "cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+        "sourceIdentifier": "nvd@nist.gov",
+        "created": "2025-01-03T18:04:09.057",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/1_item/0-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/1_item/0-3.json
@@ -1,0 +1,20 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 1,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2022-23815",
+        "eventName": "Reanalysis",
+        "cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+        "sourceIdentifier": "nvd@nist.gov",
+        "created": "2025-01-03T18:04:09.057",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_items/0-1.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_items/0-1.json
@@ -1,0 +1,20 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 3,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_items/0-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_items/0-3.json
@@ -1,0 +1,40 @@
+{
+  "resultsPerPage": 3,
+  "startIndex": 0,
+  "totalResults": 3,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-45342",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "0147E440-12A8-405E-BF5A-C937B2FF8D8F",
+        "sourceIdentifier": "security@golang.org",
+        "created": "2025-01-08T20:15:27.583",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2022-23815",
+        "eventName": "Reanalysis",
+        "cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+        "sourceIdentifier": "nvd@nist.gov",
+        "created": "2025-01-03T18:04:09.057",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_pages/0-1.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_pages/0-1.json
@@ -1,0 +1,20 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 8,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_pages/0-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_pages/0-3.json
@@ -1,0 +1,46 @@
+{
+  "resultsPerPage": 3,
+  "startIndex": 0,
+  "totalResults": 8,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-45342",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "0147E440-12A8-405E-BF5A-C937B2FF8D8F",
+        "sourceIdentifier": "security@golang.org",
+        "created": "2025-01-08T20:15:27.583",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "New CVE Received",
+        "cveChangeId": "CC438820-317D-46E7-8D4F-9857F634EB6B",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": [
+          {
+            "action": "Added",
+            "type": "Description",
+            "newValue": "Rejected reason: REJECTED"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_pages/3-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_pages/3-3.json
@@ -1,0 +1,53 @@
+{
+  "resultsPerPage": 3,
+  "startIndex": 3,
+  "totalResults": 8,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2022-23815",
+        "eventName": "Reanalysis",
+        "cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+        "sourceIdentifier": "nvd@nist.gov",
+        "created": "2025-01-03T18:04:09.057",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Modified",
+        "cveChangeId": "F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-04T21:15:10.403",
+        "details": [
+          {
+            "action": "Changed",
+            "type": "Description",
+            "oldValue": "Rejected reason: REJECTED",
+            "newValue": "Rejected reason: This is REJECTED."
+          }
+        ]
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-45342",
+        "eventName": "New CVE Received",
+        "cveChangeId": "9F98E250-EEF7-4FC7-A58E-4057DC798FEA",
+        "sourceIdentifier": "security@golang.org",
+        "created": "2025-01-08T20:15:27.583",
+        "details": [
+          {
+            "action": "Added",
+            "type": "Description",
+            "newValue": "Rejected reason: reserved but not needed"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_pages/6-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/3_pages/6-3.json
@@ -1,0 +1,30 @@
+{
+  "resultsPerPage": 2,
+  "startIndex": 6,
+  "totalResults": 8,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2017-16532",
+        "eventName": "Reanalysis",
+        "cveChangeId": "BE9AAB08-C7AF-4C04-BB34-ECA3D2368C54",
+        "sourceIdentifier": "nvd@nist.gov",
+        "created": "2024-07-17T15:30:45.187",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-2567",
+        "eventName": "CVE Modified",
+        "cveChangeId": "386BB84A-837B-4FB2-ADCC-A3EBCD964566",
+        "sourceIdentifier": "cna@vuldb.com",
+        "created": "2024-07-05T18:15:30.850",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/changedate/0-1.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/changedate/0-1.json
@@ -1,0 +1,89 @@
+{
+  "resultsPerPage": 6,
+  "startIndex": 0,
+  "totalResults": 6,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "New CVE Received",
+        "cveChangeId": "CC438820-317D-46E7-8D4F-9857F634EB6B",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": [
+          {
+            "action": "Added",
+            "type": "Description",
+            "newValue": "Rejected reason: REJECTED"
+          }
+        ]
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Modified",
+        "cveChangeId": "F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-04T21:15:10.403",
+        "details": [
+          {
+            "action": "Changed",
+            "type": "Description",
+            "oldValue": "Rejected reason: REJECTED",
+            "newValue": "Rejected reason: This is REJECTED."
+          }
+        ]
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-45342",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "0147E440-12A8-405E-BF5A-C937B2FF8D8F",
+        "sourceIdentifier": "security@golang.org",
+        "created": "2025-01-08T20:15:27.583",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-45342",
+        "eventName": "New CVE Received",
+        "cveChangeId": "9F98E250-EEF7-4FC7-A58E-4057DC798FEA",
+        "sourceIdentifier": "security@golang.org",
+        "created": "2025-01-08T20:15:27.583",
+        "details": [
+          {
+            "action": "Added",
+            "type": "Description",
+            "newValue": "Rejected reason: reserved but not needed"
+          }
+        ]
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2022-23815",
+        "eventName": "Reanalysis",
+        "cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+        "sourceIdentifier": "nvd@nist.gov",
+        "created": "2025-01-03T18:04:09.057",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/changedate/0-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/changedate/0-3.json
@@ -1,0 +1,89 @@
+{
+  "resultsPerPage": 6,
+  "startIndex": 0,
+  "totalResults": 6,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "New CVE Received",
+        "cveChangeId": "CC438820-317D-46E7-8D4F-9857F634EB6B",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": [
+          {
+            "action": "Added",
+            "type": "Description",
+            "newValue": "Rejected reason: REJECTED"
+          }
+        ]
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Modified",
+        "cveChangeId": "F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-04T21:15:10.403",
+        "details": [
+          {
+            "action": "Changed",
+            "type": "Description",
+            "oldValue": "Rejected reason: REJECTED",
+            "newValue": "Rejected reason: This is REJECTED."
+          }
+        ]
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-45342",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "0147E440-12A8-405E-BF5A-C937B2FF8D8F",
+        "sourceIdentifier": "security@golang.org",
+        "created": "2025-01-08T20:15:27.583",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-45342",
+        "eventName": "New CVE Received",
+        "cveChangeId": "9F98E250-EEF7-4FC7-A58E-4057DC798FEA",
+        "sourceIdentifier": "security@golang.org",
+        "created": "2025-01-08T20:15:27.583",
+        "details": [
+          {
+            "action": "Added",
+            "type": "Description",
+            "newValue": "Rejected reason: reserved but not needed"
+          }
+        ]
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2022-23815",
+        "eventName": "Reanalysis",
+        "cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+        "sourceIdentifier": "nvd@nist.gov",
+        "created": "2025-01-03T18:04:09.057",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/empty/0-1.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/empty/0-1.json
@@ -1,0 +1,9 @@
+{
+  "resultsPerPage": 0,
+  "startIndex": 0,
+  "totalResults": 0,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": []
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/increase/0-1.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/increase/0-1.json
@@ -1,0 +1,20 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 7,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/increase/0-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/increase/0-3.json
@@ -1,0 +1,46 @@
+{
+  "resultsPerPage": 3,
+  "startIndex": 0,
+  "totalResults": 7,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-45342",
+        "eventName": "CVE Rejected",
+        "cveChangeId": "0147E440-12A8-405E-BF5A-C937B2FF8D8F",
+        "sourceIdentifier": "security@golang.org",
+        "created": "2025-01-08T20:15:27.583",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "New CVE Received",
+        "cveChangeId": "CC438820-317D-46E7-8D4F-9857F634EB6B",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-03T19:15:05.143",
+        "details": [
+          {
+            "action": "Added",
+            "type": "Description",
+            "newValue": "Rejected reason: REJECTED"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/increase/3-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/increase/3-3.json
@@ -1,0 +1,53 @@
+{
+  "resultsPerPage": 3,
+  "startIndex": 3,
+  "totalResults": 7,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2022-23815",
+        "eventName": "Reanalysis",
+        "cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+        "sourceIdentifier": "nvd@nist.gov",
+        "created": "2025-01-03T18:04:09.057",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Modified",
+        "cveChangeId": "F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-04T21:15:10.403",
+        "details": [
+          {
+            "action": "Changed",
+            "type": "Description",
+            "oldValue": "Rejected reason: REJECTED",
+            "newValue": "Rejected reason: This is REJECTED."
+          }
+        ]
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-45342",
+        "eventName": "New CVE Received",
+        "cveChangeId": "9F98E250-EEF7-4FC7-A58E-4057DC798FEA",
+        "sourceIdentifier": "security@golang.org",
+        "created": "2025-01-08T20:15:27.583",
+        "details": [
+          {
+            "action": "Added",
+            "type": "Description",
+            "newValue": "Rejected reason: reserved but not needed"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/increase/6-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/increase/6-3.json
@@ -1,0 +1,30 @@
+{
+  "resultsPerPage": 2,
+  "startIndex": 6,
+  "totalResults": 8,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2017-16532",
+        "eventName": "Reanalysis",
+        "cveChangeId": "BE9AAB08-C7AF-4C04-BB34-ECA3D2368C54",
+        "sourceIdentifier": "nvd@nist.gov",
+        "created": "2024-07-17T15:30:45.187",
+        "details": []
+      }
+    },
+    {
+      "change": {
+        "cveId": "CVE-2024-2567",
+        "eventName": "CVE Modified",
+        "cveChangeId": "386BB84A-837B-4FB2-ADCC-A3EBCD964566",
+        "sourceIdentifier": "cna@vuldb.com",
+        "created": "2024-07-05T18:15:30.850",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/invalid_id/0-1.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/invalid_id/0-1.json
@@ -1,0 +1,20 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 1,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Modified",
+        "cveChangeId": "../../../../etc/passwd",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-04T21:15:10.403",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/invalid_id/0-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/invalid_id/0-3.json
@@ -1,0 +1,20 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 1,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2024-6488",
+        "eventName": "CVE Modified",
+        "cveChangeId": "../../../../etc/passwd",
+        "sourceIdentifier": "security@wordfence.com",
+        "created": "2024-07-04T21:15:10.403",
+        "details": []
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/nonstring_values/0-1.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/nonstring_values/0-1.json
@@ -1,0 +1,67 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 1,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2025-5914",
+        "eventName": "CVE Modified",
+        "cveChangeId": "5A88AA91-2A39-400B-8CEA-3B7871636C68",
+        "sourceIdentifier": "secalert@redhat.com",
+        "created": "2026-07-27T00:16:22.150",
+        "details": [
+          {
+            "action": "Changed",
+            "type": "Affected",
+            "oldValue": [
+              {
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://github.com/libarchive/libarchive/",
+                "packageName": "libarchive",
+                "versions": [
+                  {
+                    "version": "0",
+                    "lessThan": "3.8.0",
+                    "versionType": "semver",
+                    "status": "affected"
+                  }
+                ]
+              }
+            ],
+            "newValue": [
+              {
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://github.com/libarchive/libarchive/",
+                "packageName": "libarchive",
+                "versions": [
+                  {
+                    "version": "0",
+                    "lessThan": "3.8.0",
+                    "versionType": "semver",
+                    "status": "affected"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "action": "Changed",
+            "type": "CVSSV4",
+            "oldValue": {
+              "baseScore": 7.5,
+              "baseSeverity": "HIGH"
+            },
+            "newValue": {
+              "baseScore": 9.8,
+              "baseSeverity": "CRITICAL"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/nonstring_values/0-3.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/fixtures/nonstring_values/0-3.json
@@ -1,0 +1,67 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 1,
+  "format": "NVD_CVEHistory",
+  "version": "2.0",
+  "timestamp": "2026-07-28T12:00:00.000",
+  "cveChanges": [
+    {
+      "change": {
+        "cveId": "CVE-2025-5914",
+        "eventName": "CVE Modified",
+        "cveChangeId": "5A88AA91-2A39-400B-8CEA-3B7871636C68",
+        "sourceIdentifier": "secalert@redhat.com",
+        "created": "2026-07-27T00:16:22.150",
+        "details": [
+          {
+            "action": "Changed",
+            "type": "Affected",
+            "oldValue": [
+              {
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://github.com/libarchive/libarchive/",
+                "packageName": "libarchive",
+                "versions": [
+                  {
+                    "version": "0",
+                    "lessThan": "3.8.0",
+                    "versionType": "semver",
+                    "status": "affected"
+                  }
+                ]
+              }
+            ],
+            "newValue": [
+              {
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://github.com/libarchive/libarchive/",
+                "packageName": "libarchive",
+                "versions": [
+                  {
+                    "version": "0",
+                    "lessThan": "3.8.0",
+                    "versionType": "semver",
+                    "status": "affected"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "action": "Changed",
+            "type": "CVSSV4",
+            "oldValue": {
+              "baseScore": 7.5,
+              "baseSeverity": "HIGH"
+            },
+            "newValue": {
+              "baseScore": 9.8,
+              "baseSeverity": "CRITICAL"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/1_item/2022/CVE-2022-23815/91FE9AB8-2F77-49A0-B634-98495FCB844A.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/1_item/2022/CVE-2022-23815/91FE9AB8-2F77-49A0-B634-98495FCB844A.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2022-23815",
+	"eventName": "Reanalysis",
+	"cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+	"sourceIdentifier": "nvd@nist.gov",
+	"created": "2025-01-03T18:04:09.057"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_items/2022/CVE-2022-23815/91FE9AB8-2F77-49A0-B634-98495FCB844A.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_items/2022/CVE-2022-23815/91FE9AB8-2F77-49A0-B634-98495FCB844A.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2022-23815",
+	"eventName": "Reanalysis",
+	"cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+	"sourceIdentifier": "nvd@nist.gov",
+	"created": "2025-01-03T18:04:09.057"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_items/2024/CVE-2024-45342/0147E440-12A8-405E-BF5A-C937B2FF8D8F.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_items/2024/CVE-2024-45342/0147E440-12A8-405E-BF5A-C937B2FF8D8F.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2024-45342",
+	"eventName": "CVE Rejected",
+	"cveChangeId": "0147E440-12A8-405E-BF5A-C937B2FF8D8F",
+	"sourceIdentifier": "security@golang.org",
+	"created": "2025-01-08T20:15:27.583"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_items/2024/CVE-2024-6488/F76168A4-D7A4-4C62-9555-758EAAC5650D.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_items/2024/CVE-2024-6488/F76168A4-D7A4-4C62-9555-758EAAC5650D.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2024-6488",
+	"eventName": "CVE Rejected",
+	"cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+	"sourceIdentifier": "security@wordfence.com",
+	"created": "2024-07-03T19:15:05.143"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2017/CVE-2017-16532/BE9AAB08-C7AF-4C04-BB34-ECA3D2368C54.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2017/CVE-2017-16532/BE9AAB08-C7AF-4C04-BB34-ECA3D2368C54.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2017-16532",
+	"eventName": "Reanalysis",
+	"cveChangeId": "BE9AAB08-C7AF-4C04-BB34-ECA3D2368C54",
+	"sourceIdentifier": "nvd@nist.gov",
+	"created": "2024-07-17T15:30:45.187"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2022/CVE-2022-23815/91FE9AB8-2F77-49A0-B634-98495FCB844A.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2022/CVE-2022-23815/91FE9AB8-2F77-49A0-B634-98495FCB844A.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2022-23815",
+	"eventName": "Reanalysis",
+	"cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+	"sourceIdentifier": "nvd@nist.gov",
+	"created": "2025-01-03T18:04:09.057"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-2567/386BB84A-837B-4FB2-ADCC-A3EBCD964566.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-2567/386BB84A-837B-4FB2-ADCC-A3EBCD964566.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2024-2567",
+	"eventName": "CVE Modified",
+	"cveChangeId": "386BB84A-837B-4FB2-ADCC-A3EBCD964566",
+	"sourceIdentifier": "cna@vuldb.com",
+	"created": "2024-07-05T18:15:30.850"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-45342/0147E440-12A8-405E-BF5A-C937B2FF8D8F.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-45342/0147E440-12A8-405E-BF5A-C937B2FF8D8F.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2024-45342",
+	"eventName": "CVE Rejected",
+	"cveChangeId": "0147E440-12A8-405E-BF5A-C937B2FF8D8F",
+	"sourceIdentifier": "security@golang.org",
+	"created": "2025-01-08T20:15:27.583"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-45342/9F98E250-EEF7-4FC7-A58E-4057DC798FEA.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-45342/9F98E250-EEF7-4FC7-A58E-4057DC798FEA.json
@@ -1,0 +1,14 @@
+{
+	"cveId": "CVE-2024-45342",
+	"eventName": "New CVE Received",
+	"cveChangeId": "9F98E250-EEF7-4FC7-A58E-4057DC798FEA",
+	"sourceIdentifier": "security@golang.org",
+	"created": "2025-01-08T20:15:27.583",
+	"details": [
+		{
+			"action": "Added",
+			"type": "Description",
+			"newValue": "Rejected reason: reserved but not needed"
+		}
+	]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-6488/CC438820-317D-46E7-8D4F-9857F634EB6B.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-6488/CC438820-317D-46E7-8D4F-9857F634EB6B.json
@@ -1,0 +1,14 @@
+{
+	"cveId": "CVE-2024-6488",
+	"eventName": "New CVE Received",
+	"cveChangeId": "CC438820-317D-46E7-8D4F-9857F634EB6B",
+	"sourceIdentifier": "security@wordfence.com",
+	"created": "2024-07-03T19:15:05.143",
+	"details": [
+		{
+			"action": "Added",
+			"type": "Description",
+			"newValue": "Rejected reason: REJECTED"
+		}
+	]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-6488/F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-6488/F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09.json
@@ -1,0 +1,15 @@
+{
+	"cveId": "CVE-2024-6488",
+	"eventName": "CVE Modified",
+	"cveChangeId": "F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09",
+	"sourceIdentifier": "security@wordfence.com",
+	"created": "2024-07-04T21:15:10.403",
+	"details": [
+		{
+			"action": "Changed",
+			"type": "Description",
+			"oldValue": "Rejected reason: REJECTED",
+			"newValue": "Rejected reason: This is REJECTED."
+		}
+	]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-6488/F76168A4-D7A4-4C62-9555-758EAAC5650D.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/3_pages/2024/CVE-2024-6488/F76168A4-D7A4-4C62-9555-758EAAC5650D.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2024-6488",
+	"eventName": "CVE Rejected",
+	"cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+	"sourceIdentifier": "security@wordfence.com",
+	"created": "2024-07-03T19:15:05.143"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/changedate/2024/CVE-2024-6488/CC438820-317D-46E7-8D4F-9857F634EB6B.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/changedate/2024/CVE-2024-6488/CC438820-317D-46E7-8D4F-9857F634EB6B.json
@@ -1,0 +1,14 @@
+{
+	"cveId": "CVE-2024-6488",
+	"eventName": "New CVE Received",
+	"cveChangeId": "CC438820-317D-46E7-8D4F-9857F634EB6B",
+	"sourceIdentifier": "security@wordfence.com",
+	"created": "2024-07-03T19:15:05.143",
+	"details": [
+		{
+			"action": "Added",
+			"type": "Description",
+			"newValue": "Rejected reason: REJECTED"
+		}
+	]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/changedate/2024/CVE-2024-6488/F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/changedate/2024/CVE-2024-6488/F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09.json
@@ -1,0 +1,15 @@
+{
+	"cveId": "CVE-2024-6488",
+	"eventName": "CVE Modified",
+	"cveChangeId": "F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09",
+	"sourceIdentifier": "security@wordfence.com",
+	"created": "2024-07-04T21:15:10.403",
+	"details": [
+		{
+			"action": "Changed",
+			"type": "Description",
+			"oldValue": "Rejected reason: REJECTED",
+			"newValue": "Rejected reason: This is REJECTED."
+		}
+	]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/changedate/2024/CVE-2024-6488/F76168A4-D7A4-4C62-9555-758EAAC5650D.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/changedate/2024/CVE-2024-6488/F76168A4-D7A4-4C62-9555-758EAAC5650D.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2024-6488",
+	"eventName": "CVE Rejected",
+	"cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+	"sourceIdentifier": "security@wordfence.com",
+	"created": "2024-07-03T19:15:05.143"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2017/CVE-2017-16532/BE9AAB08-C7AF-4C04-BB34-ECA3D2368C54.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2017/CVE-2017-16532/BE9AAB08-C7AF-4C04-BB34-ECA3D2368C54.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2017-16532",
+	"eventName": "Reanalysis",
+	"cveChangeId": "BE9AAB08-C7AF-4C04-BB34-ECA3D2368C54",
+	"sourceIdentifier": "nvd@nist.gov",
+	"created": "2024-07-17T15:30:45.187"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2022/CVE-2022-23815/91FE9AB8-2F77-49A0-B634-98495FCB844A.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2022/CVE-2022-23815/91FE9AB8-2F77-49A0-B634-98495FCB844A.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2022-23815",
+	"eventName": "Reanalysis",
+	"cveChangeId": "91FE9AB8-2F77-49A0-B634-98495FCB844A",
+	"sourceIdentifier": "nvd@nist.gov",
+	"created": "2025-01-03T18:04:09.057"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-2567/386BB84A-837B-4FB2-ADCC-A3EBCD964566.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-2567/386BB84A-837B-4FB2-ADCC-A3EBCD964566.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2024-2567",
+	"eventName": "CVE Modified",
+	"cveChangeId": "386BB84A-837B-4FB2-ADCC-A3EBCD964566",
+	"sourceIdentifier": "cna@vuldb.com",
+	"created": "2024-07-05T18:15:30.850"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-45342/0147E440-12A8-405E-BF5A-C937B2FF8D8F.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-45342/0147E440-12A8-405E-BF5A-C937B2FF8D8F.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2024-45342",
+	"eventName": "CVE Rejected",
+	"cveChangeId": "0147E440-12A8-405E-BF5A-C937B2FF8D8F",
+	"sourceIdentifier": "security@golang.org",
+	"created": "2025-01-08T20:15:27.583"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-45342/9F98E250-EEF7-4FC7-A58E-4057DC798FEA.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-45342/9F98E250-EEF7-4FC7-A58E-4057DC798FEA.json
@@ -1,0 +1,14 @@
+{
+	"cveId": "CVE-2024-45342",
+	"eventName": "New CVE Received",
+	"cveChangeId": "9F98E250-EEF7-4FC7-A58E-4057DC798FEA",
+	"sourceIdentifier": "security@golang.org",
+	"created": "2025-01-08T20:15:27.583",
+	"details": [
+		{
+			"action": "Added",
+			"type": "Description",
+			"newValue": "Rejected reason: reserved but not needed"
+		}
+	]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-6488/CC438820-317D-46E7-8D4F-9857F634EB6B.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-6488/CC438820-317D-46E7-8D4F-9857F634EB6B.json
@@ -1,0 +1,14 @@
+{
+	"cveId": "CVE-2024-6488",
+	"eventName": "New CVE Received",
+	"cveChangeId": "CC438820-317D-46E7-8D4F-9857F634EB6B",
+	"sourceIdentifier": "security@wordfence.com",
+	"created": "2024-07-03T19:15:05.143",
+	"details": [
+		{
+			"action": "Added",
+			"type": "Description",
+			"newValue": "Rejected reason: REJECTED"
+		}
+	]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-6488/F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-6488/F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09.json
@@ -1,0 +1,15 @@
+{
+	"cveId": "CVE-2024-6488",
+	"eventName": "CVE Modified",
+	"cveChangeId": "F5BA0B1F-86AB-4B18-A698-3AE52EDDBD09",
+	"sourceIdentifier": "security@wordfence.com",
+	"created": "2024-07-04T21:15:10.403",
+	"details": [
+		{
+			"action": "Changed",
+			"type": "Description",
+			"oldValue": "Rejected reason: REJECTED",
+			"newValue": "Rejected reason: This is REJECTED."
+		}
+	]
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-6488/F76168A4-D7A4-4C62-9555-758EAAC5650D.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/increase/2024/CVE-2024-6488/F76168A4-D7A4-4C62-9555-758EAAC5650D.json
@@ -1,0 +1,7 @@
+{
+	"cveId": "CVE-2024-6488",
+	"eventName": "CVE Rejected",
+	"cveChangeId": "F76168A4-D7A4-4C62-9555-758EAAC5650D",
+	"sourceIdentifier": "security@wordfence.com",
+	"created": "2024-07-03T19:15:05.143"
+}

--- a/pkg/fetch/nvd/api/cvehistory/testdata/golden/nonstring_values/2025/CVE-2025-5914/5A88AA91-2A39-400B-8CEA-3B7871636C68.json
+++ b/pkg/fetch/nvd/api/cvehistory/testdata/golden/nonstring_values/2025/CVE-2025-5914/5A88AA91-2A39-400B-8CEA-3B7871636C68.json
@@ -1,0 +1,55 @@
+{
+	"cveId": "CVE-2025-5914",
+	"eventName": "CVE Modified",
+	"cveChangeId": "5A88AA91-2A39-400B-8CEA-3B7871636C68",
+	"sourceIdentifier": "secalert@redhat.com",
+	"created": "2026-07-27T00:16:22.150",
+	"details": [
+		{
+			"action": "Changed",
+			"type": "Affected",
+			"oldValue": [
+				{
+					"defaultStatus": "unaffected",
+					"collectionURL": "https://github.com/libarchive/libarchive/",
+					"packageName": "libarchive",
+					"versions": [
+						{
+							"version": "0",
+							"lessThan": "3.8.0",
+							"versionType": "semver",
+							"status": "affected"
+						}
+					]
+				}
+			],
+			"newValue": [
+				{
+					"defaultStatus": "unaffected",
+					"collectionURL": "https://github.com/libarchive/libarchive/",
+					"packageName": "libarchive",
+					"versions": [
+						{
+							"version": "0",
+							"lessThan": "3.8.0",
+							"versionType": "semver",
+							"status": "affected"
+						}
+					]
+				}
+			]
+		},
+		{
+			"action": "Changed",
+			"type": "CVSSV4",
+			"oldValue": {
+				"baseScore": 7.5,
+				"baseSeverity": "HIGH"
+			},
+			"newValue": {
+				"baseScore": 9.8,
+				"baseSeverity": "CRITICAL"
+			}
+		}
+	]
+}

--- a/pkg/fetch/nvd/api/cvehistory/types.go
+++ b/pkg/fetch/nvd/api/cvehistory/types.go
@@ -1,0 +1,38 @@
+package cvehistory
+
+import "encoding/json/jsontext"
+
+// Top level structure for CVE History JSON API 2.0 data
+// https://csrc.nist.gov/schema/nvd/api/2.0/cve_history_api_json_2.0.schema
+type api20 struct {
+	ResultsPerPage int    `json:"resultsPerPage"`
+	StartIndex     int    `json:"startIndex"`
+	TotalResults   int    `json:"totalResults"`
+	Format         string `json:"format"`
+	Version        string `json:"version"`
+	Timestamp      string `json:"timestamp"`
+	CVEChanges     []struct {
+		Change Change `json:"change"`
+	} `json:"cveChanges"`
+}
+
+// A change event of a CVE.
+// Top level structure that fetch command stores CVE change history json files is []Change.
+type Change struct {
+	CVEID            string   `json:"cveId"`
+	EventName        string   `json:"eventName"`
+	CVEChangeID      string   `json:"cveChangeId"`
+	SourceIdentifier string   `json:"sourceIdentifier"`
+	Created          string   `json:"created,omitempty"`
+	Details          []Detail `json:"details,omitempty"`
+}
+
+type Detail struct {
+	Action string `json:"action,omitempty"` // enum: Added, Removed, Changed
+	Type   string `json:"type"`
+	// oldValue and newValue are usually a string, but e.g. the "Affected" type
+	// carries the CVE v5 affected structures as an array of objects. Keep them
+	// as raw JSON so that the API response is stored as is.
+	OldValue jsontext.Value `json:"oldValue,omitzero"`
+	NewValue jsontext.Value `json:"newValue,omitzero"`
+}

--- a/pkg/fetch/nvd/api/cvehistory/types.go
+++ b/pkg/fetch/nvd/api/cvehistory/types.go
@@ -17,7 +17,7 @@ type api20 struct {
 }
 
 // A change event of a CVE.
-// Top level structure that fetch command stores CVE change history json files is []Change.
+// Top level structure that fetch command stores CVE change history json files.
 type Change struct {
 	CVEID            string   `json:"cveId"`
 	EventName        string   `json:"eventName"`


### PR DESCRIPTION
## What

Add `vuls-data-update fetch nvd-api-cvehistory`, a fetcher for the [NVD CVE Change History API 2.0](https://nvd.nist.gov/developers/vulnerabilities).

Each change event is stored in its own file:

```
<dir>/<year>/<CVE ID>/<cveChangeId>.json
```

## Why

The NVD CVE API exposes only the current state of a CVE. The change history tells *when* and *by whom* each field (CVSS, CWE, references, CPE configuration, affected, tags, ...) was added, changed or removed, which the CVE API cannot answer.

## How

Follows `pkg/fetch/nvd/api/cve`:

- Preliminary API call with `resultsPerPage=1` to get `totalResults`, then page through with `startIndex`. `resultsPerPage` max is **5,000** for this API (the CVE API is 2,000).
- Reuses `nvdutil.CheckRetry` / `nvdutil.Backoff` (408, `Retry-After`, truncated body) and the same per-page result count sanity check, including the "last page grew during execution" allowance.
- `--change-start-date` / `--change-end-date` are validated as a pair and rejected when the range exceeds 120 days, like `lastMod*` in the CVE fetcher.

One point where the response deviates from the sibling fetchers: `details[].oldValue` / `newValue` are usually strings, but the `Affected` type carries CVE v5 affected structures as an array of objects (the [schema](https://csrc.nist.gov/schema/nvd/api/2.0/cve_history_api_json_2.0.schema) allows `string`, `array` and `object`). They are typed as `jsontext.Value` so the response is stored as is, without coercing numbers through `float64` or reordering object members.

Storing one file per change event (rather than one array per CVE) keeps the fetch fully streaming: a CVE's change events are scattered across pages, so grouping them would mean either holding all ~2.2M events in memory or spilling them to disk first.

## Also included

While reviewing the retry wiring of this fetcher, the same defect turned up in the sibling packages, so it is fixed here too (fcbd1134):

`pkg/fetch/nvd/api/{cve,cpe,cpematch}` multiply `retryWaitMin`/`retryWaitMax` by `time.Second` even though #608 changed those options to `time.Duration`. That turns the 6s/30s defaults into ~190/~950 years, and since `nvdutil.Backoff` derives its sleep from `min` (clamped to `max`), the first retry hangs the fetch. All four NVD API fetchers now pass the durations as is.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` — pass
- `GOEXPERIMENT=jsonv2 go vet ./...`, `gofmt -l` — clean
- New fetch tests cover: empty result, single item, precisely paged, multiple pages, `totalResults` growing mid-execution, API key header, change date range, 120 day range violation, and non-string `oldValue`/`newValue` (fixture built from a real `Affected` change event).
- Manual run against the real API with a 2 hour change window: 8 change events written to the expected paths.

Note: a full run is ~2.2M change events over ~445 requests, so it is slow (deep `startIndex` responses take up to ~80s each). Narrowing with `changeStartDate`/`changeEndDate` was measured to be *slower* per request, so plain `startIndex` paging is used.

## Checklist

- [x] Tests pass
- [x] Golden files updated (if applicable)
- [x] Deterministic output verified (if types changed)
- [x] Backward compatibility maintained (if types/data changed) — new package only, no existing types touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
