### PR TITLE
feat(apache/tomcat/xml): add Apache Tomcat security vulnerabilities data source

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -15,6 +15,7 @@ import (
 	alpineSecDB "github.com/MaineK00n/vuls-data-update/pkg/extract/alpine/secdb"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/amazon"
 	androidOSV "github.com/MaineK00n/vuls-data-update/pkg/extract/android/osv"
+	apacheTomcatXML "github.com/MaineK00n/vuls-data-update/pkg/extract/apache/tomcat/xml"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/arch"
 	bitnamiOSV "github.com/MaineK00n/vuls-data-update/pkg/extract/bitnami/osv"
 	cargoDB "github.com/MaineK00n/vuls-data-update/pkg/extract/cargo/db"
@@ -153,6 +154,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdAlpineSecDB(), newCmdAlpineOSV(),
 		newCmdAmazon(),
 		newCmdAndroidOSV(),
+		newCmdApacheTomcatXML(),
 		newCmdArch(),
 		newCmdBitnamiOSV(),
 		newCmdCargoGHSA(), newCmdCargoOSV(), newCmdCargoDB(),
@@ -373,6 +375,31 @@ func newCmdAndroidOSV() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := androidOSV.Extract(args[0], androidOSV.WithDir(options.dir)); err != nil {
 				return errors.Wrap(err, "failed to extract android osv")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdApacheTomcatXML() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "apache", "tomcat", "xml"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "apache-tomcat-xml <Raw Apache Tomcat Security Vulnerabilities Repository PATH>",
+		Short: "Extract Apache Tomcat Security Vulnerabilities data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract apache-tomcat-xml vuls-data-raw-apache-tomcat-xml
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := apacheTomcatXML.Extract(args[0], apacheTomcatXML.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract apache tomcat xml")
 			}
 			return nil
 		},

--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -20,6 +20,7 @@ import (
 	anchoreEnrichment "github.com/MaineK00n/vuls-data-update/pkg/fetch/anchore/enrichment"
 	androidOSV "github.com/MaineK00n/vuls-data-update/pkg/fetch/android/osv"
 	anolisOVAL "github.com/MaineK00n/vuls-data-update/pkg/fetch/anolis/oval"
+	apacheTomcatXML "github.com/MaineK00n/vuls-data-update/pkg/fetch/apache/tomcat/xml"
 	"github.com/MaineK00n/vuls-data-update/pkg/fetch/arch"
 	bellsoftAlpaquitaOSV "github.com/MaineK00n/vuls-data-update/pkg/fetch/bellsoft/alpaquita/osv"
 	bellsoftHardenedContainersOSV "github.com/MaineK00n/vuls-data-update/pkg/fetch/bellsoft/hardened-containers/osv"
@@ -220,6 +221,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdAnchoreEnrichment(),
 		newCmdAndroidOSV(),
 		newCmdAnolisOVAL(),
+		newCmdApacheTomcatXML(),
 		newCmdArch(),
 		newCmdBellSoftAlpaquitaOSV(), newCmdBellSoftHardenedContainersOSV(),
 		newCmdBitnamiOSV(),
@@ -599,6 +601,43 @@ func newCmdAnolisOVAL() *cobra.Command {
 
 	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
 	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
+
+	return cmd
+}
+
+func newCmdApacheTomcatXML() *cobra.Command {
+	options := &struct {
+		base
+		concurrency int
+		wait        time.Duration
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "apache", "tomcat", "xml"),
+			retry: 3,
+		},
+		concurrency: 5,
+		wait:        1 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "apache-tomcat-xml",
+		Short: "Fetch Apache Tomcat Security Vulnerabilities (xdocs XML) data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch apache-tomcat-xml
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := apacheTomcatXML.Fetch(apacheTomcatXML.WithDir(options.dir), apacheTomcatXML.WithRetry(options.retry), apacheTomcatXML.WithConcurrency(options.concurrency), apacheTomcatXML.WithWait(options.wait)); err != nil {
+				return errors.Wrap(err, "failed to fetch apache tomcat xml")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
+	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent http requests")
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
 
 	return cmd
 }

--- a/pkg/extract/apache/tomcat/xml/affects.go
+++ b/pkg/extract/apache/tomcat/xml/affects.go
@@ -1,0 +1,158 @@
+package xml
+
+import (
+	"regexp"
+	"strings"
+)
+
+// The "Affects:" line is a comma-separated list of version ranges. Across the
+// twelve pages it uses five shapes and two spellings of the same milestone
+// suffix, so it is parsed here rather than in the fetcher, which keeps the
+// line verbatim.
+//
+//	Affects: 11.0.0-M1 to 11.0.23                      lower "to" upper
+//	Affects: 3.0, 3.1-3.1.1, 3.2-3.2.4, 3.3a-3.3.2     lower "-" upper, and singles
+//	Affects: 9.0.0.M1 to 9.0.80                        the dotted milestone spelling
+//	Affects: 3.2?, 3.2.1, 3.2.2-3.2.3?                 "?" marks an unverified bound
+//	Affects: All versions prior to 1.2.3               open lower bound
+//	Affects: Pre-release builds of 4.0.0               no released version affected
+//	Affects: JK 1.2.0-1.2.26 (mod_jk only)             product prefix and a qualifier
+var (
+	// versionPattern is deliberately loose about the tail: Tomcat has shipped
+	// 3.3a, 5.0.SVN and 11.0.0-M20 alongside ordinary 11.0.24.
+	versionPattern = `[0-9]+(?:\.[0-9A-Za-z]+)*(?:-(?:M|RC)[0-9]+)?`
+
+	rangeToPattern     = regexp.MustCompile(`^(` + versionPattern + `)\?? to (` + versionPattern + `)\??$`)
+	rangeDashPattern   = regexp.MustCompile(`^(` + versionPattern + `)\??-(` + versionPattern + `)\??$`)
+	singlePattern      = regexp.MustCompile(`^(` + versionPattern + `)\??$`)
+	priorToPattern     = regexp.MustCompile(`^All versions prior to (` + versionPattern + `)$`)
+	preReleasePattern  = regexp.MustCompile(`^Pre-release builds of (` + versionPattern + `)$`)
+	productPrefixRegex = regexp.MustCompile(`^(?:JK|tcnative|OpenSSL|APR) `)
+	qualifierPattern   = regexp.MustCompile(`\s*\([^)]*\)$`)
+
+	// dottedMilestonePattern matches the ".M1" / ".RC1" spelling that the 5.x
+	// through 9.x pages use where 10.x and 11.x write "-M1" / "-RC1".
+	dottedMilestonePattern = regexp.MustCompile(`\.(M|RC)([0-9]+)$`)
+
+	// svnPattern matches the "5.0.SVN" placeholder the 4.1 and 5.0 pages use
+	// for a fix that only ever landed on the branch in Subversion. It names no
+	// release, so it is not a usable bound.
+	svnPattern = regexp.MustCompile(`^[0-9]+(?:\.[0-9]+)*\.SVN$`)
+)
+
+// isRelease reports whether v names a released version, as opposed to the
+// "<branch>.SVN" placeholder used for unreleased branch-only fixes.
+func isRelease(v string) bool {
+	return !svnPattern.MatchString(v)
+}
+
+// affected is one version range from an "Affects:" line. An empty Equal means
+// the range is bounded by GreaterEqual/LessEqual; an empty GreaterEqual with a
+// LessEqual set means every version up to that bound.
+type affected struct {
+	Equal        string
+	GreaterEqual string
+	LessEqual    string
+}
+
+// parseAffects splits an "Affects:" line into version ranges. Tokens it does
+// not recognize are returned separately rather than dropped: the line also
+// carries downstream distribution names ("Debian", "Ubuntu and potentially
+// other downstream distributions") on entries that are not Tomcat
+// vulnerabilities, and the caller decides what to do with them.
+func parseAffects(s string) ([]affected, []string) {
+	var (
+		as      []affected
+		unknown []string
+	)
+
+	for _, tok := range splitTokens(s) {
+		// A trailing qualifier narrows the platform or component rather than
+		// the version ("(Windows only)", "(mod_jk only)", "(Memory Realm)").
+		// The version range is the same either way, so it is dropped here; the
+		// entry's description keeps the wording.
+		tok = strings.TrimSpace(qualifierPattern.ReplaceAllString(tok, ""))
+		tok = strings.TrimSpace(productPrefixRegex.ReplaceAllString(tok, ""))
+		tok = strings.TrimSuffix(tok, ".")
+		if tok == "" {
+			continue
+		}
+
+		// A bound naming no release cannot be compared against, so the whole
+		// token is reported as unrecognized rather than half-applied — an
+		// upper bound of "5.0.SVN" would otherwise silently become a range
+		// that no version can satisfy.
+		if strings.Contains(tok, ".SVN") {
+			unknown = append(unknown, tok)
+			continue
+		}
+
+		switch {
+		case rangeToPattern.MatchString(tok):
+			m := rangeToPattern.FindStringSubmatch(tok)
+			as = append(as, affected{GreaterEqual: normalize(m[1]), LessEqual: normalize(m[2])})
+		case rangeDashPattern.MatchString(tok):
+			m := rangeDashPattern.FindStringSubmatch(tok)
+			as = append(as, affected{GreaterEqual: normalize(m[1]), LessEqual: normalize(m[2])})
+		case priorToPattern.MatchString(tok):
+			m := priorToPattern.FindStringSubmatch(tok)
+			as = append(as, affected{LessEqual: normalize(m[1])})
+		case preReleasePattern.MatchString(tok):
+			// No released version is affected, so there is no range to assert.
+			continue
+		case singlePattern.MatchString(tok):
+			m := singlePattern.FindStringSubmatch(tok)
+			as = append(as, affected{Equal: normalize(m[1])})
+		default:
+			unknown = append(unknown, tok)
+		}
+	}
+
+	return as, unknown
+}
+
+// splitTokens splits on the separators upstream uses between ranges — "," and
+// " and " — while leaving the contents of a parenthesized qualifier alone, so
+// that "(DataSource and JDBC Realms)" stays with its range.
+func splitTokens(s string) []string {
+	var (
+		out   []string
+		cur   strings.Builder
+		depth int
+	)
+
+	flush := func() {
+		if t := strings.TrimSpace(cur.String()); t != "" {
+			out = append(out, t)
+		}
+		cur.Reset()
+	}
+
+	for i := 0; i < len(s); i++ {
+		switch {
+		case s[i] == '(':
+			depth++
+			cur.WriteByte(s[i])
+		case s[i] == ')':
+			depth--
+			cur.WriteByte(s[i])
+		case s[i] == ',' && depth == 0:
+			flush()
+		case depth == 0 && strings.HasPrefix(s[i:], " and "):
+			flush()
+			i += len(" and ") - 1
+		default:
+			cur.WriteByte(s[i])
+		}
+	}
+	flush()
+
+	return out
+}
+
+// normalize rewrites the dotted milestone spelling to the hyphenated one, so
+// that "9.0.0.M1" and "10.1.0-M1" are the same shape. Without it the dotted
+// form is not a parseable version at all and the range cannot be evaluated.
+func normalize(v string) string {
+	return dottedMilestonePattern.ReplaceAllString(v, "-$1$2")
+}

--- a/pkg/extract/apache/tomcat/xml/affects_test.go
+++ b/pkg/extract/apache/tomcat/xml/affects_test.go
@@ -1,0 +1,162 @@
+package xml
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_parseAffects(t *testing.T) {
+	type want struct {
+		affected []affected
+		unknown  []string
+	}
+	tests := []struct {
+		name string
+		args string
+		want want
+	}{
+		{
+			name: "lower to upper",
+			args: "11.0.0-M1 to 11.0.23",
+			want: want{affected: []affected{{GreaterEqual: "11.0.0-M1", LessEqual: "11.0.23"}}},
+		},
+		{
+			name: "dotted milestone is normalized to the hyphenated spelling",
+			args: "9.0.0.M1 to 9.0.80",
+			want: want{affected: []affected{{GreaterEqual: "9.0.0-M1", LessEqual: "9.0.80"}}},
+		},
+		{
+			name: "dotted release candidate is normalized too",
+			args: "8.0.0.RC1 to 8.0.3",
+			want: want{affected: []affected{{GreaterEqual: "8.0.0-RC1", LessEqual: "8.0.3"}}},
+		},
+		{
+			name: "comma separated list of dash ranges and singles",
+			args: "3.0, 3.1-3.1.1, 3.2-3.2.4, 3.3a-3.3.2",
+			want: want{affected: []affected{
+				{Equal: "3.0"},
+				{GreaterEqual: "3.1", LessEqual: "3.1.1"},
+				{GreaterEqual: "3.2", LessEqual: "3.2.4"},
+				{GreaterEqual: "3.3a", LessEqual: "3.3.2"},
+			}},
+		},
+		{
+			name: "unverified marker is dropped from either bound",
+			args: "3.2?, 3.2.1, 3.2.2-3.2.3?",
+			want: want{affected: []affected{
+				{Equal: "3.2"},
+				{Equal: "3.2.1"},
+				{GreaterEqual: "3.2.2", LessEqual: "3.2.3"},
+			}},
+		},
+		{
+			name: "open lower bound",
+			args: "All versions prior to 1.2.3",
+			want: want{affected: []affected{{LessEqual: "1.2.3"}}},
+		},
+		{
+			name: "pre-release builds assert no released range",
+			args: "Pre-release builds of 4.0.0",
+			want: want{},
+		},
+		{
+			name: "product prefix and platform qualifier are stripped",
+			args: "JK 1.2.0-1.2.26 (mod_jk on Unix like platforms only)",
+			want: want{affected: []affected{{GreaterEqual: "1.2.0", LessEqual: "1.2.26"}}},
+		},
+		{
+			name: `"and" separates ranges but not inside a qualifier`,
+			args: "1.3.0 to 1.3.6 and 2.0.0 to 2.0.13",
+			want: want{affected: []affected{
+				{GreaterEqual: "1.3.0", LessEqual: "1.3.6"},
+				{GreaterEqual: "2.0.0", LessEqual: "2.0.13"},
+			}},
+		},
+		{
+			name: `"and" inside a qualifier stays with its range`,
+			args: "4.0.0-4.0.6 (DataSource and JDBC Realms)",
+			want: want{affected: []affected{{GreaterEqual: "4.0.0", LessEqual: "4.0.6"}}},
+		},
+		{
+			name: "missing space after the colon is already trimmed by the fetcher",
+			args: "3.1-3.1.1, 3.2-3.2.4",
+			want: want{affected: []affected{
+				{GreaterEqual: "3.1", LessEqual: "3.1.1"},
+				{GreaterEqual: "3.2", LessEqual: "3.2.4"},
+			}},
+		},
+		{
+			name: "branch-only SVN placeholder is not a usable bound",
+			args: "5.0.0-5.0.SVN",
+			want: want{unknown: []string{"5.0.0-5.0.SVN"}},
+		},
+		{
+			name: "downstream distributions are reported, not silently dropped",
+			args: "Debian, Ubuntu and potentially other downstream distributions",
+			want: want{unknown: []string{"Debian", "Ubuntu", "potentially other downstream distributions"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			as, unknown := parseAffects(tt.args)
+			if diff := cmp.Diff(tt.want.affected, as); diff != "" {
+				t.Errorf("parseAffects() affected. (-expected +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.want.unknown, unknown); diff != "" {
+				t.Errorf("parseAffects() unknown. (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_fixedVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want []string
+	}{
+		{
+			name: "single release",
+			args: "Fixed in Apache Tomcat 11.0.24",
+			want: []string{"11.0.24"},
+		},
+		{
+			name: "a fix shipped across two maintenance lines",
+			args: "Fixed in Apache Tomcat 4.1.13, 4.0.6",
+			want: []string{"4.1.13", "4.0.6"},
+		},
+		{
+			name: "component page keeps only the version, not the product number",
+			args: "Fixed in Apache Tomcat JK Connector 1.2.50",
+			want: []string{"1.2.50"},
+		},
+		{
+			name: "milestone release is normalized",
+			args: "Fixed in Apache Tomcat 9.0.0.M22",
+			want: []string{"9.0.0-M22"},
+		},
+		{
+			name: "branch-only SVN placeholder is not a release",
+			args: "Fixed in Apache Tomcat 5.5.13, 5.0.SVN",
+			want: []string{"5.5.13"},
+		},
+		{
+			name: "a section that fixes nothing has no fixed version",
+			args: "Not fixed in Apache Tomcat 3.x",
+		},
+		{
+			name: "not-a-vulnerability section has no fixed version",
+			args: "Not a vulnerability in Tomcat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, fixedVersions(tt.args)); diff != "" {
+				t.Errorf("fixedVersions(). (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/extract/apache/tomcat/xml/entry.go
+++ b/pkg/extract/apache/tomcat/xml/entry.go
@@ -1,0 +1,322 @@
+package xml
+
+import (
+	"encoding/xml"
+	"io"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	tomcatXML "github.com/MaineK00n/vuls-data-update/pkg/fetch/apache/tomcat/xml"
+)
+
+var cveIDPattern = regexp.MustCompile(`CVE-[0-9]{4}-[0-9]{4,}`)
+
+// severityRatings are the ratings the Tomcat security team assigns. An entry
+// header reads "<severity>: <title>", but four legacy entries put something
+// else before the colon, so the prefix is only taken as a severity when it is
+// one of these.
+var severityRatings = []string{"Low", "Moderate", "Important", "High", "Critical"}
+
+// entry is one vulnerability, recovered from the run of blocks a section
+// holds. It has no counterpart element in the source.
+type entry struct {
+	CVEs             []string
+	Severity         string
+	Title            string
+	Affects          string
+	Description      []string
+	Commits          []string
+	ConnectorCommits []string
+	Revisions        []string
+	Bugs             []string
+	References       []string
+}
+
+// entries groups a section's blocks into vulnerabilities. The source nests
+// nothing — a section is a flat run of paragraphs, and where one vulnerability
+// ends and the next begins is a layout convention rather than anything the
+// document declares. An entry therefore starts at a block carrying a <strong>
+// header together with a CVE, and every following block belongs to it.
+//
+// Blocks before the first header are returned as the section's notes, in an
+// entry that carries nothing else. Sections holding no header at all — the
+// page preamble and the table of contents — yield nothing.
+func entries(s tomcatXML.Section) ([]entry, []string, error) {
+	var (
+		es    []entry
+		notes []string
+		cur   *entry
+	)
+
+	for _, b := range s.Blocks {
+		p, err := parseBlock(b)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "parse %s block of section %q", b.Tag, s.Name)
+		}
+
+		if cves, ok := header(p); ok {
+			severity, title := split(p.Strong)
+			es = append(es, entry{
+				CVEs:             cves,
+				Severity:         severity,
+				Title:            title,
+				Commits:          p.Commits,
+				ConnectorCommits: p.ConnectorCommits,
+				Revisions:        p.Revisions,
+				Bugs:             p.Bugs,
+				References:       linkedURLs(p, cves),
+			})
+			cur = &es[len(es)-1]
+			continue
+		}
+
+		// A block flattens to one line per <br/> or list item, each of which
+		// stands on its own: the qualifier a <br/> appends to the "Affects:"
+		// line ("Users who followed the security guidance to remove the
+		// examples web application are not affected.") reads as its own
+		// statement, as does every <li> of a preconditions list.
+		lines := strings.Split(p.Text, "\n")
+		if len(lines) == 1 && lines[0] == "" {
+			continue
+		}
+
+		if cur == nil {
+			notes = append(notes, lines...)
+			continue
+		}
+
+		if affects, ok := strings.CutPrefix(lines[0], "Affects"); ok {
+			if affects, ok := strings.CutPrefix(strings.TrimSpace(affects), ":"); ok {
+				cur.Affects = strings.TrimSpace(affects)
+				lines = lines[1:]
+			}
+		}
+		cur.Description = append(cur.Description, lines...)
+
+		cur.Commits = append(cur.Commits, p.Commits...)
+		cur.ConnectorCommits = append(cur.ConnectorCommits, p.ConnectorCommits...)
+		cur.Revisions = append(cur.Revisions, p.Revisions...)
+		cur.Bugs = append(cur.Bugs, p.Bugs...)
+		cur.References = append(cur.References, linkedURLs(p, nil)...)
+	}
+
+	return es, notes, nil
+}
+
+// header reports whether the block opens an entry, and with which CVEs. The
+// <cve> children are authoritative; three legacy entries predate the tag and
+// link the CVE with a plain anchor instead.
+func header(p block) ([]string, bool) {
+	if !p.HasStrong {
+		return nil, false
+	}
+	if len(p.CVEs) > 0 {
+		return p.CVEs, true
+	}
+	var cves []string
+	for _, h := range p.Hrefs {
+		if m := cveIDPattern.FindString(h); m != "" && !slices.Contains(cves, m) {
+			cves = append(cves, m)
+		}
+	}
+	return cves, len(cves) > 0
+}
+
+// linkedURLs drops the anchors that only restate a CVE the entry already
+// records, so a legacy CVE link does not appear as a reference of its own.
+func linkedURLs(p block, cves []string) []string {
+	var rs []string
+	for _, h := range p.Hrefs {
+		if h == "" || slices.Contains(cves, cveIDPattern.FindString(h)) {
+			continue
+		}
+		rs = append(rs, h)
+	}
+	return rs
+}
+
+// split separates the "<severity>: <title>" header. A prefix that is not one
+// of the assigned ratings is left with the title rather than reported as a
+// severity.
+func split(strong string) (string, string) {
+	if severity, title, ok := strings.Cut(strong, ":"); ok {
+		if severity = strings.TrimSpace(severity); slices.Contains(severityRatings, severity) {
+			return severity, strings.TrimSpace(title)
+		}
+	}
+	return "", strings.TrimSpace(strong)
+}
+
+// block is a section child with its inline markup separated out.
+//
+// Every descendant's character data accumulates into Text, while the markup
+// that carries data is collected by tag. CVEs are the one field restricted to
+// top-level children: ten entry headers quote an earlier CVE inside their
+// <strong> title (e.g. "Important: The fix for CVE-2026-29146 allowed the
+// bypass of the EncryptInterceptor", itself CVE-2026-34486), and that quoted
+// ID must not become one of the entry's own CVEs.
+type block struct {
+	// Text is the flattened content, whitespace-collapsed, one line per <br/>
+	// or list item.
+	Text string
+	// Strong is the text of the top-level <strong>, present on entry headers
+	// and on a handful of prose notes ("Note: All of conditions above must be
+	// true ...").
+	Strong           string
+	HasStrong        bool
+	CVEs             []string
+	Bugs             []string
+	Revisions        []string
+	Commits          []string
+	ConnectorCommits []string
+	Hrefs            []string
+}
+
+// parseBlock flattens the markup the fetcher kept verbatim. The stored value
+// is the element's inner XML, so it is wrapped to form a parseable fragment.
+func parseBlock(b tomcatXML.Block) (block, error) {
+	var (
+		p        block
+		sb       strings.Builder
+		strongSB strings.Builder
+		depth    int
+		// strongDepth is the depth at which the top-level <strong> opened,
+		// 0 when not inside one.
+		strongDepth int
+	)
+
+	d := xml.NewDecoder(strings.NewReader("<block>" + b.XML + "</block>"))
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return block{}, errors.Wrap(err, "decode as xml")
+		}
+
+		switch t := tok.(type) {
+		case xml.CharData:
+			// The source hard-wraps prose, so its newlines are formatting, not
+			// content. Flattening them here leaves <br/> and list items as the
+			// only producers of a line break in the buffer.
+			v := unwrap(string(t))
+			sb.WriteString(v)
+			if strongDepth > 0 {
+				strongSB.WriteString(v)
+			}
+		case xml.StartElement:
+			if t.Name.Local == "block" && depth == 0 {
+				continue
+			}
+			depth++
+
+			// <br/> and <li> are line structure at any nesting level; the rest
+			// are only recognized as the block's own markup, not the title's.
+			switch t.Name.Local {
+			case "br", "li":
+				sb.WriteString("\n")
+				continue
+			case "strong":
+				if depth == 1 {
+					p.HasStrong = true
+					strongDepth = depth
+				}
+				continue
+			}
+
+			switch t.Name.Local {
+			case "cve":
+				// Restricted to top-level children — see the type comment.
+				if depth > 1 {
+					continue
+				}
+				v, err := elementText(d, t)
+				if err != nil {
+					return block{}, err
+				}
+				sb.WriteString(v)
+				p.CVEs = append(p.CVEs, strings.TrimSpace(v))
+				depth--
+			case "bug":
+				v, err := elementText(d, t)
+				if err != nil {
+					return block{}, err
+				}
+				sb.WriteString(v)
+				p.Bugs = append(p.Bugs, strings.TrimSpace(v))
+				depth--
+			case "revlink":
+				p.Revisions = append(p.Revisions, attr(t, "rev"))
+			case "hashlink", "connectorshashlink":
+				// Both elements are empty — the rendered page turns the hash
+				// attribute into the link text — so without this the sentence
+				// reads "This was fixed with commit .". They are kept apart
+				// because they resolve against different repositories.
+				h := attr(t, "hash")
+				sb.WriteString(h)
+				switch t.Name.Local {
+				case "hashlink":
+					p.Commits = append(p.Commits, h)
+				default:
+					p.ConnectorCommits = append(p.ConnectorCommits, h)
+				}
+			case "a":
+				p.Hrefs = append(p.Hrefs, attr(t, "href"))
+			}
+		case xml.EndElement:
+			if t.Name.Local == "block" && depth == 0 {
+				continue
+			}
+			if strongDepth == depth {
+				strongDepth = 0
+			}
+			depth--
+		}
+	}
+
+	p.Text = collapse(sb.String())
+	p.Strong = collapse(strongSB.String())
+
+	return p, nil
+}
+
+// elementText consumes an element already opened as start and returns its text.
+func elementText(d *xml.Decoder, start xml.StartElement) (string, error) {
+	var v string
+	if err := d.DecodeElement(&v, &start); err != nil {
+		return "", errors.Wrapf(err, "decode <%s>", start.Name.Local)
+	}
+	return v, nil
+}
+
+func attr(e xml.StartElement, name string) string {
+	for _, a := range e.Attr {
+		if a.Name.Local == name {
+			return strings.TrimSpace(a.Value)
+		}
+	}
+	return ""
+}
+
+// unwrap replaces the source's line breaks with spaces, so that the only
+// newlines left in a block buffer are the ones <br/> and <li> put there.
+func unwrap(s string) string {
+	return strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(s)
+}
+
+// collapse trims each line and squeezes runs of whitespace, preserving the
+// line breaks parseBlock recorded.
+func collapse(s string) string {
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if f := strings.Join(strings.Fields(l), " "); f != "" {
+			out = append(out, f)
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/pkg/extract/apache/tomcat/xml/entry_test.go
+++ b/pkg/extract/apache/tomcat/xml/entry_test.go
@@ -1,0 +1,204 @@
+package xml
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	tomcatXML "github.com/MaineK00n/vuls-data-update/pkg/fetch/apache/tomcat/xml"
+)
+
+func ps(xs ...string) []tomcatXML.Block {
+	bs := make([]tomcatXML.Block, 0, len(xs))
+	for _, x := range xs {
+		bs = append(bs, tomcatXML.Block{Tag: "p", XML: x})
+	}
+	return bs
+}
+
+func Test_entries(t *testing.T) {
+	type want struct {
+		entries []entry
+		notes   []string
+	}
+	tests := []struct {
+		name string
+		args tomcatXML.Section
+		want want
+	}{
+		{
+			name: "an entry runs from its header to the next one",
+			args: tomcatXML.Section{
+				Name: "Fixed in Apache Tomcat 11.0.24",
+				Blocks: ps(
+					`<strong>Low: EncryptInterceptor requirements not clearly
+       documented</strong>
+       <cve>CVE-2026-59084</cve>`,
+					`The requirements were not clearly documented.`,
+					`This was fixed with commit
+       <hashlink hash="57e80e9b"/>.`,
+					`Affects: 11.0.0-M1 to 11.0.23`,
+					`<strong>Low: Second issue</strong> <cve>CVE-2026-59083</cve>`,
+					`Affects: 11.0.0-M1 to 11.0.23`,
+				),
+			},
+			want: want{entries: []entry{
+				{
+					CVEs:     []string{"CVE-2026-59084"},
+					Severity: "Low",
+					// The source hard-wraps prose; its newlines are not content.
+					Title:       "EncryptInterceptor requirements not clearly documented",
+					Affects:     "11.0.0-M1 to 11.0.23",
+					Description: []string{"The requirements were not clearly documented.", "This was fixed with commit 57e80e9b."},
+					Commits:     []string{"57e80e9b"},
+				},
+				{
+					CVEs:     []string{"CVE-2026-59083"},
+					Severity: "Low",
+					Title:    "Second issue",
+					Affects:  "11.0.0-M1 to 11.0.23",
+				},
+			}},
+		},
+		{
+			name: "a CVE quoted inside the title is not one of the entry's own",
+			args: tomcatXML.Section{Blocks: ps(
+				`<strong>Important: The fix for <cve>CVE-2026-29146</cve> allowed the
+       bypass of the EncryptInterceptor</strong>
+       <cve>CVE-2026-34486</cve>`,
+			)},
+			want: want{entries: []entry{{
+				CVEs:     []string{"CVE-2026-34486"},
+				Severity: "Important",
+				Title:    "The fix for CVE-2026-29146 allowed the bypass of the EncryptInterceptor",
+			}}},
+		},
+		{
+			name: "a legacy entry links its CVE with a plain anchor",
+			args: tomcatXML.Section{Blocks: ps(
+				`<strong>Moderate: Multiple weaknesses in HTTP DIGEST authentication</strong>
+       <a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-1184"
+       rel="nofollow">CVE-2011-1184</a>`,
+			)},
+			want: want{entries: []entry{{
+				CVEs:     []string{"CVE-2011-1184"},
+				Severity: "Moderate",
+				Title:    "Multiple weaknesses in HTTP DIGEST authentication",
+			}}},
+		},
+		{
+			name: "a <strong> block carrying no CVE is prose, not a header",
+			args: tomcatXML.Section{Blocks: ps(
+				`<strong>Note: The issue below was fixed in 6.0.34 but the release vote did not pass.</strong>`,
+				`<strong>Low: Real issue</strong> <cve>CVE-2011-0001</cve>`,
+				`<strong>Note: All of conditions above must be true.</strong>`,
+			)},
+			want: want{
+				entries: []entry{{
+					CVEs:        []string{"CVE-2011-0001"},
+					Severity:    "Low",
+					Title:       "Real issue",
+					Description: []string{"Note: All of conditions above must be true."},
+				}},
+				notes: []string{"Note: The issue below was fixed in 6.0.34 but the release vote did not pass."},
+			},
+		},
+		{
+			name: "list items and a mistyped <o> paragraph are description lines",
+			args: tomcatXML.Section{Blocks: []tomcatXML.Block{
+				{Tag: "p", XML: `<strong>Important: RCE</strong> <cve>CVE-2020-9484</cve>`},
+				{Tag: "p", XML: `If:`},
+				{Tag: "ul", XML: `<li>an attacker controls a file; and</li><li>the server uses the PersistenceManager</li>`},
+				{Tag: "o", XML: `Applications that do not use non-blocking I/O are not exposed.`},
+			}},
+			want: want{entries: []entry{{
+				CVEs:     []string{"CVE-2020-9484"},
+				Severity: "Important",
+				Title:    "RCE",
+				Description: []string{
+					"If:",
+					"an attacker controls a file; and",
+					"the server uses the PersistenceManager",
+					"Applications that do not use non-blocking I/O are not exposed.",
+				},
+			}}},
+		},
+		{
+			name: "prose after a <br/> on the Affects line is not part of the range",
+			args: tomcatXML.Section{Blocks: ps(
+				`<strong>Low: DoS</strong> <cve>CVE-2026-66299</cve>`,
+				`Affects: 11.0.0-M20 to 11.0.24<br/>
+       Users who followed the security guidance to remove the examples web
+       application are not affected.`,
+			)},
+			want: want{entries: []entry{{
+				CVEs:        []string{"CVE-2026-66299"},
+				Severity:    "Low",
+				Title:       "DoS",
+				Affects:     "11.0.0-M20 to 11.0.24",
+				Description: []string{"Users who followed the security guidance to remove the examples web application are not affected."},
+			}}},
+		},
+		{
+			name: "a header with no severity rating keeps the whole title",
+			args: tomcatXML.Section{Blocks: ps(
+				`<strong>JavaMail information disclosure</strong> <cve>CVE-2026-33333</cve>`,
+			)},
+			want: want{entries: []entry{{
+				CVEs:  []string{"CVE-2026-33333"},
+				Title: "JavaMail information disclosure",
+			}}},
+		},
+		{
+			name: "connector commits are kept apart from tomcat commits",
+			args: tomcatXML.Section{Blocks: ps(
+				`<strong>Low: Incorrect default permissions</strong> <cve>CVE-2024-46544</cve>`,
+				`This was fixed with commit <connectorshashlink hash="d55706e9"/>.`,
+			)},
+			want: want{entries: []entry{{
+				CVEs:             []string{"CVE-2024-46544"},
+				Severity:         "Low",
+				Title:            "Incorrect default permissions",
+				Description:      []string{"This was fixed with commit d55706e9."},
+				ConnectorCommits: []string{"d55706e9"},
+			}}},
+		},
+		{
+			name: "the page preamble holds no entry",
+			args: tomcatXML.Section{
+				Name:   "Apache Tomcat 11.x vulnerabilities",
+				Blocks: ps(`This page lists all security vulnerabilities fixed in released versions.`),
+			},
+			want: want{notes: []string{"This page lists all security vulnerabilities fixed in released versions."}},
+		},
+		{
+			name: "the table of contents holds nothing at all",
+			args: tomcatXML.Section{Name: "Table of Contents", Blocks: []tomcatXML.Block{{Tag: "toc"}}},
+			want: want{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			es, notes, err := entries(tt.args)
+			if err != nil {
+				t.Fatal("unexpected error:", err)
+			}
+			if diff := cmp.Diff(tt.want.entries, es); diff != "" {
+				t.Errorf("entries(). (-expected +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.want.notes, notes); diff != "" {
+				t.Errorf("entries() notes. (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_entries_malformedFragment(t *testing.T) {
+	if _, _, err := entries(tomcatXML.Section{
+		Name:   "Fixed in Apache Tomcat 11.0.1",
+		Blocks: []tomcatXML.Block{{Tag: "p", XML: "<strong>unclosed"}},
+	}); err == nil {
+		t.Error("expected error has not occurred")
+	}
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/fixtures/11.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/fixtures/11.json
@@ -1,0 +1,141 @@
+{
+	"branch": "11",
+	"properties": {
+		"author": "Apache Tomcat Project",
+		"title": "Apache Tomcat 11 vulnerabilities"
+	},
+	"sections": [
+		{
+			"name": "Apache Tomcat 11.x vulnerabilities",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "This page lists all security vulnerabilities fixed in released versions\n       of Apache Tomcat<sup>&#174;</sup> 11.x."
+				},
+				{
+					"tag": "p",
+					"xml": "<strong>Note:</strong> Vulnerabilities that are not Tomcat vulnerabilities\n       but have either been incorrectly reported against Tomcat or where Tomcat\n       provides a workaround are listed at the end of this page."
+				}
+			]
+		},
+		{
+			"name": "Table of Contents",
+			"blocks": [
+				{
+					"tag": "toc"
+				}
+			]
+		},
+		{
+			"name": "Fixed in Apache Tomcat 11.0.25",
+			"rtext": "not yet released",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "<strong>Low: DoS in WebSocket chat example</strong>\n       <cve>CVE-2026-66299</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "The WebSocket chat example provided an unbounded buffer for undelivered\n       messages."
+				},
+				{
+					"tag": "p",
+					"xml": "This was fixed with commit\n       <hashlink hash=\"4e8e3f8964e9653bab427bf794e026c69ee80f2b\"/>."
+				},
+				{
+					"tag": "p",
+					"xml": "Affects: 11.0.0-M20 to 11.0.24<br/>\n       Users who followed the security guidance to remove the examples web\n       application are not affected."
+				}
+			]
+		},
+		{
+			"name": "Fixed in Apache Tomcat 11.0.21",
+			"rtext": "2026-05-13",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "<strong>Note: The issue below was fixed in Apache Tomcat 11.0.20 but the\n       release vote for the 11.0.20 release candidate did not pass.</strong>"
+				},
+				{
+					"tag": "p",
+					"xml": "<strong>Important: The fix for <cve>CVE-2026-29146</cve> allowed the\n       bypass of the EncryptInterceptor</strong>\n       <cve>CVE-2026-34486</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "An error in the fix for <cve>CVE-2026-29146</cve> allowed the\n       EncryptInterceptor to be bypassed."
+				},
+				{
+					"tag": "p",
+					"xml": "This was fixed in revision <revlink rev=\"1840057\">1840057</revlink> and\n       reported as bug <bug>69420</bug>."
+				},
+				{
+					"tag": "p",
+					"xml": "Affects: 11.0.0-M1 to 11.0.20"
+				},
+				{
+					"tag": "p",
+					"xml": "<strong>Important: Remote Code Execution via session persistence</strong>\n       <cve>CVE-2026-11111</cve>,\n       <cve>CVE-2026-22222</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "If:"
+				},
+				{
+					"tag": "ul",
+					"xml": "\n      <li>an attacker is able to control the contents of a file; and</li>\n      <li>the server is configured to use the PersistenceManager</li>\n    "
+				},
+				{
+					"tag": "p",
+					"xml": "then remote code execution is possible. See the\n       <a href=\"https://lists.apache.org/thread/example\">announcement</a>."
+				},
+				{
+					"tag": "o",
+					"xml": "Applications that do not use non-blocking I/O are not exposed to this\n       vulnerability."
+				},
+				{
+					"tag": "p",
+					"xml": "Affects: 11.0.0-M1 to 11.0.20"
+				}
+			]
+		},
+		{
+			"name": "Fixed in Apache Tomcat 11.0.12",
+			"rtext": "released 18 Aug 2025",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "<strong>Moderate: Multiple weaknesses in HTTP DIGEST authentication</strong>\n       <a href=\"http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-1184\"\n       rel=\"nofollow\">CVE-2026-1184</a>"
+				},
+				{
+					"tag": "p",
+					"xml": "Several weaknesses were identified."
+				},
+				{
+					"tag": "p",
+					"xml": "Affects: 11.0.0-M1 to 11.0.11"
+				},
+				{
+					"tag": "p",
+					"xml": "<strong>JavaMail information disclosure</strong>\n       <cve>CVE-2026-33333</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "An entry whose header carries no severity rating."
+				}
+			]
+		},
+		{
+			"name": "Not a vulnerability in Tomcat",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "<strong>Critical: Remote Code Execution via log4j</strong>\n       <cve>CVE-2021-44228</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "Apache Tomcat does not ship with log4j. This is not a vulnerability in\n       Apache Tomcat."
+				}
+			]
+		}
+	]
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/fixtures/jk.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/fixtures/jk.json
@@ -1,0 +1,40 @@
+{
+	"branch": "jk",
+	"properties": {
+		"author": "Apache Tomcat Project",
+		"title": "Apache Tomcat JK Connectors vulnerabilities"
+	},
+	"sections": [
+		{
+			"name": "Apache Tomcat JK Connectors vulnerabilities",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "This page lists all security vulnerabilities fixed in released versions\n       of the Apache Tomcat JK Connectors."
+				}
+			]
+		},
+		{
+			"name": "Fixed in Apache Tomcat JK Connector 1.2.50",
+			"rtext": "2024-09-30",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "<strong>Low: Incorrect default permissions</strong>\n       <cve>CVE-2024-46544</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "Incorrect default permissions for the memory mapped file configured by\n       the <code>JkShmFile</code> directive on Unix like systems."
+				},
+				{
+					"tag": "p",
+					"xml": "This was fixed with commit\n       <connectorshashlink hash=\"d55706e92b65018c2e4c7ab14014a996b0174966\"/>."
+				},
+				{
+					"tag": "p",
+					"xml": "Affects: JK 1.2.0-1.2.49 (mod_jk on Unix like platforms only)"
+				}
+			]
+		}
+	]
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2021-44228.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2021-44228.json
@@ -1,0 +1,37 @@
+{
+	"id": "CVE-2021-44228",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2021-44228",
+				"title": "Remote Code Execution via log4j",
+				"description": "Apache Tomcat does not ship with log4j. This is not a vulnerability in Apache Tomcat.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "tomcat.apache.org",
+						"vendor": "Critical"
+					}
+				],
+				"references": [
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2021-44228"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-tomcat-xml",
+		"raws": [
+			"fixtures/11.json"
+		]
+	}
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2024-46544.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2024-46544.json
@@ -1,0 +1,86 @@
+{
+	"id": "CVE-2024-46544",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-46544",
+				"title": "Incorrect default permissions",
+				"description": "Incorrect default permissions for the memory mapped file configured by the JkShmFile directive on Unix like systems.\nThis was fixed with commit d55706e92b65018c2e4c7ab14014a996b0174966.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "tomcat.apache.org",
+						"vendor": "Low"
+					}
+				],
+				"references": [
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://github.com/apache/tomcat-connectors/commit/d55706e92b65018c2e4c7ab14014a996b0174966"
+					},
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-46544"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "jk"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:tomcat_connectors:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "version",
+										"ge": "1.2.0",
+										"le": "1.2.49"
+									},
+									"fixed": [
+										"1.2.50"
+									]
+								}
+							},
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:tomcat_jk_connector:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "version",
+										"ge": "1.2.0",
+										"le": "1.2.49"
+									},
+									"fixed": [
+										"1.2.50"
+									]
+								}
+							}
+						]
+					},
+					"tag": "jk"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-tomcat-xml",
+		"raws": [
+			"fixtures/jk.json"
+		]
+	}
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-11111.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-11111.json
@@ -1,0 +1,71 @@
+{
+	"id": "CVE-2026-11111",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-11111",
+				"title": "Remote Code Execution via session persistence",
+				"description": "If:\nan attacker is able to control the contents of a file; and\nthe server is configured to use the PersistenceManager\nthen remote code execution is possible. See the announcement.\nApplications that do not use non-blocking I/O are not exposed to this vulnerability.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "tomcat.apache.org",
+						"vendor": "Important"
+					}
+				],
+				"references": [
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://lists.apache.org/thread/example"
+					},
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-11111"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "version",
+										"ge": "11.0.0-M1",
+										"le": "11.0.20"
+									},
+									"fixed": [
+										"11.0.21"
+									]
+								}
+							}
+						]
+					},
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-tomcat-xml",
+		"raws": [
+			"fixtures/11.json"
+		]
+	}
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-1184.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-1184.json
@@ -1,0 +1,67 @@
+{
+	"id": "CVE-2026-1184",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-1184",
+				"title": "Multiple weaknesses in HTTP DIGEST authentication",
+				"description": "Several weaknesses were identified.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "tomcat.apache.org",
+						"vendor": "Moderate"
+					}
+				],
+				"references": [
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-1184"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "version",
+										"ge": "11.0.0-M1",
+										"le": "11.0.11"
+									},
+									"fixed": [
+										"11.0.12"
+									]
+								}
+							}
+						]
+					},
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-tomcat-xml",
+		"raws": [
+			"fixtures/11.json"
+		]
+	}
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-22222.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-22222.json
@@ -1,0 +1,71 @@
+{
+	"id": "CVE-2026-22222",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-22222",
+				"title": "Remote Code Execution via session persistence",
+				"description": "If:\nan attacker is able to control the contents of a file; and\nthe server is configured to use the PersistenceManager\nthen remote code execution is possible. See the announcement.\nApplications that do not use non-blocking I/O are not exposed to this vulnerability.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "tomcat.apache.org",
+						"vendor": "Important"
+					}
+				],
+				"references": [
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://lists.apache.org/thread/example"
+					},
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-22222"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "version",
+										"ge": "11.0.0-M1",
+										"le": "11.0.20"
+									},
+									"fixed": [
+										"11.0.21"
+									]
+								}
+							}
+						]
+					},
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-tomcat-xml",
+		"raws": [
+			"fixtures/11.json"
+		]
+	}
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-33333.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-33333.json
@@ -1,0 +1,30 @@
+{
+	"id": "CVE-2026-33333",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-33333",
+				"title": "JavaMail information disclosure",
+				"description": "An entry whose header carries no severity rating.",
+				"references": [
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-33333"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-tomcat-xml",
+		"raws": [
+			"fixtures/11.json"
+		]
+	}
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-34486.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-34486.json
@@ -1,0 +1,75 @@
+{
+	"id": "CVE-2026-34486",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-34486",
+				"title": "The fix for CVE-2026-29146 allowed the bypass of the EncryptInterceptor",
+				"description": "An error in the fix for CVE-2026-29146 allowed the EncryptInterceptor to be bypassed.\nThis was fixed in revision 1840057 and reported as bug 69420.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "tomcat.apache.org",
+						"vendor": "Important"
+					}
+				],
+				"references": [
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://bz.apache.org/bugzilla/show_bug.cgi?id=69420"
+					},
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://svn.apache.org/viewvc?view=rev&rev=1840057"
+					},
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-34486"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "version",
+										"ge": "11.0.0-M1",
+										"le": "11.0.20"
+									},
+									"fixed": [
+										"11.0.21"
+									]
+								}
+							}
+						]
+					},
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-tomcat-xml",
+		"raws": [
+			"fixtures/11.json"
+		]
+	}
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-66299.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/golden/data/CVE-2026-66299.json
@@ -1,0 +1,71 @@
+{
+	"id": "CVE-2026-66299",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-66299",
+				"title": "DoS in WebSocket chat example",
+				"description": "The WebSocket chat example provided an unbounded buffer for undelivered messages.\nThis was fixed with commit 4e8e3f8964e9653bab427bf794e026c69ee80f2b.\nUsers who followed the security guidance to remove the examples web application are not affected.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "tomcat.apache.org",
+						"vendor": "Low"
+					}
+				],
+				"references": [
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://github.com/apache/tomcat/commit/4e8e3f8964e9653bab427bf794e026c69ee80f2b"
+					},
+					{
+						"source": "tomcat.apache.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-66299"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe",
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "version",
+										"ge": "11.0.0-M20",
+										"le": "11.0.24"
+									},
+									"fixed": [
+										"11.0.25"
+									]
+								}
+							}
+						]
+					},
+					"tag": "11"
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-tomcat-xml",
+		"raws": [
+			"fixtures/11.json"
+		]
+	}
+}

--- a/pkg/extract/apache/tomcat/xml/testdata/golden/datasource.json
+++ b/pkg/extract/apache/tomcat/xml/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "apache-tomcat-xml",
+	"name": "Apache Tomcat Security Vulnerabilities"
+}

--- a/pkg/extract/apache/tomcat/xml/xml.go
+++ b/pkg/extract/apache/tomcat/xml/xml.go
@@ -1,0 +1,364 @@
+package xml
+
+import (
+	"cmp"
+	"encoding/json/v2"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	detectionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection"
+	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
+	criteriaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria"
+	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
+	ccTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion"
+	ccRangeTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/range"
+	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
+	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
+	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	tomcatXML "github.com/MaineK00n/vuls-data-update/pkg/fetch/apache/tomcat/xml"
+)
+
+// products maps a page to the CPEs its version numbers belong to. The three
+// component pages version independently of the server, and NVD indexes the JK
+// connector under two spellings, so each spelling gets its own criterion —
+// the db-side part:vendor:product index is built from main CPEs, so a
+// criterion is only reachable by a query using the same spelling.
+var products = map[string][]ccTypes.CPE{
+	"jk":      {"cpe:2.3:a:apache:tomcat_connectors:*:*:*:*:*:*:*:*", "cpe:2.3:a:apache:tomcat_jk_connector:*:*:*:*:*:*:*:*"},
+	"native":  {"cpe:2.3:a:apache:tomcat_native:*:*:*:*:*:*:*:*"},
+	"taglibs": {"cpe:2.3:a:apache:standard_taglibs:*:*:*:*:*:*:*:*"},
+}
+
+const tomcatCPE ccTypes.CPE = "cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*"
+
+// branchPattern matches the pages named for a Tomcat server branch
+// (security-9.xml, security-11.xml), as opposed to a component.
+var branchPattern = regexp.MustCompile(`^[0-9]+$`)
+
+// notAVulnerabilityPattern matches the section that collects issues reported
+// against Tomcat that are not Tomcat vulnerabilities. Their "Affects:" line
+// names downstream distributions rather than Tomcat versions, so no detection
+// is emitted for them.
+var notAVulnerabilityPattern = regexp.MustCompile(`^Not a vulnerability in`)
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "apache", "tomcat", "xml"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract Apache Tomcat Security Vulnerabilities")
+	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		r := utiljson.NewJSONReader()
+		var fetched tomcatXML.Advisory
+		if err := r.Read(path, args, &fetched); err != nil {
+			return errors.Wrapf(err, "read json %s", path)
+		}
+
+		// A CVE is listed once per affected branch, so the same root ID is
+		// built from several pages and the parts are merged as they arrive.
+		ds, err := extract(fetched, r.Paths())
+		if err != nil {
+			return errors.Wrapf(err, "extract %s", path)
+		}
+
+		for _, data := range ds {
+			p := filepath.Join(options.dir, "data", fmt.Sprintf("%s.json", data.ID))
+			if _, err := os.Stat(p); err == nil {
+				f, err := os.Open(p)
+				if err != nil {
+					return errors.Wrapf(err, "open %s", p)
+				}
+				defer f.Close()
+
+				var base dataTypes.Data
+				if err := json.UnmarshalRead(f, &base); err != nil {
+					return errors.Wrapf(err, "decode %s", p)
+				}
+
+				data.Merge(base)
+			}
+
+			if err := util.Write(p, data, true); err != nil {
+				return errors.Wrapf(err, "write %s", p)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", args)
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.ApacheTomcatXML,
+		Name: new("Apache Tomcat Security Vulnerabilities"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+func extract(fetched tomcatXML.Advisory, raws []string) ([]dataTypes.Data, error) {
+	// A numbered page is a server branch and carries server versions; a named
+	// one is a separately-released component and must be listed above. The
+	// fetcher picks up new security-*.xml pages on its own, so an unlisted
+	// name is a component whose CPE nobody has chosen yet — the advisory is
+	// still extracted, but attributing its versions to the server would be a
+	// silent misattribution, so no detection is emitted for it.
+	cpes, ok := products[fetched.Branch]
+	if !ok {
+		if branchPattern.MatchString(fetched.Branch) {
+			cpes = []ccTypes.CPE{tomcatCPE}
+		} else {
+			slog.Warn("no CPE known for Apache Tomcat component page, skipping detections", "branch", fetched.Branch)
+		}
+	}
+
+	var ds []dataTypes.Data
+
+	// A CVE affecting several branches is listed once per branch, each listing
+	// with its own affected range, fix commit and "upgrade to X or later"
+	// wording. Merge keeps all of them under the one root ID, so the branch is
+	// carried as the segment/condition tag to say which listing each came from.
+	tag := segmentTypes.DetectionTag(fetched.Branch)
+
+	for _, s := range fetched.Sections {
+		notAVulnerability := notAVulnerabilityPattern.MatchString(s.Name)
+
+		es, _, err := entries(s)
+		if err != nil {
+			return nil, errors.Wrapf(err, "entries of section %q", s.Name)
+		}
+
+		for _, e := range es {
+			d := detections(s, e, cpes, notAVulnerability, tag)
+
+			for _, cve := range e.CVEs {
+				ds = append(ds, dataTypes.Data{
+					ID: dataTypes.RootID(cve),
+					Vulnerabilities: []vulnerabilityTypes.Vulnerability{{
+						Content: vulnerabilityContentTypes.Content{
+							ID:          vulnerabilityContentTypes.VulnerabilityID(cve),
+							Title:       e.Title,
+							Description: strings.Join(e.Description, "\n"),
+							Severity:    severities(e),
+							References:  references(cve, e),
+						},
+						Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeCPE, Tag: tag}},
+					}},
+					Detections: d,
+					DataSource: sourceTypes.Source{
+						ID:   sourceTypes.ApacheTomcatXML,
+						Raws: raws,
+					},
+				})
+			}
+		}
+	}
+
+	return ds, nil
+}
+
+// detections turns the entry's "Affects:" line into one CPE criterion per
+// version range, per product spelling. The fixed version comes from the
+// section title ("Fixed in Apache Tomcat 11.0.24"), which can name more than
+// one release when a fix shipped across maintenance lines ("Fixed in Apache
+// Tomcat 4.1.13, 4.0.6").
+func detections(s tomcatXML.Section, e entry, cpes []ccTypes.CPE, notAVulnerability bool, tag segmentTypes.DetectionTag) []detectionTypes.Detection {
+	if notAVulnerability || e.Affects == "" || len(cpes) == 0 {
+		return nil
+	}
+
+	as, unknown := parseAffects(e.Affects)
+	if len(unknown) > 0 {
+		slog.Warn("unparseable version range in Affects", "branch", string(tag), "section", s.Name, "cves", e.CVEs, "tokens", unknown)
+	}
+	if len(as) == 0 {
+		return nil
+	}
+
+	fixed := fixedVersions(s.Name)
+
+	cns := make([]criterionTypes.Criterion, 0, len(as)*len(cpes))
+	for _, cpe := range cpes {
+		for _, a := range as {
+			cns = append(cns, criterionTypes.Criterion{
+				Type: criterionTypes.CriterionTypeCPE,
+				CPE: &ccTypes.Criterion{
+					Vulnerable: true,
+					CPE:        cpe,
+					Range: &ccRangeTypes.Range{
+						Type: ccRangeTypes.RangeTypeVersion,
+						// A single version is expressed as a closed range on
+						// itself; Range has no equality bound.
+						GreaterEqual: cmp.Or(a.GreaterEqual, a.Equal),
+						LessEqual:    cmp.Or(a.LessEqual, a.Equal),
+					},
+					Fixed: fixed,
+				},
+			})
+		}
+	}
+
+	return []detectionTypes.Detection{{
+		Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+		Conditions: []conditionTypes.Condition{{
+			Criteria: criteriaTypes.Criteria{
+				Operator:   criteriaTypes.CriteriaOperatorTypeOR,
+				Criterions: cns,
+			},
+			Tag: tag,
+		}},
+	}}
+}
+
+// sectionVersionPattern pulls the release numbers out of a section title. The
+// titles name the server ("Fixed in Apache Tomcat 11.0.24"), a component
+// ("Fixed in Apache Tomcat JK Connector 1.2.50", "Fixed in Apache Standard
+// Taglib 1.2.3") or nothing at all ("Not fixed in Apache Tomcat 3.x",
+// "Unverified"), so a title with no release yields no fixed version.
+var sectionVersionPattern = regexp.MustCompile(`[0-9]+(?:\.[0-9A-Za-z]+)*(?:-(?:M|RC)[0-9]+)?`)
+
+func fixedVersions(name string) []string {
+	if !strings.HasPrefix(name, "Fixed in ") {
+		return nil
+	}
+
+	var fixed []string
+	for _, v := range sectionVersionPattern.FindAllString(name, -1) {
+		// Neither a "3.x" wildcard nor the "5.0.SVN" branch-only placeholder
+		// names a release.
+		if strings.HasSuffix(v, ".x") || !isRelease(v) {
+			continue
+		}
+		if v = normalize(v); !slices.Contains(fixed, v) {
+			fixed = append(fixed, v)
+		}
+	}
+	return fixed
+}
+
+func severities(e entry) []severityTypes.Severity {
+	if e.Severity == "" {
+		return nil
+	}
+	return []severityTypes.Severity{{
+		Type:   severityTypes.SeverityTypeVendor,
+		Source: "tomcat.apache.org",
+		Vendor: &e.Severity,
+	}}
+}
+
+func references(cve string, e entry) []referenceTypes.Reference {
+	rs := []referenceTypes.Reference{{
+		Source: "tomcat.apache.org",
+		URL:    fmt.Sprintf("https://www.cve.org/CVERecord?id=%s", cve),
+	}}
+
+	for _, c := range e.Commits {
+		rs = append(rs, referenceTypes.Reference{
+			Source: "tomcat.apache.org",
+			URL:    fmt.Sprintf("https://github.com/apache/tomcat/commit/%s", c),
+		})
+	}
+	for _, c := range e.ConnectorCommits {
+		rs = append(rs, referenceTypes.Reference{
+			Source: "tomcat.apache.org",
+			URL:    fmt.Sprintf("https://github.com/apache/tomcat-connectors/commit/%s", c),
+		})
+	}
+	for _, r := range e.Revisions {
+		rs = append(rs, referenceTypes.Reference{
+			Source: "tomcat.apache.org",
+			URL:    fmt.Sprintf("https://svn.apache.org/viewvc?view=rev&rev=%s", r),
+		})
+	}
+	for _, b := range e.Bugs {
+		rs = append(rs, referenceTypes.Reference{
+			Source: "tomcat.apache.org",
+			URL:    fmt.Sprintf("https://bz.apache.org/bugzilla/show_bug.cgi?id=%s", b),
+		})
+	}
+	for _, u := range e.References {
+		rs = append(rs, referenceTypes.Reference{
+			Source: "tomcat.apache.org",
+			URL:    u,
+		})
+	}
+
+	return rs
+}

--- a/pkg/extract/apache/tomcat/xml/xml_test.go
+++ b/pkg/extract/apache/tomcat/xml/xml_test.go
@@ -1,0 +1,47 @@
+package xml_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	tomcat "github.com/MaineK00n/vuls-data-update/pkg/extract/apache/tomcat/xml"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := tomcat.Extract(tt.args, tomcat.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				// error was expected and occurred, test passed
+				return
+			default:
+				ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				gp, err := filepath.Abs(dir)
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -22,6 +22,7 @@ const (
 	Amazon                     SourceID = "amazon"
 	AndroidOSV                 SourceID = "android-osv"
 	AnolisOVAL                 SourceID = "anolis-oval"
+	ApacheTomcatXML            SourceID = "apache-tomcat-xml"
 	Arch                       SourceID = "arch"
 	AzureOVAL                  SourceID = "azure-oval"
 	BitnamiOSV                 SourceID = "bitnami-osv"

--- a/pkg/fetch/apache/tomcat/xml/testdata/fixtures/happy/indexof.html
+++ b/pkg/fetch/apache/tomcat/xml/testdata/fixtures/happy/indexof.html
@@ -1,0 +1,15 @@
+<html><head><title>asf - Revision 1936779: /tomcat/site/trunk/xdocs</title></head>
+<body>
+ <h2>asf - Revision 1936779: /tomcat/site/trunk/xdocs</h2>
+ <ul>
+  <li><a href="../">..</a></li>
+  <li><a href="articles/">articles/</a></li>
+  <li><a href="bugreport.xml">bugreport.xml</a></li>
+  <li><a href="security.xml">security.xml</a></li>
+  <li><a href="security-11.xml">security-11.xml</a></li>
+  <li><a href="security-impact.xml">security-impact.xml</a></li>
+  <li><a href="security-jk.xml">security-jk.xml</a></li>
+  <li><a href="security-model.xml">security-model.xml</a></li>
+  <li><a href="whoweare.xml">whoweare.xml</a></li>
+ </ul>
+</body></html>

--- a/pkg/fetch/apache/tomcat/xml/testdata/fixtures/happy/security-11.xml
+++ b/pkg/fetch/apache/tomcat/xml/testdata/fixtures/happy/security-11.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+
+  <properties>
+    <author>Apache Tomcat Project</author>
+    <title>Apache Tomcat 11 vulnerabilities</title>
+  </properties>
+
+<body>
+
+  <section name="Apache Tomcat 11.x vulnerabilities">
+    <p>This page lists all security vulnerabilities fixed in released versions
+       of Apache Tomcat<sup>&#174;</sup> 11.x.</p>
+
+    <p><strong>Note:</strong> Vulnerabilities that are not Tomcat vulnerabilities
+       but have either been incorrectly reported against Tomcat or where Tomcat
+       provides a workaround are listed at the end of this page.</p>
+  </section>
+
+  <section name="Table of Contents">
+    <toc/>
+  </section>
+
+  <section name="Fixed in Apache Tomcat 11.0.25" rtext="not yet released">
+
+    <p><strong>Low: DoS in WebSocket chat example</strong>
+       <cve>CVE-2026-66299</cve></p>
+
+    <p>The WebSocket chat example provided an unbounded buffer for undelivered
+       messages.</p>
+
+    <p>This was fixed with commit
+       <hashlink hash="4e8e3f8964e9653bab427bf794e026c69ee80f2b"/>.</p>
+
+    <p>Affects: 11.0.0-M20 to 11.0.24<br/>
+       Users who followed the security guidance to remove the examples web
+       application are not affected.</p>
+
+  </section>
+
+  <section name="Fixed in Apache Tomcat 11.0.21" rtext="2026-05-13">
+
+    <p><strong>Note: The issue below was fixed in Apache Tomcat 11.0.20 but the
+       release vote for the 11.0.20 release candidate did not pass.</strong></p>
+
+    <p><strong>Important: The fix for <cve>CVE-2026-29146</cve> allowed the
+       bypass of the EncryptInterceptor</strong>
+       <cve>CVE-2026-34486</cve></p>
+
+    <p>An error in the fix for <cve>CVE-2026-29146</cve> allowed the
+       EncryptInterceptor to be bypassed.</p>
+
+    <p>This was fixed in revision <revlink rev="1840057">1840057</revlink> and
+       reported as bug <bug>69420</bug>.</p>
+
+    <p>Affects: 11.0.0-M1 to 11.0.20</p>
+
+    <p><strong>Important: Remote Code Execution via session persistence</strong>
+       <cve>CVE-2026-11111</cve>,
+       <cve>CVE-2026-22222</cve></p>
+
+    <p>If:</p>
+    <ul>
+      <li>an attacker is able to control the contents of a file; and</li>
+      <li>the server is configured to use the PersistenceManager</li>
+    </ul>
+    <p>then remote code execution is possible. See the
+       <a href="https://lists.apache.org/thread/example">announcement</a>.</p>
+
+    <o>Applications that do not use non-blocking I/O are not exposed to this
+       vulnerability.</o>
+
+    <p>Affects: 11.0.0-M1 to 11.0.20</p>
+
+  </section>
+
+  <section name="Fixed in Apache Tomcat 11.0.12" rtext="released 18 Aug 2025">
+
+    <p><strong>Moderate: Multiple weaknesses in HTTP DIGEST authentication</strong>
+       <a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-1184"
+       rel="nofollow">CVE-2026-1184</a></p>
+
+    <p>Several weaknesses were identified.</p>
+
+    <p>Affects: 11.0.0-M1 to 11.0.11</p>
+
+    <p><strong>JavaMail information disclosure</strong>
+       <cve>CVE-2026-33333</cve></p>
+
+    <p>An entry whose header carries no severity rating.</p>
+
+  </section>
+
+  <section name="Not a vulnerability in Tomcat">
+
+    <p><strong>Critical: Remote Code Execution via log4j</strong>
+       <cve>CVE-2021-44228</cve></p>
+
+    <p>Apache Tomcat does not ship with log4j. This is not a vulnerability in
+       Apache Tomcat.</p>
+
+  </section>
+
+</body>
+</document>

--- a/pkg/fetch/apache/tomcat/xml/testdata/fixtures/happy/security-jk.xml
+++ b/pkg/fetch/apache/tomcat/xml/testdata/fixtures/happy/security-jk.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+
+  <properties>
+    <author>Apache Tomcat Project</author>
+    <title>Apache Tomcat JK Connectors vulnerabilities</title>
+  </properties>
+
+<body>
+
+  <section name="Apache Tomcat JK Connectors vulnerabilities">
+    <p>This page lists all security vulnerabilities fixed in released versions
+       of the Apache Tomcat JK Connectors.</p>
+  </section>
+
+  <section name="Fixed in Apache Tomcat JK Connector 1.2.50" rtext="2024-09-30">
+
+    <p><strong>Low: Incorrect default permissions</strong>
+       <cve>CVE-2024-46544</cve></p>
+
+    <p>Incorrect default permissions for the memory mapped file configured by
+       the <code>JkShmFile</code> directive on Unix like systems.</p>
+
+    <p>This was fixed with commit
+       <connectorshashlink hash="d55706e92b65018c2e4c7ab14014a996b0174966"/>.</p>
+
+    <p>Affects: JK 1.2.0-1.2.49 (mod_jk on Unix like platforms only)</p>
+
+  </section>
+
+</body>
+</document>

--- a/pkg/fetch/apache/tomcat/xml/testdata/fixtures/invalid-xml/indexof.html
+++ b/pkg/fetch/apache/tomcat/xml/testdata/fixtures/invalid-xml/indexof.html
@@ -1,0 +1,3 @@
+<html><body><ul>
+ <li><a href="security-11.xml">security-11.xml</a></li>
+</ul></body></html>

--- a/pkg/fetch/apache/tomcat/xml/testdata/fixtures/invalid-xml/security-11.xml
+++ b/pkg/fetch/apache/tomcat/xml/testdata/fixtures/invalid-xml/security-11.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document><body><section name="Fixed in Apache Tomcat 11.0.1">

--- a/pkg/fetch/apache/tomcat/xml/testdata/fixtures/no-security-page/indexof.html
+++ b/pkg/fetch/apache/tomcat/xml/testdata/fixtures/no-security-page/indexof.html
@@ -1,0 +1,5 @@
+<html><body><ul>
+ <li><a href="security.xml">security.xml</a></li>
+ <li><a href="security-impact.xml">security-impact.xml</a></li>
+ <li><a href="security-model.xml">security-model.xml</a></li>
+</ul></body></html>

--- a/pkg/fetch/apache/tomcat/xml/testdata/fixtures/notfound/indexof.html
+++ b/pkg/fetch/apache/tomcat/xml/testdata/fixtures/notfound/indexof.html
@@ -1,0 +1,4 @@
+<html><body><ul>
+ <li><a href="security-11.xml">security-11.xml</a></li>
+ <li><a href="security-impact.xml">security-impact.xml</a></li>
+</ul></body></html>

--- a/pkg/fetch/apache/tomcat/xml/testdata/golden/happy/11.json
+++ b/pkg/fetch/apache/tomcat/xml/testdata/golden/happy/11.json
@@ -1,0 +1,141 @@
+{
+	"branch": "11",
+	"properties": {
+		"author": "Apache Tomcat Project",
+		"title": "Apache Tomcat 11 vulnerabilities"
+	},
+	"sections": [
+		{
+			"name": "Apache Tomcat 11.x vulnerabilities",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "This page lists all security vulnerabilities fixed in released versions\n       of Apache Tomcat<sup>&#174;</sup> 11.x."
+				},
+				{
+					"tag": "p",
+					"xml": "<strong>Note:</strong> Vulnerabilities that are not Tomcat vulnerabilities\n       but have either been incorrectly reported against Tomcat or where Tomcat\n       provides a workaround are listed at the end of this page."
+				}
+			]
+		},
+		{
+			"name": "Table of Contents",
+			"blocks": [
+				{
+					"tag": "toc"
+				}
+			]
+		},
+		{
+			"name": "Fixed in Apache Tomcat 11.0.25",
+			"rtext": "not yet released",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "<strong>Low: DoS in WebSocket chat example</strong>\n       <cve>CVE-2026-66299</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "The WebSocket chat example provided an unbounded buffer for undelivered\n       messages."
+				},
+				{
+					"tag": "p",
+					"xml": "This was fixed with commit\n       <hashlink hash=\"4e8e3f8964e9653bab427bf794e026c69ee80f2b\"/>."
+				},
+				{
+					"tag": "p",
+					"xml": "Affects: 11.0.0-M20 to 11.0.24<br/>\n       Users who followed the security guidance to remove the examples web\n       application are not affected."
+				}
+			]
+		},
+		{
+			"name": "Fixed in Apache Tomcat 11.0.21",
+			"rtext": "2026-05-13",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "<strong>Note: The issue below was fixed in Apache Tomcat 11.0.20 but the\n       release vote for the 11.0.20 release candidate did not pass.</strong>"
+				},
+				{
+					"tag": "p",
+					"xml": "<strong>Important: The fix for <cve>CVE-2026-29146</cve> allowed the\n       bypass of the EncryptInterceptor</strong>\n       <cve>CVE-2026-34486</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "An error in the fix for <cve>CVE-2026-29146</cve> allowed the\n       EncryptInterceptor to be bypassed."
+				},
+				{
+					"tag": "p",
+					"xml": "This was fixed in revision <revlink rev=\"1840057\">1840057</revlink> and\n       reported as bug <bug>69420</bug>."
+				},
+				{
+					"tag": "p",
+					"xml": "Affects: 11.0.0-M1 to 11.0.20"
+				},
+				{
+					"tag": "p",
+					"xml": "<strong>Important: Remote Code Execution via session persistence</strong>\n       <cve>CVE-2026-11111</cve>,\n       <cve>CVE-2026-22222</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "If:"
+				},
+				{
+					"tag": "ul",
+					"xml": "\n      <li>an attacker is able to control the contents of a file; and</li>\n      <li>the server is configured to use the PersistenceManager</li>\n    "
+				},
+				{
+					"tag": "p",
+					"xml": "then remote code execution is possible. See the\n       <a href=\"https://lists.apache.org/thread/example\">announcement</a>."
+				},
+				{
+					"tag": "o",
+					"xml": "Applications that do not use non-blocking I/O are not exposed to this\n       vulnerability."
+				},
+				{
+					"tag": "p",
+					"xml": "Affects: 11.0.0-M1 to 11.0.20"
+				}
+			]
+		},
+		{
+			"name": "Fixed in Apache Tomcat 11.0.12",
+			"rtext": "released 18 Aug 2025",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "<strong>Moderate: Multiple weaknesses in HTTP DIGEST authentication</strong>\n       <a href=\"http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-1184\"\n       rel=\"nofollow\">CVE-2026-1184</a>"
+				},
+				{
+					"tag": "p",
+					"xml": "Several weaknesses were identified."
+				},
+				{
+					"tag": "p",
+					"xml": "Affects: 11.0.0-M1 to 11.0.11"
+				},
+				{
+					"tag": "p",
+					"xml": "<strong>JavaMail information disclosure</strong>\n       <cve>CVE-2026-33333</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "An entry whose header carries no severity rating."
+				}
+			]
+		},
+		{
+			"name": "Not a vulnerability in Tomcat",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "<strong>Critical: Remote Code Execution via log4j</strong>\n       <cve>CVE-2021-44228</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "Apache Tomcat does not ship with log4j. This is not a vulnerability in\n       Apache Tomcat."
+				}
+			]
+		}
+	]
+}

--- a/pkg/fetch/apache/tomcat/xml/testdata/golden/happy/jk.json
+++ b/pkg/fetch/apache/tomcat/xml/testdata/golden/happy/jk.json
@@ -1,0 +1,40 @@
+{
+	"branch": "jk",
+	"properties": {
+		"author": "Apache Tomcat Project",
+		"title": "Apache Tomcat JK Connectors vulnerabilities"
+	},
+	"sections": [
+		{
+			"name": "Apache Tomcat JK Connectors vulnerabilities",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "This page lists all security vulnerabilities fixed in released versions\n       of the Apache Tomcat JK Connectors."
+				}
+			]
+		},
+		{
+			"name": "Fixed in Apache Tomcat JK Connector 1.2.50",
+			"rtext": "2024-09-30",
+			"blocks": [
+				{
+					"tag": "p",
+					"xml": "<strong>Low: Incorrect default permissions</strong>\n       <cve>CVE-2024-46544</cve>"
+				},
+				{
+					"tag": "p",
+					"xml": "Incorrect default permissions for the memory mapped file configured by\n       the <code>JkShmFile</code> directive on Unix like systems."
+				},
+				{
+					"tag": "p",
+					"xml": "This was fixed with commit\n       <connectorshashlink hash=\"d55706e92b65018c2e4c7ab14014a996b0174966\"/>."
+				},
+				{
+					"tag": "p",
+					"xml": "Affects: JK 1.2.0-1.2.49 (mod_jk on Unix like platforms only)"
+				}
+			]
+		}
+	]
+}

--- a/pkg/fetch/apache/tomcat/xml/types.go
+++ b/pkg/fetch/apache/tomcat/xml/types.go
@@ -1,0 +1,108 @@
+package xml
+
+import (
+	"encoding/xml"
+)
+
+// Advisory mirrors one security-<branch>.xml page of the Apache Tomcat site
+// source.
+//
+// The document declares its structure only down to the section: <document>,
+// <properties> and <section name= rtext=> are elements with defined meaning,
+// so they map to fields one for one. Everything inside a section is prose —
+// the vulnerabilities are not elements, they are a layout convention over a
+// flat run of paragraphs — so each child is kept verbatim as innerxml and
+// interpreting it is left to the extractor. This is the same split
+// pkg/fetch/gentoo makes, where GLSA's declared fields are typed and its
+// <description>/<impact> bodies are innerxml.
+type Advisory struct {
+	Branch     string     `json:"branch,omitempty"`
+	Properties Properties `json:"properties,omitzero"`
+	Sections   []Section  `json:"sections,omitempty"`
+}
+
+type Properties struct {
+	Author string `xml:"author" json:"author,omitempty"`
+	Title  string `xml:"title" json:"title,omitempty"`
+}
+
+// Section is one <section> of the page body. Every section is kept, including
+// the page preamble and the table of contents, which carry no vulnerability
+// but are part of the document.
+type Section struct {
+	Name string `json:"name,omitempty"`
+	// RText is the rtext attribute verbatim. Upstream writes it in several
+	// shapes ("2026-07-08", "released 18 Aug 2011", "10 March 2021", "not yet
+	// released", "beta, 11 Feb 2014") and omits it on older pages.
+	RText  string  `json:"rtext,omitempty"`
+	Blocks []Block `json:"blocks,omitempty"`
+}
+
+// Block is one direct child of a section, kept as it appears. Tag is almost
+// always "p"; the rest are the <ul>/<ol> lists carrying attack preconditions,
+// the <toc/> placeholder, and one <o> that is a typo for <p> upstream.
+type Block struct {
+	Tag   string            `json:"tag,omitempty"`
+	Attrs map[string]string `json:"attrs,omitempty"`
+	XML   string            `json:"xml,omitempty"`
+}
+
+// document is the root of the page.
+type document struct {
+	Properties Properties `xml:"properties"`
+	Body       struct {
+		Sections []Section `xml:"section"`
+	} `xml:"body"`
+}
+
+// UnmarshalXML keeps every child element of the section, in document order,
+// with its markup intact. encoding/xml cannot express "any child element" as
+// a struct tag, so the token stream is walked by hand.
+func (s *Section) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	s.Name = attr(start, "name")
+	s.RText = attr(start, "rtext")
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			var v struct {
+				XML string `xml:",innerxml"`
+			}
+			if err := d.DecodeElement(&v, &t); err != nil {
+				return err
+			}
+			s.Blocks = append(s.Blocks, Block{
+				Tag:   t.Name.Local,
+				Attrs: attrs(t),
+				XML:   v.XML,
+			})
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+func attr(e xml.StartElement, name string) string {
+	for _, a := range e.Attr {
+		if a.Name.Local == name {
+			return a.Value
+		}
+	}
+	return ""
+}
+
+func attrs(e xml.StartElement) map[string]string {
+	if len(e.Attr) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(e.Attr))
+	for _, a := range e.Attr {
+		m[a.Name.Local] = a.Value
+	}
+	return m
+}

--- a/pkg/fetch/apache/tomcat/xml/xml.go
+++ b/pkg/fetch/apache/tomcat/xml/xml.go
@@ -1,0 +1,226 @@
+package xml
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+// The Apache Tomcat website is built from these xdocs sources. The published
+// security-<branch>.html pages carry the same content, but the source marks up
+// the parts that matter — <cve> for an entry's own CVEs, the rtext attribute
+// for the release date, <hashlink>/<revlink>/<bug> for fix references — where
+// the rendered page leaves them to be recovered from link targets and CSS
+// classes.
+const baseURL = "https://svn.apache.org/repos/asf/tomcat/site/trunk/xdocs/"
+
+// securityPagePattern matches the vulnerability listings, one per branch:
+// security-{3..11}.xml plus the separately-versioned components
+// security-{jk,native,taglibs}.xml. A new branch is picked up automatically.
+var securityPagePattern = regexp.MustCompile(`^security-([0-9]+|[a-z]+)\.xml$`)
+
+// nonVulnerabilityPages are the security-*.xml files under xdocs that document
+// policy rather than vulnerabilities, so they carry no advisory sections.
+var nonVulnerabilityPages = []string{"security-impact.xml", "security-model.xml"}
+
+type options struct {
+	baseURL     string
+	dir         string
+	retry       int
+	concurrency int
+	wait        time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type baseURLOption string
+
+func (u baseURLOption) apply(opts *options) {
+	opts.baseURL = string(u)
+}
+
+func WithBaseURL(url string) Option {
+	return baseURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type concurrencyOption int
+
+func (c concurrencyOption) apply(opts *options) {
+	opts.concurrency = int(c)
+}
+
+func WithConcurrency(concurrency int) Option {
+	return concurrencyOption(concurrency)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+func Fetch(opts ...Option) error {
+	options := &options{
+		baseURL:     baseURL,
+		dir:         filepath.Join(util.CacheDir(), "fetch", "apache", "tomcat", "xml"),
+		retry:       3,
+		concurrency: 5,
+		wait:        1 * time.Second,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Fetch Apache Tomcat Security Vulnerabilities")
+	if err := options.fetch(); err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+
+	return nil
+}
+
+func (opts options) fetch() error {
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
+
+	us, err := opts.fetchIndexOf(client)
+	if err != nil {
+		return errors.Wrap(err, "fetch index of")
+	}
+	if len(us) == 0 {
+		return errors.Errorf("no %s found in %s", securityPagePattern.String(), opts.baseURL)
+	}
+
+	if err := client.PipelineGet(us, opts.concurrency, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d for %q", resp.StatusCode, path.Base(resp.Request.URL.Path))
+		}
+
+		b := path.Base(resp.Request.URL.Path)
+		m := securityPagePattern.FindStringSubmatch(b)
+		if m == nil {
+			return errors.Errorf("unexpected file name. expected: %q, actual: %q", securityPagePattern.String(), b)
+		}
+
+		var doc document
+		if err := xml.NewDecoder(resp.Body).Decode(&doc); err != nil {
+			return errors.Wrapf(err, "decode %s as xml", b)
+		}
+
+		a := parse(m[1], doc)
+		if err := util.Write(filepath.Join(opts.dir, fmt.Sprintf("%s.json", a.Branch)), a); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, fmt.Sprintf("%s.json", a.Branch)))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "pipeline get")
+	}
+
+	return nil
+}
+
+// fetchIndexOf collects the per-branch vulnerability listings linked from the
+// xdocs directory index. security-*.xml files that document policy rather than
+// vulnerabilities are skipped by name; anything else matching the pattern is
+// treated as a branch listing, so a new branch (security-12.xml) is picked up
+// without a code change.
+func (opts options) fetchIndexOf(client *utilhttp.Client) ([]string, error) {
+	resp, err := client.Get(opts.baseURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "fetch %s", opts.baseURL)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, errors.Errorf("error response with status code %d", resp.StatusCode)
+	}
+
+	d, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse as html")
+	}
+
+	var us []string
+	for _, s := range d.Find("a").EachIter() {
+		href, ok := s.Attr("href")
+		if !ok {
+			continue
+		}
+
+		ref, err := url.Parse(href)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse %s", href)
+		}
+		u := resp.Request.URL.ResolveReference(ref)
+
+		b := path.Base(u.Path)
+		if slices.Contains(nonVulnerabilityPages, b) || !securityPagePattern.MatchString(b) {
+			continue
+		}
+		if !slices.Contains(us, u.String()) {
+			us = append(us, u.String())
+		}
+	}
+
+	return us, nil
+}
+
+// parse attaches the branch to the decoded document. The page's own structure
+// is preserved as decoded; grouping its paragraphs into vulnerabilities is the
+// extractor's job.
+func parse(branch string, doc document) Advisory {
+	return Advisory{
+		Branch:     branch,
+		Properties: doc.Properties,
+		Sections:   doc.Body.Sections,
+	}
+}

--- a/pkg/fetch/apache/tomcat/xml/xml_test.go
+++ b/pkg/fetch/apache/tomcat/xml/xml_test.go
@@ -1,0 +1,97 @@
+package xml_test
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	tomcat "github.com/MaineK00n/vuls-data-update/pkg/fetch/apache/tomcat/xml"
+)
+
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+		},
+		{
+			name:     "notfound",
+			hasError: true,
+		},
+		{
+			name:     "no-security-page",
+			hasError: true,
+		},
+		{
+			name:     "invalid-xml",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasSuffix(r.URL.Path, "/xdocs/"):
+					http.ServeFile(w, r, filepath.Join("testdata", "fixtures", tt.name, "indexof.html"))
+				default:
+					http.ServeFile(w, r, filepath.Join("testdata", "fixtures", tt.name, path.Base(r.URL.Path)))
+				}
+			}))
+			defer ts.Close()
+
+			u, err := url.JoinPath(ts.URL, "xdocs/")
+			if err != nil {
+				t.Error("unexpected error:", err)
+			}
+
+			dir := t.TempDir()
+			err = tomcat.Fetch(tomcat.WithBaseURL(u), tomcat.WithDir(dir), tomcat.WithRetry(0), tomcat.WithConcurrency(1), tomcat.WithWait(0))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			default:
+				if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+					if err != nil {
+						return err
+					}
+
+					if d.IsDir() {
+						return nil
+					}
+
+					dir, file := filepath.Split(strings.TrimPrefix(path, dir))
+					want, err := os.ReadFile(filepath.Join("testdata", "golden", tt.name, dir, url.QueryEscape(file)))
+					if err != nil {
+						return err
+					}
+
+					got, err := os.ReadFile(path)
+					if err != nil {
+						return err
+					}
+
+					if diff := cmp.Diff(want, got); diff != "" {
+						t.Errorf("Fetch(). (-expected +got):\n%s", diff)
+					}
+
+					return nil
+				}); err != nil {
+					t.Error("walk error:", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds Apache Tomcat security vulnerabilities as a data source, covering the
3.x–11.x server branches plus the separately-released JK, Native and Taglibs
components.

- `fetch apache-tomcat-xml` — 12 pages → one raw JSON per branch
- `extract apache-tomcat-xml` — 264 CVEs with CPE detections

## Why

`https://tomcat.apache.org/security.html` is the authoritative source for
which Tomcat releases an issue affects. It carries per-branch affected ranges
and fix versions that NVD's CPE data often states less precisely, and it
covers EOL branches whose CVE records report affected status as unknown.

## How

**Fetches the xdocs source, not the rendered HTML.** The site is built from
`security-<branch>.xml` in SVN, which marks up what the extractor needs —
`<cve>` for an entry's own CVEs, the `rtext` attribute for the release date,
`<hashlink>`/`<revlink>`/`<bug>` for fix references. The published page leaves
all of that to be recovered from link targets and CSS classes, and breaks on
any template change.

### Where the fetch/extract line is drawn

The document declares its structure only down to the section, so that is where
the mapping stops:

| | |
|---|---|
| `<document>`, `<properties>`, `<section name= rtext=>` | declared elements → typed fields, one for one |
| everything inside a `<section>` | prose → kept verbatim as `innerxml` |

The vulnerabilities are **not elements**. A section is a flat run of
paragraphs, and where one vulnerability ends and the next begins is a layout
convention. Recovering them is a hypothesis about the document rather than a
reading of it — and one that already needs three special cases — so it lives
in extract, where it can be revised against the whole history of the raw
repository without re-fetching.

This is the same split `pkg/fetch/gentoo` makes: GLSA's declared fields are
typed, its `<description>`/`<impact>` bodies are `innerxml`.

**Fidelity is verified, not asserted.** Each page is reconstructed from its
fetched JSON and compared element-tree-to-element-tree against the source:
**12/12 pages, 14030 nodes, identical.**

### What extract has to handle

Upstream irregularities, each of which loses data if missed:

| | |
|---|---|
| 10 entry headers quote an earlier CVE inside their `<strong>` title | only top-level `<cve>` children identify the entry |
| 3 entries predate the `<cve>` tag | fall back to the `cvename.cgi` anchor |
| `<strong>` also introduces prose notes carrying no CVE | not headers |
| 61 blocks are `<ul>`/`<ol>` lists or a mistyped `<o>` paragraph | every section child is parsed, not only `<p>` |
| 5.x–9.x write `9.0.0.M1` where 10.x/11.x write `10.1.0-M1` | dotted milestone normalized (108 bounds); the dotted form is not a parseable version at all |
| `5.0.SVN` names a branch, not a release | reported as unrecognized rather than becoming a bound no version can satisfy |

Unrecognized tokens are warned about, never dropped silently — the same field
also carries downstream distribution names on entries that are not Tomcat
vulnerabilities.

**Merge across branches.** A CVE is listed once per affected branch, each
listing with its own range, fix commit and upgrade wording; 204 of 264 CVEs
appear on 2+ pages. `Data.Merge` keeps them under one root ID, with the branch
carried as the segment and condition tag so each part stays attributable.

**CPEs.** `apache:tomcat` for numbered branches; the components map to
`tomcat_connectors` + `tomcat_jk_connector` (NVD indexes JK under both
spellings, and the db-side index is built from main CPEs, so each spelling
needs its own criterion), `tomcat_native` and `standard_taglibs`. A page whose
name is not a branch number and has no CPE listed emits no detection rather
than attributing its versions to the server.

### Known limitations

- `hashicorp/go-version` compares prerelease segments lexicographically, so
  `M2 > M10`. This affects ranges whose *both* bounds are milestones of the
  same release (44 of 730) and only for hosts on milestone builds; released
  versions compare correctly. Fixing it properly means a `RangeTypeTomcat`
  comparator in `cpecriterion/range` — deliberately left out of this PR.
- `3.3.1a` parses as `3.3.1-a` and sorts before `3.3.1` rather than after
  (2 entries, Tomcat 3.x, EOL since 2004).
- `4.1.SVN` / `5.0.SVN` yield no range (2 entries, both EOL branches). Warned
  at extract time.

Both are extract-side concerns, so neither needs a re-fetch to fix.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` — full suite passes
- `golangci-lint run pkg/fetch/apache/... pkg/extract/apache/...` — 0 issues
- Fetcher: httptest golden test with fixtures exercising every markup shape
  above, plus 3 error cases (404, no security page, malformed XML)
- Extractor: golden test, plus table-driven unit tests for entry recovery
  (`entry_test.go`, 11 cases incl. a malformed fragment) and for the
  `Affects:` grammar and section-title parsing (`affects_test.go`)
- Ran end-to-end against the live source: 12 pages → **387 sections / 3503
  blocks fetched with nothing dropped** → **679 entries, 0 unclassified CVE
  references** → **264 CVEs, 730 version ranges, 0 inverted**, 2 warnings (the
  known `.SVN` cases)
- Round-trip: every page reconstructs from its JSON identically to the source
  (12/12, 14030 nodes)
- Determinism: extracted the same fixtures twice into separate directories,
  byte-identical

## Checklist

- [x] Tests pass
- [x] Golden files updated (if applicable)
- [x] Deterministic output verified (if types changed)
- [x] Backward compatibility maintained (if types/data changed) — the only
      `pkg/extract/types` change is one additive `SourceID` constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
