### PR TITLE
refactor(extract/paloalto): scope unaffected-series complement to paloalto-json

### DIFF
--- a/pkg/extract/paloalto/internal/panos/panos.go
+++ b/pkg/extract/paloalto/internal/panos/panos.go
@@ -1,7 +1,9 @@
 // Package panos interprets Palo Alto PAN-OS affected-version data into
 // contiguous affected intervals. It is shared by the paloalto json and list
 // extractors, which translate their respective raw formats into a Stanza and
-// call StanzaIntervals.
+// call StanzaIntervals with their own source ID: readings that are a convention
+// of one raw format rather than of PAN-OS versioning are pinned to that source
+// so a source cannot inherit them merely by sharing this package.
 package panos
 
 import (
@@ -15,6 +17,7 @@ import (
 	panosVersion "github.com/MaineK00n/go-paloalto-version/pan-os"
 	"github.com/pkg/errors"
 
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
 )
 
@@ -77,6 +80,9 @@ type transition struct {
 }
 
 // StanzaIntervals interprets one PAN-OS stanza into affected version intervals.
+// sourceID identifies the raw format the stanza came from; it scopes the
+// source-specific readings so that a source that does not share a convention
+// does not silently get its intervals.
 //
 // PAN-OS maintains maintenance lines (X.Y.Z) in parallel and backports fixes
 // as hotfixes (X.Y.Z-hN), which PAN expresses through changes[] entries. The
@@ -101,7 +107,7 @@ type transition struct {
 // criterion). A single zero-value interval (all bounds empty) means "every
 // version affected" — it maps to a bare CPE criterion with no Range. These two
 // are distinct, so callers must not collapse nil and []Interval{{}}.
-func StanzaIntervals(stanza Stanza) ([]Interval, error) {
+func StanzaIntervals(sourceID sourceTypes.SourceID, stanza Stanza) ([]Interval, error) {
 	affected, err := statusToBool(stanza.Status)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parse status %q", stanza.Status)
@@ -207,11 +213,24 @@ func StanzaIntervals(stanza Stanza) ([]Interval, error) {
 	if len(events) == 0 {
 		switch {
 		case !affected:
-			// "unaffected <X.Y.Z> lessThan <X.Y*>" implies the series was
-			// affected before the fix release: emit the complement
-			// [X.Y.0, X.Y.Z) (e.g. PAN-SA-2015-0006 "unaffected 7.0.2,
-			// lessThan 7.0*").
-			if start != nil && upper != nil && !upperInclusive && !upperIsRelease &&
+			// In paloalto-json, "unaffected <X.Y.Z> lessThan <X.Y*>" implies
+			// the series was affected before the fix release: emit the
+			// complement [X.Y.0, X.Y.Z) (e.g. PAN-SA-2015-0006 "unaffected
+			// 7.0.2, lessThan 7.0*"). Reading an affected range out of an
+			// unaffected stanza is a convention of that raw format, not of
+			// PAN-OS versioning, so it is pinned to the source: elsewhere the
+			// stanza asserts nothing but "unaffected", and turning it into an
+			// affected range would emit a criterion the data never stated.
+			//
+			// It holds for paloalto-json as a whole and needs no per-advisory
+			// pinning: every stanza of this shape in the raw corpus names its
+			// version as the fix release in solutions/descriptions ("PAN-OS
+			// 8.1.1 and later"). x_affectedList must not be used to narrow it
+			// further — that list omits the newest train in several advisories
+			// (CVE-2018-8715 enumerates no 8.1 version although its
+			// description says "and PAN-OS 8.1.0").
+			if sourceID == sourceTypes.PaloAltoJSON &&
+				start != nil && upper != nil && !upperInclusive && !upperIsRelease &&
 				upper.Compare(panosVersion.Version{Major: start.Major, Minor: start.Minor + 1}) == 0 {
 				seriesStart := panosVersion.Version{Major: start.Major, Minor: start.Minor}
 				if seriesStart.Compare(*start) < 0 {

--- a/pkg/extract/paloalto/internal/panos/panos_test.go
+++ b/pkg/extract/paloalto/internal/panos/panos_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/paloalto/internal/panos"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 )
 
 // TestStanzaIntervals pins the PAN-OS changes interpretation directly. Each
@@ -13,84 +14,106 @@ import (
 // future change to the interpretation surfaces here rather than hiding in a
 // golden diff.
 func TestStanzaIntervals(t *testing.T) {
+	type args struct {
+		// sourceID is the raw format the stanza came from; the zero value
+		// stands for a source that has not opted into any source-specific
+		// reading. Cases that do not exercise one leave it unset.
+		sourceID sourceTypes.SourceID
+		stanza   panos.Stanza
+	}
 	tests := []struct {
 		name    string
-		stanza  panos.Stanza
+		args    args
 		want    []panos.Interval
 		wantErr bool
 	}{
 		{
 			// Simple fix point: the whole series up to the fix release.
-			name:   "simple fix: X.Y lessThan release",
-			stanza: panos.Stanza{Status: "affected", Version: "9.0", LessThan: "9.0.7"},
-			want:   []panos.Interval{{GE: "9.0.0", LT: "9.0.7", Fixed: []string{"9.0.7"}}},
+			name: "simple fix: X.Y lessThan release",
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "9.0", LessThan: "9.0.7"}},
+			want: []panos.Interval{{GE: "9.0.0", LT: "9.0.7", Fixed: []string{"9.0.7"}}},
 		},
 		{
 			// A change coinciding with the release fix.
 			name: "simple fix: change at the fix release",
-			stanza: panos.Stanza{
+			args: args{stanza: panos.Stanza{
 				Status: "affected", Version: "8.1", LessThan: "8.1.13",
 				Changes: []panos.Change{{At: "8.1.13", Status: "unaffected"}},
-			},
+			}},
 			want: []panos.Interval{{GE: "8.1.0", LT: "8.1.13", Fixed: []string{"8.1.13"}}},
 		},
 		{
 			// "X.Y.*" series form.
-			name:   "series X.Y.* affected",
-			stanza: panos.Stanza{Status: "affected", Version: "8.0.*"},
-			want:   []panos.Interval{{GE: "8.0.0", LT: "8.1.0"}},
+			name: "series X.Y.* affected",
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "8.0.*"}},
+			want: []panos.Interval{{GE: "8.0.0", LT: "8.1.0"}},
 		},
 		{
 			// "X.Y All" series form.
-			name:   "series X.Y All affected",
-			stanza: panos.Stanza{Status: "affected", Version: "7.1 All"},
-			want:   []panos.Interval{{GE: "7.1.0", LT: "7.2.0"}},
+			name: "series X.Y All affected",
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "7.1 All"}},
+			want: []panos.Interval{{GE: "7.1.0", LT: "7.2.0"}},
 		},
 		{
 			// "All" affected → one zero-value interval (every bound empty), NOT
 			// nil: it maps to a bare CPE criterion matching every PAN-OS version.
 			// Contrast with the unaffected case below, which returns nil.
-			name:   "All affected → one empty-bounds interval",
-			stanza: panos.Stanza{Status: "affected", Version: "All"},
-			want:   []panos.Interval{{}},
+			name: "All affected → one empty-bounds interval",
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "All"}},
+			want: []panos.Interval{{}},
 		},
 		{
 			// "All" unaffected → nothing affected → nil (no criterion).
-			name:   "All unaffected → no interval",
-			stanza: panos.Stanza{Status: "unaffected", Version: "All"},
-			want:   nil,
+			name: "All unaffected → no interval",
+			args: args{stanza: panos.Stanza{Status: "unaffected", Version: "All"}},
+			want: nil,
 		},
 		{
 			// Bare affected X.Y.Z (no bound, no changes) → whole series.
-			name:   "bare affected X.Y.Z → series",
-			stanza: panos.Stanza{Status: "affected", Version: "8.1.0"},
-			want:   []panos.Interval{{GE: "8.1.0", LT: "8.2.0"}},
+			name: "bare affected X.Y.Z → series",
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "8.1.0"}},
+			want: []panos.Interval{{GE: "8.1.0", LT: "8.2.0"}},
 		},
 		{
 			// version None + lessThanOrEqual: inclusive upper, unbounded lower.
-			name:   "None with lessThanOrEqual",
-			stanza: panos.Stanza{Status: "affected", Version: "None", LessThanOrEqual: "6.0.14"},
-			want:   []panos.Interval{{LE: "6.0.14"}},
+			name: "None with lessThanOrEqual",
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "None", LessThanOrEqual: "6.0.14"}},
+			want: []panos.Interval{{LE: "6.0.14"}},
 		},
 		{
 			// version None with no bound: no constraint → no interval, no error.
-			name:   "None without bound → no interval",
-			stanza: panos.Stanza{Status: "affected", Version: "None"},
-			want:   nil,
+			name: "None without bound → no interval",
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "None"}},
+			want: nil,
 		},
 		{
-			// Unaffected complement: "unaffected 7.0.2 lessThan 7.0*" means
-			// 7.0.0..7.0.2 was affected (PAN-SA-2015-0006).
-			name:   "unaffected complement",
-			stanza: panos.Stanza{Status: "unaffected", Version: "7.0.2", LessThan: "7.0*"},
-			want:   []panos.Interval{{GE: "7.0.0", LT: "7.0.2", Fixed: []string{"7.0.2"}}},
+			// Unaffected complement: for paloalto-json, "unaffected 7.0.2
+			// lessThan 7.0*" means 7.0.0..7.0.2 was affected
+			// (PAN-SA-2015-0006).
+			name: "unaffected complement (paloalto-json)",
+			args: args{
+				sourceID: sourceTypes.PaloAltoJSON,
+				stanza:   panos.Stanza{Status: "unaffected", Version: "7.0.2", LessThan: "7.0*"},
+			},
+			want: []panos.Interval{{GE: "7.0.0", LT: "7.0.2", Fixed: []string{"7.0.2"}}},
+		},
+		{
+			// The same stanza from a source that has not opted into the
+			// complement reading asserts only "unaffected": no interval, rather
+			// than an affected range the source never stated.
+			name: "unaffected complement is scoped to the source",
+			args: args{
+				sourceID: sourceTypes.PaloAltoList,
+				stanza:   panos.Stanza{Status: "unaffected", Version: "7.0.2", LessThan: "7.0*"},
+			},
+			want: nil,
 		},
 		{
 			// Backport fixes: every maintenance line affected from its base
 			// release until its own hotfix fix (CVE-2024-0012, 11.1 line). The
 			// hotfix-level lessThan (11.1.5-h1) is the 11.1.5 line's fix.
 			name: "backport fixes across maintenance lines",
-			stanza: panos.Stanza{Status: "affected", Version: "11.1.0", LessThan: "11.1.5-h1",
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "11.1.0", LessThan: "11.1.5-h1",
 				Changes: []panos.Change{
 					{At: "11.1.5-h1", Status: "unaffected"},
 					{At: "11.1.0-h4", Status: "unaffected"},
@@ -98,7 +121,7 @@ func TestStanzaIntervals(t *testing.T) {
 					{At: "11.1.2-h15", Status: "unaffected"},
 					{At: "11.1.3-h11", Status: "unaffected"},
 					{At: "11.1.4-h7", Status: "unaffected"},
-				}},
+				}}},
 			want: []panos.Interval{
 				{GE: "11.1.0", LT: "11.1.0-h4", Fixed: []string{"11.1.0-h4"}},
 				{GE: "11.1.1", LT: "11.1.1-h2", Fixed: []string{"11.1.1-h2"}},
@@ -112,22 +135,22 @@ func TestStanzaIntervals(t *testing.T) {
 			// Introduced-by-version: a base-release change switches the
 			// cross-line timeline (CVE-2024-3393 shape, minimal).
 			name: "introduced then fixed at base releases",
-			stanza: panos.Stanza{Status: "unaffected", Version: "10.2.0",
+			args: args{stanza: panos.Stanza{Status: "unaffected", Version: "10.2.0",
 				Changes: []panos.Change{
 					{At: "10.2.8", Status: "affected"},
 					{At: "10.2.14", Status: "unaffected"},
-				}},
+				}}},
 			want: []panos.Interval{{GE: "10.2.8", LT: "10.2.14", Fixed: []string{"10.2.14"}}},
 		},
 		{
 			// Hotfix-level lessThan is the first line's fix, folded into the
 			// changes rather than treated as the stanza end (CVE-2024-3400).
 			name: "hotfix-level lessThan folded into changes",
-			stanza: panos.Stanza{Status: "affected", Version: "10.2", LessThan: "10.2.0-h3",
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "10.2", LessThan: "10.2.0-h3",
 				Changes: []panos.Change{
 					{At: "10.2.0-h3", Status: "unaffected"},
 					{At: "10.2.1-h2", Status: "unaffected"},
-				}},
+				}}},
 			want: []panos.Interval{
 				{GE: "10.2.0", LT: "10.2.0-h3", Fixed: []string{"10.2.0-h3"}},
 				{GE: "10.2.1", LT: "10.2.1-h2", Fixed: []string{"10.2.1-h2"}},
@@ -137,8 +160,8 @@ func TestStanzaIntervals(t *testing.T) {
 			// Comma-separated changes.at (CVE-2019-17440 shape): both versions
 			// are parsed; here the earlier base fix closes the series.
 			name: "comma-separated changes.at",
-			stanza: panos.Stanza{Status: "affected", Version: "9.1",
-				Changes: []panos.Change{{At: "9.1.3, 9.1.5", Status: "unaffected"}}},
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "9.1",
+				Changes: []panos.Change{{At: "9.1.3, 9.1.5", Status: "unaffected"}}}},
 			want: []panos.Interval{{GE: "9.1.0", LT: "9.1.3", Fixed: []string{"9.1.3"}}},
 		},
 		{
@@ -150,12 +173,12 @@ func TestStanzaIntervals(t *testing.T) {
 			// (affected) at version 10.2.1, else the interval would wrongly
 			// start at 10.2.1 instead of 10.2.1-h2.
 			name: "regression in a hotfix line (priority tie-break)",
-			stanza: panos.Stanza{Status: "affected", Version: "10.2.0", LessThan: "10.2.3",
+			args: args{stanza: panos.Stanza{Status: "affected", Version: "10.2.0", LessThan: "10.2.3",
 				Changes: []panos.Change{
 					{At: "10.2.0-h1", Status: "unaffected"},
 					{At: "10.2.1-h2", Status: "affected"},
 					{At: "10.2.1-h5", Status: "unaffected"},
-				}},
+				}}},
 			want: []panos.Interval{
 				{GE: "10.2.0", LT: "10.2.0-h1", Fixed: []string{"10.2.0-h1"}},
 				{GE: "10.2.1-h2", LT: "10.2.1-h5", Fixed: []string{"10.2.1-h5"}},
@@ -168,19 +191,19 @@ func TestStanzaIntervals(t *testing.T) {
 			// calling, so reaching here with anything other than affected /
 			// unaffected is an error.
 			name:    "non-affected/unaffected status is an error",
-			stanza:  panos.Stanza{Status: "unknown", Version: "9.0.0"},
+			args:    args{stanza: panos.Stanza{Status: "unknown", Version: "9.0.0"}},
 			wantErr: true,
 		},
 		{
 			name:    "unparseable version",
-			stanza:  panos.Stanza{Status: "affected", Version: "garbage"},
+			args:    args{stanza: panos.Stanza{Status: "affected", Version: "garbage"}},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := panos.StanzaIntervals(tt.stanza)
+			got, err := panos.StanzaIntervals(tt.args.sourceID, tt.args.stanza)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("StanzaIntervals() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/extract/paloalto/json/json.go
+++ b/pkg/extract/paloalto/json/json.go
@@ -439,7 +439,7 @@ func detections(fetched paloaltoJSON.CVE) ([]detectionTypes.Detection, error) {
 					stanza.Changes = append(stanza.Changes, panos.Change{At: c.At, Status: c.Status})
 				}
 
-				is, err := panos.StanzaIntervals(stanza)
+				is, err := panos.StanzaIntervals(sourceTypes.PaloAltoJSON, stanza)
 				if err != nil {
 					// An unrecognized shape is a new upstream anomaly: fail loud
 					// (a warning would scroll past unnoticed in CI). Known


### PR DESCRIPTION
## What

Pin the "unaffected series complement" reading in `extract/paloalto/internal/panos` to `paloalto-json`.

`StanzaIntervals` now takes the source ID, and only for `paloalto-json` does an `unaffected <X.Y.Z> / lessThan <X.Y*>` stanza additionally yield the affected complement `[X.Y.0, X.Y.Z)`.

Output for `paloalto-json` is unchanged — no golden diff.

## Why

`panos` is shared by the json and list extractors (per its package doc), but turning an **unaffected** stanza into an **affected** range is a convention of the CVE 5.0 records the json source ships, not a property of PAN-OS versioning. As written, any future source routed through `StanzaIntervals` would inherit that reading silently and emit affected ranges its raw data never stated, i.e. wrong detection criteria.

Scoping it to the source makes the assumption explicit and reviewable at the point a new source (e.g. `paloalto-list`) opts in.

No per-advisory (`rootID`) or per-version pinning is applied, and the reasoning is recorded in the code comment:

- The shape fires for 25 stanzas across the whole `vuls-data-raw-paloalto-json` corpus, and **every one** of them names its stanza version as the fix release in `solutions` / `descriptions` (`"PAN-OS 8.1.1 and later"`), so the reading holds for the source as a whole.
- `x_affectedList` must **not** be used to narrow it: that list omits the newest train in several advisories. For example CVE-2018-8715 enumerates no 8.1 version at all, while its description says `"... and PAN-OS 8.1.0"` and its solution says `"PAN-OS 8.1.1 and later"` — narrowing by `x_affectedList` would drop 7 correct intervals (CVE-2013-5663, CVE-2016-4971, CVE-2017-3731, CVE-2018-8715, CVE-2018-9334).

## How

- `panos.StanzaIntervals(sourceID sourceTypes.SourceID, stanza Stanza)` — new first parameter
- the complement branch gains `sourceID == sourceTypes.PaloAltoJSON &&` in its guard; everything else about the interpretation is untouched
- `extract/paloalto/json` passes `sourceTypes.PaloAltoJSON`
- package doc / function doc state that source-specific readings are pinned to their source

No changes to `pkg/extract/types/**`, so no schema or backward-compatibility impact.

## Testing

- `GOEXPERIMENT=jsonv2 go build ./...`
- `GOEXPERIMENT=jsonv2 go vet ./pkg/extract/paloalto/...`
- `GOEXPERIMENT=jsonv2 go test ./...` — all packages pass
- `TestStanzaIntervals` gains a pair of cases that pin the boundary: the same stanza yields the complement for `paloalto-json` and no interval for a source that has not opted in
- `extract/paloalto/json` golden test passes unchanged, confirming the refactor is output-preserving

## Checklist

- [x] Tests pass
- [x] Golden files updated (if applicable) — no golden change expected or observed
- [ ] Deterministic output verified (if types changed) — no types changed
- [x] Backward compatibility maintained (if types/data changed) — `pkg/extract/types/**` untouched; the changed API is `internal/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
