### PR TITLE
fix(extract/suse/oval): support "less than or equal" rpminfo_state evr operation

### DIFF
--- a/pkg/extract/suse/oval/oval.go
+++ b/pkg/extract/suse/oval/oval.go
@@ -858,10 +858,8 @@ func (e extractor) translateEVRCriterion(oc oval.Criterion, t oval.RpminfoTest, 
 			},
 		}, nil
 	case "less than or equal":
-		// Used in "<package> was already fixed" criteria (present since 2026-07-22; their
-		// original "greater than <fixed version>" encoding was a generation mistake, replaced
-		// with this relation in the 2026-08-02 regeneration).
-		// The bound is the last vulnerable build, so this is a regular fixed-range criterion.
+		// Used in "<package> was already fixed" criteria. The bound is the last vulnerable
+		// build, so this is a regular fixed-range criterion.
 		return translated{
 			criterion: &criterionTypes.Criterion{
 				Type: criterionTypes.CriterionTypeVersion,

--- a/pkg/extract/suse/oval/oval.go
+++ b/pkg/extract/suse/oval/oval.go
@@ -858,8 +858,9 @@ func (e extractor) translateEVRCriterion(oc oval.Criterion, t oval.RpminfoTest, 
 			},
 		}, nil
 	case "less than or equal":
-		// Used in "<package> was already fixed" criteria (since 2026-07-22, replacing a
-		// mistaken "greater than <fixed version>" encoding in the 2026-08-02 regeneration).
+		// Used in "<package> was already fixed" criteria (present since 2026-07-22; their
+		// original "greater than <fixed version>" encoding was a generation mistake, replaced
+		// with this relation in the 2026-08-02 regeneration).
 		// The bound is the last vulnerable build, so this is a regular fixed-range criterion.
 		return translated{
 			criterion: &criterionTypes.Criterion{
@@ -1032,6 +1033,6 @@ func (e extractor) translateEVRCriterion(oc oval.Criterion, t oval.RpminfoTest, 
 			return translated{}, errors.Errorf("unexpected rpminfo_test check. test: %s, expected: %q, actual: %q", oc.TestRef, []string{"at least one", "all", "none satisfy"}, t.Check)
 		}
 	default:
-		return translated{}, errors.Errorf("unexpected evr operation. test: %s, check: %q, expected: %q, actual: %q", oc.TestRef, "at least one", []string{"less than", "less than or equal", "equals", "greater than", "greater than or equal"}, s.Evr.Operation)
+		return translated{}, errors.Errorf("unexpected evr operation. test: %s, check: %q, expected: %q, actual: %q", oc.TestRef, t.Check, []string{"less than", "less than or equal", "equals", "greater than", "greater than or equal"}, s.Evr.Operation)
 	}
 }

--- a/pkg/extract/suse/oval/oval.go
+++ b/pkg/extract/suse/oval/oval.go
@@ -857,6 +857,28 @@ func (e extractor) translateEVRCriterion(oc oval.Criterion, t oval.RpminfoTest, 
 				},
 			},
 		}, nil
+	case "less than or equal":
+		// Used in "<package> was already fixed" criteria (since 2026-07-22, replacing a
+		// mistaken "greater than <fixed version>" encoding in the 2026-08-02 regeneration).
+		// The bound is the last vulnerable build, so this is a regular fixed-range criterion.
+		return translated{
+			criterion: &criterionTypes.Criterion{
+				Type: criterionTypes.CriterionTypeVersion,
+				Version: &vcTypes.Criterion{
+					Vulnerable: true,
+					FixStatus: &fixstatusTypes.FixStatus{
+						Class: fixstatusTypes.ClassFixed,
+					},
+					Package: pkg,
+					Affected: &affectedTypes.Affected{
+						Type: affectedrangeTypes.RangeTypeRPM,
+						Range: []affectedrangeTypes.Range{{
+							LessEqual: s.Evr.Text,
+						}},
+					},
+				},
+			},
+		}, nil
 	case "equals":
 		// Should be siblings of kernel-livepatch patterns, sanity check.
 		if !strings.HasPrefix(o.Name, "kernel-") {
@@ -1010,6 +1032,6 @@ func (e extractor) translateEVRCriterion(oc oval.Criterion, t oval.RpminfoTest, 
 			return translated{}, errors.Errorf("unexpected rpminfo_test check. test: %s, expected: %q, actual: %q", oc.TestRef, []string{"at least one", "all", "none satisfy"}, t.Check)
 		}
 	default:
-		return translated{}, errors.Errorf("unexpected evr operation. test: %s, check: %q, expected: %q, actual: %q", oc.TestRef, "at least one", []string{"less than", "equals", "greater than", "greater than or equal"}, s.Evr.Operation)
+		return translated{}, errors.Errorf("unexpected evr operation. test: %s, check: %q, expected: %q, actual: %q", oc.TestRef, "at least one", []string{"less than", "less than or equal", "equals", "greater than", "greater than or equal"}, s.Evr.Operation)
 	}
 }

--- a/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/definitions/oval%3Aorg.opensuse.security%3Adef%3A19990512.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/definitions/oval%3Aorg.opensuse.security%3Adef%3A19990512.json
@@ -1,0 +1,80 @@
+{
+	"id": "oval:org.opensuse.security:def:19990512",
+	"version": "1",
+	"class": "vulnerability",
+	"metadata": {
+		"title": "CVE-1999-0512",
+		"affected": {
+			"family": "unix",
+			"platform": [
+				"openSUSE Leap 16.0"
+			]
+		},
+		"reference": [
+			{
+				"ref_id": "Mitre CVE-1999-0512",
+				"ref_url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0512",
+				"source": "CVE"
+			},
+			{
+				"ref_id": "SUSE CVE-1999-0512",
+				"ref_url": "https://www.suse.com/security/cve/CVE-1999-0512",
+				"source": "SUSE CVE"
+			}
+		],
+		"description": "\n    A mail server is explicitly configured to allow SMTP mail relay, which allows abuse by spammers.\n    ",
+		"advisory": {
+			"from": "security@suse.de",
+			"severity": "Moderate",
+			"cve": [
+				{
+					"text": "CVE-1999-0512 at SUSE",
+					"href": "https://www.suse.com/security/cve/CVE-1999-0512/",
+					"impact": "medium",
+					"cvss3": "6.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L",
+					"cvss4": "6.9/CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:L/SC:N/SI:N/SA:N"
+				},
+				{
+					"text": "CVE-1999-0512 at NVD",
+					"href": "https://nvd.nist.gov/vuln/detail/CVE-1999-0512"
+				}
+			],
+			"bugzilla": [
+				{
+					"text": "SUSE bug 1259249",
+					"href": "https://bugzilla.suse.com/1259249"
+				}
+			],
+			"issued": {
+				"date": "2026-07-22"
+			},
+			"updated": {
+				"date": "2026-07-31"
+			}
+		}
+	},
+	"criteria": {
+		"operator": "AND",
+		"criterias": [
+			{
+				"operator": "OR",
+				"criterions": [
+					{
+						"test_ref": "oval:org.opensuse.security:tst:2010121326",
+						"comment": "postfix was already fixed"
+					},
+					{
+						"test_ref": "oval:org.opensuse.security:tst:2009703857",
+						"comment": "sendmail was already fixed"
+					}
+				]
+			}
+		],
+		"criterions": [
+			{
+				"test_ref": "oval:org.opensuse.security:tst:2010063062",
+				"comment": "openSUSE Leap 16.0 is installed"
+			}
+		]
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009030854.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009030854.json
@@ -1,0 +1,6 @@
+{
+	"id": "oval:org.opensuse.security:obj:2009030854",
+	"version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"name": "postfix"
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009031187.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009031187.json
@@ -1,0 +1,6 @@
+{
+	"id": "oval:org.opensuse.security:obj:2009031187",
+	"version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"name": "sendmail"
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009072405.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009072405.json
@@ -1,0 +1,6 @@
+{
+	"id": "oval:org.opensuse.security:obj:2009072405",
+	"version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"name": "Leap-release"
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/states/rpminfo_state/oval%3Aorg.opensuse.security%3Aste%3A2009079459.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/states/rpminfo_state/oval%3Aorg.opensuse.security%3Aste%3A2009079459.json
@@ -1,0 +1,10 @@
+{
+	"id": "oval:org.opensuse.security:ste:2009079459",
+	"attr_version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"evr": {
+		"text": "0:0-0",
+		"datatype": "evr_string",
+		"operation": "greater than"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/states/rpminfo_state/oval%3Aorg.opensuse.security%3Aste%3A2009243663.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/states/rpminfo_state/oval%3Aorg.opensuse.security%3Aste%3A2009243663.json
@@ -1,0 +1,9 @@
+{
+	"id": "oval:org.opensuse.security:ste:2009243663",
+	"attr_version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"version": {
+		"text": "16.0",
+		"operation": "equals"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/states/rpminfo_state/oval%3Aorg.opensuse.security%3Aste%3A2009263830.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/states/rpminfo_state/oval%3Aorg.opensuse.security%3Aste%3A2009263830.json
@@ -1,0 +1,10 @@
+{
+	"id": "oval:org.opensuse.security:ste:2009263830",
+	"attr_version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"evr": {
+		"text": "0:3.10.2-160000.3.1",
+		"datatype": "evr_string",
+		"operation": "less than or equal"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2009703857.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2009703857.json
@@ -1,0 +1,13 @@
+{
+	"id": "oval:org.opensuse.security:tst:2009703857",
+	"version": "1",
+	"comment": "sendmail is >0",
+	"check": "at least one",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"object": {
+		"object_ref": "oval:org.opensuse.security:obj:2009031187"
+	},
+	"state": {
+		"state_ref": "oval:org.opensuse.security:ste:2009079459"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010063062.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010063062.json
@@ -1,0 +1,13 @@
+{
+	"id": "oval:org.opensuse.security:tst:2010063062",
+	"version": "1",
+	"comment": "Leap-release is ==16.0",
+	"check": "at least one",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"object": {
+		"object_ref": "oval:org.opensuse.security:obj:2009072405"
+	},
+	"state": {
+		"state_ref": "oval:org.opensuse.security:ste:2009243663"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121326.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/opensuse.leap/16.0/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121326.json
@@ -1,0 +1,13 @@
+{
+	"id": "oval:org.opensuse.security:tst:2010121326",
+	"version": "1",
+	"comment": "postfix is <=3.10.2-160000.3.1",
+	"check": "at least one",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"object": {
+		"object_ref": "oval:org.opensuse.security:obj:2009030854"
+	},
+	"state": {
+		"state_ref": "oval:org.opensuse.security:ste:2009263830"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/definitions/oval%3Aorg.opensuse.security%3Adef%3A19990512.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/definitions/oval%3Aorg.opensuse.security%3Adef%3A19990512.json
@@ -1,0 +1,148 @@
+{
+	"id": "oval:org.opensuse.security:def:19990512",
+	"version": "1",
+	"class": "vulnerability",
+	"metadata": {
+		"title": "CVE-1999-0512",
+		"affected": {
+			"family": "unix",
+			"platform": [
+				"SUSE Linux Enterprise Server 16.0",
+				"SUSE Linux Enterprise Server for SAP applications 16.0"
+			]
+		},
+		"reference": [
+			{
+				"ref_id": "Mitre CVE-1999-0512",
+				"ref_url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0512",
+				"source": "CVE"
+			},
+			{
+				"ref_id": "SUSE CVE-1999-0512",
+				"ref_url": "https://www.suse.com/security/cve/CVE-1999-0512",
+				"source": "SUSE CVE"
+			}
+		],
+		"description": "\n    A mail server is explicitly configured to allow SMTP mail relay, which allows abuse by spammers.\n    ",
+		"advisory": {
+			"from": "security@suse.de",
+			"severity": "Moderate",
+			"cve": [
+				{
+					"text": "CVE-1999-0512 at SUSE",
+					"href": "https://www.suse.com/security/cve/CVE-1999-0512/",
+					"impact": "medium",
+					"cvss3": "6.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L",
+					"cvss4": "6.9/CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:L/SC:N/SI:N/SA:N"
+				},
+				{
+					"text": "CVE-1999-0512 at NVD",
+					"href": "https://nvd.nist.gov/vuln/detail/CVE-1999-0512"
+				}
+			],
+			"bugzilla": [
+				{
+					"text": "SUSE bug 1259249",
+					"href": "https://bugzilla.suse.com/1259249"
+				}
+			],
+			"issued": {
+				"date": "2026-07-22"
+			},
+			"updated": {
+				"date": "2026-07-31"
+			},
+			"affected_cpe_list": {
+				"cpe": [
+					"cpe:/o:suse:sles:16:16.0:server",
+					"cpe:/o:suse:sles:16:16.0:server-sap"
+				]
+			}
+		}
+	},
+	"criteria": {
+		"operator": "OR",
+		"criterias": [
+			{
+				"operator": "AND",
+				"criterias": [
+					{
+						"operator": "OR",
+						"criterions": [
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121326",
+								"comment": "postfix was already fixed"
+							},
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121517",
+								"comment": "postfix-doc was already fixed"
+							},
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121518",
+								"comment": "postfix-ldap was already fixed"
+							},
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121519",
+								"comment": "postfix-mysql was already fixed"
+							},
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121520",
+								"comment": "postfix-postgresql was already fixed"
+							},
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2009703489",
+								"comment": "libmilter1_0 was already fixed"
+							}
+						]
+					}
+				],
+				"criterions": [
+					{
+						"test_ref": "oval:org.opensuse.security:tst:2010029126",
+						"comment": "SUSE Linux Enterprise Server for SAP applications 16.0 is installed"
+					}
+				]
+			},
+			{
+				"operator": "AND",
+				"criterias": [
+					{
+						"operator": "OR",
+						"criterions": [
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121326",
+								"comment": "postfix was already fixed"
+							},
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121517",
+								"comment": "postfix-doc was already fixed"
+							},
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121518",
+								"comment": "postfix-ldap was already fixed"
+							},
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121519",
+								"comment": "postfix-mysql was already fixed"
+							},
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121520",
+								"comment": "postfix-postgresql was already fixed"
+							},
+							{
+								"test_ref": "oval:org.opensuse.security:tst:2010121521",
+								"comment": "libmilter1_0 was already fixed"
+							}
+						]
+					}
+				],
+				"criterions": [
+					{
+						"test_ref": "oval:org.opensuse.security:tst:2010025976",
+						"comment": "SUSE Linux Enterprise Server 16.0 is installed"
+					}
+				]
+			}
+		]
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009030854.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009030854.json
@@ -1,0 +1,6 @@
+{
+	"id": "oval:org.opensuse.security:obj:2009030854",
+	"version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"name": "postfix"
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009031754.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009031754.json
@@ -1,0 +1,6 @@
+{
+	"id": "oval:org.opensuse.security:obj:2009031754",
+	"version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"name": "postfix-mysql"
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009031755.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009031755.json
@@ -1,0 +1,6 @@
+{
+	"id": "oval:org.opensuse.security:obj:2009031755",
+	"version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"name": "postfix-postgresql"
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009033606.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009033606.json
@@ -1,0 +1,6 @@
+{
+	"id": "oval:org.opensuse.security:obj:2009033606",
+	"version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"name": "postfix-doc"
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009060201.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009060201.json
@@ -1,0 +1,6 @@
+{
+	"id": "oval:org.opensuse.security:obj:2009060201",
+	"version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"name": "libmilter1_0"
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009062490.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval%3Aorg.opensuse.security%3Aobj%3A2009062490.json
@@ -1,0 +1,6 @@
+{
+	"id": "oval:org.opensuse.security:obj:2009062490",
+	"version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"name": "postfix-ldap"
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/states/rpminfo_state/oval%3Aorg.opensuse.security%3Aste%3A2009263830.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/states/rpminfo_state/oval%3Aorg.opensuse.security%3Aste%3A2009263830.json
@@ -1,0 +1,10 @@
+{
+	"id": "oval:org.opensuse.security:ste:2009263830",
+	"attr_version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"evr": {
+		"text": "0:3.10.2-160000.3.1",
+		"datatype": "evr_string",
+		"operation": "less than or equal"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/states/rpminfo_state/oval%3Aorg.opensuse.security%3Aste%3A2009263939.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/states/rpminfo_state/oval%3Aorg.opensuse.security%3Aste%3A2009263939.json
@@ -1,0 +1,10 @@
+{
+	"id": "oval:org.opensuse.security:ste:2009263939",
+	"attr_version": "1",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"evr": {
+		"text": "0:8.18.1-160000.2.2",
+		"datatype": "evr_string",
+		"operation": "less than or equal"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2009703489.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2009703489.json
@@ -1,0 +1,13 @@
+{
+	"id": "oval:org.opensuse.security:tst:2009703489",
+	"version": "1",
+	"comment": "libmilter1_0 is >0",
+	"check": "at least one",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"object": {
+		"object_ref": "oval:org.opensuse.security:obj:2009060201"
+	},
+	"state": {
+		"state_ref": "oval:org.opensuse.security:ste:2009079459"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121326.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121326.json
@@ -1,0 +1,13 @@
+{
+	"id": "oval:org.opensuse.security:tst:2010121326",
+	"version": "1",
+	"comment": "postfix is <=3.10.2-160000.3.1",
+	"check": "at least one",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"object": {
+		"object_ref": "oval:org.opensuse.security:obj:2009030854"
+	},
+	"state": {
+		"state_ref": "oval:org.opensuse.security:ste:2009263830"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121517.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121517.json
@@ -1,0 +1,13 @@
+{
+	"id": "oval:org.opensuse.security:tst:2010121517",
+	"version": "1",
+	"comment": "postfix-doc is <=3.10.2-160000.3.1",
+	"check": "at least one",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"object": {
+		"object_ref": "oval:org.opensuse.security:obj:2009033606"
+	},
+	"state": {
+		"state_ref": "oval:org.opensuse.security:ste:2009263830"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121518.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121518.json
@@ -1,0 +1,13 @@
+{
+	"id": "oval:org.opensuse.security:tst:2010121518",
+	"version": "1",
+	"comment": "postfix-ldap is <=3.10.2-160000.3.1",
+	"check": "at least one",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"object": {
+		"object_ref": "oval:org.opensuse.security:obj:2009062490"
+	},
+	"state": {
+		"state_ref": "oval:org.opensuse.security:ste:2009263830"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121519.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121519.json
@@ -1,0 +1,13 @@
+{
+	"id": "oval:org.opensuse.security:tst:2010121519",
+	"version": "1",
+	"comment": "postfix-mysql is <=3.10.2-160000.3.1",
+	"check": "at least one",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"object": {
+		"object_ref": "oval:org.opensuse.security:obj:2009031754"
+	},
+	"state": {
+		"state_ref": "oval:org.opensuse.security:ste:2009263830"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121520.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121520.json
@@ -1,0 +1,13 @@
+{
+	"id": "oval:org.opensuse.security:tst:2010121520",
+	"version": "1",
+	"comment": "postfix-postgresql is <=3.10.2-160000.3.1",
+	"check": "at least one",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"object": {
+		"object_ref": "oval:org.opensuse.security:obj:2009031755"
+	},
+	"state": {
+		"state_ref": "oval:org.opensuse.security:ste:2009263830"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121521.json
+++ b/pkg/extract/suse/oval/testdata/fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval%3Aorg.opensuse.security%3Atst%3A2010121521.json
@@ -1,0 +1,13 @@
+{
+	"id": "oval:org.opensuse.security:tst:2010121521",
+	"version": "1",
+	"comment": "libmilter1_0 is <=8.18.1-160000.2.2",
+	"check": "at least one",
+	"xmlns": "http://oval.mitre.org/XMLSchema/oval-definitions-5#linux",
+	"object": {
+		"object_ref": "oval:org.opensuse.security:obj:2009060201"
+	},
+	"state": {
+		"state_ref": "oval:org.opensuse.security:ste:2009263939"
+	}
+}

--- a/pkg/extract/suse/oval/testdata/golden/data/1999/CVE-1999-0512.json
+++ b/pkg/extract/suse/oval/testdata/golden/data/1999/CVE-1999-0512.json
@@ -1,0 +1,534 @@
+{
+	"id": "CVE-1999-0512",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-1999-0512",
+				"title": "CVE-1999-0512",
+				"description": "A mail server is explicitly configured to allow SMTP mail relay, which allows abuse by spammers.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "SUSE",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L",
+							"base_score": 6.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 6.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.5,
+							"environmental_severity": "MEDIUM"
+						}
+					},
+					{
+						"type": "cvss_v40",
+						"source": "SUSE",
+						"cvss_v40": {
+							"vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:L/SC:N/SI:N/SA:N",
+							"score": 6.9,
+							"severity": "MEDIUM"
+						}
+					},
+					{
+						"type": "vendor",
+						"source": "SUSE Severity",
+						"vendor": "Moderate"
+					},
+					{
+						"type": "vendor",
+						"source": "SUSE impact",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "CVE",
+						"url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0512"
+					},
+					{
+						"source": "NVD",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-1999-0512"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://bugzilla.suse.com/1259249"
+					},
+					{
+						"source": "SUSE",
+						"url": "https://www.suse.com/security/cve/CVE-1999-0512"
+					}
+				],
+				"published": "2026-07-22T00:00:00Z",
+				"modified": "2026-07-31T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "opensuse.leap:16.0"
+				},
+				{
+					"ecosystem": "suse.linux.enterprise:16"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "opensuse.leap:16.0",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "AND",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "fixed"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "postfix"
+												}
+											},
+											"affected": {
+												"type": "rpm",
+												"range": [
+													{
+														"le": "0:3.10.2-160000.3.1"
+													}
+												]
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "unfixed"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "sendmail"
+												}
+											}
+										}
+									}
+								]
+							}
+						],
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": false,
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "Leap-release"
+										}
+									},
+									"affected": {
+										"type": "rpm-version-only",
+										"range": [
+											{
+												"eq": "16.0"
+											}
+										]
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"ecosystem": "suse.linux.enterprise:16",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "AND",
+								"criterias": [
+									{
+										"operator": "OR",
+										"criterions": [
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "postfix"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:3.10.2-160000.3.1"
+															}
+														]
+													}
+												}
+											},
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "postfix-doc"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:3.10.2-160000.3.1"
+															}
+														]
+													}
+												}
+											},
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "postfix-ldap"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:3.10.2-160000.3.1"
+															}
+														]
+													}
+												}
+											},
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "postfix-mysql"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:3.10.2-160000.3.1"
+															}
+														]
+													}
+												}
+											},
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "postfix-postgresql"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:3.10.2-160000.3.1"
+															}
+														]
+													}
+												}
+											},
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "unfixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "libmilter1_0"
+														}
+													}
+												}
+											}
+										]
+									}
+								],
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": false,
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "SLES_SAP-release"
+												}
+											},
+											"affected": {
+												"type": "rpm-version-only",
+												"range": [
+													{
+														"eq": "16.0"
+													}
+												]
+											}
+										}
+									}
+								]
+							},
+							{
+								"operator": "AND",
+								"criterias": [
+									{
+										"operator": "OR",
+										"criterions": [
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "libmilter1_0"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:8.18.1-160000.2.2"
+															}
+														]
+													}
+												}
+											},
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "postfix"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:3.10.2-160000.3.1"
+															}
+														]
+													}
+												}
+											},
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "postfix-doc"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:3.10.2-160000.3.1"
+															}
+														]
+													}
+												}
+											},
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "postfix-ldap"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:3.10.2-160000.3.1"
+															}
+														]
+													}
+												}
+											},
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "postfix-mysql"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:3.10.2-160000.3.1"
+															}
+														]
+													}
+												}
+											},
+											{
+												"type": "version",
+												"version": {
+													"vulnerable": true,
+													"fix_status": {
+														"class": "fixed"
+													},
+													"package": {
+														"type": "binary",
+														"binary": {
+															"name": "postfix-postgresql"
+														}
+													},
+													"affected": {
+														"type": "rpm",
+														"range": [
+															{
+																"le": "0:3.10.2-160000.3.1"
+															}
+														]
+													}
+												}
+											}
+										]
+									}
+								],
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": false,
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "sles-release"
+												}
+											},
+											"affected": {
+												"type": "rpm-version-only",
+												"range": [
+													{
+														"eq": "16.0"
+													}
+												]
+											}
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "suse-oval",
+		"raws": [
+			"fixtures/opensuse.leap/16.0/vulnerability/definitions/oval:org.opensuse.security:def:19990512.json",
+			"fixtures/opensuse.leap/16.0/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009030854.json",
+			"fixtures/opensuse.leap/16.0/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009031187.json",
+			"fixtures/opensuse.leap/16.0/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009072405.json",
+			"fixtures/opensuse.leap/16.0/vulnerability/states/rpminfo_state/oval:org.opensuse.security:ste:2009079459.json",
+			"fixtures/opensuse.leap/16.0/vulnerability/states/rpminfo_state/oval:org.opensuse.security:ste:2009243663.json",
+			"fixtures/opensuse.leap/16.0/vulnerability/states/rpminfo_state/oval:org.opensuse.security:ste:2009263830.json",
+			"fixtures/opensuse.leap/16.0/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2009703857.json",
+			"fixtures/opensuse.leap/16.0/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2010063062.json",
+			"fixtures/opensuse.leap/16.0/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2010121326.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/definitions/oval:org.opensuse.security:def:19990512.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009030854.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009030884.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009031754.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009031755.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009033606.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009047546.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009060201.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/objects/rpminfo_object/oval:org.opensuse.security:obj:2009062490.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/states/rpminfo_state/oval:org.opensuse.security:ste:2009079459.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/states/rpminfo_state/oval:org.opensuse.security:ste:2009243663.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/states/rpminfo_state/oval:org.opensuse.security:ste:2009263830.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/states/rpminfo_state/oval:org.opensuse.security:ste:2009263939.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2009703489.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2010025976.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2010029126.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2010121326.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2010121517.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2010121518.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2010121519.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2010121520.json",
+			"fixtures/suse.linux.enterprise/16/vulnerability/tests/rpminfo_test/oval:org.opensuse.security:tst:2010121521.json"
+		]
+	}
+}


### PR DESCRIPTION
## What

Add `less than or equal` to the rpminfo_state EVR operations handled by `translateEVRCriterion`, translating it as a regular fixed-range criterion (`le` on an rpm range, `Vulnerable: true`, fix status `fixed`).

## Why

`extract suse-oval` in the vuls-data-db "Extract All" pipeline currently fails with:

```
unexpected evr operation. test: oval:org.opensuse.security:tst:2010121326, check: "at least one", expected: ["less than" "equals" "greater than" "greater than or equal"], actual: "less than or equal"
```

Background: since 2026-07-22 the SUSE `-affected` OVAL files (openSUSE Leap 16.0, SLE 12/15/16, SLE Micro 5, SL Micro 6 — ~14,000 definitions) carry `<package> was already fixed` criteria. Their initial encoding — `greater than` a concrete version, which read literally marked *patched* systems as vulnerable — was reported to SUSE, who confirmed it was a data generation mistake. The 2026-08-02 regeneration replaced it with a spec-conformant `less than or equal <last vulnerable build>` relation (e.g. `postfix is <=3.10.2-160000.3.1`), which the extractor did not support yet.

The remaining `was already fixed` criteria of the form `greater than 0:0-0` (package installed at all) are untouched by this PR; they translate as before (vulnerable/unfixed) and do not break the pipeline.

## How

- Add a `case "less than or equal"` to the EVR operation switch, mirroring the existing `less than` case but emitting `Range{LessEqual: ...}`.
- Include the new operation in the default-case error message.

## Testing

- Golden fixtures generated from the real regenerated data (raw dotgit HEAD, 2026-08-02): `oval:org.opensuse.security:def:19990512` (CVE-1999-0512) for both `opensuse.leap/16.0` and `suse.linux.enterprise/16`, covering the new `less than or equal` state, the surviving `greater than 0:0-0` form, and multi-release criteria.
- `GOEXPERIMENT=jsonv2 go test ./...` passes; pre-existing golden files are unchanged.
- Full end-to-end verification: ran `vuls-data-update extract suse-oval` against the latest `vuls-data-raw-suse-oval` dotgit HEAD (all 38 product directories, ~140k definitions) — completes without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)