### PR TITLE
feat(fetch,extract/nginx/security-advisories): add nginx security advisories data source

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -75,6 +75,7 @@ import (
 	mitreCWE "github.com/MaineK00n/vuls-data-update/pkg/extract/mitre/cwe"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/msf"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/netbsd"
+	nginxSecurityAdvisories "github.com/MaineK00n/vuls-data-update/pkg/extract/nginx/security-advisories"
 	npmDB "github.com/MaineK00n/vuls-data-update/pkg/extract/npm/db"
 	npmGHSA "github.com/MaineK00n/vuls-data-update/pkg/extract/npm/ghsa"
 	npmGLSA "github.com/MaineK00n/vuls-data-update/pkg/extract/npm/glsa"
@@ -183,6 +184,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
 		newCmdNetBSD(),
+		newCmdNginxSecurityAdvisories(),
 		newCmdNpmGHSA(), newCmdNpmGLSA(), newCmdNpmOSV(), newCmdNpmDB(),
 		newCmdNugetGHSA(), newCmdNugetGLSA(), newCmdNugetOSV(),
 		newCmdNucleiRepository(),
@@ -1880,6 +1882,31 @@ func newCmdNetBSD() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := netbsd.Extract(args[0], netbsd.WithDir(options.dir)); err != nil {
 				return errors.Wrap(err, "failed to extract netbsd")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdNginxSecurityAdvisories() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "nginx", "security-advisories"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "nginx-security-advisories <Raw nginx Security Advisories Repository PATH>",
+		Short: "Extract nginx Security Advisories data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract nginx-security-advisories vuls-data-raw-nginx-security-advisories
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := nginxSecurityAdvisories.Extract(args[0], nginxSecurityAdvisories.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract nginx security advisories")
 			}
 			return nil
 		},

--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -105,6 +105,7 @@ import (
 	"github.com/MaineK00n/vuls-data-update/pkg/fetch/msf"
 	ncscCSAF "github.com/MaineK00n/vuls-data-update/pkg/fetch/ncsc/csaf"
 	"github.com/MaineK00n/vuls-data-update/pkg/fetch/netbsd"
+	nginxSecurityAdvisories "github.com/MaineK00n/vuls-data-update/pkg/fetch/nginx/security-advisories"
 	nozominetworksCSAF "github.com/MaineK00n/vuls-data-update/pkg/fetch/nozominetworks/csaf"
 	npmGHSA "github.com/MaineK00n/vuls-data-update/pkg/fetch/npm/ghsa"
 	npmGLSA "github.com/MaineK00n/vuls-data-update/pkg/fetch/npm/glsa"
@@ -258,6 +259,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdMSF(),
 		newCmdNCSCCSAF(),
 		newCmdNetBSD(),
+		newCmdNginxSecurityAdvisories(),
 		newCmdNozomiNetworksCSAF(),
 		newCmdNpmGHSA(), newCmdNpmGLSA(), newCmdNpmOSV(), newCmdNpmDB(),
 		newCmdNucleiAPI(), newCmdNucleiRepository(),
@@ -3160,6 +3162,33 @@ func newCmdNetBSD() *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := netbsd.Fetch(netbsd.WithDir(options.dir), netbsd.WithRetry(options.retry)); err != nil {
 				return errors.Wrap(err, "failed to fetch netbsd")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
+
+	return cmd
+}
+
+func newCmdNginxSecurityAdvisories() *cobra.Command {
+	options := &base{
+		dir:   filepath.Join(util.CacheDir(), "fetch", "nginx", "security-advisories"),
+		retry: 3,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "nginx-security-advisories",
+		Short: "Fetch nginx Security Advisories data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch nginx-security-advisories
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := nginxSecurityAdvisories.Fetch(nginxSecurityAdvisories.WithDir(options.dir), nginxSecurityAdvisories.WithRetry(options.retry)); err != nil {
+				return errors.Wrap(err, "failed to fetch nginx security advisories")
 			}
 			return nil
 		},

--- a/pkg/extract/nginx/security-advisories/security-advisories.go
+++ b/pkg/extract/nginx/security-advisories/security-advisories.go
@@ -1,0 +1,338 @@
+package securityadvisories
+
+import (
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
+	advisoryContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory/content"
+	detectionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection"
+	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
+	criteriaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria"
+	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
+	ccTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion"
+	ccRangeTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/range"
+	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
+	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
+	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	remediationTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/remediation"
+	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	nginxSecurityAdvisories "github.com/MaineK00n/vuls-data-update/pkg/fetch/nginx/security-advisories"
+)
+
+// source names the publisher of every content the page carries.
+const source = "nginx.org"
+
+const (
+	// nginxCPE is the CPE the advisories describe. NVD files nginx releases
+	// under the f5 vendor regardless of when they were published, including
+	// the pre-F5 ones.
+	nginxCPE = "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*"
+	// windowsCPE qualifies the "nginx/Windows" entries. The Windows build is
+	// expressed as a platform the vulnerable nginx runs on, not as a variant
+	// of the nginx CPE, which is also how NVD publishes these advisories.
+	windowsCPE = "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*"
+)
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "nginx", "security-advisories"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract nginx Security Advisories")
+	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		r := utiljson.NewJSONReader()
+		var fetched nginxSecurityAdvisories.Advisory
+		if err := r.Read(path, args, &fetched); err != nil {
+			return errors.Wrapf(err, "read json %s", path)
+		}
+
+		extracted, err := extract(fetched, r.Paths())
+		if err != nil {
+			return errors.Wrapf(err, "extract %s", path)
+		}
+
+		if err := util.Write(filepath.Join(options.dir, "data", filepath.Base(filepath.Dir(path)), fmt.Sprintf("%s.json", extracted.ID)), extracted, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", filepath.Base(filepath.Dir(path)), fmt.Sprintf("%s.json", extracted.ID)))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", args)
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.NginxSecurityAdvisories,
+		Name: func() *string { s := "nginx Security Advisories"; return &s }(),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+func extract(fetched nginxSecurityAdvisories.Advisory, raws []string) (dataTypes.Data, error) {
+	ds, err := detections(fetched)
+	if err != nil {
+		return dataTypes.Data{}, errors.Wrap(err, "detections")
+	}
+
+	data := dataTypes.Data{
+		ID:         dataTypes.RootID(fetched.ID),
+		Detections: ds,
+		DataSource: sourceTypes.Source{
+			ID:   sourceTypes.NginxSecurityAdvisories,
+			Raws: raws,
+		},
+	}
+
+	// The page identifies almost every entry by its CVE, which becomes a
+	// Vulnerability carrying nginx's statement about it. The one entry that
+	// predates its CVE assignment is identified by a Core Security advisory ID
+	// instead; being advisory-class, it becomes an Advisory, mirroring how the
+	// paloalto extractor places a PAN-SA root.
+	ss, ms, rs := severities(fetched), mitigations(fetched), references(fetched)
+
+	if strings.HasPrefix(fetched.ID, "CVE-") {
+		data.Vulnerabilities = []vulnerabilityTypes.Vulnerability{{
+			Content: vulnerabilityContentTypes.Content{
+				ID:          vulnerabilityContentTypes.VulnerabilityID(fetched.ID),
+				Title:       fetched.Title,
+				Severity:    ss,
+				Mitigations: ms,
+				References:  rs,
+			},
+			Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeCPE}},
+		}}
+		return data, nil
+	}
+
+	data.Advisories = []advisoryTypes.Advisory{{
+		Content: advisoryContentTypes.Content{
+			ID:          advisoryContentTypes.AdvisoryID(fetched.ID),
+			Title:       fetched.Title,
+			Severity:    ss,
+			Mitigations: ms,
+			References:  rs,
+		},
+		Segments: []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeCPE}},
+	}}
+	return data, nil
+}
+
+// severities carries the page's own severity word ("none", "minor", "low",
+// "medium", "major") as a vendor severity. The page publishes no CVSS.
+func severities(fetched nginxSecurityAdvisories.Advisory) []severityTypes.Severity {
+	if fetched.Severity == "" {
+		return nil
+	}
+	return []severityTypes.Severity{{
+		Type:   severityTypes.SeverityTypeVendor,
+		Source: source,
+		Vendor: &fetched.Severity,
+	}}
+}
+
+// references keeps every link of the entry: the advisory article or mailing
+// list post, the CVE record, any CERT note, and the patch downloads.
+func references(fetched nginxSecurityAdvisories.Advisory) []referenceTypes.Reference {
+	refs := make([]referenceTypes.Reference, 0, len(fetched.References)+2*len(fetched.Patches))
+	for _, r := range fetched.References {
+		refs = append(refs, referenceTypes.Reference{Source: source, URL: r.URL})
+	}
+	for _, p := range fetched.Patches {
+		refs = append(refs, referenceTypes.Reference{Source: source, URL: p.URL})
+		if p.SignatureURL != "" {
+			refs = append(refs, referenceTypes.Reference{Source: source, URL: p.SignatureURL})
+		}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	return refs
+}
+
+// mitigations records the patches offered for releases that never got a fixed
+// build. The applicability remark ("(for 1.9.13-1.11.0)") is what tells the two
+// patches of an entry apart, so it is kept alongside the URL.
+func mitigations(fetched nginxSecurityAdvisories.Advisory) []remediationTypes.Remediation {
+	if len(fetched.Patches) == 0 {
+		return nil
+	}
+	rs := make([]remediationTypes.Remediation, 0, len(fetched.Patches))
+	for _, p := range fetched.Patches {
+		d := p.URL
+		if p.Note != "" {
+			d = fmt.Sprintf("%s %s", p.URL, p.Note)
+		}
+		rs = append(rs, remediationTypes.Remediation{Source: source, Description: d})
+	}
+	return rs
+}
+
+// detections turns the "Vulnerable:" / "Not vulnerable:" lists into criteria.
+// Each vulnerable entry becomes one child criteria of a top level OR, so the
+// entries that apply to the Windows build only can carry their platform without
+// constraining the others.
+func detections(fetched nginxSecurityAdvisories.Advisory) ([]detectionTypes.Detection, error) {
+	fixes, err := parseNotVulnerable(fetched.NotVulnerable)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse not vulnerable")
+	}
+
+	cas := make([]criteriaTypes.Criteria, 0, len(fetched.Vulnerable))
+	for _, s := range fetched.Vulnerable {
+		r, err := parseVulnerable(s)
+		if err != nil {
+			return nil, errors.Wrap(err, "parse vulnerable")
+		}
+
+		var cns []criterionTypes.Criterion
+		switch {
+		case r.All:
+			// Every release is affected and none is fixed: a bare criterion
+			// with no range, matching any nginx version.
+			cns = []criterionTypes.Criterion{nginxCriterion(nil)}
+		default:
+			is := affectedIntervals(r, fixes)
+			cns = make([]criterionTypes.Criterion, 0, len(is))
+			for _, i := range is {
+				cns = append(cns, nginxCriterion(&i))
+			}
+		}
+
+		ca := criteriaTypes.Criteria{Operator: criteriaTypes.CriteriaOperatorTypeOR, Criterions: cns}
+		if r.Windows {
+			ca = criteriaTypes.Criteria{
+				Operator: criteriaTypes.CriteriaOperatorTypeAND,
+				Criterias: []criteriaTypes.Criteria{
+					ca,
+					{
+						Operator: criteriaTypes.CriteriaOperatorTypeOR,
+						Criterions: []criterionTypes.Criterion{{
+							Type: criterionTypes.CriterionTypeCPE,
+							CPE: &ccTypes.Criterion{
+								// The platform is a precondition, not the
+								// vulnerable component.
+								Vulnerable: false,
+								CPE:        ccTypes.CPE(windowsCPE),
+							},
+						}},
+					},
+				},
+			}
+		}
+		cas = append(cas, ca)
+	}
+
+	if len(cas) == 0 {
+		return nil, nil
+	}
+
+	return []detectionTypes.Detection{{
+		Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+		Conditions: []conditionTypes.Condition{{
+			Criteria: criteriaTypes.Criteria{
+				Operator:  criteriaTypes.CriteriaOperatorTypeOR,
+				Criterias: cas,
+			},
+		}},
+	}}, nil
+}
+
+// nginxCriterion builds the criterion for one affected interval. A nil interval
+// means every version is affected, which is a criterion with no range.
+func nginxCriterion(i *interval) criterionTypes.Criterion {
+	c := ccTypes.Criterion{
+		Vulnerable: true,
+		CPE:        ccTypes.CPE(nginxCPE),
+	}
+
+	if i != nil {
+		c.Range = &ccRangeTypes.Range{
+			Type:         ccRangeTypes.RangeTypeVersion,
+			GreaterEqual: i.GreaterEqual.String(),
+		}
+		switch {
+		case i.LessThan != nil:
+			c.Range.LessThan = i.LessThan.String()
+		case i.LessEqual != nil:
+			c.Range.LessEqual = i.LessEqual.String()
+		}
+		if i.Fixed != nil {
+			c.Fixed = []string{i.Fixed.String()}
+		}
+	}
+
+	return criterionTypes.Criterion{Type: criterionTypes.CriterionTypeCPE, CPE: &c}
+}

--- a/pkg/extract/nginx/security-advisories/security-advisories_test.go
+++ b/pkg/extract/nginx/security-advisories/security-advisories_test.go
@@ -1,0 +1,47 @@
+package securityadvisories_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	securityadvisories "github.com/MaineK00n/vuls-data-update/pkg/extract/nginx/security-advisories"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := securityadvisories.Extract(tt.args, securityadvisories.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				// error was expected and occurred, test passed
+				return
+			default:
+				ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				gp, err := filepath.Abs(dir)
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}

--- a/pkg/extract/nginx/security-advisories/testdata/fixtures/2009/CVE-2009-3555.json
+++ b/pkg/extract/nginx/security-advisories/testdata/fixtures/2009/CVE-2009-3555.json
@@ -1,0 +1,28 @@
+{
+	"id": "CVE-2009-3555",
+	"title": "The renegotiation vulnerability in SSL protocol",
+	"severity": "major",
+	"not_vulnerable": [
+		"0.8.23+",
+		"0.7.64+"
+	],
+	"vulnerable": [
+		"0.1.0-0.8.22"
+	],
+	"references": [
+		{
+			"text": "VU#120541",
+			"url": "http://www.kb.cert.org/vuls/id/120541"
+		},
+		{
+			"text": "CVE-2009-3555",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2009-3555"
+		}
+	],
+	"patches": [
+		{
+			"url": "https://nginx.org/download/patch.cve-2009-3555.txt",
+			"signature_url": "https://nginx.org/download/patch.cve-2009-3555.txt.asc"
+		}
+	]
+}

--- a/pkg/extract/nginx/security-advisories/testdata/fixtures/2009/CVE-2009-4487.json
+++ b/pkg/extract/nginx/security-advisories/testdata/fixtures/2009/CVE-2009-4487.json
@@ -1,0 +1,17 @@
+{
+	"id": "CVE-2009-4487",
+	"title": "An error log data are not sanitized",
+	"severity": "none",
+	"not_vulnerable": [
+		"none"
+	],
+	"vulnerable": [
+		"all"
+	],
+	"references": [
+		{
+			"text": "CVE-2009-4487",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2009-4487"
+		}
+	]
+}

--- a/pkg/extract/nginx/security-advisories/testdata/fixtures/2010/CORE-2010-0121.json
+++ b/pkg/extract/nginx/security-advisories/testdata/fixtures/2010/CORE-2010-0121.json
@@ -1,0 +1,18 @@
+{
+	"id": "CORE-2010-0121",
+	"title": "Vulnerabilities with Windows 8.3 filename pseudonyms",
+	"severity": "major",
+	"not_vulnerable": [
+		"0.8.33+",
+		"0.7.65+"
+	],
+	"vulnerable": [
+		"nginx/Windows 0.7.52-0.8.32"
+	],
+	"references": [
+		{
+			"text": "CORE-2010-0121",
+			"url": "http://www.coresecurity.com/content/filename-pseudonyms-vulnerabilities"
+		}
+	]
+}

--- a/pkg/extract/nginx/security-advisories/testdata/fixtures/2011/CVE-2011-4963.json
+++ b/pkg/extract/nginx/security-advisories/testdata/fixtures/2011/CVE-2011-4963.json
@@ -1,0 +1,22 @@
+{
+	"id": "CVE-2011-4963",
+	"title": "Vulnerabilities with Windows directory aliases",
+	"severity": "medium",
+	"not_vulnerable": [
+		"1.3.1+",
+		"1.2.1+"
+	],
+	"vulnerable": [
+		"nginx/Windows 0.7.52-1.3.0"
+	],
+	"references": [
+		{
+			"text": "Advisory",
+			"url": "https://mailman.nginx.org/pipermail/nginx-announce/2012/000086.html"
+		},
+		{
+			"text": "CVE-2011-4963",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2011-4963"
+		}
+	]
+}

--- a/pkg/extract/nginx/security-advisories/testdata/fixtures/2013/CVE-2013-2070.json
+++ b/pkg/extract/nginx/security-advisories/testdata/fixtures/2013/CVE-2013-2070.json
@@ -1,0 +1,36 @@
+{
+	"id": "CVE-2013-2070",
+	"title": "Memory disclosure with specially crafted HTTP backend responses",
+	"severity": "medium",
+	"not_vulnerable": [
+		"1.5.0+",
+		"1.4.1+",
+		"1.2.9+"
+	],
+	"vulnerable": [
+		"1.1.4-1.2.8",
+		"1.3.9-1.4.0"
+	],
+	"references": [
+		{
+			"text": "Advisory",
+			"url": "https://mailman.nginx.org/pipermail/nginx-announce/2013/000114.html"
+		},
+		{
+			"text": "CVE-2013-2070",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2013-2070"
+		}
+	],
+	"patches": [
+		{
+			"url": "https://nginx.org/download/patch.2013.chunked.txt",
+			"signature_url": "https://nginx.org/download/patch.2013.chunked.txt.asc",
+			"note": "(for 1.3.9-1.4.0)"
+		},
+		{
+			"url": "https://nginx.org/download/patch.2013.proxy.txt",
+			"signature_url": "https://nginx.org/download/patch.2013.proxy.txt.asc",
+			"note": "(for 1.1.4-1.2.8)"
+		}
+	]
+}

--- a/pkg/extract/nginx/security-advisories/testdata/fixtures/2016/CVE-2016-4450.json
+++ b/pkg/extract/nginx/security-advisories/testdata/fixtures/2016/CVE-2016-4450.json
@@ -1,0 +1,34 @@
+{
+	"id": "CVE-2016-4450",
+	"title": "NULL pointer dereference while writing client request body",
+	"severity": "medium",
+	"not_vulnerable": [
+		"1.11.1+",
+		"1.10.1+"
+	],
+	"vulnerable": [
+		"1.3.9-1.11.0"
+	],
+	"references": [
+		{
+			"text": "Advisory",
+			"url": "https://mailman.nginx.org/pipermail/nginx-announce/2016/000179.html"
+		},
+		{
+			"text": "CVE-2016-4450",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2016-4450"
+		}
+	],
+	"patches": [
+		{
+			"url": "https://nginx.org/download/patch.2016.write.txt",
+			"signature_url": "https://nginx.org/download/patch.2016.write.txt.asc",
+			"note": "(for 1.9.13-1.11.0)"
+		},
+		{
+			"url": "https://nginx.org/download/patch.2016.write2.txt",
+			"signature_url": "https://nginx.org/download/patch.2016.write2.txt.asc",
+			"note": "(for 1.3.9-1.9.12)"
+		}
+	]
+}

--- a/pkg/extract/nginx/security-advisories/testdata/fixtures/2024/CVE-2024-7347.json
+++ b/pkg/extract/nginx/security-advisories/testdata/fixtures/2024/CVE-2024-7347.json
@@ -1,0 +1,28 @@
+{
+	"id": "CVE-2024-7347",
+	"title": "Buffer overread in the ngx_http_mp4_module",
+	"severity": "low",
+	"not_vulnerable": [
+		"1.27.1+",
+		"1.26.2+"
+	],
+	"vulnerable": [
+		"1.5.13-1.27.0"
+	],
+	"references": [
+		{
+			"text": "Advisory",
+			"url": "https://mailman.nginx.org/pipermail/nginx-announce/2024/UUOCLLONPR6244YQYU65PO5LB7JDYCWM.html"
+		},
+		{
+			"text": "CVE-2024-7347",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2024-7347"
+		}
+	],
+	"patches": [
+		{
+			"url": "https://nginx.org/download/patch.2024.mp4.txt",
+			"signature_url": "https://nginx.org/download/patch.2024.mp4.txt.asc"
+		}
+	]
+}

--- a/pkg/extract/nginx/security-advisories/testdata/fixtures/2026/CVE-2026-42533.json
+++ b/pkg/extract/nginx/security-advisories/testdata/fixtures/2026/CVE-2026-42533.json
@@ -1,0 +1,22 @@
+{
+	"id": "CVE-2026-42533",
+	"title": "Buffer overflow when using map and regex",
+	"severity": "major",
+	"not_vulnerable": [
+		"1.31.3+",
+		"1.30.4+"
+	],
+	"vulnerable": [
+		"0.9.6-1.31.2"
+	],
+	"references": [
+		{
+			"text": "Advisory",
+			"url": "https://my.f5.com/manage/s/article/K000162097"
+		},
+		{
+			"text": "CVE-2026-42533",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2026-42533"
+		}
+	]
+}

--- a/pkg/extract/nginx/security-advisories/testdata/golden/data/2009/CVE-2009-3555.json
+++ b/pkg/extract/nginx/security-advisories/testdata/golden/data/2009/CVE-2009-3555.json
@@ -1,0 +1,102 @@
+{
+	"id": "CVE-2009-3555",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2009-3555",
+				"title": "The renegotiation vulnerability in SSL protocol",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "nginx.org",
+						"vendor": "major"
+					}
+				],
+				"mitigations": [
+					{
+						"source": "nginx.org",
+						"description": "https://nginx.org/download/patch.cve-2009-3555.txt"
+					}
+				],
+				"references": [
+					{
+						"source": "nginx.org",
+						"url": "http://www.kb.cert.org/vuls/id/120541"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.cve-2009-3555.txt"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.cve-2009-3555.txt.asc"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2009-3555"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+											"range": {
+												"type": "version",
+												"ge": "0.1.0",
+												"lt": "0.7.64"
+											},
+											"fixed": [
+												"0.7.64"
+											]
+										}
+									},
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+											"range": {
+												"type": "version",
+												"ge": "0.8.0",
+												"le": "0.8.22"
+											},
+											"fixed": [
+												"0.8.23"
+											]
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "nginx-security-advisories",
+		"raws": [
+			"fixtures/2009/CVE-2009-3555.json"
+		]
+	}
+}

--- a/pkg/extract/nginx/security-advisories/testdata/golden/data/2009/CVE-2009-4487.json
+++ b/pkg/extract/nginx/security-advisories/testdata/golden/data/2009/CVE-2009-4487.json
@@ -1,0 +1,61 @@
+{
+	"id": "CVE-2009-4487",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2009-4487",
+				"title": "An error log data are not sanitized",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "nginx.org",
+						"vendor": "none"
+					}
+				],
+				"references": [
+					{
+						"source": "nginx.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2009-4487"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*"
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "nginx-security-advisories",
+		"raws": [
+			"fixtures/2009/CVE-2009-4487.json"
+		]
+	}
+}

--- a/pkg/extract/nginx/security-advisories/testdata/golden/data/2010/CORE-2010-0121.json
+++ b/pkg/extract/nginx/security-advisories/testdata/golden/data/2010/CORE-2010-0121.json
@@ -1,0 +1,101 @@
+{
+	"id": "CORE-2010-0121",
+	"advisories": [
+		{
+			"content": {
+				"id": "CORE-2010-0121",
+				"title": "Vulnerabilities with Windows 8.3 filename pseudonyms",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "nginx.org",
+						"vendor": "major"
+					}
+				],
+				"references": [
+					{
+						"source": "nginx.org",
+						"url": "http://www.coresecurity.com/content/filename-pseudonyms-vulnerabilities"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "AND",
+								"criterias": [
+									{
+										"operator": "OR",
+										"criterions": [
+											{
+												"type": "cpe",
+												"cpe": {
+													"vulnerable": false,
+													"cpe": "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*"
+												}
+											}
+										]
+									},
+									{
+										"operator": "OR",
+										"criterions": [
+											{
+												"type": "cpe",
+												"cpe": {
+													"vulnerable": true,
+													"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+													"range": {
+														"type": "version",
+														"ge": "0.7.52",
+														"lt": "0.7.65"
+													},
+													"fixed": [
+														"0.7.65"
+													]
+												}
+											},
+											{
+												"type": "cpe",
+												"cpe": {
+													"vulnerable": true,
+													"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+													"range": {
+														"type": "version",
+														"ge": "0.8.0",
+														"le": "0.8.32"
+													},
+													"fixed": [
+														"0.8.33"
+													]
+												}
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "nginx-security-advisories",
+		"raws": [
+			"fixtures/2010/CORE-2010-0121.json"
+		]
+	}
+}

--- a/pkg/extract/nginx/security-advisories/testdata/golden/data/2011/CVE-2011-4963.json
+++ b/pkg/extract/nginx/security-advisories/testdata/golden/data/2011/CVE-2011-4963.json
@@ -1,0 +1,105 @@
+{
+	"id": "CVE-2011-4963",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2011-4963",
+				"title": "Vulnerabilities with Windows directory aliases",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "nginx.org",
+						"vendor": "medium"
+					}
+				],
+				"references": [
+					{
+						"source": "nginx.org",
+						"url": "https://mailman.nginx.org/pipermail/nginx-announce/2012/000086.html"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2011-4963"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "AND",
+								"criterias": [
+									{
+										"operator": "OR",
+										"criterions": [
+											{
+												"type": "cpe",
+												"cpe": {
+													"vulnerable": false,
+													"cpe": "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*"
+												}
+											}
+										]
+									},
+									{
+										"operator": "OR",
+										"criterions": [
+											{
+												"type": "cpe",
+												"cpe": {
+													"vulnerable": true,
+													"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+													"range": {
+														"type": "version",
+														"ge": "0.7.52",
+														"lt": "1.2.1"
+													},
+													"fixed": [
+														"1.2.1"
+													]
+												}
+											},
+											{
+												"type": "cpe",
+												"cpe": {
+													"vulnerable": true,
+													"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+													"range": {
+														"type": "version",
+														"ge": "1.3.0",
+														"le": "1.3.0"
+													},
+													"fixed": [
+														"1.3.1"
+													]
+												}
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "nginx-security-advisories",
+		"raws": [
+			"fixtures/2011/CVE-2011-4963.json"
+		]
+	}
+}

--- a/pkg/extract/nginx/security-advisories/testdata/golden/data/2013/CVE-2013-2070.json
+++ b/pkg/extract/nginx/security-advisories/testdata/golden/data/2013/CVE-2013-2070.json
@@ -1,0 +1,119 @@
+{
+	"id": "CVE-2013-2070",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2013-2070",
+				"title": "Memory disclosure with specially crafted HTTP backend responses",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "nginx.org",
+						"vendor": "medium"
+					}
+				],
+				"mitigations": [
+					{
+						"source": "nginx.org",
+						"description": "https://nginx.org/download/patch.2013.chunked.txt (for 1.3.9-1.4.0)"
+					},
+					{
+						"source": "nginx.org",
+						"description": "https://nginx.org/download/patch.2013.proxy.txt (for 1.1.4-1.2.8)"
+					}
+				],
+				"references": [
+					{
+						"source": "nginx.org",
+						"url": "https://mailman.nginx.org/pipermail/nginx-announce/2013/000114.html"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.2013.chunked.txt"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.2013.chunked.txt.asc"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.2013.proxy.txt"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.2013.proxy.txt.asc"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2013-2070"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+											"range": {
+												"type": "version",
+												"ge": "1.1.4",
+												"le": "1.2.8"
+											},
+											"fixed": [
+												"1.2.9"
+											]
+										}
+									}
+								]
+							},
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+											"range": {
+												"type": "version",
+												"ge": "1.3.9",
+												"le": "1.4.0"
+											},
+											"fixed": [
+												"1.4.1"
+											]
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "nginx-security-advisories",
+		"raws": [
+			"fixtures/2013/CVE-2013-2070.json"
+		]
+	}
+}

--- a/pkg/extract/nginx/security-advisories/testdata/golden/data/2016/CVE-2016-4450.json
+++ b/pkg/extract/nginx/security-advisories/testdata/golden/data/2016/CVE-2016-4450.json
@@ -1,0 +1,114 @@
+{
+	"id": "CVE-2016-4450",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2016-4450",
+				"title": "NULL pointer dereference while writing client request body",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "nginx.org",
+						"vendor": "medium"
+					}
+				],
+				"mitigations": [
+					{
+						"source": "nginx.org",
+						"description": "https://nginx.org/download/patch.2016.write.txt (for 1.9.13-1.11.0)"
+					},
+					{
+						"source": "nginx.org",
+						"description": "https://nginx.org/download/patch.2016.write2.txt (for 1.3.9-1.9.12)"
+					}
+				],
+				"references": [
+					{
+						"source": "nginx.org",
+						"url": "https://mailman.nginx.org/pipermail/nginx-announce/2016/000179.html"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.2016.write.txt"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.2016.write.txt.asc"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.2016.write2.txt"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.2016.write2.txt.asc"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2016-4450"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+											"range": {
+												"type": "version",
+												"ge": "1.11.0",
+												"le": "1.11.0"
+											},
+											"fixed": [
+												"1.11.1"
+											]
+										}
+									},
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+											"range": {
+												"type": "version",
+												"ge": "1.3.9",
+												"lt": "1.10.1"
+											},
+											"fixed": [
+												"1.10.1"
+											]
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "nginx-security-advisories",
+		"raws": [
+			"fixtures/2016/CVE-2016-4450.json"
+		]
+	}
+}

--- a/pkg/extract/nginx/security-advisories/testdata/golden/data/2024/CVE-2024-7347.json
+++ b/pkg/extract/nginx/security-advisories/testdata/golden/data/2024/CVE-2024-7347.json
@@ -1,0 +1,102 @@
+{
+	"id": "CVE-2024-7347",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-7347",
+				"title": "Buffer overread in the ngx_http_mp4_module",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "nginx.org",
+						"vendor": "low"
+					}
+				],
+				"mitigations": [
+					{
+						"source": "nginx.org",
+						"description": "https://nginx.org/download/patch.2024.mp4.txt"
+					}
+				],
+				"references": [
+					{
+						"source": "nginx.org",
+						"url": "https://mailman.nginx.org/pipermail/nginx-announce/2024/UUOCLLONPR6244YQYU65PO5LB7JDYCWM.html"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.2024.mp4.txt"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://nginx.org/download/patch.2024.mp4.txt.asc"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-7347"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+											"range": {
+												"type": "version",
+												"ge": "1.27.0",
+												"le": "1.27.0"
+											},
+											"fixed": [
+												"1.27.1"
+											]
+										}
+									},
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+											"range": {
+												"type": "version",
+												"ge": "1.5.13",
+												"lt": "1.26.2"
+											},
+											"fixed": [
+												"1.26.2"
+											]
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "nginx-security-advisories",
+		"raws": [
+			"fixtures/2024/CVE-2024-7347.json"
+		]
+	}
+}

--- a/pkg/extract/nginx/security-advisories/testdata/golden/data/2026/CVE-2026-42533.json
+++ b/pkg/extract/nginx/security-advisories/testdata/golden/data/2026/CVE-2026-42533.json
@@ -1,0 +1,88 @@
+{
+	"id": "CVE-2026-42533",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-42533",
+				"title": "Buffer overflow when using map and regex",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "nginx.org",
+						"vendor": "major"
+					}
+				],
+				"references": [
+					{
+						"source": "nginx.org",
+						"url": "https://my.f5.com/manage/s/article/K000162097"
+					},
+					{
+						"source": "nginx.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2026-42533"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterions": [
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+											"range": {
+												"type": "version",
+												"ge": "0.9.6",
+												"lt": "1.30.4"
+											},
+											"fixed": [
+												"1.30.4"
+											]
+										}
+									},
+									{
+										"type": "cpe",
+										"cpe": {
+											"vulnerable": true,
+											"cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+											"range": {
+												"type": "version",
+												"ge": "1.31.0",
+												"le": "1.31.2"
+											},
+											"fixed": [
+												"1.31.3"
+											]
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "nginx-security-advisories",
+		"raws": [
+			"fixtures/2026/CVE-2026-42533.json"
+		]
+	}
+}

--- a/pkg/extract/nginx/security-advisories/testdata/golden/datasource.json
+++ b/pkg/extract/nginx/security-advisories/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "nginx-security-advisories",
+	"name": "nginx Security Advisories"
+}

--- a/pkg/extract/nginx/security-advisories/version.go
+++ b/pkg/extract/nginx/security-advisories/version.go
@@ -1,0 +1,210 @@
+package securityadvisories
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// windowsPrefix marks a vulnerable expression that only applies to the Windows
+// build, e.g. "nginx/Windows 0.7.52-1.3.0".
+const windowsPrefix = "nginx/Windows "
+
+const (
+	allVersions  = "all"
+	noneVersions = "none"
+)
+
+// nginx releases are always <major>.<minor>.<patch>; anything else is a change
+// in how the page expresses versions and must not be guessed at.
+var versionPattern = regexp.MustCompile(`^([0-9]+)\.([0-9]+)\.([0-9]+)$`)
+
+// version is an nginx release. The three components are kept separate because
+// the branch a release belongs to (major.minor) is what decides where an
+// affected range resumes after a fix — see affectedIntervals.
+type version struct {
+	major, minor, patch int
+}
+
+func parseVersion(s string) (version, error) {
+	m := versionPattern.FindStringSubmatch(s)
+	if m == nil {
+		return version{}, errors.Errorf("unexpected version format. expected: %q, actual: %q", versionPattern.String(), s)
+	}
+
+	// The pattern admits digits only, so the conversions cannot fail short of
+	// an integer overflow, which a released nginx version never reaches.
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return version{}, errors.Wrapf(err, "parse major of %q", s)
+	}
+	minor, err := strconv.Atoi(m[2])
+	if err != nil {
+		return version{}, errors.Wrapf(err, "parse minor of %q", s)
+	}
+	patch, err := strconv.Atoi(m[3])
+	if err != nil {
+		return version{}, errors.Wrapf(err, "parse patch of %q", s)
+	}
+
+	return version{major: major, minor: minor, patch: patch}, nil
+}
+
+func (v version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+}
+
+func (v version) compare(o version) int {
+	if v.major != o.major {
+		return v.major - o.major
+	}
+	if v.minor != o.minor {
+		return v.minor - o.minor
+	}
+	return v.patch - o.patch
+}
+
+// nextBranch is the first release of the branch following v's. nginx develops
+// stable (even minor) and mainline (odd minor) branches in parallel and fixes
+// each separately, so a fix released on one branch says nothing about releases
+// on the next one — the affected range resumes there.
+func (v version) nextBranch() version {
+	return version{major: v.major, minor: v.minor + 1}
+}
+
+// interval is one contiguous affected version range. Exactly one of LessThan
+// and LessEqual is set. Fixed names the release that closes the interval, i.e.
+// the earliest listed fix a user inside the interval can move to.
+type interval struct {
+	GreaterEqual version
+	LessThan     *version
+	LessEqual    *version
+	Fixed        *version
+}
+
+// vulnerableRange is one entry of the page's "Vulnerable:" list.
+type vulnerableRange struct {
+	// All reports "Vulnerable: all", where no version bound applies.
+	All bool
+	// Windows reports the "nginx/Windows" prefix: only the Windows build is
+	// affected.
+	Windows bool
+	Lower   version
+	Upper   version
+}
+
+// parseVulnerable reads one "Vulnerable:" entry. The page writes these as a
+// closed range ("0.9.6-1.31.2"), a single release ("1.26.0"), the literal
+// "all", and any of those optionally prefixed with "nginx/Windows".
+func parseVulnerable(s string) (vulnerableRange, error) {
+	if s == allVersions {
+		return vulnerableRange{All: true}, nil
+	}
+
+	var r vulnerableRange
+	if rest, ok := strings.CutPrefix(s, windowsPrefix); ok {
+		r.Windows = true
+		s = rest
+	}
+
+	lo, hi, ok := strings.Cut(s, "-")
+	if !ok {
+		v, err := parseVersion(s)
+		if err != nil {
+			return vulnerableRange{}, errors.Wrapf(err, "parse vulnerable %q", s)
+		}
+		r.Lower, r.Upper = v, v
+		return r, nil
+	}
+
+	l, err := parseVersion(lo)
+	if err != nil {
+		return vulnerableRange{}, errors.Wrapf(err, "parse lower bound of %q", s)
+	}
+	u, err := parseVersion(hi)
+	if err != nil {
+		return vulnerableRange{}, errors.Wrapf(err, "parse upper bound of %q", s)
+	}
+	if l.compare(u) > 0 {
+		return vulnerableRange{}, errors.Errorf("unexpected vulnerable range. expected: %q, actual: %q", "lower bound not above upper bound", s)
+	}
+
+	r.Lower, r.Upper = l, u
+	return r, nil
+}
+
+// parseNotVulnerable reads the "Not vulnerable:" list into the fixed releases it
+// names, sorted ascending. Each entry is a release followed by "+" meaning "this
+// release and later on its branch"; the literal "none" yields no fix.
+func parseNotVulnerable(ss []string) ([]version, error) {
+	if len(ss) == 1 && ss[0] == noneVersions {
+		return nil, nil
+	}
+
+	vs := make([]version, 0, len(ss))
+	for _, s := range ss {
+		t, ok := strings.CutSuffix(s, "+")
+		if !ok {
+			return nil, errors.Errorf("unexpected not vulnerable format. expected: %q, actual: %q", "<version>+", s)
+		}
+		v, err := parseVersion(t)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse not vulnerable %q", s)
+		}
+		vs = append(vs, v)
+	}
+
+	slices.SortFunc(vs, version.compare)
+	return slices.CompactFunc(vs, func(a, b version) bool { return a.compare(b) == 0 }), nil
+}
+
+// affectedIntervals splits a vulnerable range at the fixes that land inside it.
+//
+// The page states one range spanning every affected branch together with a fix
+// per branch, so a fix for an older branch sits in the middle of the range: for
+// CVE-2026-42533 ("Vulnerable: 0.9.6-1.31.2", "Not vulnerable: 1.31.3+,
+// 1.30.4+") the stable release 1.30.4 is inside 0.9.6-1.31.2 yet not affected.
+// Emitting the range verbatim would report those releases as vulnerable, so each
+// fix inside the range closes an interval and the next interval resumes at the
+// start of the following branch.
+//
+// This reproduces how NVD splits the same advisories, e.g. CVE-2011-4963
+// ("Vulnerable: nginx/Windows 0.7.52-1.3.0", "Not vulnerable: 1.3.1+, 1.2.1+")
+// is published as 0.7.52 <= v < 1.2.1 plus 1.3.0.
+func affectedIntervals(r vulnerableRange, fixes []version) []interval {
+	if r.All {
+		return nil
+	}
+
+	var is []interval
+	cur := r.Lower
+	for _, f := range fixes {
+		// Fixes at or below the range's start, and those beyond its end, do
+		// not split it.
+		if f.compare(cur) <= 0 || f.compare(r.Upper) > 0 {
+			continue
+		}
+		lt, fixed := f, f
+		is = append(is, interval{GreaterEqual: cur, LessThan: &lt, Fixed: &fixed})
+		cur = f.nextBranch()
+		if cur.compare(r.Upper) > 0 {
+			return is
+		}
+	}
+
+	return append(is, interval{GreaterEqual: cur, LessEqual: &r.Upper, Fixed: fixedAfter(r.Upper, fixes)})
+}
+
+// fixedAfter is the earliest listed fix a user on the interval's last affected
+// release can move to. The branch's own fix is preferred implicitly: fixes are
+// ascending, so the first one past the bound is the nearest upgrade target.
+func fixedAfter(upper version, fixes []version) *version {
+	if i := slices.IndexFunc(fixes, func(f version) bool { return f.compare(upper) > 0 }); i >= 0 {
+		return &fixes[i]
+	}
+	return nil
+}

--- a/pkg/extract/nginx/security-advisories/version_test.go
+++ b/pkg/extract/nginx/security-advisories/version_test.go
@@ -1,0 +1,227 @@
+package securityadvisories
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseVulnerable(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		want     vulnerableRange
+		hasError bool
+	}{
+		{
+			name: "range",
+			args: args{s: "0.9.6-1.31.2"},
+			want: vulnerableRange{Lower: version{0, 9, 6}, Upper: version{1, 31, 2}},
+		},
+		{
+			name: "single release",
+			args: args{s: "1.26.0"},
+			want: vulnerableRange{Lower: version{1, 26, 0}, Upper: version{1, 26, 0}},
+		},
+		{
+			name: "all",
+			args: args{s: "all"},
+			want: vulnerableRange{All: true},
+		},
+		{
+			name: "windows only",
+			args: args{s: "nginx/Windows 0.7.52-1.3.0"},
+			want: vulnerableRange{Windows: true, Lower: version{0, 7, 52}, Upper: version{1, 3, 0}},
+		},
+		{
+			name:     "reversed bounds",
+			args:     args{s: "1.31.2-0.9.6"},
+			hasError: true,
+		},
+		{
+			name:     "two component version",
+			args:     args{s: "1.31-1.32"},
+			hasError: true,
+		},
+		{
+			name:     "unknown platform prefix",
+			args:     args{s: "nginx/Darwin 1.0.0-1.0.1"},
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseVulnerable(tt.args.s)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				return
+			default:
+				if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(version{})); diff != "" {
+					t.Errorf("parseVulnerable(). (-expected +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestParseNotVulnerable(t *testing.T) {
+	type args struct {
+		ss []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		want     []version
+		hasError bool
+	}{
+		{
+			name: "sorted ascending",
+			args: args{ss: []string{"1.31.3+", "1.30.4+"}},
+			want: []version{{1, 30, 4}, {1, 31, 3}},
+		},
+		{
+			name: "three branches",
+			args: args{ss: []string{"1.5.0+", "1.4.1+", "1.2.9+"}},
+			want: []version{{1, 2, 9}, {1, 4, 1}, {1, 5, 0}},
+		},
+		{
+			name: "none",
+			args: args{ss: []string{"none"}},
+			want: nil,
+		},
+		{
+			name:     "missing plus",
+			args:     args{ss: []string{"1.31.3"}},
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNotVulnerable(tt.args.ss)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				return
+			default:
+				if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(version{})); diff != "" {
+					t.Errorf("parseNotVulnerable(). (-expected +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestAffectedIntervals(t *testing.T) {
+	v := func(major, minor, patch int) *version {
+		return &version{major, minor, patch}
+	}
+
+	type args struct {
+		r     vulnerableRange
+		fixes []version
+	}
+	tests := []struct {
+		name string
+		args args
+		want []interval
+	}{
+		{
+			// CVE-2026-42533: the stable fix 1.30.4 sits inside the stated
+			// range, so the range must not be emitted verbatim.
+			name: "fix inside the range splits it",
+			args: args{
+				r:     vulnerableRange{Lower: version{0, 9, 6}, Upper: version{1, 31, 2}},
+				fixes: []version{{1, 30, 4}, {1, 31, 3}},
+			},
+			want: []interval{
+				{GreaterEqual: version{0, 9, 6}, LessThan: v(1, 30, 4), Fixed: v(1, 30, 4)},
+				{GreaterEqual: version{1, 31, 0}, LessEqual: v(1, 31, 2), Fixed: v(1, 31, 3)},
+			},
+		},
+		{
+			// CVE-2011-4963, which NVD publishes as 0.7.52 <= v < 1.2.1 plus
+			// the single release 1.3.0.
+			name: "trailing interval is a single release",
+			args: args{
+				r:     vulnerableRange{Windows: true, Lower: version{0, 7, 52}, Upper: version{1, 3, 0}},
+				fixes: []version{{1, 2, 1}, {1, 3, 1}},
+			},
+			want: []interval{
+				{GreaterEqual: version{0, 7, 52}, LessThan: v(1, 2, 1), Fixed: v(1, 2, 1)},
+				{GreaterEqual: version{1, 3, 0}, LessEqual: v(1, 3, 0), Fixed: v(1, 3, 1)},
+			},
+		},
+		{
+			// CVE-2013-2070 states its ranges pre-split, so every fix falls
+			// outside and nothing more is cut.
+			name: "fixes above the range leave it whole",
+			args: args{
+				r:     vulnerableRange{Lower: version{1, 1, 4}, Upper: version{1, 2, 8}},
+				fixes: []version{{1, 2, 9}, {1, 4, 1}, {1, 5, 0}},
+			},
+			want: []interval{
+				{GreaterEqual: version{1, 1, 4}, LessEqual: v(1, 2, 8), Fixed: v(1, 2, 9)},
+			},
+		},
+		{
+			// CVE-2024-32760's "1.26.0" entry: the nearest upgrade target is
+			// on another branch than the affected release.
+			name: "single release with the fix on another branch",
+			args: args{
+				r:     vulnerableRange{Lower: version{1, 26, 0}, Upper: version{1, 26, 0}},
+				fixes: []version{{1, 26, 1}, {1, 27, 0}},
+			},
+			want: []interval{
+				{GreaterEqual: version{1, 26, 0}, LessEqual: v(1, 26, 0), Fixed: v(1, 26, 1)},
+			},
+		},
+		{
+			name: "no fix at all",
+			args: args{
+				r:     vulnerableRange{Lower: version{1, 0, 0}, Upper: version{1, 0, 5}},
+				fixes: nil,
+			},
+			want: []interval{
+				{GreaterEqual: version{1, 0, 0}, LessEqual: v(1, 0, 5)},
+			},
+		},
+		{
+			// The range ends before the branch that follows the last fix,
+			// so no trailing interval is emitted.
+			name: "range ends inside the fixed branch",
+			args: args{
+				r:     vulnerableRange{Lower: version{1, 0, 0}, Upper: version{1, 2, 5}},
+				fixes: []version{{1, 2, 3}},
+			},
+			want: []interval{
+				{GreaterEqual: version{1, 0, 0}, LessThan: v(1, 2, 3), Fixed: v(1, 2, 3)},
+			},
+		},
+		{
+			name: "all versions affected",
+			args: args{r: vulnerableRange{All: true}},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := affectedIntervals(tt.args.r, tt.args.fixes)
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(version{})); diff != "" {
+				t.Errorf("affectedIntervals(). (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -99,6 +99,7 @@ const (
 	MitreCVEV5                 SourceID = "mitre-cve-v5"
 	MitreCWE                   SourceID = "mitre-cwe"
 	NetBSD                     SourceID = "netbsd"
+	NginxSecurityAdvisories    SourceID = "nginx-security-advisories"
 	NpmDB                      SourceID = "npm-db"
 	NpmGHSA                    SourceID = "npm-ghsa"
 	NpmGLSA                    SourceID = "npm-glsa"

--- a/pkg/fetch/nginx/security-advisories/security-advisories.go
+++ b/pkg/fetch/nginx/security-advisories/security-advisories.go
@@ -1,0 +1,348 @@
+package securityadvisories
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+const dataURL = "https://nginx.org/en/security_advisories.html"
+
+const (
+	severityLabel      = "Severity:"
+	notVulnerableLabel = "Not vulnerable:"
+	vulnerableLabel    = "Vulnerable:"
+)
+
+// A patch line is recognised by either its anchor text or its download path,
+// and parsePatch then requires both to hold. Accepting either keeps a rename of
+// one of them from silently demoting a patch line to a reference line, and
+// requiring both makes that rename surface as an error.
+const (
+	patchLinkText          = "The patch"
+	patchSignatureLinkText = "pgp"
+	patchPathPrefix        = "/download/patch"
+)
+
+// The ID is taken from the remote page and is used as a path element, so accept
+// only the formats the page is known to use. Every entry links a CVE record
+// except the 8.3 filename pseudonyms one, which predates its CVE assignment and
+// carries a Core Security ID instead.
+var advisoryIDPattern = regexp.MustCompile(`^(?:CVE|CORE)-([0-9]{4})-[0-9]{4,}$`)
+
+type options struct {
+	dataURL string
+	dir     string
+	retry   int
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dataURLOption string
+
+func (u dataURLOption) apply(opts *options) {
+	opts.dataURL = string(u)
+}
+
+func WithDataURL(url string) Option {
+	return dataURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+func Fetch(opts ...Option) error {
+	options := &options{
+		dataURL: dataURL,
+		dir:     filepath.Join(util.CacheDir(), "fetch", "nginx", "security-advisories"),
+		retry:   3,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Fetch nginx Security Advisories")
+	resp, err := utilhttp.NewClient(utilhttp.WithClientRetryMax(options.retry)).Get(options.dataURL)
+	if err != nil {
+		return errors.Wrap(err, "fetch nginx security advisories")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return errors.Errorf("error response with status code %d", resp.StatusCode)
+	}
+
+	// Relative links (the patch downloads) are resolved against the canonical
+	// page URL instead of the fetched one, so that the stored URLs keep
+	// pointing at nginx.org when the page is read from a mirror or a test
+	// server.
+	base, err := url.Parse(dataURL)
+	if err != nil {
+		return errors.Wrapf(err, "parse %s", dataURL)
+	}
+
+	d, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "parse as html")
+	}
+
+	// The advisories are the only list in the content area. Pinning the count
+	// makes a page restructure fail here rather than silently yield nothing.
+	uls := d.Find("#content > ul")
+	if uls.Length() != 1 {
+		return errors.Errorf("unexpected number of advisory lists. expected: %d, actual: %d", 1, uls.Length())
+	}
+
+	lis := uls.Find("li")
+	if lis.Length() == 0 {
+		return errors.Errorf("no advisory found in %s", options.dataURL)
+	}
+
+	for _, li := range lis.EachIter() {
+		a, year, err := parseAdvisory(base, li)
+		if err != nil {
+			h, herr := goquery.OuterHtml(li)
+			if herr != nil {
+				return errors.Wrap(err, "parse advisory")
+			}
+			return errors.Wrapf(err, "parse advisory. html: %q", h)
+		}
+
+		if err := util.Write(filepath.Join(options.dir, year, fmt.Sprintf("%s.json", a.ID)), a); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, year, fmt.Sprintf("%s.json", a.ID)))
+		}
+	}
+
+	return nil
+}
+
+// link is an anchor of an advisory line, keeping the parsed URL so that a patch
+// line can be told apart from a reference line without re-parsing.
+type link struct {
+	text string
+	u    *url.URL
+}
+
+// line is one <br> separated line of an advisory entry. text holds the text
+// outside the anchors only, which is what carries the labels and the patch
+// applicability remark.
+type line struct {
+	text  string
+	links []link
+}
+
+// parseAdvisory converts one <li> of the advisories list. It returns the
+// advisory and the year its ID was issued for, which is the output directory.
+func parseAdvisory(base *url.URL, li *goquery.Selection) (Advisory, string, error) {
+	ps := li.ChildrenFiltered("p")
+	if ps.Length() != 1 {
+		return Advisory{}, "", errors.Errorf("unexpected number of paragraphs in an advisory. expected: %d, actual: %d", 1, ps.Length())
+	}
+
+	lines, err := splitLines(base, ps.Contents())
+	if err != nil {
+		return Advisory{}, "", errors.Wrap(err, "split lines")
+	}
+
+	// The title is the only line carrying bare text and no label.
+	title := strings.TrimSpace(lines[0].text)
+	if title == "" || len(lines[0].links) > 0 {
+		return Advisory{}, "", errors.Errorf("unexpected first line. expected: %q, actual: %q", "a title without links", lines[0].text)
+	}
+
+	a := Advisory{Title: title}
+	for _, l := range lines[1:] {
+		t := strings.TrimSpace(l.text)
+
+		switch {
+		case strings.HasPrefix(t, severityLabel):
+			if a.Severity != "" {
+				return Advisory{}, "", errors.Errorf("duplicate %q line", severityLabel)
+			}
+			a.Severity = strings.TrimSpace(strings.TrimPrefix(t, severityLabel))
+		case strings.HasPrefix(t, notVulnerableLabel):
+			if len(a.NotVulnerable) > 0 {
+				return Advisory{}, "", errors.Errorf("duplicate %q line", notVulnerableLabel)
+			}
+			a.NotVulnerable = splitVersions(strings.TrimPrefix(t, notVulnerableLabel))
+		case strings.HasPrefix(t, vulnerableLabel):
+			if len(a.Vulnerable) > 0 {
+				return Advisory{}, "", errors.Errorf("duplicate %q line", vulnerableLabel)
+			}
+			a.Vulnerable = splitVersions(strings.TrimPrefix(t, vulnerableLabel))
+		case len(l.links) > 0 && isPatchLink(l.links[0]):
+			p, err := parsePatch(l)
+			if err != nil {
+				return Advisory{}, "", errors.Wrap(err, "parse patch line")
+			}
+			a.Patches = append(a.Patches, p)
+		case len(l.links) > 0 && t == "":
+			for _, lnk := range l.links {
+				a.References = append(a.References, Reference{Text: lnk.text, URL: lnk.u.String()})
+			}
+		default:
+			return Advisory{}, "", errors.Errorf("unexpected line. expected: %q, actual: %q", []string{severityLabel, notVulnerableLabel, vulnerableLabel, "a reference or patch line"}, t)
+		}
+	}
+
+	switch {
+	case a.Severity == "":
+		return Advisory{}, "", errors.Errorf("no %q line", severityLabel)
+	case len(a.NotVulnerable) == 0:
+		return Advisory{}, "", errors.Errorf("no %q line", notVulnerableLabel)
+	case len(a.Vulnerable) == 0:
+		return Advisory{}, "", errors.Errorf("no %q line", vulnerableLabel)
+	}
+
+	id, year, err := advisoryID(a.References)
+	if err != nil {
+		return Advisory{}, "", errors.Wrap(err, "advisory id")
+	}
+	a.ID = id
+
+	return a, year, nil
+}
+
+// splitLines groups the children of an advisory paragraph into <br> separated
+// lines. Anchor text is kept out of line.text so that a label, or the remark
+// trailing a patch link, can be read without stripping the link captions.
+func splitLines(base *url.URL, contents *goquery.Selection) ([]line, error) {
+	lines := make([]line, 0, contents.Length())
+	var cur line
+
+	for _, n := range contents.EachIter() {
+		switch goquery.NodeName(n) {
+		case "br":
+			lines = append(lines, cur)
+			cur = line{}
+		case "a":
+			href, ok := n.Attr("href")
+			if !ok {
+				return nil, errors.Errorf("no href on the %q anchor", n.Text())
+			}
+			ref, err := url.Parse(href)
+			if err != nil {
+				return nil, errors.Wrapf(err, "parse %s", href)
+			}
+			cur.links = append(cur.links, link{text: strings.TrimSpace(n.Text()), u: base.ResolveReference(ref)})
+		default:
+			// Only <b> around a "major" severity is expected to wrap text.
+			// An anchor nested somewhere else means the markup changed in a
+			// way the flat line model no longer describes.
+			if n.Find("a").Length() > 0 {
+				return nil, errors.Errorf("unexpected nested anchor in a %q element", goquery.NodeName(n))
+			}
+			cur.text += n.Text()
+		}
+	}
+
+	return append(lines, cur), nil
+}
+
+func isPatchLink(l link) bool {
+	return l.text == patchLinkText || strings.HasPrefix(l.u.Path, patchPathPrefix)
+}
+
+func parsePatch(l line) (Patch, error) {
+	if len(l.links) > 2 {
+		return Patch{}, errors.Errorf("unexpected number of links in a patch line. expected: %q, actual: %d", "1 or 2", len(l.links))
+	}
+
+	if l.links[0].text != patchLinkText {
+		return Patch{}, errors.Errorf("unexpected patch link text. expected: %q, actual: %q", patchLinkText, l.links[0].text)
+	}
+	if !strings.HasPrefix(l.links[0].u.Path, patchPathPrefix) {
+		return Patch{}, errors.Errorf("unexpected patch link path. expected: %q, actual: %q", patchPathPrefix, l.links[0].u.Path)
+	}
+
+	p := Patch{
+		URL:  l.links[0].u.String(),
+		Note: strings.TrimSpace(l.text),
+	}
+
+	if len(l.links) == 2 {
+		if l.links[1].text != patchSignatureLinkText {
+			return Patch{}, errors.Errorf("unexpected patch signature link text. expected: %q, actual: %q", patchSignatureLinkText, l.links[1].text)
+		}
+		p.SignatureURL = l.links[1].u.String()
+	}
+
+	return p, nil
+}
+
+// advisoryID picks the reference that identifies the advisory and returns it
+// with its year. More than one candidate is an error rather than a silent
+// choice, so that an entry covering several IDs surfaces instead of being
+// filed under an arbitrary one.
+func advisoryID(refs []Reference) (string, string, error) {
+	var (
+		id   string
+		year string
+	)
+	for _, r := range refs {
+		m := advisoryIDPattern.FindStringSubmatch(r.Text)
+		if m == nil {
+			continue
+		}
+		if id != "" {
+			return "", "", errors.Errorf("multiple advisory ids. first: %q, second: %q", id, r.Text)
+		}
+		id, year = r.Text, m[1]
+	}
+
+	if id == "" {
+		texts := make([]string, 0, len(refs))
+		for _, r := range refs {
+			texts = append(texts, r.Text)
+		}
+		return "", "", errors.Errorf("no advisory id found. expected: %q, actual: %q", advisoryIDPattern.String(), texts)
+	}
+
+	return id, year, nil
+}
+
+func splitVersions(s string) []string {
+	vs := make([]string, 0, strings.Count(s, ",")+1)
+	for v := range strings.SplitSeq(s, ",") {
+		if v = strings.TrimSpace(v); v != "" {
+			vs = append(vs, v)
+		}
+	}
+	return vs
+}

--- a/pkg/fetch/nginx/security-advisories/security-advisories_test.go
+++ b/pkg/fetch/nginx/security-advisories/security-advisories_test.go
@@ -1,0 +1,104 @@
+package securityadvisories_test
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	securityadvisories "github.com/MaineK00n/vuls-data-update/pkg/fetch/nginx/security-advisories"
+)
+
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+		},
+		{
+			name:     "notfound",
+			hasError: true,
+		},
+		{
+			name:     "no-list",
+			hasError: true,
+		},
+		{
+			name:     "invalid-id",
+			hasError: true,
+		},
+		{
+			name:     "multiple-ids",
+			hasError: true,
+		},
+		{
+			name:     "unexpected-line",
+			hasError: true,
+		},
+		{
+			name:     "unexpected-patch",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.ServeFile(w, r, filepath.Join("testdata", "fixtures", tt.name, path.Base(r.URL.Path)))
+			}))
+			defer ts.Close()
+
+			u, err := url.JoinPath(ts.URL, "en", "security_advisories.html")
+			if err != nil {
+				t.Error("unexpected error:", err)
+			}
+
+			dir := t.TempDir()
+			err = securityadvisories.Fetch(securityadvisories.WithDataURL(u), securityadvisories.WithDir(dir), securityadvisories.WithRetry(0))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			default:
+				if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+					if err != nil {
+						return err
+					}
+
+					if d.IsDir() {
+						return nil
+					}
+
+					dir, file := filepath.Split(strings.TrimPrefix(path, dir))
+					want, err := os.ReadFile(filepath.Join("testdata", "golden", tt.name, dir, url.QueryEscape(file)))
+					if err != nil {
+						return err
+					}
+
+					got, err := os.ReadFile(path)
+					if err != nil {
+						return err
+					}
+
+					if diff := cmp.Diff(want, got); diff != "" {
+						t.Errorf("Fetch(). (-expected +got):\n%s", diff)
+					}
+
+					return nil
+				}); err != nil {
+					t.Error("walk error:", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/fetch/nginx/security-advisories/testdata/fixtures/happy/security_advisories.html
+++ b/pkg/fetch/nginx/security-advisories/testdata/fixtures/happy/security_advisories.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><title>nginx security advisories</title></head><body><div id="main"><div id="menu"><nav class="nav"><ul class="mobilemenu"><li><a href="../news.html">news</a></li><li><a href="download.html">download</a></li></ul></nav></div><div id="content"><h2>nginx security advisories</h2><p>
+All nginx security issues should be reported
+via one of the methods listed
+<a href="https://github.com/nginx/nginx/blob/master/SECURITY.md">here</a>.
+</p><p>
+Patches are signed using one of the
+<a href="pgp_keys.html">PGP public keys</a>.
+</p><ul>
+
+<li><p>Buffer overflow when using map and regex<br>Severity: <b>major</b><br><a href="https://my.f5.com/manage/s/article/K000162097">Advisory</a><br><a href="https://www.cve.org/CVERecord?id=CVE-2026-42533">CVE-2026-42533</a><br>Not vulnerable: 1.31.3+, 1.30.4+<br>Vulnerable: 0.9.6-1.31.2</p></li>
+
+<li><p>Buffer overread in the ngx_http_mp4_module<br>Severity: low<br><a href="https://mailman.nginx.org/pipermail/nginx-announce/2024/UUOCLLONPR6244YQYU65PO5LB7JDYCWM.html">Advisory</a><br><a href="https://www.cve.org/CVERecord?id=CVE-2024-7347">CVE-2024-7347</a><br>Not vulnerable: 1.27.1+, 1.26.2+<br>Vulnerable: 1.5.13-1.27.0<br><a href="/download/patch.2024.mp4.txt">The patch</a>  <a href="/download/patch.2024.mp4.txt.asc">pgp</a></p></li>
+
+<li><p>NULL pointer dereference while writing client request body<br>Severity: medium<br><a href="https://mailman.nginx.org/pipermail/nginx-announce/2016/000179.html">Advisory</a><br><a href="https://www.cve.org/CVERecord?id=CVE-2016-4450">CVE-2016-4450</a><br>Not vulnerable: 1.11.1+, 1.10.1+<br>Vulnerable: 1.3.9-1.11.0<br><a href="/download/patch.2016.write.txt">The patch</a>  <a href="/download/patch.2016.write.txt.asc">pgp</a>  (for 1.9.13-1.11.0)<br><a href="/download/patch.2016.write2.txt">The patch</a>  <a href="/download/patch.2016.write2.txt.asc">pgp</a>  (for 1.3.9-1.9.12)</p></li>
+
+<li><p>Memory disclosure with specially crafted HTTP backend responses<br>Severity: medium<br><a href="https://mailman.nginx.org/pipermail/nginx-announce/2013/000114.html">Advisory</a><br><a href="https://www.cve.org/CVERecord?id=CVE-2013-2070">CVE-2013-2070</a><br>Not vulnerable: 1.5.0+, 1.4.1+, 1.2.9+<br>Vulnerable: 1.1.4-1.2.8, 1.3.9-1.4.0<br><a href="/download/patch.2013.chunked.txt">The patch</a>  <a href="/download/patch.2013.chunked.txt.asc">pgp</a>  (for 1.3.9-1.4.0)<br><a href="/download/patch.2013.proxy.txt">The patch</a>  <a href="/download/patch.2013.proxy.txt.asc">pgp</a>  (for 1.1.4-1.2.8)</p></li>
+
+<li><p>Vulnerabilities with Windows directory aliases<br>Severity: medium<br><a href="https://mailman.nginx.org/pipermail/nginx-announce/2012/000086.html">Advisory</a><br><a href="https://www.cve.org/CVERecord?id=CVE-2011-4963">CVE-2011-4963</a><br>Not vulnerable: 1.3.1+, 1.2.1+<br>Vulnerable: nginx/Windows 0.7.52-1.3.0</p></li>
+
+<li><p>Vulnerabilities with Windows 8.3 filename pseudonyms<br>Severity: <b>major</b><br><a href="http://www.coresecurity.com/content/filename-pseudonyms-vulnerabilities">CORE-2010-0121</a><br>Not vulnerable: 0.8.33+, 0.7.65+<br>Vulnerable: nginx/Windows 0.7.52-0.8.32</p></li>
+
+<li><p>An error log data are not sanitized<br>Severity: none<br><a href="https://www.cve.org/CVERecord?id=CVE-2009-4487">CVE-2009-4487</a><br>Not vulnerable: none<br>Vulnerable: all</p></li>
+
+<li><p>The renegotiation vulnerability in SSL protocol<br>Severity: <b>major</b><br><a href="http://www.kb.cert.org/vuls/id/120541">VU#120541</a>  <a href="https://www.cve.org/CVERecord?id=CVE-2009-3555">CVE-2009-3555</a><br>Not vulnerable: 0.8.23+, 0.7.64+<br>Vulnerable: 0.1.0-0.8.22<br><a href="/download/patch.cve-2009-3555.txt">The patch</a>  <a href="/download/patch.cve-2009-3555.txt.asc">pgp</a></p></li>
+
+</ul></div></div></body></html>

--- a/pkg/fetch/nginx/security-advisories/testdata/fixtures/invalid-id/security_advisories.html
+++ b/pkg/fetch/nginx/security-advisories/testdata/fixtures/invalid-id/security_advisories.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><title>nginx security advisories</title></head><body><div id="main"><div id="menu"><nav class="nav"><ul class="mobilemenu"><li><a href="../news.html">news</a></li><li><a href="download.html">download</a></li></ul></nav></div><div id="content"><h2>nginx security advisories</h2><p>
+All nginx security issues should be reported
+via one of the methods listed
+<a href="https://github.com/nginx/nginx/blob/master/SECURITY.md">here</a>.
+</p><p>
+Patches are signed using one of the
+<a href="pgp_keys.html">PGP public keys</a>.
+</p><ul>
+
+<li><p>Buffer overread in the ngx_http_mp4_module<br>Severity: low<br><a href="https://mailman.nginx.org/pipermail/nginx-announce/2024/UUOCLLONPR6244YQYU65PO5LB7JDYCWM.html">Advisory</a><br><a href="https://www.cve.org/CVERecord?id=CVE-2024-7347">CVE-24-7347</a><br>Not vulnerable: 1.27.1+, 1.26.2+<br>Vulnerable: 1.5.13-1.27.0<br><a href="/download/patch.2024.mp4.txt">The patch</a>  <a href="/download/patch.2024.mp4.txt.asc">pgp</a></p></li>
+
+</ul></div></div></body></html>

--- a/pkg/fetch/nginx/security-advisories/testdata/fixtures/multiple-ids/security_advisories.html
+++ b/pkg/fetch/nginx/security-advisories/testdata/fixtures/multiple-ids/security_advisories.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><title>nginx security advisories</title></head><body><div id="main"><div id="menu"><nav class="nav"><ul class="mobilemenu"><li><a href="../news.html">news</a></li><li><a href="download.html">download</a></li></ul></nav></div><div id="content"><h2>nginx security advisories</h2><p>
+All nginx security issues should be reported
+via one of the methods listed
+<a href="https://github.com/nginx/nginx/blob/master/SECURITY.md">here</a>.
+</p><p>
+Patches are signed using one of the
+<a href="pgp_keys.html">PGP public keys</a>.
+</p><ul>
+
+<li><p>Buffer overread in the ngx_http_mp4_module<br>Severity: low<br><a href="https://mailman.nginx.org/pipermail/nginx-announce/2024/UUOCLLONPR6244YQYU65PO5LB7JDYCWM.html">Advisory</a><br><a href="https://www.cve.org/CVERecord?id=CVE-2024-7347">CVE-2024-7347</a><br><a href="https://www.cve.org/CVERecord?id=CVE-2024-9999">CVE-2024-9999</a><br>Not vulnerable: 1.27.1+, 1.26.2+<br>Vulnerable: 1.5.13-1.27.0<br><a href="/download/patch.2024.mp4.txt">The patch</a>  <a href="/download/patch.2024.mp4.txt.asc">pgp</a></p></li>
+
+</ul></div></div></body></html>

--- a/pkg/fetch/nginx/security-advisories/testdata/fixtures/no-list/security_advisories.html
+++ b/pkg/fetch/nginx/security-advisories/testdata/fixtures/no-list/security_advisories.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><title>nginx security advisories</title></head><body><div id="main"><div id="menu"><nav class="nav"><ul class="mobilemenu"><li><a href="../news.html">news</a></li><li><a href="download.html">download</a></li></ul></nav></div><div id="content"><h2>nginx security advisories</h2><p>
+All nginx security issues should be reported
+via one of the methods listed
+<a href="https://github.com/nginx/nginx/blob/master/SECURITY.md">here</a>.
+</p><p>
+Patches are signed using one of the
+<a href="pgp_keys.html">PGP public keys</a>.
+</p><p>The advisories have moved.</p></div></div></body></html>

--- a/pkg/fetch/nginx/security-advisories/testdata/fixtures/unexpected-line/security_advisories.html
+++ b/pkg/fetch/nginx/security-advisories/testdata/fixtures/unexpected-line/security_advisories.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><title>nginx security advisories</title></head><body><div id="main"><div id="menu"><nav class="nav"><ul class="mobilemenu"><li><a href="../news.html">news</a></li><li><a href="download.html">download</a></li></ul></nav></div><div id="content"><h2>nginx security advisories</h2><p>
+All nginx security issues should be reported
+via one of the methods listed
+<a href="https://github.com/nginx/nginx/blob/master/SECURITY.md">here</a>.
+</p><p>
+Patches are signed using one of the
+<a href="pgp_keys.html">PGP public keys</a>.
+</p><ul>
+
+<li><p>Buffer overread in the ngx_http_mp4_module<br>Published: 2024-08-14<br>Severity: low<br><a href="https://mailman.nginx.org/pipermail/nginx-announce/2024/UUOCLLONPR6244YQYU65PO5LB7JDYCWM.html">Advisory</a><br><a href="https://www.cve.org/CVERecord?id=CVE-2024-7347">CVE-2024-7347</a><br>Not vulnerable: 1.27.1+, 1.26.2+<br>Vulnerable: 1.5.13-1.27.0<br><a href="/download/patch.2024.mp4.txt">The patch</a>  <a href="/download/patch.2024.mp4.txt.asc">pgp</a></p></li>
+
+</ul></div></div></body></html>

--- a/pkg/fetch/nginx/security-advisories/testdata/fixtures/unexpected-patch/security_advisories.html
+++ b/pkg/fetch/nginx/security-advisories/testdata/fixtures/unexpected-patch/security_advisories.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><title>nginx security advisories</title></head><body><div id="main"><div id="menu"><nav class="nav"><ul class="mobilemenu"><li><a href="../news.html">news</a></li><li><a href="download.html">download</a></li></ul></nav></div><div id="content"><h2>nginx security advisories</h2><p>
+All nginx security issues should be reported
+via one of the methods listed
+<a href="https://github.com/nginx/nginx/blob/master/SECURITY.md">here</a>.
+</p><p>
+Patches are signed using one of the
+<a href="pgp_keys.html">PGP public keys</a>.
+</p><ul>
+
+<li><p>Buffer overread in the ngx_http_mp4_module<br>Severity: low<br><a href="https://mailman.nginx.org/pipermail/nginx-announce/2024/UUOCLLONPR6244YQYU65PO5LB7JDYCWM.html">Advisory</a><br><a href="https://www.cve.org/CVERecord?id=CVE-2024-7347">CVE-2024-7347</a><br>Not vulnerable: 1.27.1+, 1.26.2+<br>Vulnerable: 1.5.13-1.27.0<br><a href="/download/patch.2024.mp4.txt">Patch</a>  <a href="/download/patch.2024.mp4.txt.asc">pgp</a></p></li>
+
+</ul></div></div></body></html>

--- a/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2009/CVE-2009-3555.json
+++ b/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2009/CVE-2009-3555.json
@@ -1,0 +1,28 @@
+{
+	"id": "CVE-2009-3555",
+	"title": "The renegotiation vulnerability in SSL protocol",
+	"severity": "major",
+	"not_vulnerable": [
+		"0.8.23+",
+		"0.7.64+"
+	],
+	"vulnerable": [
+		"0.1.0-0.8.22"
+	],
+	"references": [
+		{
+			"text": "VU#120541",
+			"url": "http://www.kb.cert.org/vuls/id/120541"
+		},
+		{
+			"text": "CVE-2009-3555",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2009-3555"
+		}
+	],
+	"patches": [
+		{
+			"url": "https://nginx.org/download/patch.cve-2009-3555.txt",
+			"signature_url": "https://nginx.org/download/patch.cve-2009-3555.txt.asc"
+		}
+	]
+}

--- a/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2009/CVE-2009-4487.json
+++ b/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2009/CVE-2009-4487.json
@@ -1,0 +1,17 @@
+{
+	"id": "CVE-2009-4487",
+	"title": "An error log data are not sanitized",
+	"severity": "none",
+	"not_vulnerable": [
+		"none"
+	],
+	"vulnerable": [
+		"all"
+	],
+	"references": [
+		{
+			"text": "CVE-2009-4487",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2009-4487"
+		}
+	]
+}

--- a/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2010/CORE-2010-0121.json
+++ b/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2010/CORE-2010-0121.json
@@ -1,0 +1,18 @@
+{
+	"id": "CORE-2010-0121",
+	"title": "Vulnerabilities with Windows 8.3 filename pseudonyms",
+	"severity": "major",
+	"not_vulnerable": [
+		"0.8.33+",
+		"0.7.65+"
+	],
+	"vulnerable": [
+		"nginx/Windows 0.7.52-0.8.32"
+	],
+	"references": [
+		{
+			"text": "CORE-2010-0121",
+			"url": "http://www.coresecurity.com/content/filename-pseudonyms-vulnerabilities"
+		}
+	]
+}

--- a/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2011/CVE-2011-4963.json
+++ b/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2011/CVE-2011-4963.json
@@ -1,0 +1,22 @@
+{
+	"id": "CVE-2011-4963",
+	"title": "Vulnerabilities with Windows directory aliases",
+	"severity": "medium",
+	"not_vulnerable": [
+		"1.3.1+",
+		"1.2.1+"
+	],
+	"vulnerable": [
+		"nginx/Windows 0.7.52-1.3.0"
+	],
+	"references": [
+		{
+			"text": "Advisory",
+			"url": "https://mailman.nginx.org/pipermail/nginx-announce/2012/000086.html"
+		},
+		{
+			"text": "CVE-2011-4963",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2011-4963"
+		}
+	]
+}

--- a/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2013/CVE-2013-2070.json
+++ b/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2013/CVE-2013-2070.json
@@ -1,0 +1,36 @@
+{
+	"id": "CVE-2013-2070",
+	"title": "Memory disclosure with specially crafted HTTP backend responses",
+	"severity": "medium",
+	"not_vulnerable": [
+		"1.5.0+",
+		"1.4.1+",
+		"1.2.9+"
+	],
+	"vulnerable": [
+		"1.1.4-1.2.8",
+		"1.3.9-1.4.0"
+	],
+	"references": [
+		{
+			"text": "Advisory",
+			"url": "https://mailman.nginx.org/pipermail/nginx-announce/2013/000114.html"
+		},
+		{
+			"text": "CVE-2013-2070",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2013-2070"
+		}
+	],
+	"patches": [
+		{
+			"url": "https://nginx.org/download/patch.2013.chunked.txt",
+			"signature_url": "https://nginx.org/download/patch.2013.chunked.txt.asc",
+			"note": "(for 1.3.9-1.4.0)"
+		},
+		{
+			"url": "https://nginx.org/download/patch.2013.proxy.txt",
+			"signature_url": "https://nginx.org/download/patch.2013.proxy.txt.asc",
+			"note": "(for 1.1.4-1.2.8)"
+		}
+	]
+}

--- a/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2016/CVE-2016-4450.json
+++ b/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2016/CVE-2016-4450.json
@@ -1,0 +1,34 @@
+{
+	"id": "CVE-2016-4450",
+	"title": "NULL pointer dereference while writing client request body",
+	"severity": "medium",
+	"not_vulnerable": [
+		"1.11.1+",
+		"1.10.1+"
+	],
+	"vulnerable": [
+		"1.3.9-1.11.0"
+	],
+	"references": [
+		{
+			"text": "Advisory",
+			"url": "https://mailman.nginx.org/pipermail/nginx-announce/2016/000179.html"
+		},
+		{
+			"text": "CVE-2016-4450",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2016-4450"
+		}
+	],
+	"patches": [
+		{
+			"url": "https://nginx.org/download/patch.2016.write.txt",
+			"signature_url": "https://nginx.org/download/patch.2016.write.txt.asc",
+			"note": "(for 1.9.13-1.11.0)"
+		},
+		{
+			"url": "https://nginx.org/download/patch.2016.write2.txt",
+			"signature_url": "https://nginx.org/download/patch.2016.write2.txt.asc",
+			"note": "(for 1.3.9-1.9.12)"
+		}
+	]
+}

--- a/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2024/CVE-2024-7347.json
+++ b/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2024/CVE-2024-7347.json
@@ -1,0 +1,28 @@
+{
+	"id": "CVE-2024-7347",
+	"title": "Buffer overread in the ngx_http_mp4_module",
+	"severity": "low",
+	"not_vulnerable": [
+		"1.27.1+",
+		"1.26.2+"
+	],
+	"vulnerable": [
+		"1.5.13-1.27.0"
+	],
+	"references": [
+		{
+			"text": "Advisory",
+			"url": "https://mailman.nginx.org/pipermail/nginx-announce/2024/UUOCLLONPR6244YQYU65PO5LB7JDYCWM.html"
+		},
+		{
+			"text": "CVE-2024-7347",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2024-7347"
+		}
+	],
+	"patches": [
+		{
+			"url": "https://nginx.org/download/patch.2024.mp4.txt",
+			"signature_url": "https://nginx.org/download/patch.2024.mp4.txt.asc"
+		}
+	]
+}

--- a/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2026/CVE-2026-42533.json
+++ b/pkg/fetch/nginx/security-advisories/testdata/golden/happy/2026/CVE-2026-42533.json
@@ -1,0 +1,22 @@
+{
+	"id": "CVE-2026-42533",
+	"title": "Buffer overflow when using map and regex",
+	"severity": "major",
+	"not_vulnerable": [
+		"1.31.3+",
+		"1.30.4+"
+	],
+	"vulnerable": [
+		"0.9.6-1.31.2"
+	],
+	"references": [
+		{
+			"text": "Advisory",
+			"url": "https://my.f5.com/manage/s/article/K000162097"
+		},
+		{
+			"text": "CVE-2026-42533",
+			"url": "https://www.cve.org/CVERecord?id=CVE-2026-42533"
+		}
+	]
+}

--- a/pkg/fetch/nginx/security-advisories/types.go
+++ b/pkg/fetch/nginx/security-advisories/types.go
@@ -1,0 +1,43 @@
+package securityadvisories
+
+// Advisory is one entry of the nginx security advisories page.
+//
+// The page carries no publication date and no per-advisory permalink, so the
+// only identifier available is the vulnerability ID linked from the entry.
+type Advisory struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+
+	// Severity is stored verbatim ("none", "minor", "low", "medium",
+	// "major"). It is deliberately not validated against a closed
+	// vocabulary: a new severity word is data drift, not a structural
+	// change, and must not break the fetch of the whole page.
+	Severity string `json:"severity"`
+
+	// NotVulnerable and Vulnerable hold the comma separated version
+	// expressions exactly as written ("1.31.3+", "0.9.6-1.31.2",
+	// "nginx/Windows 0.7.52-1.3.0", "none", "all"). Interpreting them is
+	// left to extract.
+	NotVulnerable []string `json:"not_vulnerable,omitempty"`
+	Vulnerable    []string `json:"vulnerable,omitempty"`
+
+	References []Reference `json:"references,omitempty"`
+	Patches    []Patch     `json:"patches,omitempty"`
+}
+
+// Reference is a link of an advisory entry, such as the F5 article or the
+// mailing list announcement ("Advisory"), the CVE record ("CVE-yyyy-nnnn") or a
+// CERT note ("VU#nnnnnn").
+type Reference struct {
+	Text string `json:"text"`
+	URL  string `json:"url"`
+}
+
+// Patch is a patch download offered by an advisory entry. Note carries the
+// parenthesized applicability remark shown after the links, if any, e.g.
+// "(for 1.9.13-1.11.0)".
+type Patch struct {
+	URL          string `json:"url"`
+	SignatureURL string `json:"signature_url,omitempty"`
+	Note         string `json:"note,omitempty"`
+}


### PR DESCRIPTION
## What

Add a fetcher and an extractor for the nginx security advisories page
(https://nginx.org/en/security_advisories.html).

- `vuls-data-update fetch nginx-security-advisories`
- `vuls-data-update extract nginx-security-advisories <raw repo path>`

## Why

The page is the more complete source for nginx core. NVD carries CPE data for
41 CVEs under `cpe:2.3:a:f5:nginx` and none published after 2023, while the
page lists 62 entries — the 2024 HTTP/3 set, CVE-2025-53859 and the 20 entries
from 2026 have no CPE-matched NVD data at all.

The 8 CVEs NVD has that the page does not are ones the nginx team does not
consider nginx core issues (distro packaging, configuration dependent, the
SSL/TLS layer, HTTP/2 Rapid Reset).

## How

**fetch** parses the page with goquery and writes one deterministic JSON per
entry under `{year}/{ID}.json`. The page's own wording is kept verbatim — the
severity word, the version expressions (`1.31.3+`, `nginx/Windows
0.7.52-1.3.0`, `none`, `all`), every reference (CVE, VU#, CORE) and the patch
applicability remarks — leaving interpretation to extract. Nothing that fails
to parse is skipped: an unrecognised `<li>`, ID or patch line aborts the fetch
with the raw HTML in the error, so a markup change surfaces rather than
silently yielding fewer advisories. Relative patch links resolve against the
canonical page URL, not the fetched one, so a mirror or the test server cannot
leak into the output.

One entry (`CORE-2010-0121`, the Windows 8.3 filename pseudonyms issue)
predates its CVE assignment and carries a Core Security ID; it files under
`2010/` like any other, so no separate bucket is needed.

**extract** emits a Vulnerability per CVE entry (an Advisory for the Core
Security root, mirroring how the paloalto extractor places a PAN-SA root), the
severity word as a vendor severity, the patches as mitigations, and CPE
detections against `cpe:2.3:a:f5:nginx`.

The version ranges cannot be emitted verbatim. nginx develops stable and
mainline branches in parallel and fixes each separately, so a branch's fix sits
*inside* the single range the page states — CVE-2026-42533 lists `Vulnerable:
0.9.6-1.31.2` with `Not vulnerable: 1.31.3+, 1.30.4+`, where the patched 1.30.4
falls inside the range. Each fix landing inside a range therefore closes an
interval and the next one resumes at the following branch:

```json
{"ge": "0.9.6",  "lt": "1.30.4", "fixed": ["1.30.4"]}
{"ge": "1.31.0", "le": "1.31.2", "fixed": ["1.31.3"]}
```

`Fixed` does not participate in `cpecriterion.Accept`, so splitting the range
is what avoids the false positives, not listing the fixed releases.

The `nginx/Windows` entries become a platform precondition ANDed with
`cpe:2.3:o:microsoft:windows:-`, as NVD models them, so a Linux nginx in range
does not match.

## Testing

`go build ./... && go test ./...` — full suite green.

- fetch: golden test plus five error fixtures (404, missing list, malformed ID,
  two IDs on one entry, unclassifiable line, renamed patch link), each verified
  to fail for its intended reason.
- extract: golden test, and table-driven unit tests for the version parsing and
  interval splitting covering the real shapes (fix inside the range, trailing
  single release, pre-split ranges, fix on another branch, `all`/`none`) and the
  rejected ones.
- End to end against the live page: all 62 entries parse and extract, 61
  Vulnerabilities and 1 Advisory, no entry loses its detections.
- Cross-checked the emitted ranges against NVD for the 33 advisories it has CPE
  data for: **24 agree as version sets**. Every remaining difference is one
  where the page is the more precise source — NVD calls 1.12.1 vulnerable in
  CVE-2017-7529 though it is the fix, covers 1.14.1–1.15.0 with a single range
  in CVE-2018-16845, and leaks NGINX Plus release numbers (`r22`–`r27`) into
  CVE-2022-41741. No case where this extractor is the wrong one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
