### PR TITLE
fix(extract/fortinet): add FortiSIEMWindowsAgent to the product whitelist

### DIFF
--- a/pkg/extract/fortinet/csaf/testdata/fixtures/2026/FG-IR-26-155.json
+++ b/pkg/extract/fortinet/csaf/testdata/fixtures/2026/FG-IR-26-155.json
@@ -1,0 +1,193 @@
+{
+	"document": {
+		"acknowledgments": [
+			{
+				"summary": "Fortinet is pleased to thank Nicola Scremin (@ScreSys) for reporting this vulnerability under responsible disclosure."
+			}
+		],
+		"category": "Fortinet PSIRT Advisories",
+		"csaf_version": "2.0",
+		"publisher": {
+			"category": "vendor",
+			"contact_details": "https://fortiguard.fortinet.com/faq/psirt-contact",
+			"issuing_authority": "Fortinet PSIRT",
+			"name": "Fortinet PSIRT",
+			"namespace": "https://fortiguard.fortinet.com/psirt"
+		},
+		"title": "Supers override fails to properly override supervisor address",
+		"tracking": {
+			"current_release_date": "2026-07-14T00:00:00",
+			"id": "FG-IR-26-155",
+			"initial_release_date": "2026-07-14T00:00:00",
+			"revision_history": [
+				{
+					"date": "2026-07-14T00:00:00",
+					"number": "1",
+					"summary": "Initial Publication"
+				}
+			],
+			"status": "final",
+			"version": "0"
+		}
+	},
+	"product_tree": {
+		"branches": [
+			{
+				"branches": [
+					{
+						"branches": [
+							{
+								"category": "product_version_range",
+								"name": "FortiSIEMWindowsAgent/ 7.5 all versions",
+								"product": {
+									"name": "FortiSIEMWindowsAgent",
+									"product_id": "FortiSIEMWindowsAgent/ 7.5 all versions"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSIEMWindowsAgent/>=7.4.0|<=7.4.1",
+								"product": {
+									"name": "FortiSIEMWindowsAgent",
+									"product_id": "FortiSIEMWindowsAgent >=7.4.0|<=7.4.1"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSIEMWindowsAgent/ 7.3 all versions",
+								"product": {
+									"name": "FortiSIEMWindowsAgent",
+									"product_id": "FortiSIEMWindowsAgent/ 7.3 all versions"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSIEMWindowsAgent/ 7.2 all versions",
+								"product": {
+									"name": "FortiSIEMWindowsAgent",
+									"product_id": "FortiSIEMWindowsAgent/ 7.2 all versions"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSIEMWindowsAgent/ 7.1 all versions",
+								"product": {
+									"name": "FortiSIEMWindowsAgent",
+									"product_id": "FortiSIEMWindowsAgent/ 7.1 all versions"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSIEMWindowsAgent/ 5.0 all versions",
+								"product": {
+									"name": "FortiSIEMWindowsAgent",
+									"product_id": "FortiSIEMWindowsAgent/ 5.0 all versions"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSIEMWindowsAgent/ 4.4 all versions",
+								"product": {
+									"name": "FortiSIEMWindowsAgent",
+									"product_id": "FortiSIEMWindowsAgent/ 4.4 all versions"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSIEMWindowsAgent/ 4.3 all versions",
+								"product": {
+									"name": "FortiSIEMWindowsAgent",
+									"product_id": "FortiSIEMWindowsAgent/ 4.3 all versions"
+								}
+							},
+							{
+								"category": "product_version_range",
+								"name": "FortiSIEMWindowsAgent/ 4.2 all versions",
+								"product": {
+									"name": "FortiSIEMWindowsAgent",
+									"product_id": "FortiSIEMWindowsAgent/ 4.2 all versions"
+								}
+							}
+						],
+						"category": "product",
+						"name": "FortiSIEMWindowsAgent"
+					}
+				],
+				"category": "vendor",
+				"name": "Fortinet PSIRT"
+			}
+		]
+	},
+	"vulnerabilities": [
+		{
+			"cve": "CVE-2026-59841",
+			"cwe": {
+				"id": "CWE-923",
+				"name": "Improper Restriction of Communication Channel to Intended Endpoints"
+			},
+			"notes": [
+				{
+					"category": "summary",
+					"text": "Vulnerability in supers override feature in FortiSIEM Windows Agent installer can lead to unintended behavior \n\n",
+					"title": "Summary"
+				},
+				{
+					"category": "general",
+					"text": "N/A",
+					"title": "Workarounds"
+				}
+			],
+			"product_status": {
+				"known_affected": [
+					"FortiSIEMWindowsAgent >=7.4.0|<=7.4.1"
+				],
+				"known_not_affected": [
+					"FortiSIEMWindowsAgent/ 7.5 all versions",
+					"FortiSIEMWindowsAgent-7.4.2",
+					"FortiSIEMWindowsAgent/ 7.3 all versions",
+					"FortiSIEMWindowsAgent/ 7.2 all versions",
+					"FortiSIEMWindowsAgent/ 7.1 all versions",
+					"FortiSIEMWindowsAgent/ 5.0 all versions",
+					"FortiSIEMWindowsAgent/ 4.4 all versions",
+					"FortiSIEMWindowsAgent/ 4.3 all versions",
+					"FortiSIEMWindowsAgent/ 4.2 all versions"
+				]
+			},
+			"references": [
+				{
+					"summary": "An Improper Restriction of Communication Channel to Intended Endpoints [CWE-923] vulnerability in FortiSIEM Windows Agent may allow an unauthorized attacker on the same local network to execute arbitrary code via spoofing the supervisors hostname when the Windows device is configured with the 'Supers Override' feature. ",
+					"url": "https://fortiguard.fortinet.com/psirt/FG-IR-26-155"
+				}
+			],
+			"remediations": [
+				{
+					"category": "vendor_fix",
+					"details": "FortiSIEMWindowsAgent 7.5: Not Applicable\nFortiSIEMWindowsAgent 7.4: Upgrade to 7.4.2 or above\nFortiSIEMWindowsAgent 7.3: Not Applicable\nFortiSIEMWindowsAgent 7.2: Not Applicable\nFortiSIEMWindowsAgent 7.1: Not Applicable\nFortiSIEMWindowsAgent 5.0: Not Applicable\nFortiSIEMWindowsAgent 4.4: Not Applicable\nFortiSIEMWindowsAgent 4.3: Not Applicable\nFortiSIEMWindowsAgent 4.2: Not Applicable",
+					"product_ids": [
+						"FortiSIEMWindowsAgent"
+					]
+				}
+			],
+			"scores": [
+				{
+					"cvss_v3": {
+						"baseScore": 6.9,
+						"baseSeverity": "MEDIUM",
+						"vectorString": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+						"version": "3.1"
+					},
+					"products": [
+						"FortiSIEMWindowsAgent"
+					]
+				}
+			],
+			"threats": [
+				{
+					"category": "impact",
+					"details": "Escalation of privilege"
+				}
+			],
+			"title": "FortiSIEMWindowsAgent - MEDIUM - FG-IR-26-155"
+		}
+	]
+}

--- a/pkg/extract/fortinet/csaf/testdata/golden/data/2026/FG-IR-26-155.json
+++ b/pkg/extract/fortinet/csaf/testdata/golden/data/2026/FG-IR-26-155.json
@@ -1,0 +1,110 @@
+{
+	"id": "FG-IR-26-155",
+	"advisories": [
+		{
+			"content": {
+				"id": "FG-IR-26-155",
+				"title": "Supers override fails to properly override supervisor address",
+				"references": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"url": "https://fortiguard.fortinet.com/psirt/FG-IR-26-155"
+					}
+				],
+				"published": "2026-07-14T00:00:00Z",
+				"modified": "2026-07-14T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "CVE-2026-59841"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-59841",
+				"title": "Supers override fails to properly override supervisor address",
+				"description": "Vulnerability in supers override feature in FortiSIEM Windows Agent installer can lead to unintended behavior",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "fortiguard.fortinet.com",
+						"vendor": "Escalation of privilege"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "fortiguard.fortinet.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+							"base_score": 7.5,
+							"base_severity": "HIGH",
+							"temporal_score": 6.7,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.7,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"cwe": [
+							"CWE-923"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"url": "https://fortiguard.fortinet.com/psirt/FG-IR-26-155"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "CVE-2026-59841"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "unknown"
+									},
+									"cpe": "cpe:2.3:a:fortinet:fortisiem_windows_agent:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "fortinet-fortisiem_windows_agent",
+										"ge": "7.4.0",
+										"le": "7.4.1"
+									}
+								}
+							}
+						]
+					},
+					"tag": "CVE-2026-59841"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "fortinet-csaf",
+		"raws": [
+			"fixtures/2026/FG-IR-26-155.json"
+		]
+	}
+}

--- a/pkg/extract/fortinet/cvrf/testdata/fixtures/2026/FG-IR-26-155.json
+++ b/pkg/extract/fortinet/cvrf/testdata/fixtures/2026/FG-IR-26-155.json
@@ -1,0 +1,183 @@
+{
+	"document_title": "Supers override fails to properly override supervisor address",
+	"document_type": "Fortinet PSIRT Advisories",
+	"documentpublisher": {
+		"type": "Vendor",
+		"contact_details": "\n            Fortinet PSIRT Contact:\n            Website: https://fortiguard.fortinet.com/faq/psirt-contact\n        "
+	},
+	"documenttracking": {
+		"identification": {
+			"id": "FG-IR-26-155"
+		},
+		"status": "Final",
+		"version": "1",
+		"revisionhistory": {
+			"revision": {
+				"number": "1",
+				"date": "2026-07-14T00:00:00",
+				"description": "Current version"
+			}
+		},
+		"initial_release_date": "2026-07-14T00:00:00",
+		"current_release_date": "2026-07-14T00:00:00"
+	},
+	"documentnotes": {
+		"note": [
+			{
+				"text": "\n            An Improper Restriction of Communication Channel to Intended Endpoints [CWE-923] vulnerability in FortiSIEM Windows Agent may allow an unauthorized attacker on the same local network to execute arbitrary code via spoofing the supervisors hostname when the Windows device is configured with the 'Supers Override' feature.\n        ",
+				"title": "Summary",
+				"type": "Summary",
+				"ordinal": "1"
+			},
+			{
+				"text": "\n            None\n        ",
+				"title": "Description",
+				"type": "General",
+				"ordinal": "2"
+			},
+			{
+				"text": "\n            Escalation of privilege\n        ",
+				"title": "Impact",
+				"type": "General",
+				"ordinal": "3"
+			},
+			{
+				"text": "\n            None\n        ",
+				"title": "Solutions",
+				"type": "General",
+				"ordinal": "4"
+			}
+		]
+	},
+	"acknowledgments": {
+		"acknowledgment": [
+			{
+				"description": "Fortinet is pleased to thank Nicola Scremin (@ScreSys) for reporting this vulnerability under responsible disclosure."
+			}
+		]
+	},
+	"vulnerability": {
+		"ordinal": "1",
+		"title": "Supers override fails to properly override supervisor address",
+		"references": {
+			"type": "Self",
+			"reference": [
+				{
+					"url": "https://fortiguard.fortinet.com/psirt/FG-IR-26-155",
+					"description": "Supers override fails to properly override supervisor address"
+				}
+			]
+		},
+		"cve": [
+			"CVE-2026-59841"
+		],
+		"product_statuses": {
+			"status": {
+				"type": "Known Affected",
+				"product_id": [
+					"FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 7.5",
+					"FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 7.4",
+					"FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 7.3",
+					"FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 7.2",
+					"FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 7.1",
+					"FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 5.0",
+					"FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 4.4",
+					"FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 4.3",
+					"FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 4.2"
+				]
+			}
+		},
+		"cvss_scoresets": {
+			"scoreset_v3": {
+				"base_score_v3": "6.9",
+				"vector_v3": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C"
+			}
+		}
+	},
+	"product_tree": {
+		"branch": {
+			"name": "Fortinet",
+			"type": "Vendor",
+			"branch": [
+				{
+					"name": "FortiSIEMWindowsAgent",
+					"type": "Product Name",
+					"branch": [
+						{
+							"name": "FortiSIEMWindowsAgent 7.5",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiSIEMWindowsAgent FortiSIEMWindowsAgent 7.5",
+								"product_id": "FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 7.5"
+							}
+						},
+						{
+							"name": "FortiSIEMWindowsAgent 7.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiSIEMWindowsAgent FortiSIEMWindowsAgent 7.4",
+								"product_id": "FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 7.4"
+							}
+						},
+						{
+							"name": "FortiSIEMWindowsAgent 7.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiSIEMWindowsAgent FortiSIEMWindowsAgent 7.3",
+								"product_id": "FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 7.3"
+							}
+						},
+						{
+							"name": "FortiSIEMWindowsAgent 7.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiSIEMWindowsAgent FortiSIEMWindowsAgent 7.2",
+								"product_id": "FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 7.2"
+							}
+						},
+						{
+							"name": "FortiSIEMWindowsAgent 7.1",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiSIEMWindowsAgent FortiSIEMWindowsAgent 7.1",
+								"product_id": "FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 7.1"
+							}
+						},
+						{
+							"name": "FortiSIEMWindowsAgent 5.0",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiSIEMWindowsAgent FortiSIEMWindowsAgent 5.0",
+								"product_id": "FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 5.0"
+							}
+						},
+						{
+							"name": "FortiSIEMWindowsAgent 4.4",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiSIEMWindowsAgent FortiSIEMWindowsAgent 4.4",
+								"product_id": "FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 4.4"
+							}
+						},
+						{
+							"name": "FortiSIEMWindowsAgent 4.3",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiSIEMWindowsAgent FortiSIEMWindowsAgent 4.3",
+								"product_id": "FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 4.3"
+							}
+						},
+						{
+							"name": "FortiSIEMWindowsAgent 4.2",
+							"type": "Product Version",
+							"full_product_name": {
+								"text": "FortiSIEMWindowsAgent FortiSIEMWindowsAgent 4.2",
+								"product_id": "FortiSIEMWindowsAgent-FortiSIEMWindowsAgent 4.2"
+							}
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/pkg/extract/fortinet/cvrf/testdata/golden/data/2026/FG-IR-26-155.json
+++ b/pkg/extract/fortinet/cvrf/testdata/golden/data/2026/FG-IR-26-155.json
@@ -1,0 +1,56 @@
+{
+	"id": "FG-IR-26-155",
+	"advisories": [
+		{
+			"content": {
+				"id": "FG-IR-26-155",
+				"title": "Supers override fails to properly override supervisor address",
+				"description": "An Improper Restriction of Communication Channel to Intended Endpoints [CWE-923] vulnerability in FortiSIEM Windows Agent may allow an unauthorized attacker on the same local network to execute arbitrary code via spoofing the supervisors hostname when the Windows device is configured with the 'Supers Override' feature.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "fortiguard.fortinet.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+							"base_score": 7.5,
+							"base_severity": "HIGH",
+							"temporal_score": 6.7,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.7,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"cwe": [
+							"CWE-923"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "fortiguard.fortinet.com",
+						"url": "https://fortiguard.fortinet.com/psirt/FG-IR-26-155"
+					}
+				],
+				"published": "2026-07-14T00:00:00Z",
+				"modified": "2026-07-14T00:00:00Z"
+			}
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-59841"
+			}
+		}
+	],
+	"data_source": {
+		"id": "fortinet-cvrf",
+		"raws": [
+			"fixtures/2026/FG-IR-26-155.json"
+		]
+	}
+}

--- a/pkg/extract/fortinet/internal/product/table.go
+++ b/pkg/extract/fortinet/internal/product/table.go
@@ -86,6 +86,7 @@ var nameToProduct = map[string]productInfo{
 	"FortiRecorder":                        {cpe: "cpe:2.3:o:fortinet:fortirecorder:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiRecorder},
 	"FortiSASE":                            {cpe: "cpe:2.3:a:fortinet:fortisase:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSASE},
 	"FortiSIEM":                            {cpe: "cpe:2.3:o:fortinet:fortisiem:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSIEM},
+	"FortiSIEMWindowsAgent":                {cpe: "cpe:2.3:a:fortinet:fortisiem_windows_agent:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSIEMWindowsAgent},
 	"FortiSOAR Agent Communication Bridge": {cpe: "cpe:2.3:a:fortinet:fortisoar_agent_communication_bridge:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSOARAgentCommunicationBridge},
 	"FortiSOAR PaaS":                       {cpe: "cpe:2.3:a:fortinet:fortisoar:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSOAR},
 	"FortiSOAR on-premise":                 {cpe: "cpe:2.3:a:fortinet:fortisoar:*:*:*:*:*:*:*:*", rangeType: ccRangeTypes.RangeTypeFortinetFortiSOAR},

--- a/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/range/range.go
+++ b/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/range/range.go
@@ -101,6 +101,7 @@ const (
 	RangeTypeFortinetFortiSandboxPaaS                            RangeType = "fortinet-fortisandbox_paas"
 	RangeTypeFortinetFortiSASE                                   RangeType = "fortinet-fortisase"
 	RangeTypeFortinetFortiSIEM                                   RangeType = "fortinet-fortisiem"
+	RangeTypeFortinetFortiSIEMWindowsAgent                       RangeType = "fortinet-fortisiem_windows_agent"
 	RangeTypeFortinetFortiSOAR                                   RangeType = "fortinet-fortisoar"
 	RangeTypeFortinetFortiSOARAgentCommunicationBridge           RangeType = "fortinet-fortisoar_agent_communication_bridge"
 	RangeTypeFortinetFortiSRA                                    RangeType = "fortinet-fortisra"
@@ -183,6 +184,7 @@ func RangeTypes() []RangeType {
 		RangeTypeFortinetFortiSandboxPaaS,
 		RangeTypeFortinetFortiSASE,
 		RangeTypeFortinetFortiSIEM,
+		RangeTypeFortinetFortiSIEMWindowsAgent,
 		RangeTypeFortinetFortiSOAR,
 		RangeTypeFortinetFortiSOARAgentCommunicationBridge,
 		RangeTypeFortinetFortiSRA,
@@ -418,6 +420,7 @@ func (t RangeType) CompareVersions(v1, v2 string) (int, error) {
 		RangeTypeFortinetFortiSandboxCloud,
 		RangeTypeFortinetFortiSandboxPaaS,
 		RangeTypeFortinetFortiSIEM,
+		RangeTypeFortinetFortiSIEMWindowsAgent,
 		RangeTypeFortinetFortiSOAR,
 		RangeTypeFortinetFortiSOARAgentCommunicationBridge,
 		RangeTypeFortinetFortiSRA,


### PR DESCRIPTION
## What

Add `FortiSIEMWindowsAgent` to the Fortinet product whitelist (`pkg/extract/fortinet/internal/product`) with a dedicated cpecriterion range type `fortinet-fortisiem_windows_agent`, and add FG-IR-26-155 as a golden fixture for both the CSAF and CVRF extractors.

## Why

The nightly Extract All pipeline (vulsio/vuls-data-db) fails on both Fortinet sources since FG-IR-26-155 (published 2026-07-14) reached the raw datasets:

- CSAF: `unknown fortinet product "FortiSIEMWindowsAgent" (known_affected "FortiSIEMWindowsAgent >=7.4.0|<=7.4.1"; add it to internal/product)`
- CVRF: `unknown fortinet product "FortiSIEMWindowsAgent" (whitelist miss; add it to internal/product)`

Failing run: https://github.com/vulsio/vuls-data-db/actions/runs/30572863569

## How

- `range.go`: append `RangeTypeFortinetFortiSIEMWindowsAgent` (constant, `RangeTypes()`, numeric comparator group) — append-only, following the per-product range type convention
- `table.go`: map `FortiSIEMWindowsAgent` to `cpe:2.3:a:fortinet:fortisiem_windows_agent:*:*:*:*:*:*:*:*`
- Golden tests: FG-IR-26-155 fixture + golden for csaf/cvrf. The CSAF output carries the precise range (>=7.4.0 <=7.4.1); the CVRF output has no detections because the advisory only enumerates coarse trains ("7.4" etc.), which the CVRF extractor drops by design (CSAF supplies the ranges)

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` passes
- Ran `extract fortinet-cvrf` / `extract fortinet-csaf` locally against the full latest raw dotgits (`ghcr.io/vulsio/vuls-data-db:vuls-data-raw-fortinet-{cvrf,csaf}`): both complete without error, and FG-IR-26-155 is the only advisory that needed a new product
- Existing goldens are unchanged; the only golden diff is the two new FG-IR-26-155 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)