### PR TITLE
feat(fetch/openssl/secjson): add OpenSSL security advisory JSON fetcher

### DIFF
--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -128,6 +128,7 @@ import (
 	openeulerCSAF "github.com/MaineK00n/vuls-data-update/pkg/fetch/openeuler/csaf"
 	openeulerCVRF "github.com/MaineK00n/vuls-data-update/pkg/fetch/openeuler/cvrf"
 	openeulerOSV "github.com/MaineK00n/vuls-data-update/pkg/fetch/openeuler/osv"
+	opensslSecJSON "github.com/MaineK00n/vuls-data-update/pkg/fetch/openssl/secjson"
 	oracleLinux "github.com/MaineK00n/vuls-data-update/pkg/fetch/oracle/linux"
 	oracleOLAM "github.com/MaineK00n/vuls-data-update/pkg/fetch/oracle/olam"
 	oracleOpenStack "github.com/MaineK00n/vuls-data-update/pkg/fetch/oracle/openstack"
@@ -264,6 +265,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdNVDAPICVE(), newCmdNVDAPICVEHistory(), newCmdNVDAPICPE(), newCmdNVDAPICPEMatch(), newCmdNVDFeedCVEv1(), newCmdNVDFeedCPEv1(), newCmdNVDFeedCPEMATCHv1(), newCmdNVDFeedCVEv2(), newCmdNVDFeedCPEv2(), newCmdNVDFeedCPEMATCHv2(),
 		newCmdOcamlOSV(),
 		newCmdOpenEulerCVRF(), newCmdOpenEulerCSAF(), newCmdOpenEulerOSV(),
+		newCmdOpenSSLSecJSON(),
 		newCmdOracleLinux(), newCmdOracleOLAM(), newCmdOracleOpenStack(), newCmdOracleVM(),
 		newCmdOSSFuzzOSV(),
 		newCmdOXCSAF(),
@@ -4016,6 +4018,43 @@ func newCmdOpenEulerOSV() *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := openeulerOSV.Fetch(openeulerOSV.WithDir(options.dir), openeulerOSV.WithRetry(options.retry), openeulerOSV.WithConcurrency(options.concurrency), openeulerOSV.WithWait(options.wait)); err != nil {
 				return errors.Wrap(err, "failed to fetch openeuler osv")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
+	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent http requests")
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
+
+	return cmd
+}
+
+func newCmdOpenSSLSecJSON() *cobra.Command {
+	options := &struct {
+		base
+		concurrency int
+		wait        time.Duration
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "openssl", "secjson"),
+			retry: 3,
+		},
+		concurrency: 5,
+		wait:        1 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "openssl-secjson",
+		Short: "Fetch OpenSSL Security Advisory (JSON) data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch openssl-secjson
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := opensslSecJSON.Fetch(opensslSecJSON.WithDir(options.dir), opensslSecJSON.WithRetry(options.retry), opensslSecJSON.WithConcurrency(options.concurrency), opensslSecJSON.WithWait(options.wait)); err != nil {
+				return errors.Wrap(err, "failed to fetch openssl secjson")
 			}
 			return nil
 		},

--- a/pkg/fetch/openssl/secjson/secjson.go
+++ b/pkg/fetch/openssl/secjson/secjson.go
@@ -1,0 +1,242 @@
+package secjson
+
+import (
+	"encoding/json/v2"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+const baseURL = "https://openssl-library.org/news/secjson/"
+
+const statementsFilename = "statements.json"
+
+// Pattern defined by the CVE Record Format
+// https://github.com/CVEProject/cve-schema/blob/main/schema/CVE_Record_Format.json
+var cveIDPattern = regexp.MustCompile(`^CVE-([0-9]{4})-[0-9]{4,}$`)
+
+type options struct {
+	baseURL     string
+	dir         string
+	retry       int
+	concurrency int
+	wait        time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type baseURLOption string
+
+func (u baseURLOption) apply(opts *options) {
+	opts.baseURL = string(u)
+}
+
+func WithBaseURL(url string) Option {
+	return baseURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type concurrencyOption int
+
+func (c concurrencyOption) apply(opts *options) {
+	opts.concurrency = int(c)
+}
+
+func WithConcurrency(concurrency int) Option {
+	return concurrencyOption(concurrency)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+func Fetch(opts ...Option) error {
+	options := &options{
+		baseURL:     baseURL,
+		dir:         filepath.Join(util.CacheDir(), "fetch", "openssl", "secjson"),
+		retry:       3,
+		concurrency: 5,
+		wait:        1 * time.Second,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Fetch OpenSSL Security Advisory (JSON)")
+	if err := options.fetch(); err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+
+	return nil
+}
+
+func (opts options) fetch() error {
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
+
+	statementsURL, cveURLs, err := opts.fetchIndexOf(client)
+	if err != nil {
+		return errors.Wrap(err, "fetch index of")
+	}
+
+	if statementsURL == "" {
+		return errors.Errorf("%s not found in %s", statementsFilename, opts.baseURL)
+	}
+	if err := opts.fetchStatements(client, statementsURL); err != nil {
+		return errors.Wrap(err, "fetch statements")
+	}
+
+	if err := client.PipelineGet(cveURLs, opts.concurrency, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d for %q", resp.StatusCode, path.Base(resp.Request.URL.Path))
+		}
+
+		var v CVE
+		if err := json.UnmarshalRead(resp.Body, &v); err != nil {
+			return errors.Wrap(err, "decode json")
+		}
+
+		// The ID comes from the remote payload and is used as a path element,
+		// so accept only the format the schema defines.
+		m := cveIDPattern.FindStringSubmatch(v.CVEMetadata.CVEID)
+		if m == nil {
+			return errors.Errorf("unexpected ID format. expected: %q, actual: %q", cveIDPattern.String(), v.CVEMetadata.CVEID)
+		}
+
+		if err := util.Write(filepath.Join(opts.dir, m[1], fmt.Sprintf("%s.json", v.CVEMetadata.CVEID)), v); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, m[1], fmt.Sprintf("%s.json", v.CVEMetadata.CVEID)))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "pipeline get")
+	}
+
+	return nil
+}
+
+// fetchIndexOf collects the JSON files linked from the index page. It returns
+// the statements.json URL, which is empty if the page does not link it, and the
+// URLs of the per-CVE records. A linked JSON file matching neither is an error,
+// so that additions to the data set surface instead of being silently dropped.
+func (opts options) fetchIndexOf(client *utilhttp.Client) (string, []string, error) {
+	resp, err := client.Get(opts.baseURL)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "fetch %s", opts.baseURL)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", nil, errors.Errorf("error response with status code %d", resp.StatusCode)
+	}
+
+	d, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "parse as html")
+	}
+
+	var (
+		statementsURL string
+		cveURLs       []string
+	)
+	for _, s := range d.Find("main a").EachIter() {
+		href, ok := s.Attr("href")
+		if !ok {
+			continue
+		}
+
+		ref, err := url.Parse(href)
+		if err != nil {
+			return "", nil, errors.Wrapf(err, "parse %s", href)
+		}
+		u := resp.Request.URL.ResolveReference(ref)
+
+		switch b := path.Base(u.Path); {
+		case path.Ext(b) == ".json":
+			switch {
+			case b == statementsFilename:
+				statementsURL = u.String()
+			case strings.HasPrefix(b, "cve-"):
+				cveURLs = append(cveURLs, u.String())
+			default:
+				return "", nil, errors.Errorf("unexpected json file name. expected: %q, actual: %q", []string{statementsFilename, "cve-yyyy-\\d{4,}.json"}, b)
+			}
+		default:
+			continue
+		}
+	}
+
+	return statementsURL, cveURLs, nil
+}
+
+func (opts options) fetchStatements(client *utilhttp.Client, u string) error {
+	resp, err := client.Get(u)
+	if err != nil {
+		return errors.Wrapf(err, "fetch %s", u)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return errors.Errorf("error response with status code %d", resp.StatusCode)
+	}
+
+	var ss Statements
+	if err := json.UnmarshalRead(resp.Body, &ss); err != nil {
+		return errors.Wrap(err, "decode json")
+	}
+
+	if err := util.Write(filepath.Join(opts.dir, statementsFilename), ss); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, statementsFilename))
+	}
+
+	return nil
+}

--- a/pkg/fetch/openssl/secjson/secjson_test.go
+++ b/pkg/fetch/openssl/secjson/secjson_test.go
@@ -1,0 +1,101 @@
+package secjson_test
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/openssl/secjson"
+)
+
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+		},
+		{
+			name:     "notfound",
+			hasError: true,
+		},
+		{
+			name:     "no-statements",
+			hasError: true,
+		},
+		{
+			name:     "unexpected",
+			hasError: true,
+		},
+		{
+			name:     "invalid-id",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/news/secjson/":
+					http.ServeFile(w, r, filepath.Join("testdata", "fixtures", tt.name, "indexof.html"))
+				default:
+					http.ServeFile(w, r, filepath.Join("testdata", "fixtures", tt.name, path.Base(r.URL.Path)))
+				}
+			}))
+			defer ts.Close()
+
+			u, err := url.JoinPath(ts.URL, "news/secjson/")
+			if err != nil {
+				t.Error("unexpected error:", err)
+			}
+
+			dir := t.TempDir()
+			err = secjson.Fetch(secjson.WithBaseURL(u), secjson.WithDir(dir), secjson.WithRetry(0), secjson.WithConcurrency(1), secjson.WithWait(0))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			default:
+				if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+					if err != nil {
+						return err
+					}
+
+					if d.IsDir() {
+						return nil
+					}
+
+					dir, file := filepath.Split(strings.TrimPrefix(path, dir))
+					want, err := os.ReadFile(filepath.Join("testdata", "golden", tt.name, dir, url.QueryEscape(file)))
+					if err != nil {
+						return err
+					}
+
+					got, err := os.ReadFile(path)
+					if err != nil {
+						return err
+					}
+
+					if diff := cmp.Diff(want, got); diff != "" {
+						t.Errorf("Fetch(). (-expected +got):\n%s", diff)
+					}
+
+					return nil
+				}); err != nil {
+					t.Error("walk error:", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/happy/cve-2002-0655.json
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/happy/cve-2002-0655.json
@@ -1,0 +1,69 @@
+{
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "defaultStatus": "unaffected",
+                    "product": "OpenSSL",
+                    "vendor": "OpenSSL",
+                    "versions": [
+                        {
+                            "lessThan": "0.9.6e",
+                            "status": "affected",
+                            "version": "0.9.6",
+                            "versionType": "custom"
+                        }
+                    ]
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "type": "finder",
+                    "value": "OpenSSL Group (A.L. Digital)"
+                }
+            ],
+            "datePublic": "2002-07-30T00:00:00Z",
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "Inproper handling of ASCII representations of integers on 64 bit platforms allowed remote attackers to cause a denial of service or possibly execute arbitrary code."
+                }
+            ],
+            "metrics": [
+                {
+                    "format": "other",
+                    "other": {
+                        "content": {
+                            "text": "unknown"
+                        },
+                        "type": "https://www.openssl.org/policies/secpolicy.html#"
+                    }
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+                "shortName": "openssl"
+            },
+            "references": [
+                {
+                    "name": "OpenSSL Advisory",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://www.openssl.org/news/secadv/20020730.txt"
+                }
+            ],
+            "x_generator": {
+                "importer": "vulnxml2json5.py 2022-11-04 07:19:07.063650"
+            }
+        }
+    },
+    "cveMetadata": {
+        "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+        "cveId": "CVE-2002-0655",
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
+}

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/happy/cve-2022-3996.json
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/happy/cve-2022-3996.json
@@ -1,0 +1,107 @@
+{
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "defaultStatus": "unaffected",
+                    "product": "OpenSSL",
+                    "vendor": "OpenSSL",
+                    "versions": [
+                        {
+                            "lessThanOrEqual": "3.0.7",
+                            "status": "affected",
+                            "version": "3.0.0",
+                            "versionType": "semver"
+                        }
+                    ]
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "type": "finder",
+                    "user": "00000000-0000-4000-9000-000000000000",
+                    "value": "Polar Bear"
+                },
+                {
+                    "lang": "en",
+                    "type": "remediation developer",
+                    "user": "00000000-0000-4000-9000-000000000000",
+                    "value": "Paul Dale"
+                }
+            ],
+            "datePublic": "2022-12-13T07:00:00.000Z",
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "supportingMedia": [
+                        {
+                            "base64": false,
+                            "type": "text/html",
+                            "value": "If an X.509 certificate contains a malformed policy constraint and<br>policy processing is enabled, then a write lock will be taken twice<br>recursively.  On some operating systems (most widely: Windows) this<br>results in a denial of service when the affected process hangs.  Policy<br>processing being enabled on a publicly facing server is not considered<br>to be a common setup.<br><br>Policy processing is enabled by passing the `-policy`<br>argument to the command line utilities or by calling the<br>`X509_VERIFY_PARAM_set1_policies()` function.<br><br>Update (31 March 2023): The description of the policy processing enablement<br>was corrected based on CVE-2023-0466."
+                        }
+                    ],
+                    "value": "If an X.509 certificate contains a malformed policy constraint and\npolicy processing is enabled, then a write lock will be taken twice\nrecursively.  On some operating systems (most widely: Windows) this\nresults in a denial of service when the affected process hangs.  Policy\nprocessing being enabled on a publicly facing server is not considered\nto be a common setup.\n\nPolicy processing is enabled by passing the `-policy`\nargument to the command line utilities or by calling the\n`X509_VERIFY_PARAM_set1_policies()` function.\n\nUpdate (31 March 2023): The description of the policy processing enablement\nwas corrected based on CVE-2023-0466."
+                }
+            ],
+            "metrics": [
+                {
+                    "format": "other",
+                    "other": {
+                        "content": {
+                            "text": "Low"
+                        },
+                        "type": "https://www.openssl.org/policies/secpolicy.html#low"
+                    }
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-667",
+                            "description": "CWE-667 Improper Locking",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "3a12439a-ef3a-4c79-92e6-6081a721f1e5",
+                "shortName": "openssl"
+            },
+            "references": [
+                {
+                    "name": "OpenSSL Advisory",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://www.openssl.org/news/secadv/20221213.txt"
+                },
+                {
+                    "tags": [
+                        "patch"
+                    ],
+                    "url": "https://github.com/openssl/openssl/commit/7725e7bfe6f2ce8146b6552b44e0d226be7638e7"
+                }
+            ],
+            "source": {
+                "discovery": "UNKNOWN"
+            },
+            "title": "X.509 Policy Constraints Double Locking",
+            "x_generator": {
+                "engine": "Vulnogram 0.1.0-dev"
+            }
+        }
+    },
+    "cveMetadata": {
+        "assignerOrgId": "3a12439a-ef3a-4c79-92e6-6081a721f1e5",
+        "cveId": "CVE-2022-3996",
+        "requesterUserId": "00000000-0000-4000-9000-000000000000",
+        "serial": 1,
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
+}

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/happy/cve-2024-6119.json
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/happy/cve-2024-6119.json
@@ -1,0 +1,145 @@
+{
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "defaultStatus": "unaffected",
+                    "product": "OpenSSL",
+                    "vendor": "OpenSSL",
+                    "versions": [
+                        {
+                            "lessThan": "3.3.2",
+                            "status": "affected",
+                            "version": "3.3.0",
+                            "versionType": "semver"
+                        },
+                        {
+                            "lessThan": "3.2.3",
+                            "status": "affected",
+                            "version": "3.2.0",
+                            "versionType": "semver"
+                        },
+                        {
+                            "lessThan": "3.1.7",
+                            "status": "affected",
+                            "version": "3.1.0",
+                            "versionType": "semver"
+                        },
+                        {
+                            "lessThan": "3.0.15",
+                            "status": "affected",
+                            "version": "3.0.0",
+                            "versionType": "semver"
+                        }
+                    ]
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "type": "finder",
+                    "value": "David Benjamin (Google)"
+                },
+                {
+                    "lang": "en",
+                    "type": "remediation developer",
+                    "value": "Viktor Dukhovni"
+                }
+            ],
+            "datePublic": "2024-09-03T14:00:00.000Z",
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "supportingMedia": [
+                        {
+                            "base64": false,
+                            "type": "text/html",
+                            "value": "Issue summary: Applications performing certificate name checks (e.g., TLS<br>clients checking server certificates) may attempt to read an invalid memory<br>address resulting in abnormal termination of the application process.<br><br>Impact summary: Abnormal termination of an application can a cause a denial of<br>service.<br><br>Applications performing certificate name checks (e.g., TLS clients checking<br>server certificates) may attempt to read an invalid memory address when<br>comparing the expected name with an `otherName` subject alternative name of an<br>X.509 certificate. This may result in an exception that terminates the<br>application program.<br><br>Note that basic certificate chain validation (signatures, dates, ...) is not<br>affected, the denial of service can occur only when the application also<br>specifies an expected DNS name, Email address or IP address.<br><br>TLS servers rarely solicit client certificates, and even when they do, they<br>generally don't perform a name check against a reference identifier (expected<br>identity), but rather extract the presented identity after checking the<br>certificate chain.  So TLS servers are generally not affected and the severity<br>of the issue is Moderate.<br><br>The FIPS modules in 3.3, 3.2, 3.1 and 3.0 are not affected by this issue."
+                        }
+                    ],
+                    "value": "Issue summary: Applications performing certificate name checks (e.g., TLS\nclients checking server certificates) may attempt to read an invalid memory\naddress resulting in abnormal termination of the application process.\n\nImpact summary: Abnormal termination of an application can a cause a denial of\nservice.\n\nApplications performing certificate name checks (e.g., TLS clients checking\nserver certificates) may attempt to read an invalid memory address when\ncomparing the expected name with an `otherName` subject alternative name of an\nX.509 certificate. This may result in an exception that terminates the\napplication program.\n\nNote that basic certificate chain validation (signatures, dates, ...) is not\naffected, the denial of service can occur only when the application also\nspecifies an expected DNS name, Email address or IP address.\n\nTLS servers rarely solicit client certificates, and even when they do, they\ngenerally don't perform a name check against a reference identifier (expected\nidentity), but rather extract the presented identity after checking the\ncertificate chain.  So TLS servers are generally not affected and the severity\nof the issue is Moderate.\n\nThe FIPS modules in 3.3, 3.2, 3.1 and 3.0 are not affected by this issue."
+                }
+            ],
+            "metrics": [
+                {
+                    "format": "other",
+                    "other": {
+                        "content": {
+                            "text": "Moderate"
+                        },
+                        "type": "https://www.openssl.org/policies/secpolicy.html"
+                    }
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-843",
+                            "description": "CWE-843 Access of Resource Using Incompatible Type ('Type Confusion')",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "00000000-0000-4000-9000-000000000000",
+                "shortName": "openssl"
+            },
+            "references": [
+                {
+                    "name": "OpenSSL Advisory",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://openssl-library.org/news/secadv/20240903.txt"
+                },
+                {
+                    "name": "3.3.2 git commit",
+                    "tags": [
+                        "patch"
+                    ],
+                    "url": "https://github.com/openssl/openssl/commit/7dfcee2cd2a63b2c64b9b4b0850be64cb695b0a0"
+                },
+                {
+                    "name": "3.2.3 git commit",
+                    "tags": [
+                        "patch"
+                    ],
+                    "url": "https://github.com/openssl/openssl/commit/05f360d9e849a1b277db628f1f13083a7f8dd04f"
+                },
+                {
+                    "name": "3.1.7 git commit",
+                    "tags": [
+                        "patch"
+                    ],
+                    "url": "https://github.com/openssl/openssl/commit/621f3729831b05ee828a3203eddb621d014ff2b2"
+                },
+                {
+                    "name": "3.0.15 git commit",
+                    "tags": [
+                        "patch"
+                    ],
+                    "url": "https://github.com/openssl/openssl/commit/06d1dc3fa96a2ba5a3e22735a033012aadc9f0d6"
+                }
+            ],
+            "source": {
+                "discovery": "UNKNOWN"
+            },
+            "title": "Possible denial of service in X.509 name checks",
+            "x_generator": {
+                "engine": "Vulnogram 0.2.0"
+            }
+        }
+    },
+    "cveMetadata": {
+        "assignerOrgId": "00000000-0000-4000-9000-000000000000",
+        "cveId": "CVE-2024-6119",
+        "requesterUserId": "00000000-0000-4000-9000-000000000000",
+        "serial": 1,
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1"
+}

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/happy/indexof.html
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/happy/indexof.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Security advisory list (json)</title>
+    <link rel="stylesheet" href="/css/main.css" />
+  </head>
+  <body>
+    <nav>
+      <ul>
+        <li><a href="/">Home</a></li>
+        <li><a href="/news/secadv/">Security advisories</a></li>
+      </ul>
+    </nav>
+    <main>
+      <header>
+        <h1>Security advisory list (json)</h1>
+      </header>
+      <ul>
+        <li><a href="statements.json">statements</a></li>
+        <li><a href="cve-2024-6119.json">CVE-2024-6119</a></li>
+        <li><a href="cve-2022-3996.json">CVE-2022-3996</a></li>
+        <li><a href="cve-2002-0655.json">CVE-2002-0655</a></li>
+        <li><a href="../secadv/20240903.txt">OpenSSL Advisory</a></li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/happy/statements.json
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/happy/statements.json
@@ -1,0 +1,55 @@
+{
+    "statements": [
+        {
+            "base":"none",
+            "text":"Note: All OpenSSL versions before 1.1.1 are out of support and no longer receiving updates.  Extended support is available for 1.0.2 from OpenSSL Software Services for premium support customers."
+        },
+        {
+            "base":"0.9.6",
+            "text":"OpenSSL 0.9.6 is out of support and no longer receiving updates."
+        },
+        {
+            "base":"0.9.7",
+            "text":"OpenSSL 0.9.7 is out of support and no longer receiving updates."
+        },
+        {
+            "base":"0.9.8",
+            "text":"OpenSSL 0.9.8 is out of support since 1st January 2016 and no longer receiving updates."
+        },
+        {
+            "base":"1.0.0",
+            "text":"OpenSSL 1.0.0 is out of support since 1st January 2016 and no longer receiving updates."
+        },
+        {
+            "base":"1.0.1",
+            "text":"OpenSSL 1.0.1 is out of support since 1st January 2017 and no longer receiving updates."
+        },
+        {
+            "base":"1.0.2",
+            "text":"OpenSSL 1.0.2 is out of support since 1st January 2020 and is no longer receiving updates.  Extended support is available from OpenSSL Software Services for premium support customers."
+        },
+        {
+            "base":"1.1.0",
+            "text":"OpenSSL 1.1.0 is out of support since 12th September 2019 and no longer receiving updates."
+        }
+    ],
+    "disputed": [
+        {
+            "base":"0.9.8",
+            "cve":"CVE-2010-0928",
+            "text":"This was not treated as a security issue as it is outside of the OpenSSL threat model."
+        },
+        {
+            "base":"fips",
+            "cve":"CVE-2007-6755",
+            "text":"Only OpenSSL FIPS module shipped Dual EC DRBG, and it [was not affected](https://marc.info/?l=openssl-announce&m=138747119822324)."
+        },
+        {
+            "base":"none",
+            "cve":"CVE-2002-20001",
+            "text":"[We do not consider this to be a vulnerability in OpenSSL](https://github.com/openssl/openssl/issues/17374)."
+        }
+
+    ]
+}
+          

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/invalid-id/cve-2024-6119.json
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/invalid-id/cve-2024-6119.json
@@ -1,0 +1,145 @@
+{
+  "containers": {
+    "cna": {
+      "affected": [
+        {
+          "defaultStatus": "unaffected",
+          "product": "OpenSSL",
+          "vendor": "OpenSSL",
+          "versions": [
+            {
+              "lessThan": "3.3.2",
+              "status": "affected",
+              "version": "3.3.0",
+              "versionType": "semver"
+            },
+            {
+              "lessThan": "3.2.3",
+              "status": "affected",
+              "version": "3.2.0",
+              "versionType": "semver"
+            },
+            {
+              "lessThan": "3.1.7",
+              "status": "affected",
+              "version": "3.1.0",
+              "versionType": "semver"
+            },
+            {
+              "lessThan": "3.0.15",
+              "status": "affected",
+              "version": "3.0.0",
+              "versionType": "semver"
+            }
+          ]
+        }
+      ],
+      "credits": [
+        {
+          "lang": "en",
+          "type": "finder",
+          "value": "David Benjamin (Google)"
+        },
+        {
+          "lang": "en",
+          "type": "remediation developer",
+          "value": "Viktor Dukhovni"
+        }
+      ],
+      "datePublic": "2024-09-03T14:00:00.000Z",
+      "descriptions": [
+        {
+          "lang": "en",
+          "supportingMedia": [
+            {
+              "base64": false,
+              "type": "text/html",
+              "value": "Issue summary: Applications performing certificate name checks (e.g., TLS<br>clients checking server certificates) may attempt to read an invalid memory<br>address resulting in abnormal termination of the application process.<br><br>Impact summary: Abnormal termination of an application can a cause a denial of<br>service.<br><br>Applications performing certificate name checks (e.g., TLS clients checking<br>server certificates) may attempt to read an invalid memory address when<br>comparing the expected name with an `otherName` subject alternative name of an<br>X.509 certificate. This may result in an exception that terminates the<br>application program.<br><br>Note that basic certificate chain validation (signatures, dates, ...) is not<br>affected, the denial of service can occur only when the application also<br>specifies an expected DNS name, Email address or IP address.<br><br>TLS servers rarely solicit client certificates, and even when they do, they<br>generally don't perform a name check against a reference identifier (expected<br>identity), but rather extract the presented identity after checking the<br>certificate chain.  So TLS servers are generally not affected and the severity<br>of the issue is Moderate.<br><br>The FIPS modules in 3.3, 3.2, 3.1 and 3.0 are not affected by this issue."
+            }
+          ],
+          "value": "Issue summary: Applications performing certificate name checks (e.g., TLS\nclients checking server certificates) may attempt to read an invalid memory\naddress resulting in abnormal termination of the application process.\n\nImpact summary: Abnormal termination of an application can a cause a denial of\nservice.\n\nApplications performing certificate name checks (e.g., TLS clients checking\nserver certificates) may attempt to read an invalid memory address when\ncomparing the expected name with an `otherName` subject alternative name of an\nX.509 certificate. This may result in an exception that terminates the\napplication program.\n\nNote that basic certificate chain validation (signatures, dates, ...) is not\naffected, the denial of service can occur only when the application also\nspecifies an expected DNS name, Email address or IP address.\n\nTLS servers rarely solicit client certificates, and even when they do, they\ngenerally don't perform a name check against a reference identifier (expected\nidentity), but rather extract the presented identity after checking the\ncertificate chain.  So TLS servers are generally not affected and the severity\nof the issue is Moderate.\n\nThe FIPS modules in 3.3, 3.2, 3.1 and 3.0 are not affected by this issue."
+        }
+      ],
+      "metrics": [
+        {
+          "format": "other",
+          "other": {
+            "content": {
+              "text": "Moderate"
+            },
+            "type": "https://www.openssl.org/policies/secpolicy.html"
+          }
+        }
+      ],
+      "problemTypes": [
+        {
+          "descriptions": [
+            {
+              "cweId": "CWE-843",
+              "description": "CWE-843 Access of Resource Using Incompatible Type ('Type Confusion')",
+              "lang": "en",
+              "type": "CWE"
+            }
+          ]
+        }
+      ],
+      "providerMetadata": {
+        "orgId": "00000000-0000-4000-9000-000000000000",
+        "shortName": "openssl"
+      },
+      "references": [
+        {
+          "name": "OpenSSL Advisory",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://openssl-library.org/news/secadv/20240903.txt"
+        },
+        {
+          "name": "3.3.2 git commit",
+          "tags": [
+            "patch"
+          ],
+          "url": "https://github.com/openssl/openssl/commit/7dfcee2cd2a63b2c64b9b4b0850be64cb695b0a0"
+        },
+        {
+          "name": "3.2.3 git commit",
+          "tags": [
+            "patch"
+          ],
+          "url": "https://github.com/openssl/openssl/commit/05f360d9e849a1b277db628f1f13083a7f8dd04f"
+        },
+        {
+          "name": "3.1.7 git commit",
+          "tags": [
+            "patch"
+          ],
+          "url": "https://github.com/openssl/openssl/commit/621f3729831b05ee828a3203eddb621d014ff2b2"
+        },
+        {
+          "name": "3.0.15 git commit",
+          "tags": [
+            "patch"
+          ],
+          "url": "https://github.com/openssl/openssl/commit/06d1dc3fa96a2ba5a3e22735a033012aadc9f0d6"
+        }
+      ],
+      "source": {
+        "discovery": "UNKNOWN"
+      },
+      "title": "Possible denial of service in X.509 name checks",
+      "x_generator": {
+        "engine": "Vulnogram 0.2.0"
+      }
+    }
+  },
+  "cveMetadata": {
+    "assignerOrgId": "00000000-0000-4000-9000-000000000000",
+    "cveId": "CVE-2024-../../../../etc/passwd",
+    "requesterUserId": "00000000-0000-4000-9000-000000000000",
+    "serial": 1,
+    "state": "PUBLISHED"
+  },
+  "dataType": "CVE_RECORD",
+  "dataVersion": "5.1"
+}

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/invalid-id/indexof.html
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/invalid-id/indexof.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Security advisory list (json)</title>
+  </head>
+  <body>
+    <main>
+      <ul>
+        <li><a href="statements.json">statements</a></li>
+        <li><a href="cve-2024-6119.json">CVE-2024-6119</a></li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/invalid-id/statements.json
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/invalid-id/statements.json
@@ -1,0 +1,55 @@
+{
+    "statements": [
+        {
+            "base":"none",
+            "text":"Note: All OpenSSL versions before 1.1.1 are out of support and no longer receiving updates.  Extended support is available for 1.0.2 from OpenSSL Software Services for premium support customers."
+        },
+        {
+            "base":"0.9.6",
+            "text":"OpenSSL 0.9.6 is out of support and no longer receiving updates."
+        },
+        {
+            "base":"0.9.7",
+            "text":"OpenSSL 0.9.7 is out of support and no longer receiving updates."
+        },
+        {
+            "base":"0.9.8",
+            "text":"OpenSSL 0.9.8 is out of support since 1st January 2016 and no longer receiving updates."
+        },
+        {
+            "base":"1.0.0",
+            "text":"OpenSSL 1.0.0 is out of support since 1st January 2016 and no longer receiving updates."
+        },
+        {
+            "base":"1.0.1",
+            "text":"OpenSSL 1.0.1 is out of support since 1st January 2017 and no longer receiving updates."
+        },
+        {
+            "base":"1.0.2",
+            "text":"OpenSSL 1.0.2 is out of support since 1st January 2020 and is no longer receiving updates.  Extended support is available from OpenSSL Software Services for premium support customers."
+        },
+        {
+            "base":"1.1.0",
+            "text":"OpenSSL 1.1.0 is out of support since 12th September 2019 and no longer receiving updates."
+        }
+    ],
+    "disputed": [
+        {
+            "base":"0.9.8",
+            "cve":"CVE-2010-0928",
+            "text":"This was not treated as a security issue as it is outside of the OpenSSL threat model."
+        },
+        {
+            "base":"fips",
+            "cve":"CVE-2007-6755",
+            "text":"Only OpenSSL FIPS module shipped Dual EC DRBG, and it [was not affected](https://marc.info/?l=openssl-announce&m=138747119822324)."
+        },
+        {
+            "base":"none",
+            "cve":"CVE-2002-20001",
+            "text":"[We do not consider this to be a vulnerability in OpenSSL](https://github.com/openssl/openssl/issues/17374)."
+        }
+
+    ]
+}
+          

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/no-statements/indexof.html
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/no-statements/indexof.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Security advisory list (json)</title>
+  </head>
+  <body>
+    <main>
+      <ul>
+        <li><a href="cve-2024-6119.json">CVE-2024-6119</a></li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/notfound/indexof.html
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/notfound/indexof.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Security advisory list (json)</title>
+  </head>
+  <body>
+    <main>
+      <ul>
+        <li><a href="statements.json">statements</a></li>
+        <li><a href="cve-2024-6119.json">CVE-2024-6119</a></li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/notfound/statements.json
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/notfound/statements.json
@@ -1,0 +1,55 @@
+{
+    "statements": [
+        {
+            "base":"none",
+            "text":"Note: All OpenSSL versions before 1.1.1 are out of support and no longer receiving updates.  Extended support is available for 1.0.2 from OpenSSL Software Services for premium support customers."
+        },
+        {
+            "base":"0.9.6",
+            "text":"OpenSSL 0.9.6 is out of support and no longer receiving updates."
+        },
+        {
+            "base":"0.9.7",
+            "text":"OpenSSL 0.9.7 is out of support and no longer receiving updates."
+        },
+        {
+            "base":"0.9.8",
+            "text":"OpenSSL 0.9.8 is out of support since 1st January 2016 and no longer receiving updates."
+        },
+        {
+            "base":"1.0.0",
+            "text":"OpenSSL 1.0.0 is out of support since 1st January 2016 and no longer receiving updates."
+        },
+        {
+            "base":"1.0.1",
+            "text":"OpenSSL 1.0.1 is out of support since 1st January 2017 and no longer receiving updates."
+        },
+        {
+            "base":"1.0.2",
+            "text":"OpenSSL 1.0.2 is out of support since 1st January 2020 and is no longer receiving updates.  Extended support is available from OpenSSL Software Services for premium support customers."
+        },
+        {
+            "base":"1.1.0",
+            "text":"OpenSSL 1.1.0 is out of support since 12th September 2019 and no longer receiving updates."
+        }
+    ],
+    "disputed": [
+        {
+            "base":"0.9.8",
+            "cve":"CVE-2010-0928",
+            "text":"This was not treated as a security issue as it is outside of the OpenSSL threat model."
+        },
+        {
+            "base":"fips",
+            "cve":"CVE-2007-6755",
+            "text":"Only OpenSSL FIPS module shipped Dual EC DRBG, and it [was not affected](https://marc.info/?l=openssl-announce&m=138747119822324)."
+        },
+        {
+            "base":"none",
+            "cve":"CVE-2002-20001",
+            "text":"[We do not consider this to be a vulnerability in OpenSSL](https://github.com/openssl/openssl/issues/17374)."
+        }
+
+    ]
+}
+          

--- a/pkg/fetch/openssl/secjson/testdata/fixtures/unexpected/indexof.html
+++ b/pkg/fetch/openssl/secjson/testdata/fixtures/unexpected/indexof.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Security advisory list (json)</title>
+  </head>
+  <body>
+    <main>
+      <ul>
+        <li><a href="statements.json">statements</a></li>
+        <li><a href="cve-2024-6119.json">CVE-2024-6119</a></li>
+        <li><a href="advisories.json">advisories</a></li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/pkg/fetch/openssl/secjson/testdata/golden/happy/2002/CVE-2002-0655.json
+++ b/pkg/fetch/openssl/secjson/testdata/golden/happy/2002/CVE-2002-0655.json
@@ -1,0 +1,69 @@
+{
+	"dataType": "CVE_RECORD",
+	"dataVersion": "5.0",
+	"cveMetadata": {
+		"cveId": "CVE-2002-0655",
+		"assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+		"state": "PUBLISHED"
+	},
+	"containers": {
+		"cna": {
+			"providerMetadata": {
+				"orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+				"shortName": "openssl"
+			},
+			"descriptions": [
+				{
+					"lang": "en",
+					"value": "Inproper handling of ASCII representations of integers on 64 bit platforms allowed remote attackers to cause a denial of service or possibly execute arbitrary code."
+				}
+			],
+			"affected": [
+				{
+					"vendor": "OpenSSL",
+					"product": "OpenSSL",
+					"defaultStatus": "unaffected",
+					"versions": [
+						{
+							"status": "affected",
+							"versionType": "custom",
+							"version": "0.9.6",
+							"lessThan": "0.9.6e"
+						}
+					]
+				}
+			],
+			"metrics": [
+				{
+					"format": "other",
+					"other": {
+						"type": "https://www.openssl.org/policies/secpolicy.html#",
+						"content": {
+							"text": "unknown"
+						}
+					}
+				}
+			],
+			"references": [
+				{
+					"name": "OpenSSL Advisory",
+					"tags": [
+						"vendor-advisory"
+					],
+					"url": "https://www.openssl.org/news/secadv/20020730.txt"
+				}
+			],
+			"credits": [
+				{
+					"type": "finder",
+					"lang": "en",
+					"value": "OpenSSL Group (A.L. Digital)"
+				}
+			],
+			"datePublic": "2002-07-30T00:00:00Z",
+			"x_generator": {
+				"importer": "vulnxml2json5.py 2022-11-04 07:19:07.063650"
+			}
+		}
+	}
+}

--- a/pkg/fetch/openssl/secjson/testdata/golden/happy/2022/CVE-2022-3996.json
+++ b/pkg/fetch/openssl/secjson/testdata/golden/happy/2022/CVE-2022-3996.json
@@ -1,0 +1,107 @@
+{
+	"dataType": "CVE_RECORD",
+	"dataVersion": "5.0",
+	"cveMetadata": {
+		"cveId": "CVE-2022-3996",
+		"assignerOrgId": "3a12439a-ef3a-4c79-92e6-6081a721f1e5",
+		"requesterUserId": "00000000-0000-4000-9000-000000000000",
+		"serial": 1,
+		"state": "PUBLISHED"
+	},
+	"containers": {
+		"cna": {
+			"providerMetadata": {
+				"orgId": "3a12439a-ef3a-4c79-92e6-6081a721f1e5",
+				"shortName": "openssl"
+			},
+			"title": "X.509 Policy Constraints Double Locking",
+			"descriptions": [
+				{
+					"lang": "en",
+					"value": "If an X.509 certificate contains a malformed policy constraint and\npolicy processing is enabled, then a write lock will be taken twice\nrecursively.  On some operating systems (most widely: Windows) this\nresults in a denial of service when the affected process hangs.  Policy\nprocessing being enabled on a publicly facing server is not considered\nto be a common setup.\n\nPolicy processing is enabled by passing the `-policy`\nargument to the command line utilities or by calling the\n`X509_VERIFY_PARAM_set1_policies()` function.\n\nUpdate (31 March 2023): The description of the policy processing enablement\nwas corrected based on CVE-2023-0466.",
+					"supportingMedia": [
+						{
+							"type": "text/html",
+							"base64": false,
+							"value": "If an X.509 certificate contains a malformed policy constraint and<br>policy processing is enabled, then a write lock will be taken twice<br>recursively.  On some operating systems (most widely: Windows) this<br>results in a denial of service when the affected process hangs.  Policy<br>processing being enabled on a publicly facing server is not considered<br>to be a common setup.<br><br>Policy processing is enabled by passing the `-policy`<br>argument to the command line utilities or by calling the<br>`X509_VERIFY_PARAM_set1_policies()` function.<br><br>Update (31 March 2023): The description of the policy processing enablement<br>was corrected based on CVE-2023-0466."
+						}
+					]
+				}
+			],
+			"affected": [
+				{
+					"vendor": "OpenSSL",
+					"product": "OpenSSL",
+					"defaultStatus": "unaffected",
+					"versions": [
+						{
+							"status": "affected",
+							"versionType": "semver",
+							"version": "3.0.0",
+							"lessThanOrEqual": "3.0.7"
+						}
+					]
+				}
+			],
+			"problemTypes": [
+				{
+					"descriptions": [
+						{
+							"type": "CWE",
+							"lang": "en",
+							"description": "CWE-667 Improper Locking",
+							"cweId": "CWE-667"
+						}
+					]
+				}
+			],
+			"metrics": [
+				{
+					"format": "other",
+					"other": {
+						"type": "https://www.openssl.org/policies/secpolicy.html#low",
+						"content": {
+							"text": "Low"
+						}
+					}
+				}
+			],
+			"references": [
+				{
+					"name": "OpenSSL Advisory",
+					"tags": [
+						"vendor-advisory"
+					],
+					"url": "https://www.openssl.org/news/secadv/20221213.txt"
+				},
+				{
+					"tags": [
+						"patch"
+					],
+					"url": "https://github.com/openssl/openssl/commit/7725e7bfe6f2ce8146b6552b44e0d226be7638e7"
+				}
+			],
+			"credits": [
+				{
+					"type": "finder",
+					"lang": "en",
+					"user": "00000000-0000-4000-9000-000000000000",
+					"value": "Polar Bear"
+				},
+				{
+					"type": "remediation developer",
+					"lang": "en",
+					"user": "00000000-0000-4000-9000-000000000000",
+					"value": "Paul Dale"
+				}
+			],
+			"source": {
+				"discovery": "UNKNOWN"
+			},
+			"datePublic": "2022-12-13T07:00:00.000Z",
+			"x_generator": {
+				"engine": "Vulnogram 0.1.0-dev"
+			}
+		}
+	}
+}

--- a/pkg/fetch/openssl/secjson/testdata/golden/happy/2024/CVE-2024-6119.json
+++ b/pkg/fetch/openssl/secjson/testdata/golden/happy/2024/CVE-2024-6119.json
@@ -1,0 +1,145 @@
+{
+	"dataType": "CVE_RECORD",
+	"dataVersion": "5.1",
+	"cveMetadata": {
+		"cveId": "CVE-2024-6119",
+		"assignerOrgId": "00000000-0000-4000-9000-000000000000",
+		"requesterUserId": "00000000-0000-4000-9000-000000000000",
+		"serial": 1,
+		"state": "PUBLISHED"
+	},
+	"containers": {
+		"cna": {
+			"providerMetadata": {
+				"orgId": "00000000-0000-4000-9000-000000000000",
+				"shortName": "openssl"
+			},
+			"title": "Possible denial of service in X.509 name checks",
+			"descriptions": [
+				{
+					"lang": "en",
+					"value": "Issue summary: Applications performing certificate name checks (e.g., TLS\nclients checking server certificates) may attempt to read an invalid memory\naddress resulting in abnormal termination of the application process.\n\nImpact summary: Abnormal termination of an application can a cause a denial of\nservice.\n\nApplications performing certificate name checks (e.g., TLS clients checking\nserver certificates) may attempt to read an invalid memory address when\ncomparing the expected name with an `otherName` subject alternative name of an\nX.509 certificate. This may result in an exception that terminates the\napplication program.\n\nNote that basic certificate chain validation (signatures, dates, ...) is not\naffected, the denial of service can occur only when the application also\nspecifies an expected DNS name, Email address or IP address.\n\nTLS servers rarely solicit client certificates, and even when they do, they\ngenerally don't perform a name check against a reference identifier (expected\nidentity), but rather extract the presented identity after checking the\ncertificate chain.  So TLS servers are generally not affected and the severity\nof the issue is Moderate.\n\nThe FIPS modules in 3.3, 3.2, 3.1 and 3.0 are not affected by this issue.",
+					"supportingMedia": [
+						{
+							"type": "text/html",
+							"base64": false,
+							"value": "Issue summary: Applications performing certificate name checks (e.g., TLS<br>clients checking server certificates) may attempt to read an invalid memory<br>address resulting in abnormal termination of the application process.<br><br>Impact summary: Abnormal termination of an application can a cause a denial of<br>service.<br><br>Applications performing certificate name checks (e.g., TLS clients checking<br>server certificates) may attempt to read an invalid memory address when<br>comparing the expected name with an `otherName` subject alternative name of an<br>X.509 certificate. This may result in an exception that terminates the<br>application program.<br><br>Note that basic certificate chain validation (signatures, dates, ...) is not<br>affected, the denial of service can occur only when the application also<br>specifies an expected DNS name, Email address or IP address.<br><br>TLS servers rarely solicit client certificates, and even when they do, they<br>generally don't perform a name check against a reference identifier (expected<br>identity), but rather extract the presented identity after checking the<br>certificate chain.  So TLS servers are generally not affected and the severity<br>of the issue is Moderate.<br><br>The FIPS modules in 3.3, 3.2, 3.1 and 3.0 are not affected by this issue."
+						}
+					]
+				}
+			],
+			"affected": [
+				{
+					"vendor": "OpenSSL",
+					"product": "OpenSSL",
+					"defaultStatus": "unaffected",
+					"versions": [
+						{
+							"status": "affected",
+							"versionType": "semver",
+							"version": "3.3.0",
+							"lessThan": "3.3.2"
+						},
+						{
+							"status": "affected",
+							"versionType": "semver",
+							"version": "3.2.0",
+							"lessThan": "3.2.3"
+						},
+						{
+							"status": "affected",
+							"versionType": "semver",
+							"version": "3.1.0",
+							"lessThan": "3.1.7"
+						},
+						{
+							"status": "affected",
+							"versionType": "semver",
+							"version": "3.0.0",
+							"lessThan": "3.0.15"
+						}
+					]
+				}
+			],
+			"problemTypes": [
+				{
+					"descriptions": [
+						{
+							"type": "CWE",
+							"lang": "en",
+							"description": "CWE-843 Access of Resource Using Incompatible Type ('Type Confusion')",
+							"cweId": "CWE-843"
+						}
+					]
+				}
+			],
+			"metrics": [
+				{
+					"format": "other",
+					"other": {
+						"type": "https://www.openssl.org/policies/secpolicy.html",
+						"content": {
+							"text": "Moderate"
+						}
+					}
+				}
+			],
+			"references": [
+				{
+					"name": "OpenSSL Advisory",
+					"tags": [
+						"vendor-advisory"
+					],
+					"url": "https://openssl-library.org/news/secadv/20240903.txt"
+				},
+				{
+					"name": "3.3.2 git commit",
+					"tags": [
+						"patch"
+					],
+					"url": "https://github.com/openssl/openssl/commit/7dfcee2cd2a63b2c64b9b4b0850be64cb695b0a0"
+				},
+				{
+					"name": "3.2.3 git commit",
+					"tags": [
+						"patch"
+					],
+					"url": "https://github.com/openssl/openssl/commit/05f360d9e849a1b277db628f1f13083a7f8dd04f"
+				},
+				{
+					"name": "3.1.7 git commit",
+					"tags": [
+						"patch"
+					],
+					"url": "https://github.com/openssl/openssl/commit/621f3729831b05ee828a3203eddb621d014ff2b2"
+				},
+				{
+					"name": "3.0.15 git commit",
+					"tags": [
+						"patch"
+					],
+					"url": "https://github.com/openssl/openssl/commit/06d1dc3fa96a2ba5a3e22735a033012aadc9f0d6"
+				}
+			],
+			"credits": [
+				{
+					"type": "finder",
+					"lang": "en",
+					"value": "David Benjamin (Google)"
+				},
+				{
+					"type": "remediation developer",
+					"lang": "en",
+					"value": "Viktor Dukhovni"
+				}
+			],
+			"source": {
+				"discovery": "UNKNOWN"
+			},
+			"datePublic": "2024-09-03T14:00:00.000Z",
+			"x_generator": {
+				"engine": "Vulnogram 0.2.0"
+			}
+		}
+	}
+}

--- a/pkg/fetch/openssl/secjson/testdata/golden/happy/statements.json
+++ b/pkg/fetch/openssl/secjson/testdata/golden/happy/statements.json
@@ -1,0 +1,53 @@
+{
+	"statements": [
+		{
+			"base": "none",
+			"text": "Note: All OpenSSL versions before 1.1.1 are out of support and no longer receiving updates.  Extended support is available for 1.0.2 from OpenSSL Software Services for premium support customers."
+		},
+		{
+			"base": "0.9.6",
+			"text": "OpenSSL 0.9.6 is out of support and no longer receiving updates."
+		},
+		{
+			"base": "0.9.7",
+			"text": "OpenSSL 0.9.7 is out of support and no longer receiving updates."
+		},
+		{
+			"base": "0.9.8",
+			"text": "OpenSSL 0.9.8 is out of support since 1st January 2016 and no longer receiving updates."
+		},
+		{
+			"base": "1.0.0",
+			"text": "OpenSSL 1.0.0 is out of support since 1st January 2016 and no longer receiving updates."
+		},
+		{
+			"base": "1.0.1",
+			"text": "OpenSSL 1.0.1 is out of support since 1st January 2017 and no longer receiving updates."
+		},
+		{
+			"base": "1.0.2",
+			"text": "OpenSSL 1.0.2 is out of support since 1st January 2020 and is no longer receiving updates.  Extended support is available from OpenSSL Software Services for premium support customers."
+		},
+		{
+			"base": "1.1.0",
+			"text": "OpenSSL 1.1.0 is out of support since 12th September 2019 and no longer receiving updates."
+		}
+	],
+	"disputed": [
+		{
+			"base": "0.9.8",
+			"cve": "CVE-2010-0928",
+			"text": "This was not treated as a security issue as it is outside of the OpenSSL threat model."
+		},
+		{
+			"base": "fips",
+			"cve": "CVE-2007-6755",
+			"text": "Only OpenSSL FIPS module shipped Dual EC DRBG, and it [was not affected](https://marc.info/?l=openssl-announce&m=138747119822324)."
+		},
+		{
+			"base": "none",
+			"cve": "CVE-2002-20001",
+			"text": "[We do not consider this to be a vulnerability in OpenSSL](https://github.com/openssl/openssl/issues/17374)."
+		}
+	]
+}

--- a/pkg/fetch/openssl/secjson/testdata/golden/invalid-id/statements.json
+++ b/pkg/fetch/openssl/secjson/testdata/golden/invalid-id/statements.json
@@ -1,0 +1,53 @@
+{
+	"statements": [
+		{
+			"base": "none",
+			"text": "Note: All OpenSSL versions before 1.1.1 are out of support and no longer receiving updates.  Extended support is available for 1.0.2 from OpenSSL Software Services for premium support customers."
+		},
+		{
+			"base": "0.9.6",
+			"text": "OpenSSL 0.9.6 is out of support and no longer receiving updates."
+		},
+		{
+			"base": "0.9.7",
+			"text": "OpenSSL 0.9.7 is out of support and no longer receiving updates."
+		},
+		{
+			"base": "0.9.8",
+			"text": "OpenSSL 0.9.8 is out of support since 1st January 2016 and no longer receiving updates."
+		},
+		{
+			"base": "1.0.0",
+			"text": "OpenSSL 1.0.0 is out of support since 1st January 2016 and no longer receiving updates."
+		},
+		{
+			"base": "1.0.1",
+			"text": "OpenSSL 1.0.1 is out of support since 1st January 2017 and no longer receiving updates."
+		},
+		{
+			"base": "1.0.2",
+			"text": "OpenSSL 1.0.2 is out of support since 1st January 2020 and is no longer receiving updates.  Extended support is available from OpenSSL Software Services for premium support customers."
+		},
+		{
+			"base": "1.1.0",
+			"text": "OpenSSL 1.1.0 is out of support since 12th September 2019 and no longer receiving updates."
+		}
+	],
+	"disputed": [
+		{
+			"base": "0.9.8",
+			"cve": "CVE-2010-0928",
+			"text": "This was not treated as a security issue as it is outside of the OpenSSL threat model."
+		},
+		{
+			"base": "fips",
+			"cve": "CVE-2007-6755",
+			"text": "Only OpenSSL FIPS module shipped Dual EC DRBG, and it [was not affected](https://marc.info/?l=openssl-announce&m=138747119822324)."
+		},
+		{
+			"base": "none",
+			"cve": "CVE-2002-20001",
+			"text": "[We do not consider this to be a vulnerability in OpenSSL](https://github.com/openssl/openssl/issues/17374)."
+		}
+	]
+}

--- a/pkg/fetch/openssl/secjson/testdata/golden/notfound/statements.json
+++ b/pkg/fetch/openssl/secjson/testdata/golden/notfound/statements.json
@@ -1,0 +1,53 @@
+{
+	"statements": [
+		{
+			"base": "none",
+			"text": "Note: All OpenSSL versions before 1.1.1 are out of support and no longer receiving updates.  Extended support is available for 1.0.2 from OpenSSL Software Services for premium support customers."
+		},
+		{
+			"base": "0.9.6",
+			"text": "OpenSSL 0.9.6 is out of support and no longer receiving updates."
+		},
+		{
+			"base": "0.9.7",
+			"text": "OpenSSL 0.9.7 is out of support and no longer receiving updates."
+		},
+		{
+			"base": "0.9.8",
+			"text": "OpenSSL 0.9.8 is out of support since 1st January 2016 and no longer receiving updates."
+		},
+		{
+			"base": "1.0.0",
+			"text": "OpenSSL 1.0.0 is out of support since 1st January 2016 and no longer receiving updates."
+		},
+		{
+			"base": "1.0.1",
+			"text": "OpenSSL 1.0.1 is out of support since 1st January 2017 and no longer receiving updates."
+		},
+		{
+			"base": "1.0.2",
+			"text": "OpenSSL 1.0.2 is out of support since 1st January 2020 and is no longer receiving updates.  Extended support is available from OpenSSL Software Services for premium support customers."
+		},
+		{
+			"base": "1.1.0",
+			"text": "OpenSSL 1.1.0 is out of support since 12th September 2019 and no longer receiving updates."
+		}
+	],
+	"disputed": [
+		{
+			"base": "0.9.8",
+			"cve": "CVE-2010-0928",
+			"text": "This was not treated as a security issue as it is outside of the OpenSSL threat model."
+		},
+		{
+			"base": "fips",
+			"cve": "CVE-2007-6755",
+			"text": "Only OpenSSL FIPS module shipped Dual EC DRBG, and it [was not affected](https://marc.info/?l=openssl-announce&m=138747119822324)."
+		},
+		{
+			"base": "none",
+			"cve": "CVE-2002-20001",
+			"text": "[We do not consider this to be a vulnerability in OpenSSL](https://github.com/openssl/openssl/issues/17374)."
+		}
+	]
+}

--- a/pkg/fetch/openssl/secjson/types.go
+++ b/pkg/fetch/openssl/secjson/types.go
@@ -1,0 +1,362 @@
+package secjson
+
+import "encoding/json/jsontext"
+
+// Statements is the content of statements.json, which collects OpenSSL's
+// remarks that are not tied to a single CVE record.
+type Statements struct {
+	Statements []Statement `json:"statements,omitempty"`
+	Disputed   []Statement `json:"disputed,omitempty"`
+}
+
+type Statement struct {
+	Base string  `json:"base"`
+	CVE  *string `json:"cve,omitempty"`
+	Text string  `json:"text"`
+}
+
+// CVE follows the MITRE CVE Record Format (CVE JSON 5.x), the same schema as
+// pkg/fetch/mitre/cve/v5.
+type CVE struct {
+	DataType    string      `json:"dataType"`
+	DataVersion string      `json:"dataVersion"`
+	CVEMetadata CVEMetadata `json:"cveMetadata"`
+	Containers  struct {
+		CNA struct {
+			ProviderMetadata ProviderMetadata `json:"providerMetadata"`
+			Title            *string          `json:"title,omitempty"`
+			Descriptions     []Description    `json:"descriptions,omitempty"`
+			Affected         []Product        `json:"affected,omitempty"`
+			ProblemTypes     []ProblemType    `json:"problemTypes,omitempty"`
+			Impacts          []Impact         `json:"impacts,omitempty"`
+			Metrics          []Metric         `json:"metrics,omitempty"`
+			Workarounds      []Description    `json:"workarounds,omitempty"`
+			Solutions        []Description    `json:"solutions,omitempty"`
+			Exploits         []Description    `json:"exploits,omitempty"`
+			Configurations   []Description    `json:"configurations,omitempty"`
+			References       []Reference      `json:"references,omitempty"`
+			Timeline         Timeline         `json:"timeline,omitempty"`
+			Credits          Credits          `json:"credits,omitempty"`
+			Source           any              `json:"source,omitempty"`
+			Tags             []string         `json:"tags,omitempty"`
+			TaxonomyMappings TaxonomyMappings `json:"taxonomyMappings,omitzero"`
+			DateAssigned     *string          `json:"dateAssigned,omitempty"`
+			DatePublic       *string          `json:"datePublic,omitempty"`
+			RejectedReasons  []Description    `json:"rejectedReasons,omitempty"`
+			ReplacedBy       []string         `json:"replacedBy,omitempty"`
+			XGenerator       jsontext.Value   `json:"x_generator,omitempty"`
+			XLegacyV4Record  jsontext.Value   `json:"x_legacyV4Record,omitempty"`
+			XRedhatCweChain  jsontext.Value   `json:"x_redhatCweChain,omitempty"`
+			XAffectedList    jsontext.Value   `json:"x_affectedList,omitempty"`
+			XConverterErrors jsontext.Value   `json:"x_ConverterErrors,omitempty"`
+		} `json:"cna"`
+		ADP []struct {
+			ProviderMetadata ProviderMetadata `json:"providerMetadata"`
+			Title            *string          `json:"title,omitempty"`
+			Descriptions     []Description    `json:"descriptions,omitempty"`
+			Affected         []Product        `json:"affected,omitempty"`
+			ProblemTypes     []ProblemType    `json:"problemTypes,omitempty"`
+			Impacts          []Impact         `json:"impacts,omitempty"`
+			Metrics          []Metric         `json:"metrics,omitempty"`
+			Workarounds      []Description    `json:"workarounds,omitempty"`
+			Solutions        []Description    `json:"solutions,omitempty"`
+			Exploits         []Description    `json:"exploits,omitempty"`
+			Configurations   []Description    `json:"configurations,omitempty"`
+			References       []Reference      `json:"references,omitempty"`
+			Timeline         Timeline         `json:"timeline,omitempty"`
+			Credits          Credits          `json:"credits,omitempty"`
+			Source           any              `json:"source,omitempty"`
+			Tags             []string         `json:"tags,omitempty"`
+			TaxonomyMappings TaxonomyMappings `json:"taxonomyMappings,omitzero"`
+			DatePublic       *string          `json:"datePublic,omitempty"`
+		} `json:"adp,omitempty"`
+	} `json:"containers"`
+}
+
+type CVEMetadata struct {
+	CVEID             string  `json:"cveId"`
+	AssignerOrgID     string  `json:"assignerOrgId"`
+	AssignerShortName *string `json:"assignerShortName,omitempty"`
+	RequesterUserID   *string `json:"requesterUserId,omitempty"`
+	Serial            *int    `json:"serial,omitempty"`
+	State             string  `json:"state"`
+	DatePublished     *string `json:"datePublished,omitempty"`
+	DateUpdated       *string `json:"dateUpdated,omitempty"`
+	DateReserved      *string `json:"dateReserved,omitempty"`
+	DateRejected      *string `json:"dateRejected,omitempty"`
+}
+
+type ProviderMetadata struct {
+	OrgID       string  `json:"orgId"`
+	ShortName   *string `json:"shortName,omitempty"`
+	DateUpdated *string `json:"dateUpdated,omitempty"`
+}
+
+type Description struct {
+	Lang            string `json:"lang"`
+	Value           string `json:"value"`
+	SupportingMedia []struct {
+		Type   string `json:"type"`
+		Base64 *bool  `json:"base64,omitempty"`
+		Value  string `json:"value"`
+	} `json:"supportingMedia,omitempty"`
+}
+
+type Product struct {
+	Vendor          *string  `json:"vendor,omitempty"`
+	Product         *string  `json:"product,omitempty"`
+	CollectionURL   *string  `json:"collectionURL,omitempty"`
+	PackageName     *string  `json:"packageName,omitempty"`
+	Cpes            []string `json:"cpes,omitempty"`
+	Modules         []string `json:"modules,omitempty"`
+	ProgramFiles    []string `json:"programFiles,omitempty"`
+	ProgramRoutines []struct {
+		Name string `json:"name"`
+	} `json:"programRoutines,omitempty"`
+	Platforms     []string `json:"platforms,omitempty"`
+	Repo          *string  `json:"repo,omitempty"`
+	DefaultStatus *string  `json:"defaultStatus,omitempty"`
+	Versions      []struct {
+		Status          string  `json:"status"`
+		VersionType     *string `json:"versionType,omitempty"`
+		Version         string  `json:"version"`
+		LessThan        *string `json:"lessThan,omitempty"`
+		LessThanOrEqual *string `json:"lessThanOrEqual,omitempty"`
+		Changes         []struct {
+			At     string `json:"at"`
+			Status string `json:"status"`
+		} `json:"changes,omitempty"`
+	} `json:"versions,omitempty"`
+}
+
+type ProblemType struct {
+	Descriptions []struct {
+		Type        *string     `json:"type,omitempty"`
+		Lang        string      `json:"lang"`
+		Description string      `json:"description"`
+		CweID       *string     `json:"cweId,omitempty"`
+		References  []Reference `json:"references,omitempty"`
+	} `json:"descriptions"`
+}
+
+type Impact struct {
+	Descriptions []Description `json:"descriptions"`
+	CapecID      *string       `json:"capecId,omitempty"`
+}
+
+type Metric struct {
+	Format    *string `json:"format,omitempty"`
+	Scenarios []struct {
+		Lang  string `json:"lang"`
+		Value string `json:"value"`
+	} `json:"scenarios,omitempty"`
+	CVSSv2  *CVSSv2  `json:"cvssV2_0,omitempty"`
+	CVSSv30 *CVSSv30 `json:"cvssV3_0,omitempty"`
+	CVSSv31 *CVSSv31 `json:"cvssV3_1,omitempty"`
+	CVSSv40 *CVSSv40 `json:"cvssV4_0,omitempty"`
+	Other   *struct {
+		Type    string         `json:"type"`
+		Content jsontext.Value `json:"content"`
+	} `json:"other,omitempty"`
+}
+
+type CVSSv2 struct {
+	Version                    string   `json:"version"`
+	VectorString               string   `json:"vectorString"`
+	AccessVector               *string  `json:"accessVector,omitempty"`
+	AccessComplexity           *string  `json:"accessComplexity,omitempty"`
+	Authentication             *string  `json:"authentication,omitempty"`
+	ConfidentialityImpact      *string  `json:"confidentialityImpact,omitempty"`
+	IntegrityImpact            *string  `json:"integrityImpact,omitempty"`
+	AvailabilityImpact         *string  `json:"availabilityImpact,omitempty"`
+	BaseScore                  float64  `json:"baseScore"`
+	Exploitability             *string  `json:"exploitability,omitempty"`
+	RemediationLevel           *string  `json:"remediationLevel,omitempty"`
+	ReportConfidence           *string  `json:"reportConfidence,omitempty"`
+	TemporalScore              *float64 `json:"temporalScore,omitempty"`
+	CollateralDamagePotential  *string  `json:"collateralDamagePotential,omitempty"`
+	TargetDistribution         *string  `json:"targetDistribution,omitempty"`
+	ConfidentialityRequirement *string  `json:"confidentialityRequirement,omitempty"`
+	IntegrityRequirement       *string  `json:"integrityRequirement,omitempty"`
+	AvailabilityRequirement    *string  `json:"availabilityRequirement,omitempty"`
+	EnvironmentalScore         *float64 `json:"environmentalScore,omitempty"`
+}
+
+type CVSSv30 struct {
+	Version                       string   `json:"version"`
+	VectorString                  string   `json:"vectorString"`
+	AttackVector                  *string  `json:"attackVector,omitempty"`
+	AttackComplexity              *string  `json:"attackComplexity,omitempty"`
+	PrivilegesRequired            *string  `json:"privilegesRequired,omitempty"`
+	UserInteraction               *string  `json:"userInteraction,omitempty"`
+	Scope                         *string  `json:"scope,omitempty"`
+	ConfidentialityImpact         *string  `json:"confidentialityImpact,omitempty"`
+	IntegrityImpact               *string  `json:"integrityImpact,omitempty"`
+	AvailabilityImpact            *string  `json:"availabilityImpact,omitempty"`
+	BaseScore                     float64  `json:"baseScore"`
+	BaseSeverity                  string   `json:"baseSeverity"`
+	ExploitCodeMaturity           *string  `json:"exploitCodeMaturity,omitempty"`
+	RemediationLevel              *string  `json:"remediationLevel,omitempty"`
+	ReportConfidence              *string  `json:"reportConfidence,omitempty"`
+	TemporalScore                 *float64 `json:"temporalScore,omitempty"`
+	TemporalSeverity              *string  `json:"temporalSeverity,omitempty"`
+	ConfidentialityRequirement    *string  `json:"confidentialityRequirement,omitempty"`
+	IntegrityRequirement          *string  `json:"integrityRequirement,omitempty"`
+	AvailabilityRequirement       *string  `json:"availabilityRequirement,omitempty"`
+	ModifiedAttackVector          *string  `json:"modifiedAttackVector,omitempty"`
+	ModifiedAttackComplexity      *string  `json:"modifiedAttackComplexity,omitempty"`
+	ModifiedPrivilegesRequired    *string  `json:"modifiedPrivilegesRequired,omitempty"`
+	ModifiedUserInteraction       *string  `json:"modifiedUserInteraction,omitempty"`
+	ModifiedScope                 *string  `json:"modifiedScope,omitempty"`
+	ModifiedConfidentialityImpact *string  `json:"modifiedConfidentialityImpact,omitempty"`
+	ModifiedIntegrityImpact       *string  `json:"modifiedIntegrityImpact,omitempty"`
+	ModifiedAvailabilityImpact    *string  `json:"modifiedAvailabilityImpact,omitempty"`
+	EnvironmentalScore            *float64 `json:"environmentalScore,omitempty"`
+	EnvironmentalSeverity         *string  `json:"environmentalSeverity,omitempty"`
+}
+
+type CVSSv31 struct {
+	Version                       string   `json:"version"`
+	VectorString                  string   `json:"vectorString"`
+	AttackVector                  *string  `json:"attackVector,omitempty"`
+	AttackComplexity              *string  `json:"attackComplexity,omitempty"`
+	PrivilegesRequired            *string  `json:"privilegesRequired,omitempty"`
+	UserInteraction               *string  `json:"userInteraction,omitempty"`
+	Scope                         *string  `json:"scope,omitempty"`
+	ConfidentialityImpact         *string  `json:"confidentialityImpact,omitempty"`
+	IntegrityImpact               *string  `json:"integrityImpact,omitempty"`
+	AvailabilityImpact            *string  `json:"availabilityImpact,omitempty"`
+	BaseScore                     float64  `json:"baseScore"`
+	BaseSeverity                  string   `json:"baseSeverity"`
+	ExploitCodeMaturity           *string  `json:"exploitCodeMaturity,omitempty"`
+	RemediationLevel              *string  `json:"remediationLevel,omitempty"`
+	ReportConfidence              *string  `json:"reportConfidence,omitempty"`
+	TemporalScore                 *float64 `json:"temporalScore,omitempty"`
+	TemporalSeverity              *string  `json:"temporalSeverity,omitempty"`
+	ConfidentialityRequirement    *string  `json:"confidentialityRequirement,omitempty"`
+	IntegrityRequirement          *string  `json:"integrityRequirement,omitempty"`
+	AvailabilityRequirement       *string  `json:"availabilityRequirement,omitempty"`
+	ModifiedAttackVector          *string  `json:"modifiedAttackVector,omitempty"`
+	ModifiedAttackComplexity      *string  `json:"modifiedAttackComplexity,omitempty"`
+	ModifiedPrivilegesRequired    *string  `json:"modifiedPrivilegesRequired,omitempty"`
+	ModifiedUserInteraction       *string  `json:"modifiedUserInteraction,omitempty"`
+	ModifiedScope                 *string  `json:"modifiedScope,omitempty"`
+	ModifiedConfidentialityImpact *string  `json:"modifiedConfidentialityImpact,omitempty"`
+	ModifiedIntegrityImpact       *string  `json:"modifiedIntegrityImpact,omitempty"`
+	ModifiedAvailabilityImpact    *string  `json:"modifiedAvailabilityImpact,omitempty"`
+	EnvironmentalScore            *float64 `json:"environmentalScore,omitempty"`
+	EnvironmentalSeverity         *string  `json:"environmentalSeverity,omitempty"`
+}
+
+type CVSSv40 struct {
+	Version                           string   `json:"version"`
+	VectorString                      string   `json:"vectorString"`
+	BaseScore                         float64  `json:"baseScore"`
+	BaseSeverity                      string   `json:"baseSeverity"`
+	AttackVector                      *string  `json:"attackVector,omitempty"`
+	AttackComplexity                  *string  `json:"attackComplexity,omitempty"`
+	AttackRequirements                *string  `json:"attackRequirements,omitempty"`
+	PrivilegesRequired                *string  `json:"privilegesRequired,omitempty"`
+	UserInteraction                   *string  `json:"userInteraction,omitempty"`
+	VulnConfidentialityImpact         *string  `json:"vulnConfidentialityImpact,omitempty"`
+	VulnIntegrityImpact               *string  `json:"vulnIntegrityImpact,omitempty"`
+	VulnAvailabilityImpact            *string  `json:"vulnAvailabilityImpact,omitempty"`
+	SubConfidentialityImpact          *string  `json:"subConfidentialityImpact,omitempty"`
+	SubIntegrityImpact                *string  `json:"subIntegrityImpact,omitempty"`
+	SubAvailabilityImpact             *string  `json:"subAvailabilityImpact,omitempty"`
+	ExploitMaturity                   *string  `json:"exploitMaturity,omitempty"`
+	ConfidentialityRequirement        *string  `json:"confidentialityRequirement,omitempty"`
+	IntegrityRequirement              *string  `json:"integrityRequirement,omitempty"`
+	AvailabilityRequirement           *string  `json:"availabilityRequirement,omitempty"`
+	ModifiedAttackVector              *string  `json:"modifiedAttackVector,omitempty"`
+	ModifiedAttackComplexity          *string  `json:"modifiedAttackComplexity,omitempty"`
+	ModifiedAttackRequirements        *string  `json:"modifiedAttackRequirements,omitempty"`
+	ModifiedPrivilegesRequired        *string  `json:"modifiedPrivilegesRequired,omitempty"`
+	ModifiedUserInteraction           *string  `json:"modifiedUserInteraction,omitempty"`
+	ModifiedVulnConfidentialityImpact *string  `json:"modifiedVulnConfidentialityImpact,omitempty"`
+	ModifiedVulnIntegrityImpact       *string  `json:"modifiedVulnIntegrityImpact,omitempty"`
+	ModifiedVulnAvailabilityImpact    *string  `json:"modifiedVulnAvailabilityImpact,omitempty"`
+	ModifiedSubConfidentialityImpact  *string  `json:"modifiedSubConfidentialityImpact,omitempty"`
+	ModifiedSubIntegrityImpact        *string  `json:"modifiedSubIntegrityImpact,omitempty"`
+	ModifiedSubAvailabilityImpact     *string  `json:"modifiedSubAvailabilityImpact,omitempty"`
+	Safety                            *string  `json:"Safety,omitempty"`
+	Automatable                       *string  `json:"Automatable,omitempty"`
+	Recovery                          *string  `json:"Recovery,omitempty"`
+	ValueDensity                      *string  `json:"valueDensity,omitempty"`
+	VulnerabilityResponseEffort       *string  `json:"vulnerabilityResponseEffort,omitempty"`
+	ProviderUrgency                   *string  `json:"providerUrgency,omitempty"`
+	ThreatScore                       *float64 `json:"threatScore,omitempty"`
+	ThreatSeverity                    *string  `json:"threatSeverity,omitempty"`
+	EnvironmentalScore                *float64 `json:"environmentalScore,omitempty"`
+	EnvironmentalSeverity             *string  `json:"environmentalSeverity,omitempty"`
+}
+
+// https://github.com/CERTCC/SSVC/blob/a34a9768ef75209f8c1dd1bc2cf0523ba4d243c8/data/schema/SSVC_Computed.schema.json for other:ssvc
+type SSVC struct {
+	ID           string  `json:"id"`
+	Role         string  `json:"role"`
+	Version      string  `json:"version"`
+	Schema       *string `json:"$schema,omitempty"`
+	Computed     *string `json:"computed,omitempty"`
+	Options      []any   `json:"options"`
+	DecisionTree *struct {
+		Version        string   `json:"version"`
+		Lang           string   `json:"lang"`
+		Title          *string  `json:"title,omitempty"`
+		Roles          []string `json:"roles,omitempty"`
+		DecisionTable  []any    `json:"decision_table"`
+		DecisionPoints []struct {
+			DecisionType string  `json:"decision_type"`
+			Label        string  `json:"label"`
+			Key          *string `json:"key,omitempty"`
+			Options      []struct {
+				Label       string  `json:"label"`
+				Key         *string `json:"key,omitempty"`
+				Color       *string `json:"color,omitempty"`
+				Description string  `json:"description"`
+			} `json:"options"`
+			Children []struct {
+				Label string  `json:"label"`
+				Key   *string `json:"key,omitempty"`
+			} `json:"children,omitempty"`
+		} `json:"decision_points"`
+	} `json:"decision_tree,omitempty"`
+	DecisionTreeURL *string `json:"decision_tree_url,omitempty"`
+	Generator       *string `json:"generator,omitempty"`
+	Timestamp       string  `json:"timestamp"`
+}
+
+// for other:kev
+type KEV struct {
+	DateAdded string `json:"date_added"`
+	Reference string `json:"reference"`
+}
+
+type Reference struct {
+	Name *string  `json:"name,omitempty"`
+	Tags []string `json:"tags,omitempty"`
+	URL  string   `json:"url"`
+}
+
+type Timeline []struct {
+	Time  string `json:"time"`
+	Lang  string `json:"lang"`
+	Value string `json:"value"`
+}
+
+type Credits []struct {
+	Type  *string `json:"type,omitempty"`
+	Lang  string  `json:"lang"`
+	User  *string `json:"user,omitempty"`
+	Value string  `json:"value"`
+}
+
+type TaxonomyMappings []struct {
+	TaxonomyVersion   *string `json:"taxonomyVersion,omitempty"`
+	TaxonomyName      string  `json:"taxonomyName"`
+	TaxonomyRelations []struct {
+		TaxonomyID        string `json:"taxonomyId"`
+		RelationshipName  string `json:"relationshipName"`
+		RelationshipValue string `json:"relationshipValue"`
+	} `json:"taxonomyRelations"`
+}


### PR DESCRIPTION
## What

Add a new fetch data source `openssl-secjson` that collects OpenSSL's security advisory JSON files from <https://openssl-library.org/news/secjson/>.

- `pkg/fetch/openssl/secjson/` — fetcher + types + golden tests
- `pkg/cmd/fetch/fetch.go` — wire `newCmdOpenSSLSecJSON()`

Output layout:

```
<dir>/statements.json
<dir>/<year>/CVE-yyyy-nnnn.json
```

## Why

OpenSSL publishes its own advisories as per-CVE records in the MITRE CVE Record Format (`dataType: CVE_RECORD`, `dataVersion` 5.0 / 5.1), i.e. the same schema as `fetch/mitre/cve/v5`, and as the CNA for its own CVEs it is the authoritative source for affected version ranges.

`statements.json` is fetched as well because its `disputed` entries (CVE-2002-20001, CVE-2007-6755, CVE-2010-0928) do **not** exist as per-CVE files — this is the only place in the dataset where "OpenSSL considers this not a vulnerability / not affected" is recorded, which maps naturally onto `fixstatus.ClassNotAffected` for a future extractor. Its `statements` entries are OpenSSL's own out-of-support declarations per version series, which map onto `types/eol`.

## How

Types are copied from `pkg/fetch/mitre/cve/v5/types.go` (the same duplication `fetch/paloalto/json` already does for this schema), plus a small `Statements` / `Statement` type for `statements.json`.

Upstream offers no aggregate feed or index API — only the HTML index — so the fetcher scrapes it with goquery (`main a`), resolves hrefs via `url.ResolveReference`, and then:

- `statements.json` → `<dir>/statements.json`
- `cve-*.json` → `PipelineGet` → `<dir>/<year>/CVE-yyyy-nnnn.json`, year taken from `cveMetadata.cveId` exactly as `mitre/cve/v5` does

Since the data set depends on `statements.json` for the disputed records, the index scan is strict rather than lenient: a **missing** `statements.json` link and an **unrecognized** JSON file name in the index are both errors. A quietly shrinking data set is worse than a failed run, and a new upstream file should be a deliberate decision, not a silent drop. Non-JSON links (e.g. the `secadv/*.txt` advisories) are ignored.

Defaults: `retry=3`, `concurrency=5`, `wait=1s`.

## Testing

- `GOEXPERIMENT=jsonv2 go build ./...`
- `GOEXPERIMENT=jsonv2 go test -race ./pkg/fetch/openssl/...` — golden test with four cases, each error case verified to fail for its intended reason:
  - `happy` — a legacy `x_generator.importer` record, one with `lessThanOrEqual` + `credits[].user` + `supportingMedia`, one full Vulnogram record, `statements.json`, plus a non-JSON link
  - `notfound` — a listed record that 404s; also asserts the `statements.json` written before the failure is correct
  - `no-statements` — index that no longer links `statements.json`
  - `unexpected` — index carrying an unrecognized `advisories.json`
- `GOEXPERIMENT=jsonv2 go vet`, `gofmt -l`, `golangci-lint run` — clean
- Live run against the real site: `vuls-data-update fetch openssl-secjson` → 272 CVE records + `statements.json`
- Re-checked the live index after making the scan strict: it links exactly `statements.json` + 272 `cve-*.json` and nothing else, so the strict path does not trip on the current upstream page
- **Lossless check**: every one of the 273 written files was compared semantically (parsed-JSON equality) against the upstream file it came from — 0 mismatches, so no field of the OpenSSL data is dropped by the types
- The live run and a run against a local mirror of the same data produced byte-identical trees

## Checklist

- [x] Tests pass
- [x] Golden files updated
- [x] Deterministic output verified — all output goes through `util.Write`; two independent runs produced byte-identical trees
- [x] Backward compatibility maintained — no changes under `pkg/extract/types`

## Notes for reviewers

- No extractor in this PR; `vuls-data-db` keeps the `extract-*` matrix entries commented out (see vulsio/vuls-data-db#206).
- If an extractor is written later, note that `statements[].base` takes non-version sentinels (`none`, `fips`) in addition to version series like `0.9.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
