### PR TITLE
feat(fetch,extract/apache/httpd/json): add Apache HTTP Server CVE JSON data source

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -15,6 +15,7 @@ import (
 	alpineSecDB "github.com/MaineK00n/vuls-data-update/pkg/extract/alpine/secdb"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/amazon"
 	androidOSV "github.com/MaineK00n/vuls-data-update/pkg/extract/android/osv"
+	apacheHTTPDJSON "github.com/MaineK00n/vuls-data-update/pkg/extract/apache/httpd/json"
 	"github.com/MaineK00n/vuls-data-update/pkg/extract/arch"
 	bitnamiOSV "github.com/MaineK00n/vuls-data-update/pkg/extract/bitnami/osv"
 	cargoDB "github.com/MaineK00n/vuls-data-update/pkg/extract/cargo/db"
@@ -153,6 +154,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdAlpineSecDB(), newCmdAlpineOSV(),
 		newCmdAmazon(),
 		newCmdAndroidOSV(),
+		newCmdApacheHTTPDJSON(),
 		newCmdArch(),
 		newCmdBitnamiOSV(),
 		newCmdCargoGHSA(), newCmdCargoOSV(), newCmdCargoDB(),
@@ -373,6 +375,31 @@ func newCmdAndroidOSV() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := androidOSV.Extract(args[0], androidOSV.WithDir(options.dir)); err != nil {
 				return errors.Wrap(err, "failed to extract android osv")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdApacheHTTPDJSON() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "apache", "httpd", "json"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "apache-httpd-json <Raw Apache HTTP Server CVE (JSON) Repository PATH>",
+		Short: "Extract Apache HTTP Server CVE (JSON) data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract apache-httpd-json vuls-data-raw-apache-httpd-json
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := apacheHTTPDJSON.Extract(args[0], apacheHTTPDJSON.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract apache httpd json")
 			}
 			return nil
 		},

--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -20,6 +20,7 @@ import (
 	anchoreEnrichment "github.com/MaineK00n/vuls-data-update/pkg/fetch/anchore/enrichment"
 	androidOSV "github.com/MaineK00n/vuls-data-update/pkg/fetch/android/osv"
 	anolisOVAL "github.com/MaineK00n/vuls-data-update/pkg/fetch/anolis/oval"
+	apacheHTTPDJSON "github.com/MaineK00n/vuls-data-update/pkg/fetch/apache/httpd/json"
 	"github.com/MaineK00n/vuls-data-update/pkg/fetch/arch"
 	bellsoftAlpaquitaOSV "github.com/MaineK00n/vuls-data-update/pkg/fetch/bellsoft/alpaquita/osv"
 	bellsoftHardenedContainersOSV "github.com/MaineK00n/vuls-data-update/pkg/fetch/bellsoft/hardened-containers/osv"
@@ -220,6 +221,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdAnchoreEnrichment(),
 		newCmdAndroidOSV(),
 		newCmdAnolisOVAL(),
+		newCmdApacheHTTPDJSON(),
 		newCmdArch(),
 		newCmdBellSoftAlpaquitaOSV(), newCmdBellSoftHardenedContainersOSV(),
 		newCmdBitnamiOSV(),
@@ -599,6 +601,43 @@ func newCmdAnolisOVAL() *cobra.Command {
 
 	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
 	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
+
+	return cmd
+}
+
+func newCmdApacheHTTPDJSON() *cobra.Command {
+	options := &struct {
+		base
+		concurrency int
+		wait        time.Duration
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "apache", "httpd", "json"),
+			retry: 3,
+		},
+		concurrency: 5,
+		wait:        1 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "apache-httpd-json",
+		Short: "Fetch Apache HTTP Server CVE (JSON) data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch apache-httpd-json
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := apacheHTTPDJSON.Fetch(apacheHTTPDJSON.WithDir(options.dir), apacheHTTPDJSON.WithRetry(options.retry), apacheHTTPDJSON.WithConcurrency(options.concurrency), apacheHTTPDJSON.WithWait(options.wait)); err != nil {
+				return errors.Wrap(err, "failed to fetch apache httpd json")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
+	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent http requests")
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
 
 	return cmd
 }

--- a/pkg/extract/apache/httpd/json/json.go
+++ b/pkg/extract/apache/httpd/json/json.go
@@ -1,0 +1,437 @@
+package json
+
+import (
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/knqyf263/go-cpe/common"
+	"github.com/knqyf263/go-cpe/naming"
+	"github.com/pkg/errors"
+
+	httpdjson "github.com/MaineK00n/vuls-data-update/pkg/fetch/apache/httpd/json"
+
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
+	detectionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection"
+	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
+	criteriaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria"
+	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
+	cpecriterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion"
+	cperangeTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/range"
+	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
+	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
+	referenceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/reference"
+	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	utiljson "github.com/MaineK00n/vuls-data-update/pkg/extract/util/json"
+	utiltime "github.com/MaineK00n/vuls-data-update/pkg/extract/util/time"
+)
+
+// Every record describes the one product, so the criterion CPE is fixed and
+// only the version part varies.
+const (
+	productCPE  = "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
+	versionCPE  = "cpe:2.3:a:apache:http_server:%s:*:*:*:*:*:*:*"
+	sourceLabel = "httpd.apache.org"
+)
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "apache", "httpd", "json"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract Apache HTTP Server CVE (JSON)")
+	if err := filepath.WalkDir(args, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		extracted, err := extractFile(path, args)
+		if err != nil {
+			return errors.Wrapf(err, "extract %s", path)
+		}
+
+		if err := util.Write(filepath.Join(options.dir, "data", filepath.Base(filepath.Dir(path)), fmt.Sprintf("%s.json", extracted.ID)), extracted, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "data", filepath.Base(filepath.Dir(path)), fmt.Sprintf("%s.json", extracted.ID)))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", args)
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.ApacheHTTPDJSON,
+		Name: new("Apache HTTP Server CVE (JSON)"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{
+					URL: u,
+				}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+// extractFile reads one fetched record. The ASF serves two schema generations
+// side by side, so which type to decode into is decided by the version member
+// the record carries, the same way the fetcher routes them.
+func extractFile(path, args string) (dataTypes.Data, error) {
+	r := utiljson.NewJSONReader()
+
+	var probe struct {
+		DataVersion4 string `json:"data_version"`
+		DataVersion5 string `json:"dataVersion"`
+	}
+	if err := r.Read(path, args, &probe); err != nil {
+		return dataTypes.Data{}, errors.Wrapf(err, "read json %s", path)
+	}
+
+	switch {
+	case probe.DataVersion5 != "":
+		var fetched httpdjson.CVE5
+		if err := r.Read(path, args, &fetched); err != nil {
+			return dataTypes.Data{}, errors.Wrapf(err, "read json %s", path)
+		}
+		return extract5(fetched, r.Paths()), nil
+	case probe.DataVersion4 != "":
+		var fetched httpdjson.CVE4
+		if err := r.Read(path, args, &fetched); err != nil {
+			return dataTypes.Data{}, errors.Wrapf(err, "read json %s", path)
+		}
+		return extract4(fetched, r.Paths()), nil
+	default:
+		return dataTypes.Data{}, errors.Errorf("unexpected schema. expected one of: %q", []string{"data_version", "dataVersion"})
+	}
+}
+
+func extract4(fetched httpdjson.CVE4, raws []string) dataTypes.Data {
+	// version_data enumerates concrete versions with "=" (verified) or "?="
+	// (listed but unverified, per the vulnerability page's own wording); the
+	// 2021-2022 records instead bound a range with "<=" for the upper end and
+	// ">=" / "!<" ("not less than") for the lower one. Exact versions become
+	// CPEMatches, bounds become a Range — the two never co-occur in the current
+	// corpus, but the criterion carries both fields so a record using them
+	// together still extracts.
+	var (
+		matches []cpecriterionTypes.CPE
+		rng     cperangeTypes.Range
+		bounded bool
+	)
+	for _, vendor := range fetched.Affects.Vendor.VendorData {
+		for _, product := range vendor.Product.ProductData {
+			for _, v := range product.Version.VersionData {
+				switch v.VersionAffected {
+				case "=", "?=":
+					matches = append(matches, cpecriterionTypes.CPE(fmt.Sprintf(versionCPE, v.VersionValue)))
+				case "<=":
+					rng.LessEqual = v.VersionValue
+					bounded = true
+				case "<":
+					rng.LessThan = v.VersionValue
+					bounded = true
+				case ">=", "!<":
+					rng.GreaterEqual = v.VersionValue
+					bounded = true
+				case ">":
+					rng.GreaterThan = v.VersionValue
+					bounded = true
+				default:
+					// A comparator the CVE JSON 4.0 vocabulary allows but the
+					// ASF has never used. Skipping it would silently shrink the
+					// affected set, so record it and move on rather than drop
+					// the whole record.
+					slog.Warn("skip unsupported version_affected", "cve", fetched.CVEDataMeta.ID, "version_affected", v.VersionAffected, "version_value", v.VersionValue)
+				}
+			}
+		}
+	}
+	if bounded {
+		rng.Type = cperangeTypes.RangeTypeSEMVER
+	}
+
+	return dataTypes.Data{
+		ID: dataTypes.RootID(fetched.CVEDataMeta.ID),
+		Vulnerabilities: []vulnerabilityTypes.Vulnerability{{
+			Content: vulnerabilityContentTypes.Content{
+				ID:    vulnerabilityContentTypes.VulnerabilityID(fetched.CVEDataMeta.ID),
+				Title: fetched.CVEDataMeta.Title,
+				Description: func() string {
+					for _, d := range fetched.Description.DescriptionData {
+						if d.Lang == "eng" || d.Lang == "en" {
+							return d.Value
+						}
+					}
+					return ""
+				}(),
+				Severity: func() []severityTypes.Severity {
+					var ss []severityTypes.Severity
+					for _, i := range fetched.Impact {
+						if i.Other == "" || i.Other == "n/a" {
+							continue
+						}
+						ss = append(ss, severityTypes.Severity{
+							Type:   severityTypes.SeverityTypeVendor,
+							Source: sourceLabel,
+							Vendor: &i.Other,
+						})
+					}
+					return ss
+				}(),
+				// problemtype_data carries the flaw's short name here, not a
+				// CWE identifier, so there is nothing to map onto cwe.
+				References: func() []referenceTypes.Reference {
+					var rs []referenceTypes.Reference
+					for _, ref := range fetched.References.ReferenceData {
+						if ref.URL == nil || *ref.URL == "" {
+							continue
+						}
+						rs = append(rs, referenceTypes.Reference{
+							Source: sourceLabel,
+							URL:    *ref.URL,
+						})
+					}
+					return rs
+				}(),
+				Published: func() *time.Time {
+					if fetched.CVEDataMeta.DatePublic == nil || *fetched.CVEDataMeta.DatePublic == "" {
+						return nil
+					}
+					return utiltime.Parse([]string{"2006-01-02"}, *fetched.CVEDataMeta.DatePublic)
+				}(),
+			},
+			Segments: segments(matches, bounded),
+		}},
+		Detections: detections(matches, rng, bounded),
+		DataSource: sourceTypes.Source{
+			ID:   sourceTypes.ApacheHTTPDJSON,
+			Raws: raws,
+		},
+	}
+}
+
+func extract5(fetched httpdjson.CVE5, raws []string) dataTypes.Data {
+	cna := fetched.Containers.CNA
+
+	// A versions[] entry with an upper bound describes a range; one carrying
+	// only "version" pins that single release. "0" is the schema's way of
+	// saying "from the first release", so it sets no lower bound.
+	var (
+		matches []cpecriterionTypes.CPE
+		rng     cperangeTypes.Range
+		bounded bool
+	)
+	for _, a := range cna.Affected {
+		for _, v := range a.Versions {
+			switch {
+			case v.LessThan != nil && *v.LessThan != "":
+				rng.LessThan = *v.LessThan
+				bounded = true
+			case v.LessThanOrEqual != nil && *v.LessThanOrEqual != "":
+				rng.LessEqual = *v.LessThanOrEqual
+				bounded = true
+			default:
+				if v.Version != "" && v.Version != "0" {
+					matches = append(matches, cpecriterionTypes.CPE(fmt.Sprintf(versionCPE, v.Version)))
+				}
+				continue
+			}
+			if v.Version != "" && v.Version != "0" {
+				rng.GreaterEqual = v.Version
+			}
+		}
+		for _, c := range a.CPEs {
+			matches = appendCPEMatch(matches, fetched.CVEMetadata.CVEID, c)
+		}
+	}
+	if bounded {
+		rng.Type = cperangeTypes.RangeTypeSEMVER
+	}
+
+	return dataTypes.Data{
+		ID: dataTypes.RootID(fetched.CVEMetadata.CVEID),
+		Vulnerabilities: []vulnerabilityTypes.Vulnerability{{
+			Content: vulnerabilityContentTypes.Content{
+				ID:    vulnerabilityContentTypes.VulnerabilityID(fetched.CVEMetadata.CVEID),
+				Title: cna.Title,
+				Description: func() string {
+					for _, d := range cna.Descriptions {
+						if d.Lang == "en" {
+							return d.Value
+						}
+					}
+					return ""
+				}(),
+				Severity: func() []severityTypes.Severity {
+					var ss []severityTypes.Severity
+					for _, m := range cna.Metrics {
+						if m.Other.Content.Text == "" || m.Other.Content.Text == "n/a" {
+							continue
+						}
+						ss = append(ss, severityTypes.Severity{
+							Type:   severityTypes.SeverityTypeVendor,
+							Source: sourceLabel,
+							Vendor: &m.Other.Content.Text,
+						})
+					}
+					return ss
+				}(),
+				CWE: func() []cweTypes.CWE {
+					var cs []string
+					for _, p := range cna.ProblemTypes {
+						for _, d := range p.Descriptions {
+							if d.CWEID != nil && *d.CWEID != "" {
+								cs = append(cs, *d.CWEID)
+							}
+						}
+					}
+					if len(cs) == 0 {
+						return nil
+					}
+					return []cweTypes.CWE{{Source: sourceLabel, CWE: cs}}
+				}(),
+				References: func() []referenceTypes.Reference {
+					rs := make([]referenceTypes.Reference, 0, len(cna.References))
+					for _, ref := range cna.References {
+						if ref.URL == "" {
+							continue
+						}
+						rs = append(rs, referenceTypes.Reference{
+							Source: sourceLabel,
+							URL:    ref.URL,
+						})
+					}
+					if len(rs) == 0 {
+						return nil
+					}
+					return rs
+				}(),
+				// The CVE Record Format records the ASF serves carry no
+				// datePublished and no "public" timeline entry, so there is no
+				// publication date to map.
+			},
+			Segments: segments(matches, bounded),
+		}},
+		Detections: detections(matches, rng, bounded),
+		DataSource: sourceTypes.Source{
+			ID:   sourceTypes.ApacheHTTPDJSON,
+			Raws: raws,
+		},
+	}
+}
+
+// appendCPEMatch adds an entry from affected[].cpes to the criterion's explicit
+// match list. The criterion is already pinned to the product by productCPE, so
+// an entry carrying no concrete version adds nothing — and as a CPEMatch it
+// would match every version and quietly defeat the criterion's Range. Such an
+// entry is dropped when it merely restates productCPE, and reported otherwise.
+func appendCPEMatch(matches []cpecriterionTypes.CPE, id, c string) []cpecriterionTypes.CPE {
+	wfn, err := naming.UnbindFS(c)
+	if err != nil {
+		slog.Warn("skip unparseable cpe", "cve", id, "cpe", c, "error", err)
+		return matches
+	}
+
+	switch wfn.GetString(common.AttributeVersion) {
+	case "ANY", "NA":
+		if c != productCPE {
+			slog.Warn("skip cpe without a concrete version", "cve", id, "cpe", c)
+		}
+		return matches
+	default:
+		return append(matches, cpecriterionTypes.CPE(c))
+	}
+}
+
+func segments(matches []cpecriterionTypes.CPE, bounded bool) []segmentTypes.Segment {
+	if len(matches) == 0 && !bounded {
+		return nil
+	}
+	return []segmentTypes.Segment{{Ecosystem: ecosystemTypes.EcosystemTypeCPE}}
+}
+
+func detections(matches []cpecriterionTypes.CPE, rng cperangeTypes.Range, bounded bool) []detectionTypes.Detection {
+	if len(matches) == 0 && !bounded {
+		return nil
+	}
+
+	c := cpecriterionTypes.Criterion{
+		Vulnerable: true,
+		CPE:        productCPE,
+		CPEMatches: matches,
+	}
+	if bounded {
+		c.Range = &rng
+	}
+
+	return []detectionTypes.Detection{{
+		Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+		Conditions: []conditionTypes.Condition{{
+			Criteria: criteriaTypes.Criteria{
+				Operator: criteriaTypes.CriteriaOperatorTypeOR,
+				Criterions: []criterionTypes.Criterion{{
+					Type: criterionTypes.CriterionTypeCPE,
+					CPE:  &c,
+				}},
+			},
+		}},
+	}}
+}

--- a/pkg/extract/apache/httpd/json/json_test.go
+++ b/pkg/extract/apache/httpd/json/json_test.go
@@ -1,0 +1,47 @@
+package json_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	httpdjson "github.com/MaineK00n/vuls-data-update/pkg/extract/apache/httpd/json"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := httpdjson.Extract(tt.args, httpdjson.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				// error was expected and occurred, test passed
+				return
+			default:
+				ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				gp, err := filepath.Abs(dir)
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/fixtures/2004/CVE-2004-0174.json
+++ b/pkg/extract/apache/httpd/json/testdata/fixtures/2004/CVE-2004-0174.json
@@ -1,0 +1,244 @@
+{
+	"data_type": "CVE",
+	"data_format": "MITRE",
+	"data_version": "4.0",
+	"generator": {
+		"engine": "xmltojsonmjc 1.0"
+	},
+	"CVE_data_meta": {
+		"ID": "CVE-2004-0174",
+		"ASSIGNER": "security@apache.org",
+		"STATE": "PUBLIC",
+		"TITLE": "listening socket starvation",
+		"DATE_PUBLIC": "2004-03-18"
+	},
+	"source": {
+		"discovery": "UNKNOWN"
+	},
+	"affects": {
+		"vendor": {
+			"vendor_data": [
+				{
+					"vendor_name": "Apache Software Foundation",
+					"product": {
+						"product_data": [
+							{
+								"product_name": "Apache HTTP Server",
+								"version": {
+									"version_data": [
+										{
+											"version_affected": "=",
+											"version_value": "1.3.29",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.48",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.47",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.46",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.45",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.44",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.43",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.42",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.40",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.39",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.37",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.36",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.35",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.28",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.27",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.26",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.24",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.22",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.20",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.19",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.17",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.14",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.12",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.11",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.9",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.6",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.4",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.3",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.2",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.1",
+											"version_name": "1.3"
+										},
+										{
+											"version_affected": "?=",
+											"version_value": "1.3.0",
+											"version_name": "1.3"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	},
+	"problemtype": {
+		"problemtype_data": [
+			{
+				"description": [
+					{
+						"lang": "eng",
+						"value": "listening socket starvation"
+					}
+				]
+			}
+		]
+	},
+	"description": {
+		"description_data": [
+			{
+				"lang": "eng",
+				"value": "A starvation issue on listening sockets occurs when a short-lived connection on a rarely-accessed listening socket will cause a child to hold the accept mutex and block out new connections until another connection arrives on that rarely-accessed listening socket. This issue is known to affect some versions of AIX, Solaris, and Tru64; it is known to not affect FreeBSD or Linux."
+			}
+		]
+	},
+	"references": {},
+	"impact": [
+		{
+			"other": "important"
+		}
+	],
+	"timeline": [
+		{
+			"lang": "eng",
+			"time": "2004-02-25",
+			"value": "reported"
+		},
+		{
+			"lang": "eng",
+			"time": "2004-03-18",
+			"value": "public"
+		},
+		{
+			"lang": "eng",
+			"time": "2004-05-12",
+			"value": "1.3.31 released"
+		},
+		{
+			"lang": "eng",
+			"time": "2004-03-19",
+			"value": "2.0.49 released"
+		}
+	],
+	"CNA_private": {
+		"owner": "httpd"
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/fixtures/2006/CVE-2006-20001.json
+++ b/pkg/extract/apache/httpd/json/testdata/fixtures/2006/CVE-2006-20001.json
@@ -1,0 +1,107 @@
+{
+	"dataType": "CVE_RECORD",
+	"dataVersion": "5.0",
+	"cveMetadata": {
+		"cveId": "CVE-2006-20001",
+		"assignerOrgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09",
+		"serial": 1,
+		"state": "PUBLISHED"
+	},
+	"containers": {
+		"cna": {
+			"providerMetadata": {
+				"orgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09"
+			},
+			"title": "mod_dav out of  bounds read, or write of zero byte",
+			"descriptions": [
+				{
+					"lang": "en",
+					"value": "A carefully crafted If: request header can cause a memory read, or write of a single zero byte, in a pool (heap) memory location beyond the header value sent. This could cause the process to crash.\n\nThis issue affects Apache HTTP Server 2.4.54 and earlier.\n",
+					"supportingMedia": [
+						{
+							"type": "text/html",
+							"base64": false,
+							"value": "A carefully crafted If: request header can cause a memory read, or write of a single zero byte, in a pool (heap) memory location beyond the header value sent. This could cause the process to crash.<br><br>This issue affects Apache HTTP Server 2.4.54 and earlier.<br>"
+						}
+					]
+				}
+			],
+			"affected": [
+				{
+					"vendor": "Apache Software Foundation",
+					"product": "Apache HTTP Server",
+					"defaultStatus": "unaffected",
+					"versions": [
+						{
+							"status": "affected",
+							"version": "2.4",
+							"versionType": "semver",
+							"lessThanOrEqual": "2.4.54"
+						}
+					]
+				}
+			],
+			"problemTypes": [
+				{
+					"descriptions": [
+						{
+							"lang": "en",
+							"description": "CWE-787 Out-of-bounds Write",
+							"cweId": "CWE-787",
+							"type": "CWE"
+						}
+					]
+				}
+			],
+			"metrics": [
+				{
+					"other": {
+						"type": "Textual description of severity",
+						"content": {
+							"text": "moderate"
+						}
+					}
+				}
+			],
+			"timeline": [
+				{
+					"lang": "en",
+					"time": "2006-10-31T19:00:00.000Z",
+					"value": "Described in first edition of \"The Art of Software Security Assessment\""
+				},
+				{
+					"lang": "en",
+					"time": "2022-08-10T19:00:00.000Z",
+					"value": "Reported to security team"
+				},
+				{
+					"lang": "eng",
+					"time": "2023-01-17",
+					"value": "2.4.55 released"
+				}
+			],
+			"source": {
+				"discovery": "UNKNOWN"
+			},
+			"x_generator": {
+				"engine": "Vulnogram 0.1.0-dev"
+			},
+			"references": [
+				{
+					"url": "https://httpd.apache.org/security/vulnerabilities_24.html",
+					"tags": [
+						"vendor-advisory"
+					]
+				}
+			]
+		}
+	},
+	"CNA_private": {
+		"owner": "httpd",
+		"state": "REVIEW",
+		"type": "unsure",
+		"todo": [],
+		"projecturl": "https://httpd.apache.org/",
+		"userslist": "users@httpd.apache.org"
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/fixtures/2011/CVE-2011-3192.json
+++ b/pkg/extract/apache/httpd/json/testdata/fixtures/2011/CVE-2011-3192.json
@@ -1,0 +1,299 @@
+{
+	"data_type": "CVE",
+	"data_format": "MITRE",
+	"data_version": "4.0",
+	"generator": {
+		"engine": "xmltojsonmjc 1.0"
+	},
+	"CVE_data_meta": {
+		"ID": "CVE-2011-3192",
+		"ASSIGNER": "security@apache.org",
+		"STATE": "PUBLIC",
+		"TITLE": "Range header remote DoS",
+		"DATE_PUBLIC": "2011-08-20"
+	},
+	"source": {
+		"discovery": "UNKNOWN"
+	},
+	"affects": {
+		"vendor": {
+			"vendor_data": [
+				{
+					"vendor_name": "Apache Software Foundation",
+					"product": {
+						"product_data": [
+							{
+								"product_name": "Apache HTTP Server",
+								"version": {
+									"version_data": [
+										{
+											"version_affected": "=",
+											"version_value": "2.2.19",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.18",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.17",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.16",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.15",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.14",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.13",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.12",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.11",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.10",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.9",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.8",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.6",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.5",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.4",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.3",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.2",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.0",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.64",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.63",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.61",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.59",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.58",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.55",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.54",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.53",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.52",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.51",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.50",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.49",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.48",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.47",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.46",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.45",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.44",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.43",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.42",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.40",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.39",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.37",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.36",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.35",
+											"version_name": "2.0"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	},
+	"problemtype": {
+		"problemtype_data": [
+			{
+				"description": [
+					{
+						"lang": "eng",
+						"value": "Range header remote DoS"
+					}
+				]
+			}
+		]
+	},
+	"description": {
+		"description_data": [
+			{
+				"lang": "eng",
+				"value": "A flaw was found in the way the Apache HTTP Server handled Range HTTP headers. A remote attacker could use this flaw to cause httpd to use an excessive amount of memory and CPU time via HTTP requests with a specially-crafted Range header. This could be used in a denial of service attack. Advisory: CVE-2011-3192.txt"
+			}
+		]
+	},
+	"references": {},
+	"impact": [
+		{
+			"other": "important"
+		}
+	],
+	"timeline": [
+		{
+			"lang": "eng",
+			"time": "2011-08-20",
+			"value": "reported"
+		},
+		{
+			"lang": "eng",
+			"time": "2011-08-20",
+			"value": "public"
+		},
+		{
+			"lang": "eng",
+			"time": "2011-08-30",
+			"value": "2.2.20 released"
+		},
+		{
+			"lang": "eng",
+			"time": "2013-07-12",
+			"value": "2.0.65 released"
+		}
+	],
+	"CNA_private": {
+		"owner": "httpd"
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/fixtures/2021/CVE-2021-44224.json
+++ b/pkg/extract/apache/httpd/json/testdata/fixtures/2021/CVE-2021-44224.json
@@ -1,0 +1,106 @@
+{
+	"data_type": "CVE",
+	"data_format": "MITRE",
+	"data_version": "4.0",
+	"generator": {
+		"engine": "Vulnogram 0.0.9"
+	},
+	"CVE_data_meta": {
+		"ID": "CVE-2021-44224",
+		"ASSIGNER": "security@apache.org",
+		"STATE": "REVIEW",
+		"TITLE": "Possible NULL dereference or SSRF in forward proxy configurations in Apache HTTP Server 2.4.51 and earlier"
+	},
+	"source": {
+		"discovery": "UNKNOWN"
+	},
+	"affects": {
+		"vendor": {
+			"vendor_data": [
+				{
+					"vendor_name": "Apache Software Foundation",
+					"product": {
+						"product_data": [
+							{
+								"product_name": "Apache HTTP Server",
+								"version": {
+									"version_data": [
+										{
+											"version_affected": ">=",
+											"version_value": "2.4.7",
+											"version_name": "Apache HTTP Server 2.4"
+										},
+										{
+											"version_affected": "<=",
+											"version_value": "2.4.51",
+											"version_name": "Apache HTTP Server 2.4"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	},
+	"problemtype": {
+		"problemtype_data": [
+			{
+				"description": [
+					{
+						"lang": "eng",
+						"value": "CWE-476 NULL Pointer Dereference"
+					}
+				]
+			}
+		]
+	},
+	"description": {
+		"description_data": [
+			{
+				"lang": "eng",
+				"value": "A crafted URI sent to httpd configured as a forward proxy (ProxyRequests on) can cause a crash (NULL pointer dereference) or, for configurations mixing forward and reverse proxy declarations, can allow for requests to be directed to a declared Unix Domain Socket endpoint (Server Side Request Forgery).\n\nThis issue affects Apache HTTP Server 2.4.7 up to 2.4.51 (included)."
+			}
+		]
+	},
+	"references": {
+		"reference_data": [
+			{
+				"refsource": "CONFIRM"
+			}
+		]
+	},
+	"impact": [
+		{
+			"other": "moderate"
+		}
+	],
+	"timeline": [
+		{
+			"lang": "eng",
+			"time": "2021-11-18",
+			"value": "Reported to security team"
+		},
+		{
+			"lang": "eng",
+			"time": "2021-12-14",
+			"value": "fixed by r1895955, r1896044 in 2.4.x"
+		},
+		{
+			"lang": "eng",
+			"time": "2021-12-20",
+			"value": "2.4.52 released"
+		}
+	],
+	"credit": [
+		{
+			"lang": "eng",
+			"value": "漂亮鼠"
+		},
+		{
+			"lang": "eng",
+			"value": "TengMA(@Te3t123)"
+		}
+	]
+}

--- a/pkg/extract/apache/httpd/json/testdata/fixtures/2024/CVE-2024-39884.json
+++ b/pkg/extract/apache/httpd/json/testdata/fixtures/2024/CVE-2024-39884.json
@@ -1,0 +1,95 @@
+{
+	"dataType": "CVE_RECORD",
+	"dataVersion": "5.0",
+	"cveMetadata": {
+		"cveId": "CVE-2024-39884",
+		"assignerOrgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09",
+		"serial": 1,
+		"state": "PUBLISHED"
+	},
+	"containers": {
+		"cna": {
+			"providerMetadata": {
+				"orgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09"
+			},
+			"title": "Apache HTTP Server: source code disclosure with handlers configured via AddType",
+			"descriptions": [
+				{
+					"lang": "en",
+					"value": "A regression in the core of Apache HTTP Server 2.4.60 ignores some use of the legacy content-type based configuration of handlers.   \"AddType\" and similar configuration, under some circumstances where files are requested indirectly, result in source code disclosure of local content. For example, PHP scripts may be served instead of interpreted.\n\nUsers are recommended to upgrade to version 2.4.61, which fixes this issue.",
+					"supportingMedia": [
+						{
+							"type": "text/html",
+							"base64": false,
+							"value": "A regression in the core of Apache HTTP Server 2.4.60 ignores some use of the legacy content-type based configuration of handlers.&nbsp; &nbsp;\"AddType\" and similar configuration, under some circumstances where files are requested indirectly, result in source code disclosure of local content. For example, PHP scripts may be served instead of interpreted.<br><br>Users are recommended to upgrade to version 2.4.61, which fixes this issue."
+						}
+					]
+				}
+			],
+			"affected": [
+				{
+					"vendor": "Apache Software Foundation",
+					"product": "Apache HTTP Server",
+					"defaultStatus": "unaffected",
+					"versions": [
+						{
+							"status": "affected",
+							"version": "2.4.60"
+						}
+					]
+				}
+			],
+			"problemTypes": [
+				{
+					"descriptions": [
+						{
+							"lang": "en",
+							"description": "Handler configuration not honored"
+						}
+					]
+				}
+			],
+			"metrics": [
+				{
+					"other": {
+						"type": "Textual description of severity",
+						"content": {
+							"text": "important"
+						}
+					}
+				}
+			],
+			"timeline": [
+				{
+					"lang": "en",
+					"time": "2024-07-01T12:00:00.000Z",
+					"value": "reported"
+				},
+				{
+					"lang": "en",
+					"time": "2024-07-03",
+					"value": "fixed by r1918839 in 2.4.x"
+				},
+				{
+					"lang": "eng",
+					"time": "2024-07-03",
+					"value": "2.4.61 released"
+				}
+			],
+			"source": {
+				"discovery": "UNKNOWN"
+			},
+			"x_generator": {
+				"engine": "Vulnogram 0.1.0-dev"
+			},
+			"references": [
+				{
+					"url": "https://httpd.apache.org/security/vulnerabilities_24.html",
+					"tags": [
+						"vendor-advisory"
+					]
+				}
+			]
+		}
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/fixtures/2026/CVE-2026-29168.json
+++ b/pkg/extract/apache/httpd/json/testdata/fixtures/2026/CVE-2026-29168.json
@@ -1,0 +1,109 @@
+{
+	"dataType": "CVE_RECORD",
+	"dataVersion": "5.1",
+	"cveMetadata": {
+		"cveId": "CVE-2026-29168",
+		"assignerOrgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09",
+		"serial": 1,
+		"state": "PUBLISHED"
+	},
+	"containers": {
+		"cna": {
+			"providerMetadata": {
+				"orgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09"
+			},
+			"title": "Apache HTTP Server: mod_md unrestricted OCSP response",
+			"descriptions": [
+				{
+					"lang": "en",
+					"value": "Allocation of Resources Without Limits or Throttling vulnerability in Apache HTTP Server's  mod_md via OCSP response data.\n\nThis issue affects Apache HTTP Server: from 2.4.30 through 2.4.66.\n\nUsers are recommended to upgrade to version 2.4.67, which fixes the issue.",
+					"supportingMedia": [
+						{
+							"type": "text/html",
+							"base64": false,
+							"value": "<p>Allocation of Resources Without Limits or Throttling vulnerability in Apache HTTP Server's&nbsp; mod_md via OCSP response data.</p><p>This issue affects Apache HTTP Server: from 2.4.30 through 2.4.66.</p><p>Users are recommended to upgrade to version 2.4.67, which fixes the issue.</p>"
+						}
+					]
+				}
+			],
+			"affected": [
+				{
+					"vendor": "Apache Software Foundation",
+					"product": "Apache HTTP Server",
+					"defaultStatus": "unaffected",
+					"versions": [
+						{
+							"status": "affected",
+							"version": "2.4.30",
+							"versionType": "semver",
+							"lessThanOrEqual": "2.4.66"
+						}
+					],
+					"cpes": [
+						"cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
+					]
+				}
+			],
+			"problemTypes": [
+				{
+					"descriptions": [
+						{
+							"lang": "en",
+							"description": "CWE-770: Allocation of Resources Without Limits or Throttling",
+							"cweId": "CWE-770",
+							"type": "CWE"
+						}
+					]
+				}
+			],
+			"metrics": [
+				{
+					"other": {
+						"type": "Textual description of severity",
+						"content": {
+							"text": "low"
+						}
+					}
+				}
+			],
+			"timeline": [
+				{
+					"lang": "en",
+					"time": "2026-03-02T12:00:00.000Z",
+					"value": "reported"
+				},
+				{
+					"lang": "en",
+					"time": "2026-05-04T12:00:00.000Z",
+					"value": "fixed in 2.4.x by r1933352"
+				},
+				{
+					"lang": "en",
+					"time": "2026-05-04T12:00:00.000Z",
+					"value": "2.4.67 released"
+				}
+			],
+			"source": {
+				"discovery": "UNKNOWN"
+			},
+			"x_generator": {
+				"engine": "Vulnogram 0.2.0"
+			},
+			"references": [
+				{
+					"url": "https://httpd.apache.org/security/vulnerabilities_24.html",
+					"tags": [
+						"vendor-advisory"
+					]
+				}
+			],
+			"credits": [
+				{
+					"lang": "en",
+					"type": "finder",
+					"value": "Pavel Kohout, Aisle Research, Aisle.com"
+				}
+			]
+		}
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/golden/data/2004/CVE-2004-0174.json
+++ b/pkg/extract/apache/httpd/json/testdata/golden/data/2004/CVE-2004-0174.json
@@ -1,0 +1,85 @@
+{
+	"id": "CVE-2004-0174",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2004-0174",
+				"title": "listening socket starvation",
+				"description": "A starvation issue on listening sockets occurs when a short-lived connection on a rarely-accessed listening socket will cause a child to hold the accept mutex and block out new connections until another connection arrives on that rarely-accessed listening socket. This issue is known to affect some versions of AIX, Solaris, and Tru64; it is known to not affect FreeBSD or Linux.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "httpd.apache.org",
+						"vendor": "important"
+					}
+				],
+				"published": "2004-03-18T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:a:apache:http_server:1.3.0:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.11:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.12:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.14:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.17:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.19:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.1:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.20:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.22:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.24:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.26:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.27:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.28:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.29:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.2:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.3:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.4:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.6:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:1.3.9:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.35:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.36:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.37:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.39:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.40:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.42:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.43:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.44:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.45:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.46:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.47:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.48:*:*:*:*:*:*:*"
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-httpd-json",
+		"raws": [
+			"fixtures/2004/CVE-2004-0174.json"
+		]
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/golden/data/2006/CVE-2006-20001.json
+++ b/pkg/extract/apache/httpd/json/testdata/golden/data/2006/CVE-2006-20001.json
@@ -1,0 +1,70 @@
+{
+	"id": "CVE-2006-20001",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2006-20001",
+				"title": "mod_dav out of  bounds read, or write of zero byte",
+				"description": "A carefully crafted If: request header can cause a memory read, or write of a single zero byte, in a pool (heap) memory location beyond the header value sent. This could cause the process to crash.\n\nThis issue affects Apache HTTP Server 2.4.54 and earlier.\n",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "httpd.apache.org",
+						"vendor": "moderate"
+					}
+				],
+				"cwe": [
+					{
+						"source": "httpd.apache.org",
+						"cwe": [
+							"CWE-787"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "httpd.apache.org",
+						"url": "https://httpd.apache.org/security/vulnerabilities_24.html"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "semver",
+										"ge": "2.4",
+										"le": "2.4.54"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-httpd-json",
+		"raws": [
+			"fixtures/2006/CVE-2006-20001.json"
+		]
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/golden/data/2011/CVE-2011-3192.json
+++ b/pkg/extract/apache/httpd/json/testdata/golden/data/2011/CVE-2011-3192.json
@@ -1,0 +1,96 @@
+{
+	"id": "CVE-2011-3192",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2011-3192",
+				"title": "Range header remote DoS",
+				"description": "A flaw was found in the way the Apache HTTP Server handled Range HTTP headers. A remote attacker could use this flaw to cause httpd to use an excessive amount of memory and CPU time via HTTP requests with a specially-crafted Range header. This could be used in a denial of service attack. Advisory: CVE-2011-3192.txt",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "httpd.apache.org",
+						"vendor": "important"
+					}
+				],
+				"published": "2011-08-20T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:a:apache:http_server:2.0.35:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.36:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.37:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.39:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.40:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.42:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.43:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.44:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.45:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.46:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.47:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.48:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.49:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.50:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.51:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.52:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.53:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.54:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.55:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.58:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.59:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.61:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.63:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.0.64:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.0:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.10:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.11:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.12:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.13:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.14:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.15:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.16:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.17:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.18:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.19:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.2:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.3:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.4:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.5:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.6:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.8:*:*:*:*:*:*:*",
+										"cpe:2.3:a:apache:http_server:2.2.9:*:*:*:*:*:*:*"
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-httpd-json",
+		"raws": [
+			"fixtures/2011/CVE-2011-3192.json"
+		]
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/golden/data/2021/CVE-2021-44224.json
+++ b/pkg/extract/apache/httpd/json/testdata/golden/data/2021/CVE-2021-44224.json
@@ -1,0 +1,56 @@
+{
+	"id": "CVE-2021-44224",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2021-44224",
+				"title": "Possible NULL dereference or SSRF in forward proxy configurations in Apache HTTP Server 2.4.51 and earlier",
+				"description": "A crafted URI sent to httpd configured as a forward proxy (ProxyRequests on) can cause a crash (NULL pointer dereference) or, for configurations mixing forward and reverse proxy declarations, can allow for requests to be directed to a declared Unix Domain Socket endpoint (Server Side Request Forgery).\n\nThis issue affects Apache HTTP Server 2.4.7 up to 2.4.51 (included).",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "httpd.apache.org",
+						"vendor": "moderate"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "semver",
+										"ge": "2.4.7",
+										"le": "2.4.51"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-httpd-json",
+		"raws": [
+			"fixtures/2021/CVE-2021-44224.json"
+		]
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/golden/data/2024/CVE-2024-39884.json
+++ b/pkg/extract/apache/httpd/json/testdata/golden/data/2024/CVE-2024-39884.json
@@ -1,0 +1,60 @@
+{
+	"id": "CVE-2024-39884",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-39884",
+				"title": "Apache HTTP Server: source code disclosure with handlers configured via AddType",
+				"description": "A regression in the core of Apache HTTP Server 2.4.60 ignores some use of the legacy content-type based configuration of handlers.   \"AddType\" and similar configuration, under some circumstances where files are requested indirectly, result in source code disclosure of local content. For example, PHP scripts may be served instead of interpreted.\n\nUsers are recommended to upgrade to version 2.4.61, which fixes this issue.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "httpd.apache.org",
+						"vendor": "important"
+					}
+				],
+				"references": [
+					{
+						"source": "httpd.apache.org",
+						"url": "https://httpd.apache.org/security/vulnerabilities_24.html"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*",
+									"cpe_matches": [
+										"cpe:2.3:a:apache:http_server:2.4.60:*:*:*:*:*:*:*"
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-httpd-json",
+		"raws": [
+			"fixtures/2024/CVE-2024-39884.json"
+		]
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/golden/data/2026/CVE-2026-29168.json
+++ b/pkg/extract/apache/httpd/json/testdata/golden/data/2026/CVE-2026-29168.json
@@ -1,0 +1,70 @@
+{
+	"id": "CVE-2026-29168",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2026-29168",
+				"title": "Apache HTTP Server: mod_md unrestricted OCSP response",
+				"description": "Allocation of Resources Without Limits or Throttling vulnerability in Apache HTTP Server's  mod_md via OCSP response data.\n\nThis issue affects Apache HTTP Server: from 2.4.30 through 2.4.66.\n\nUsers are recommended to upgrade to version 2.4.67, which fixes the issue.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "httpd.apache.org",
+						"vendor": "low"
+					}
+				],
+				"cwe": [
+					{
+						"source": "httpd.apache.org",
+						"cwe": [
+							"CWE-770"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "httpd.apache.org",
+						"url": "https://httpd.apache.org/security/vulnerabilities_24.html"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"cpe": "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "semver",
+										"ge": "2.4.30",
+										"le": "2.4.66"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apache-httpd-json",
+		"raws": [
+			"fixtures/2026/CVE-2026-29168.json"
+		]
+	}
+}

--- a/pkg/extract/apache/httpd/json/testdata/golden/datasource.json
+++ b/pkg/extract/apache/httpd/json/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "apache-httpd-json",
+	"name": "Apache HTTP Server CVE (JSON)"
+}

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -22,6 +22,7 @@ const (
 	Amazon                     SourceID = "amazon"
 	AndroidOSV                 SourceID = "android-osv"
 	AnolisOVAL                 SourceID = "anolis-oval"
+	ApacheHTTPDJSON            SourceID = "apache-httpd-json"
 	Arch                       SourceID = "arch"
 	AzureOVAL                  SourceID = "azure-oval"
 	BitnamiOSV                 SourceID = "bitnami-osv"

--- a/pkg/fetch/apache/httpd/json/json.go
+++ b/pkg/fetch/apache/httpd/json/json.go
@@ -1,0 +1,246 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+const baseURL = "https://httpd.apache.org/security/json/"
+
+// Pattern defined by the CVE Record Format
+// https://github.com/CVEProject/cve-schema/blob/main/schema/CVE_Record_Format.json
+var cveIDPattern = regexp.MustCompile(`^CVE-([0-9]{4})-[0-9]{4,}$`)
+
+type options struct {
+	baseURL     string
+	dir         string
+	retry       int
+	concurrency int
+	wait        time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type baseURLOption string
+
+func (u baseURLOption) apply(opts *options) {
+	opts.baseURL = string(u)
+}
+
+func WithBaseURL(url string) Option {
+	return baseURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type concurrencyOption int
+
+func (c concurrencyOption) apply(opts *options) {
+	opts.concurrency = int(c)
+}
+
+func WithConcurrency(concurrency int) Option {
+	return concurrencyOption(concurrency)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+func Fetch(opts ...Option) error {
+	options := &options{
+		baseURL:     baseURL,
+		dir:         filepath.Join(util.CacheDir(), "fetch", "apache", "httpd", "json"),
+		retry:       3,
+		concurrency: 5,
+		wait:        1 * time.Second,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Fetch Apache HTTP Server CVE (JSON)")
+	if err := options.fetch(); err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+
+	return nil
+}
+
+func (opts options) fetch() error {
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
+
+	us, err := opts.fetchIndexOf(client)
+	if err != nil {
+		return errors.Wrap(err, "fetch index of")
+	}
+
+	if len(us) == 0 {
+		return errors.Errorf("no cve record found in %s", opts.baseURL)
+	}
+
+	if err := client.PipelineGet(us, opts.concurrency, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d for %q", resp.StatusCode, path.Base(resp.Request.URL.Path))
+		}
+
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", path.Base(resp.Request.URL.Path))
+		}
+
+		id, record, err := decode(bs)
+		if err != nil {
+			return errors.Wrapf(err, "decode %s", path.Base(resp.Request.URL.Path))
+		}
+
+		// The ID comes from the remote payload and is used as a path element,
+		// so accept only the format the schema defines.
+		m := cveIDPattern.FindStringSubmatch(id)
+		if m == nil {
+			return errors.Errorf("unexpected ID format. expected: %q, actual: %q", cveIDPattern.String(), id)
+		}
+
+		if err := util.Write(filepath.Join(opts.dir, m[1], fmt.Sprintf("%s.json", id)), record); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, m[1], fmt.Sprintf("%s.json", id)))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "pipeline get")
+	}
+
+	return nil
+}
+
+// fetchIndexOf collects the per-CVE JSON files linked from the directory index.
+// A linked JSON file whose name is not a CVE ID is an error, so that additions
+// to the data set surface instead of being silently dropped.
+func (opts options) fetchIndexOf(client *utilhttp.Client) ([]string, error) {
+	resp, err := client.Get(opts.baseURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "fetch %s", opts.baseURL)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, errors.Errorf("error response with status code %d", resp.StatusCode)
+	}
+
+	d, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse as html")
+	}
+
+	as := d.Find("a")
+	us := make([]string, 0, as.Length())
+	for _, s := range as.EachIter() {
+		href, ok := s.Attr("href")
+		if !ok {
+			continue
+		}
+
+		ref, err := url.Parse(href)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse %s", href)
+		}
+		u := resp.Request.URL.ResolveReference(ref)
+
+		// The index also links the parent directory and the column sort
+		// controls, neither of which resolves to a JSON file.
+		b := path.Base(u.Path)
+		if path.Ext(b) != ".json" {
+			continue
+		}
+
+		if !cveIDPattern.MatchString(strings.TrimSuffix(b, ".json")) {
+			return nil, errors.Errorf("unexpected json file name. expected: %q, actual: %q", "CVE-yyyy-\\d{4,}.json", b)
+		}
+
+		us = append(us, u.String())
+	}
+
+	return us, nil
+}
+
+// decode picks the schema the record is written in and returns its CVE ID along
+// with the decoded record. The two generations are told apart by which version
+// member they carry; a record with neither is an error, so that a further
+// generation surfaces instead of being decoded into the wrong shape.
+func decode(bs []byte) (string, any, error) {
+	var probe struct {
+		DataVersion4 string `json:"data_version"`
+		DataVersion5 string `json:"dataVersion"`
+	}
+	if err := json.UnmarshalRead(bytes.NewReader(bs), &probe); err != nil {
+		return "", nil, errors.Wrap(err, "decode json")
+	}
+
+	switch {
+	case probe.DataVersion5 != "":
+		var v CVE5
+		if err := json.UnmarshalRead(bytes.NewReader(bs), &v); err != nil {
+			return "", nil, errors.Wrap(err, "decode cve record format")
+		}
+		return v.CVEMetadata.CVEID, v, nil
+	case probe.DataVersion4 != "":
+		var v CVE4
+		if err := json.UnmarshalRead(bytes.NewReader(bs), &v); err != nil {
+			return "", nil, errors.Wrap(err, "decode cve json 4.0")
+		}
+		return v.CVEDataMeta.ID, v, nil
+	default:
+		return "", nil, errors.Errorf("unexpected schema. expected one of: %q", []string{"data_version", "dataVersion"})
+	}
+}

--- a/pkg/fetch/apache/httpd/json/json_test.go
+++ b/pkg/fetch/apache/httpd/json/json_test.go
@@ -1,0 +1,101 @@
+package json_test
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	httpdjson "github.com/MaineK00n/vuls-data-update/pkg/fetch/apache/httpd/json"
+)
+
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+		},
+		{
+			name:     "notfound",
+			hasError: true,
+		},
+		{
+			name:     "unexpected",
+			hasError: true,
+		},
+		{
+			name:     "invalid-id",
+			hasError: true,
+		},
+		{
+			name:     "unknown-schema",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/security/json/":
+					http.ServeFile(w, r, filepath.Join("testdata", "fixtures", tt.name, "indexof.html"))
+				default:
+					http.ServeFile(w, r, filepath.Join("testdata", "fixtures", tt.name, path.Base(r.URL.Path)))
+				}
+			}))
+			defer ts.Close()
+
+			u, err := url.JoinPath(ts.URL, "security/json/")
+			if err != nil {
+				t.Error("unexpected error:", err)
+			}
+
+			dir := t.TempDir()
+			err = httpdjson.Fetch(httpdjson.WithBaseURL(u), httpdjson.WithDir(dir), httpdjson.WithRetry(0), httpdjson.WithConcurrency(1), httpdjson.WithWait(0))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			default:
+				if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+					if err != nil {
+						return err
+					}
+
+					if d.IsDir() {
+						return nil
+					}
+
+					dir, file := filepath.Split(strings.TrimPrefix(path, dir))
+					want, err := os.ReadFile(filepath.Join("testdata", "golden", tt.name, dir, url.QueryEscape(file)))
+					if err != nil {
+						return err
+					}
+
+					got, err := os.ReadFile(path)
+					if err != nil {
+						return err
+					}
+
+					if diff := cmp.Diff(want, got); diff != "" {
+						t.Errorf("Fetch(). (-expected +got):\n%s", diff)
+					}
+
+					return nil
+				}); err != nil {
+					t.Error("walk error:", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/happy/CVE-2006-20001.json
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/happy/CVE-2006-20001.json
@@ -1,0 +1,108 @@
+{
+  "cveMetadata": {
+    "cveId": "CVE-2006-20001",
+    "assignerOrgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09",
+    "serial": 1,
+    "state": "PUBLISHED"
+  },
+  "CNA_private": {
+    "emailed": null,
+    "projecturl": "https://httpd.apache.org/",
+    "owner": "httpd",
+    "userslist": "users@httpd.apache.org",
+    "state": "REVIEW",
+    "todo": [],
+    "type": "unsure"
+  },
+  "containers": {
+    "cna": {
+      "providerMetadata": {
+        "orgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09"
+      },
+      "title": "mod_dav out of  bounds read, or write of zero byte",
+      "problemTypes": [
+        {
+          "descriptions": [
+            {
+              "description": "CWE-787 Out-of-bounds Write",
+              "lang": "en",
+              "cweId": "CWE-787",
+              "type": "CWE"
+            }
+          ]
+        }
+      ],
+      "source": {
+        "discovery": "UNKNOWN"
+      },
+      "affected": [
+        {
+          "vendor": "Apache Software Foundation",
+          "product": "Apache HTTP Server",
+          "versions": [
+            {
+              "status": "affected",
+              "version": "2.4",
+              "lessThanOrEqual": "2.4.54",
+              "versionType": "semver"
+            }
+          ],
+          "defaultStatus": "unaffected"
+        }
+      ],
+      "descriptions": [
+        {
+          "value": "A carefully crafted If: request header can cause a memory read, or write of a single zero byte, in a pool (heap) memory location beyond the header value sent. This could cause the process to crash.\n\nThis issue affects Apache HTTP Server 2.4.54 and earlier.\n",
+          "lang": "en",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "A carefully crafted If: request header can cause a memory read, or write of a single zero byte, in a pool (heap) memory location beyond the header value sent. This could cause the process to crash.<br><br>This issue affects Apache HTTP Server 2.4.54 and earlier.<br>"
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "url": "https://httpd.apache.org/security/vulnerabilities_24.html",
+          "tags": [
+            "vendor-advisory"
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "other": {
+            "type": "Textual description of severity",
+            "content": {
+              "text": "moderate"
+            }
+          }
+        }
+      ],
+      "timeline": [
+        {
+          "time": "2006-10-31T19:00:00.000Z",
+          "lang": "en",
+          "value": "Described in first edition of \"The Art of Software Security Assessment\""
+        },
+        {
+          "time": "2022-08-10T19:00:00.000Z",
+          "lang": "en",
+          "value": "Reported to security team"
+        },
+        {
+          "lang": "eng",
+          "time": "2023-01-17",
+          "value": "2.4.55 released"
+        }
+      ],
+      "x_generator": {
+        "engine": "Vulnogram 0.1.0-dev"
+      }
+    }
+  },
+  "dataType": "CVE_RECORD",
+  "dataVersion": "5.0"
+}

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/happy/CVE-2011-3192.json
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/happy/CVE-2011-3192.json
@@ -1,0 +1,302 @@
+{
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "xmltojsonmjc 1.0"
+  },
+  "references": {},
+  "timeline": [
+    {
+      "time": "2011-08-20",
+      "lang": "eng",
+      "value": "reported"
+    },
+    {
+      "time": "2011-08-20",
+      "lang": "eng",
+      "value": "public"
+    },
+    {
+      "time": "2011-08-30",
+      "lang": "eng",
+      "value": "2.2.20 released"
+    },
+    {
+      "time": "2013-07-12",
+      "lang": "eng",
+      "value": "2.0.65 released"
+    }
+  ],
+  "CNA_private": {
+    "owner": "httpd"
+  },
+  "CVE_data_meta": {
+    "ASSIGNER": "security@apache.org",
+    "AKA": "",
+    "STATE": "PUBLIC",
+    "DATE_PUBLIC": "2011-08-20",
+    "ID": "CVE-2011-3192",
+    "TITLE": "Range header remote DoS"
+  },
+  "source": {
+    "defect": [],
+    "advisory": "",
+    "discovery": "UNKNOWN"
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "Range header remote DoS"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "A flaw was found in the way the Apache HTTP Server handled Range HTTP headers. A remote attacker could use this flaw to cause httpd to use an excessive amount of memory and CPU time via HTTP requests with a specially-crafted Range header. This could be used in a denial of service attack. Advisory: CVE-2011-3192.txt"
+      }
+    ]
+  },
+  "impact": [
+    {
+      "other": "important"
+    }
+  ],
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "Apache Software Foundation",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Apache HTTP Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.19"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.18"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.17"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.16"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.15"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.14"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.13"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.12"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.11"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.10"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.9"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.8"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.6"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.5"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.4"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.3"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.2"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.0"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.64"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.63"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.61"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.59"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.58"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.55"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.54"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.53"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.52"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.51"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.50"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.49"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.48"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.47"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.46"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.45"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.44"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.43"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.42"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.40"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.39"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.37"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.36"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.35"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/happy/CVE-2021-31618.json
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/happy/CVE-2021-31618.json
@@ -1,0 +1,127 @@
+{ 
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "Vulnogram 0.0.9"
+  },
+  "CVE_data_meta": {
+    "ID": "CVE-2021-31618",
+    "ASSIGNER": "security@apache.org",
+    "DATE_PUBLIC": "2021-06-01",
+    "TITLE": "NULL pointer dereference on specially crafted HTTP/2 request",
+    "AKA": "",
+    "STATE": "DRAFT"
+  },
+  "source": {
+    "defect": [],
+    "advisory": "",
+    "discovery": "UNKNOWN"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "Apache Software Foundation",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Apache HTTP Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "",
+                      "version_affected": "=",
+                      "version_value": "2.4.47",
+                      "platform": ""
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-476 NULL Pointer Dereference"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "value": "Apache HTTP Server protocol handler for the HTTP/2 protocol checks received request headers against the size limitations as configured for the server and used for the HTTP/1 protocol as well. On violation of these restrictions and HTTP response is sent to the client with a status code indicating why the request was rejected.\n\nThis rejection response was not fully initialised in the HTTP/2 protocol handler if the offending header was the very first one received or appeared in a a footer. This led to a NULL pointer dereference on initialised memory, crashing reliably the child process. Since such a triggering HTTP/2 request is easy to craft and submit, this can be exploited to DoS the server.\n\nThis issue affected  mod_http2 1.15.17 and Apache HTTP Server version 2.4.47 only. Apache HTTP Server 2.4.47 was never released.",
+        "lang": "eng"
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "CONFIRM",
+        "url": "",
+        "name": ""
+      }
+    ]
+  },
+  "configuration": [],
+  "impact": [
+    {
+      "other": "important"
+    }
+  ],
+  "exploit": [],
+  "work_around": [
+    {
+      "lang": "eng",
+      "value": "On unpatched servers, the `h2` protocol can be disabled by removing it from the `Protocols` configuration. If the `h2` protocol is not enabled, the server is not affected by this vulnerability."
+    }
+  ],
+  "solution": [],
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "Apache HTTP server would like to thank  LI ZHI XIN from NSFoucs for reporting this."
+    }
+  ],
+  "CNA_private": {
+    "owner": "httpd",
+    "publish": {
+      "ym": "",
+      "year": "",
+      "month": ""
+    },
+    "share_with_CVE": true,
+    "CVE_table_description": [],
+    "CVE_list": [],
+    "internal_comments": "",
+    "todo": [],
+    "email": ""
+  },
+  "timeline": [
+    {
+      "time": "2021-04-22",
+      "lang": "eng",
+      "value": "reported"
+    },
+    {
+      "time": "2021-06-01",
+      "lang": "eng",
+      "value": "public"
+    },
+    {
+      "time": "2021-06-01",
+      "lang": "eng",
+      "value": "2.4.48 released"
+    }
+  ]
+}

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/happy/CVE-2026-29168.json
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/happy/CVE-2026-29168.json
@@ -1,0 +1,109 @@
+{
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "cpes": [
+                        "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
+                    ],
+                    "defaultStatus": "unaffected",
+                    "product": "Apache HTTP Server",
+                    "vendor": "Apache Software Foundation",
+                    "versions": [
+                        {
+                            "lessThanOrEqual": "2.4.66",
+                            "status": "affected",
+                            "version": "2.4.30",
+                            "versionType": "semver"
+                        }
+                    ]
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "type": "finder",
+                    "value": "Pavel Kohout, Aisle Research, Aisle.com"
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "supportingMedia": [
+                        {
+                            "base64": false,
+                            "type": "text/html",
+                            "value": "<p>Allocation of Resources Without Limits or Throttling vulnerability in Apache HTTP Server's&nbsp; mod_md via OCSP response data.</p><p>This issue affects Apache HTTP Server: from 2.4.30 through 2.4.66.</p><p>Users are recommended to upgrade to version 2.4.67, which fixes the issue.</p>"
+                        }
+                    ],
+                    "value": "Allocation of Resources Without Limits or Throttling vulnerability in Apache HTTP Server's  mod_md via OCSP response data.\n\nThis issue affects Apache HTTP Server: from 2.4.30 through 2.4.66.\n\nUsers are recommended to upgrade to version 2.4.67, which fixes the issue."
+                }
+            ],
+            "metrics": [
+                {
+                    "other": {
+                        "content": {
+                            "text": "low"
+                        },
+                        "type": "Textual description of severity"
+                    }
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-770",
+                            "description": "CWE-770: Allocation of Resources Without Limits or Throttling",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09"
+            },
+            "references": [
+                {
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://httpd.apache.org/security/vulnerabilities_24.html"
+                }
+            ],
+            "source": {
+                "discovery": "UNKNOWN"
+            },
+            "timeline": [
+                {
+                    "lang": "en",
+                    "time": "2026-03-02T12:00:00.000Z",
+                    "value": "reported"
+                },
+                {
+                    "lang": "en",
+                    "time": "2026-05-04T12:00:00.000Z",
+                    "value": "fixed in 2.4.x by r1933352"
+                },
+                {
+                    "lang": "en",
+                    "time": "2026-05-04T12:00:00.000Z",
+                    "value": "2.4.67 released"
+                }
+            ],
+            "title": "Apache HTTP Server: mod_md unrestricted OCSP response",
+            "x_generator": {
+                "engine": "Vulnogram 0.2.0"
+            }
+        }
+    },
+    "cveMetadata": {
+        "assignerOrgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09",
+        "cveId": "CVE-2026-29168",
+        "serial": 1,
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1"
+}

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/happy/indexof.html
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/happy/indexof.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of /security/json</title>
+ </head>
+ <body>
+<h1>Index of /security/json</h1>
+  <table>
+   <tr><th valign="top"><img src="/icons/blank.gif" alt="[ICO]"></th><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th><th><a href="?C=D;O=A">Description</a></th></tr>
+   <tr><th colspan="5"><hr></th></tr>
+<tr><td valign="top"><img src="/icons/back.gif" alt="[PARENTDIR]"></td><td><a href="/security/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="CVE-2011-3192.json">CVE-2011-3192.json</a></td><td align="right">2026-03-17 20:44  </td><td align="right">2.2K</td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="CVE-2021-31618.json">CVE-2021-31618.json</a></td><td align="right">2026-03-17 20:44  </td><td align="right">2.2K</td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="CVE-2006-20001.json">CVE-2006-20001.json</a></td><td align="right">2026-03-17 20:44  </td><td align="right">2.2K</td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="CVE-2026-29168.json">CVE-2026-29168.json</a></td><td align="right">2026-03-17 20:44  </td><td align="right">2.2K</td><td>&nbsp;</td></tr>
+   <tr><th colspan="5"><hr></th></tr>
+</table>
+</body></html>

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/invalid-id/CVE-2011-3192.json
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/invalid-id/CVE-2011-3192.json
@@ -1,0 +1,302 @@
+{
+ "data_type": "CVE",
+ "data_format": "MITRE",
+ "data_version": "4.0",
+ "generator": {
+  "engine": "xmltojsonmjc 1.0"
+ },
+ "references": {},
+ "timeline": [
+  {
+   "time": "2011-08-20",
+   "lang": "eng",
+   "value": "reported"
+  },
+  {
+   "time": "2011-08-20",
+   "lang": "eng",
+   "value": "public"
+  },
+  {
+   "time": "2011-08-30",
+   "lang": "eng",
+   "value": "2.2.20 released"
+  },
+  {
+   "time": "2013-07-12",
+   "lang": "eng",
+   "value": "2.0.65 released"
+  }
+ ],
+ "CNA_private": {
+  "owner": "httpd"
+ },
+ "CVE_data_meta": {
+  "ASSIGNER": "security@apache.org",
+  "AKA": "",
+  "STATE": "PUBLIC",
+  "DATE_PUBLIC": "2011-08-20",
+  "ID": "CVE-2011-319",
+  "TITLE": "Range header remote DoS"
+ },
+ "source": {
+  "defect": [],
+  "advisory": "",
+  "discovery": "UNKNOWN"
+ },
+ "problemtype": {
+  "problemtype_data": [
+   {
+    "description": [
+     {
+      "lang": "eng",
+      "value": "Range header remote DoS"
+     }
+    ]
+   }
+  ]
+ },
+ "description": {
+  "description_data": [
+   {
+    "lang": "eng",
+    "value": "A flaw was found in the way the Apache HTTP Server handled Range HTTP headers. A remote attacker could use this flaw to cause httpd to use an excessive amount of memory and CPU time via HTTP requests with a specially-crafted Range header. This could be used in a denial of service attack. Advisory: CVE-2011-3192.txt"
+   }
+  ]
+ },
+ "impact": [
+  {
+   "other": "important"
+  }
+ ],
+ "affects": {
+  "vendor": {
+   "vendor_data": [
+    {
+     "vendor_name": "Apache Software Foundation",
+     "product": {
+      "product_data": [
+       {
+        "product_name": "Apache HTTP Server",
+        "version": {
+         "version_data": [
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.19"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.18"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.17"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.16"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.15"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.14"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.13"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.12"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.11"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.10"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.9"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.8"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.6"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.5"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.4"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.3"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.2"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.0"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.64"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.63"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.61"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.59"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.58"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.55"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.54"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.53"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.52"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.51"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.50"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.49"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.48"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.47"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.46"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.45"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.44"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.43"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.42"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.40"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.39"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.37"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.36"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.35"
+          }
+         ]
+        }
+       }
+      ]
+     }
+    }
+   ]
+  }
+ }
+}

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/invalid-id/indexof.html
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/invalid-id/indexof.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of /security/json</title>
+ </head>
+ <body>
+<h1>Index of /security/json</h1>
+  <table>
+   <tr><th valign="top"><img src="/icons/blank.gif" alt="[ICO]"></th><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th><th><a href="?C=D;O=A">Description</a></th></tr>
+   <tr><th colspan="5"><hr></th></tr>
+<tr><td valign="top"><img src="/icons/back.gif" alt="[PARENTDIR]"></td><td><a href="/security/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="CVE-2011-3192.json">CVE-2011-3192.json</a></td><td align="right">2026-03-17 20:44  </td><td align="right">2.2K</td><td>&nbsp;</td></tr>
+   <tr><th colspan="5"><hr></th></tr>
+</table>
+</body></html>

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/notfound/CVE-2011-3192.json
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/notfound/CVE-2011-3192.json
@@ -1,0 +1,302 @@
+{
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "xmltojsonmjc 1.0"
+  },
+  "references": {},
+  "timeline": [
+    {
+      "time": "2011-08-20",
+      "lang": "eng",
+      "value": "reported"
+    },
+    {
+      "time": "2011-08-20",
+      "lang": "eng",
+      "value": "public"
+    },
+    {
+      "time": "2011-08-30",
+      "lang": "eng",
+      "value": "2.2.20 released"
+    },
+    {
+      "time": "2013-07-12",
+      "lang": "eng",
+      "value": "2.0.65 released"
+    }
+  ],
+  "CNA_private": {
+    "owner": "httpd"
+  },
+  "CVE_data_meta": {
+    "ASSIGNER": "security@apache.org",
+    "AKA": "",
+    "STATE": "PUBLIC",
+    "DATE_PUBLIC": "2011-08-20",
+    "ID": "CVE-2011-3192",
+    "TITLE": "Range header remote DoS"
+  },
+  "source": {
+    "defect": [],
+    "advisory": "",
+    "discovery": "UNKNOWN"
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "Range header remote DoS"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "A flaw was found in the way the Apache HTTP Server handled Range HTTP headers. A remote attacker could use this flaw to cause httpd to use an excessive amount of memory and CPU time via HTTP requests with a specially-crafted Range header. This could be used in a denial of service attack. Advisory: CVE-2011-3192.txt"
+      }
+    ]
+  },
+  "impact": [
+    {
+      "other": "important"
+    }
+  ],
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "Apache Software Foundation",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Apache HTTP Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.19"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.18"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.17"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.16"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.15"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.14"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.13"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.12"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.11"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.10"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.9"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.8"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.6"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.5"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.4"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.3"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.2"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.0"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.64"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.63"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.61"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.59"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.58"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.55"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.54"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.53"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.52"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.51"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.50"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.49"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.48"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.47"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.46"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.45"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.44"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.43"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.42"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.40"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.39"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.37"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.36"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.35"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/notfound/indexof.html
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/notfound/indexof.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of /security/json</title>
+ </head>
+ <body>
+<h1>Index of /security/json</h1>
+  <table>
+   <tr><th valign="top"><img src="/icons/blank.gif" alt="[ICO]"></th><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th><th><a href="?C=D;O=A">Description</a></th></tr>
+   <tr><th colspan="5"><hr></th></tr>
+<tr><td valign="top"><img src="/icons/back.gif" alt="[PARENTDIR]"></td><td><a href="/security/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="CVE-2011-3192.json">CVE-2011-3192.json</a></td><td align="right">2026-03-17 20:44  </td><td align="right">2.2K</td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="CVE-2011-9999.json">CVE-2011-9999.json</a></td><td align="right">2026-03-17 20:44  </td><td align="right">2.2K</td><td>&nbsp;</td></tr>
+   <tr><th colspan="5"><hr></th></tr>
+</table>
+</body></html>

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/unexpected/CVE-2011-3192.json
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/unexpected/CVE-2011-3192.json
@@ -1,0 +1,302 @@
+{
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "xmltojsonmjc 1.0"
+  },
+  "references": {},
+  "timeline": [
+    {
+      "time": "2011-08-20",
+      "lang": "eng",
+      "value": "reported"
+    },
+    {
+      "time": "2011-08-20",
+      "lang": "eng",
+      "value": "public"
+    },
+    {
+      "time": "2011-08-30",
+      "lang": "eng",
+      "value": "2.2.20 released"
+    },
+    {
+      "time": "2013-07-12",
+      "lang": "eng",
+      "value": "2.0.65 released"
+    }
+  ],
+  "CNA_private": {
+    "owner": "httpd"
+  },
+  "CVE_data_meta": {
+    "ASSIGNER": "security@apache.org",
+    "AKA": "",
+    "STATE": "PUBLIC",
+    "DATE_PUBLIC": "2011-08-20",
+    "ID": "CVE-2011-3192",
+    "TITLE": "Range header remote DoS"
+  },
+  "source": {
+    "defect": [],
+    "advisory": "",
+    "discovery": "UNKNOWN"
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "Range header remote DoS"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "A flaw was found in the way the Apache HTTP Server handled Range HTTP headers. A remote attacker could use this flaw to cause httpd to use an excessive amount of memory and CPU time via HTTP requests with a specially-crafted Range header. This could be used in a denial of service attack. Advisory: CVE-2011-3192.txt"
+      }
+    ]
+  },
+  "impact": [
+    {
+      "other": "important"
+    }
+  ],
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "Apache Software Foundation",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Apache HTTP Server",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.19"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.18"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.17"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.16"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.15"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.14"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.13"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.12"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.11"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.10"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.9"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.8"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.6"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.5"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.4"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.3"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.2"
+                    },
+                    {
+                      "version_name": "2.2",
+                      "version_affected": "=",
+                      "version_value": "2.2.0"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.64"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.63"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.61"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.59"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.58"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.55"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.54"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.53"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.52"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.51"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.50"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.49"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.48"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.47"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.46"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.45"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.44"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.43"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.42"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.40"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.39"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.37"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.36"
+                    },
+                    {
+                      "version_name": "2.0",
+                      "version_affected": "=",
+                      "version_value": "2.0.35"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/unexpected/indexof.html
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/unexpected/indexof.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of /security/json</title>
+ </head>
+ <body>
+<h1>Index of /security/json</h1>
+  <table>
+   <tr><th valign="top"><img src="/icons/blank.gif" alt="[ICO]"></th><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th><th><a href="?C=D;O=A">Description</a></th></tr>
+   <tr><th colspan="5"><hr></th></tr>
+<tr><td valign="top"><img src="/icons/back.gif" alt="[PARENTDIR]"></td><td><a href="/security/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="CVE-2011-3192.json">CVE-2011-3192.json</a></td><td align="right">2026-03-17 20:44  </td><td align="right">2.2K</td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="statements.json">statements.json</a></td><td align="right">2026-03-17 20:44  </td><td align="right">2.2K</td><td>&nbsp;</td></tr>
+   <tr><th colspan="5"><hr></th></tr>
+</table>
+</body></html>

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/unknown-schema/CVE-2011-3192.json
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/unknown-schema/CVE-2011-3192.json
@@ -1,0 +1,301 @@
+{
+ "data_type": "CVE",
+ "data_format": "MITRE",
+ "generator": {
+  "engine": "xmltojsonmjc 1.0"
+ },
+ "references": {},
+ "timeline": [
+  {
+   "time": "2011-08-20",
+   "lang": "eng",
+   "value": "reported"
+  },
+  {
+   "time": "2011-08-20",
+   "lang": "eng",
+   "value": "public"
+  },
+  {
+   "time": "2011-08-30",
+   "lang": "eng",
+   "value": "2.2.20 released"
+  },
+  {
+   "time": "2013-07-12",
+   "lang": "eng",
+   "value": "2.0.65 released"
+  }
+ ],
+ "CNA_private": {
+  "owner": "httpd"
+ },
+ "CVE_data_meta": {
+  "ASSIGNER": "security@apache.org",
+  "AKA": "",
+  "STATE": "PUBLIC",
+  "DATE_PUBLIC": "2011-08-20",
+  "ID": "CVE-2011-3192",
+  "TITLE": "Range header remote DoS"
+ },
+ "source": {
+  "defect": [],
+  "advisory": "",
+  "discovery": "UNKNOWN"
+ },
+ "problemtype": {
+  "problemtype_data": [
+   {
+    "description": [
+     {
+      "lang": "eng",
+      "value": "Range header remote DoS"
+     }
+    ]
+   }
+  ]
+ },
+ "description": {
+  "description_data": [
+   {
+    "lang": "eng",
+    "value": "A flaw was found in the way the Apache HTTP Server handled Range HTTP headers. A remote attacker could use this flaw to cause httpd to use an excessive amount of memory and CPU time via HTTP requests with a specially-crafted Range header. This could be used in a denial of service attack. Advisory: CVE-2011-3192.txt"
+   }
+  ]
+ },
+ "impact": [
+  {
+   "other": "important"
+  }
+ ],
+ "affects": {
+  "vendor": {
+   "vendor_data": [
+    {
+     "vendor_name": "Apache Software Foundation",
+     "product": {
+      "product_data": [
+       {
+        "product_name": "Apache HTTP Server",
+        "version": {
+         "version_data": [
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.19"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.18"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.17"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.16"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.15"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.14"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.13"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.12"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.11"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.10"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.9"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.8"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.6"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.5"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.4"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.3"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.2"
+          },
+          {
+           "version_name": "2.2",
+           "version_affected": "=",
+           "version_value": "2.2.0"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.64"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.63"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.61"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.59"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.58"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.55"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.54"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.53"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.52"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.51"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.50"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.49"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.48"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.47"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.46"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.45"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.44"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.43"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.42"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.40"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.39"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.37"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.36"
+          },
+          {
+           "version_name": "2.0",
+           "version_affected": "=",
+           "version_value": "2.0.35"
+          }
+         ]
+        }
+       }
+      ]
+     }
+    }
+   ]
+  }
+ }
+}

--- a/pkg/fetch/apache/httpd/json/testdata/fixtures/unknown-schema/indexof.html
+++ b/pkg/fetch/apache/httpd/json/testdata/fixtures/unknown-schema/indexof.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of /security/json</title>
+ </head>
+ <body>
+<h1>Index of /security/json</h1>
+  <table>
+   <tr><th valign="top"><img src="/icons/blank.gif" alt="[ICO]"></th><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th><th><a href="?C=D;O=A">Description</a></th></tr>
+   <tr><th colspan="5"><hr></th></tr>
+<tr><td valign="top"><img src="/icons/back.gif" alt="[PARENTDIR]"></td><td><a href="/security/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td><td>&nbsp;</td></tr>
+<tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="CVE-2011-3192.json">CVE-2011-3192.json</a></td><td align="right">2026-03-17 20:44  </td><td align="right">2.2K</td><td>&nbsp;</td></tr>
+   <tr><th colspan="5"><hr></th></tr>
+</table>
+</body></html>

--- a/pkg/fetch/apache/httpd/json/testdata/golden/happy/2006/CVE-2006-20001.json
+++ b/pkg/fetch/apache/httpd/json/testdata/golden/happy/2006/CVE-2006-20001.json
@@ -1,0 +1,107 @@
+{
+	"dataType": "CVE_RECORD",
+	"dataVersion": "5.0",
+	"cveMetadata": {
+		"cveId": "CVE-2006-20001",
+		"assignerOrgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09",
+		"serial": 1,
+		"state": "PUBLISHED"
+	},
+	"containers": {
+		"cna": {
+			"providerMetadata": {
+				"orgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09"
+			},
+			"title": "mod_dav out of  bounds read, or write of zero byte",
+			"descriptions": [
+				{
+					"lang": "en",
+					"value": "A carefully crafted If: request header can cause a memory read, or write of a single zero byte, in a pool (heap) memory location beyond the header value sent. This could cause the process to crash.\n\nThis issue affects Apache HTTP Server 2.4.54 and earlier.\n",
+					"supportingMedia": [
+						{
+							"type": "text/html",
+							"base64": false,
+							"value": "A carefully crafted If: request header can cause a memory read, or write of a single zero byte, in a pool (heap) memory location beyond the header value sent. This could cause the process to crash.<br><br>This issue affects Apache HTTP Server 2.4.54 and earlier.<br>"
+						}
+					]
+				}
+			],
+			"affected": [
+				{
+					"vendor": "Apache Software Foundation",
+					"product": "Apache HTTP Server",
+					"defaultStatus": "unaffected",
+					"versions": [
+						{
+							"status": "affected",
+							"version": "2.4",
+							"versionType": "semver",
+							"lessThanOrEqual": "2.4.54"
+						}
+					]
+				}
+			],
+			"problemTypes": [
+				{
+					"descriptions": [
+						{
+							"lang": "en",
+							"description": "CWE-787 Out-of-bounds Write",
+							"cweId": "CWE-787",
+							"type": "CWE"
+						}
+					]
+				}
+			],
+			"metrics": [
+				{
+					"other": {
+						"type": "Textual description of severity",
+						"content": {
+							"text": "moderate"
+						}
+					}
+				}
+			],
+			"timeline": [
+				{
+					"lang": "en",
+					"time": "2006-10-31T19:00:00.000Z",
+					"value": "Described in first edition of \"The Art of Software Security Assessment\""
+				},
+				{
+					"lang": "en",
+					"time": "2022-08-10T19:00:00.000Z",
+					"value": "Reported to security team"
+				},
+				{
+					"lang": "eng",
+					"time": "2023-01-17",
+					"value": "2.4.55 released"
+				}
+			],
+			"source": {
+				"discovery": "UNKNOWN"
+			},
+			"x_generator": {
+				"engine": "Vulnogram 0.1.0-dev"
+			},
+			"references": [
+				{
+					"url": "https://httpd.apache.org/security/vulnerabilities_24.html",
+					"tags": [
+						"vendor-advisory"
+					]
+				}
+			]
+		}
+	},
+	"CNA_private": {
+		"owner": "httpd",
+		"state": "REVIEW",
+		"type": "unsure",
+		"todo": [],
+		"projecturl": "https://httpd.apache.org/",
+		"userslist": "users@httpd.apache.org"
+	}
+}

--- a/pkg/fetch/apache/httpd/json/testdata/golden/happy/2011/CVE-2011-3192.json
+++ b/pkg/fetch/apache/httpd/json/testdata/golden/happy/2011/CVE-2011-3192.json
@@ -1,0 +1,299 @@
+{
+	"data_type": "CVE",
+	"data_format": "MITRE",
+	"data_version": "4.0",
+	"generator": {
+		"engine": "xmltojsonmjc 1.0"
+	},
+	"CVE_data_meta": {
+		"ID": "CVE-2011-3192",
+		"ASSIGNER": "security@apache.org",
+		"STATE": "PUBLIC",
+		"TITLE": "Range header remote DoS",
+		"DATE_PUBLIC": "2011-08-20"
+	},
+	"source": {
+		"discovery": "UNKNOWN"
+	},
+	"affects": {
+		"vendor": {
+			"vendor_data": [
+				{
+					"vendor_name": "Apache Software Foundation",
+					"product": {
+						"product_data": [
+							{
+								"product_name": "Apache HTTP Server",
+								"version": {
+									"version_data": [
+										{
+											"version_affected": "=",
+											"version_value": "2.2.19",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.18",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.17",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.16",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.15",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.14",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.13",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.12",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.11",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.10",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.9",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.8",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.6",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.5",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.4",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.3",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.2",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.0",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.64",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.63",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.61",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.59",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.58",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.55",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.54",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.53",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.52",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.51",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.50",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.49",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.48",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.47",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.46",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.45",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.44",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.43",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.42",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.40",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.39",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.37",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.36",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.35",
+											"version_name": "2.0"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	},
+	"problemtype": {
+		"problemtype_data": [
+			{
+				"description": [
+					{
+						"lang": "eng",
+						"value": "Range header remote DoS"
+					}
+				]
+			}
+		]
+	},
+	"description": {
+		"description_data": [
+			{
+				"lang": "eng",
+				"value": "A flaw was found in the way the Apache HTTP Server handled Range HTTP headers. A remote attacker could use this flaw to cause httpd to use an excessive amount of memory and CPU time via HTTP requests with a specially-crafted Range header. This could be used in a denial of service attack. Advisory: CVE-2011-3192.txt"
+			}
+		]
+	},
+	"references": {},
+	"impact": [
+		{
+			"other": "important"
+		}
+	],
+	"timeline": [
+		{
+			"lang": "eng",
+			"time": "2011-08-20",
+			"value": "reported"
+		},
+		{
+			"lang": "eng",
+			"time": "2011-08-20",
+			"value": "public"
+		},
+		{
+			"lang": "eng",
+			"time": "2011-08-30",
+			"value": "2.2.20 released"
+		},
+		{
+			"lang": "eng",
+			"time": "2013-07-12",
+			"value": "2.0.65 released"
+		}
+	],
+	"CNA_private": {
+		"owner": "httpd"
+	}
+}

--- a/pkg/fetch/apache/httpd/json/testdata/golden/happy/2021/CVE-2021-31618.json
+++ b/pkg/fetch/apache/httpd/json/testdata/golden/happy/2021/CVE-2021-31618.json
@@ -1,0 +1,112 @@
+{
+	"data_type": "CVE",
+	"data_format": "MITRE",
+	"data_version": "4.0",
+	"generator": {
+		"engine": "Vulnogram 0.0.9"
+	},
+	"CVE_data_meta": {
+		"ID": "CVE-2021-31618",
+		"ASSIGNER": "security@apache.org",
+		"STATE": "DRAFT",
+		"TITLE": "NULL pointer dereference on specially crafted HTTP/2 request",
+		"DATE_PUBLIC": "2021-06-01"
+	},
+	"source": {
+		"discovery": "UNKNOWN"
+	},
+	"affects": {
+		"vendor": {
+			"vendor_data": [
+				{
+					"vendor_name": "Apache Software Foundation",
+					"product": {
+						"product_data": [
+							{
+								"product_name": "Apache HTTP Server",
+								"version": {
+									"version_data": [
+										{
+											"version_affected": "=",
+											"version_value": "2.4.47"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	},
+	"problemtype": {
+		"problemtype_data": [
+			{
+				"description": [
+					{
+						"lang": "eng",
+						"value": "CWE-476 NULL Pointer Dereference"
+					}
+				]
+			}
+		]
+	},
+	"description": {
+		"description_data": [
+			{
+				"lang": "eng",
+				"value": "Apache HTTP Server protocol handler for the HTTP/2 protocol checks received request headers against the size limitations as configured for the server and used for the HTTP/1 protocol as well. On violation of these restrictions and HTTP response is sent to the client with a status code indicating why the request was rejected.\n\nThis rejection response was not fully initialised in the HTTP/2 protocol handler if the offending header was the very first one received or appeared in a a footer. This led to a NULL pointer dereference on initialised memory, crashing reliably the child process. Since such a triggering HTTP/2 request is easy to craft and submit, this can be exploited to DoS the server.\n\nThis issue affected  mod_http2 1.15.17 and Apache HTTP Server version 2.4.47 only. Apache HTTP Server 2.4.47 was never released."
+			}
+		]
+	},
+	"references": {
+		"reference_data": [
+			{
+				"refsource": "CONFIRM"
+			}
+		]
+	},
+	"impact": [
+		{
+			"other": "important"
+		}
+	],
+	"timeline": [
+		{
+			"lang": "eng",
+			"time": "2021-04-22",
+			"value": "reported"
+		},
+		{
+			"lang": "eng",
+			"time": "2021-06-01",
+			"value": "public"
+		},
+		{
+			"lang": "eng",
+			"time": "2021-06-01",
+			"value": "2.4.48 released"
+		}
+	],
+	"credit": [
+		{
+			"lang": "eng",
+			"value": "Apache HTTP server would like to thank  LI ZHI XIN from NSFoucs for reporting this."
+		}
+	],
+	"work_around": [
+		{
+			"lang": "eng",
+			"value": "On unpatched servers, the `h2` protocol can be disabled by removing it from the `Protocols` configuration. If the `h2` protocol is not enabled, the server is not affected by this vulnerability."
+		}
+	],
+	"CNA_private": {
+		"owner": "httpd",
+		"share_with_CVE": true,
+		"publish": {
+			"month": "",
+			"year": "",
+			"ym": ""
+		}
+	}
+}

--- a/pkg/fetch/apache/httpd/json/testdata/golden/happy/2026/CVE-2026-29168.json
+++ b/pkg/fetch/apache/httpd/json/testdata/golden/happy/2026/CVE-2026-29168.json
@@ -1,0 +1,109 @@
+{
+	"dataType": "CVE_RECORD",
+	"dataVersion": "5.1",
+	"cveMetadata": {
+		"cveId": "CVE-2026-29168",
+		"assignerOrgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09",
+		"serial": 1,
+		"state": "PUBLISHED"
+	},
+	"containers": {
+		"cna": {
+			"providerMetadata": {
+				"orgId": "f0158376-9dc2-43b6-827c-5f631a4d8d09"
+			},
+			"title": "Apache HTTP Server: mod_md unrestricted OCSP response",
+			"descriptions": [
+				{
+					"lang": "en",
+					"value": "Allocation of Resources Without Limits or Throttling vulnerability in Apache HTTP Server's  mod_md via OCSP response data.\n\nThis issue affects Apache HTTP Server: from 2.4.30 through 2.4.66.\n\nUsers are recommended to upgrade to version 2.4.67, which fixes the issue.",
+					"supportingMedia": [
+						{
+							"type": "text/html",
+							"base64": false,
+							"value": "<p>Allocation of Resources Without Limits or Throttling vulnerability in Apache HTTP Server's&nbsp; mod_md via OCSP response data.</p><p>This issue affects Apache HTTP Server: from 2.4.30 through 2.4.66.</p><p>Users are recommended to upgrade to version 2.4.67, which fixes the issue.</p>"
+						}
+					]
+				}
+			],
+			"affected": [
+				{
+					"vendor": "Apache Software Foundation",
+					"product": "Apache HTTP Server",
+					"defaultStatus": "unaffected",
+					"versions": [
+						{
+							"status": "affected",
+							"version": "2.4.30",
+							"versionType": "semver",
+							"lessThanOrEqual": "2.4.66"
+						}
+					],
+					"cpes": [
+						"cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
+					]
+				}
+			],
+			"problemTypes": [
+				{
+					"descriptions": [
+						{
+							"lang": "en",
+							"description": "CWE-770: Allocation of Resources Without Limits or Throttling",
+							"cweId": "CWE-770",
+							"type": "CWE"
+						}
+					]
+				}
+			],
+			"metrics": [
+				{
+					"other": {
+						"type": "Textual description of severity",
+						"content": {
+							"text": "low"
+						}
+					}
+				}
+			],
+			"timeline": [
+				{
+					"lang": "en",
+					"time": "2026-03-02T12:00:00.000Z",
+					"value": "reported"
+				},
+				{
+					"lang": "en",
+					"time": "2026-05-04T12:00:00.000Z",
+					"value": "fixed in 2.4.x by r1933352"
+				},
+				{
+					"lang": "en",
+					"time": "2026-05-04T12:00:00.000Z",
+					"value": "2.4.67 released"
+				}
+			],
+			"source": {
+				"discovery": "UNKNOWN"
+			},
+			"x_generator": {
+				"engine": "Vulnogram 0.2.0"
+			},
+			"references": [
+				{
+					"url": "https://httpd.apache.org/security/vulnerabilities_24.html",
+					"tags": [
+						"vendor-advisory"
+					]
+				}
+			],
+			"credits": [
+				{
+					"lang": "en",
+					"type": "finder",
+					"value": "Pavel Kohout, Aisle Research, Aisle.com"
+				}
+			]
+		}
+	}
+}

--- a/pkg/fetch/apache/httpd/json/testdata/golden/notfound/2011/CVE-2011-3192.json
+++ b/pkg/fetch/apache/httpd/json/testdata/golden/notfound/2011/CVE-2011-3192.json
@@ -1,0 +1,299 @@
+{
+	"data_type": "CVE",
+	"data_format": "MITRE",
+	"data_version": "4.0",
+	"generator": {
+		"engine": "xmltojsonmjc 1.0"
+	},
+	"CVE_data_meta": {
+		"ID": "CVE-2011-3192",
+		"ASSIGNER": "security@apache.org",
+		"STATE": "PUBLIC",
+		"TITLE": "Range header remote DoS",
+		"DATE_PUBLIC": "2011-08-20"
+	},
+	"source": {
+		"discovery": "UNKNOWN"
+	},
+	"affects": {
+		"vendor": {
+			"vendor_data": [
+				{
+					"vendor_name": "Apache Software Foundation",
+					"product": {
+						"product_data": [
+							{
+								"product_name": "Apache HTTP Server",
+								"version": {
+									"version_data": [
+										{
+											"version_affected": "=",
+											"version_value": "2.2.19",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.18",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.17",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.16",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.15",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.14",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.13",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.12",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.11",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.10",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.9",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.8",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.6",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.5",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.4",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.3",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.2",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.2.0",
+											"version_name": "2.2"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.64",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.63",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.61",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.59",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.58",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.55",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.54",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.53",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.52",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.51",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.50",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.49",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.48",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.47",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.46",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.45",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.44",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.43",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.42",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.40",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.39",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.37",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.36",
+											"version_name": "2.0"
+										},
+										{
+											"version_affected": "=",
+											"version_value": "2.0.35",
+											"version_name": "2.0"
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	},
+	"problemtype": {
+		"problemtype_data": [
+			{
+				"description": [
+					{
+						"lang": "eng",
+						"value": "Range header remote DoS"
+					}
+				]
+			}
+		]
+	},
+	"description": {
+		"description_data": [
+			{
+				"lang": "eng",
+				"value": "A flaw was found in the way the Apache HTTP Server handled Range HTTP headers. A remote attacker could use this flaw to cause httpd to use an excessive amount of memory and CPU time via HTTP requests with a specially-crafted Range header. This could be used in a denial of service attack. Advisory: CVE-2011-3192.txt"
+			}
+		]
+	},
+	"references": {},
+	"impact": [
+		{
+			"other": "important"
+		}
+	],
+	"timeline": [
+		{
+			"lang": "eng",
+			"time": "2011-08-20",
+			"value": "reported"
+		},
+		{
+			"lang": "eng",
+			"time": "2011-08-20",
+			"value": "public"
+		},
+		{
+			"lang": "eng",
+			"time": "2011-08-30",
+			"value": "2.2.20 released"
+		},
+		{
+			"lang": "eng",
+			"time": "2013-07-12",
+			"value": "2.0.65 released"
+		}
+	],
+	"CNA_private": {
+		"owner": "httpd"
+	}
+}

--- a/pkg/fetch/apache/httpd/json/types.go
+++ b/pkg/fetch/apache/httpd/json/types.go
@@ -1,0 +1,218 @@
+package json
+
+// The ASF serves two generations of CVE records side by side under
+// /security/json/. Records that predate the migration keep the CVE JSON 4.0
+// schema, the rest use the CVE Record Format. Both carry CNA_private, an
+// ASF-only member that belongs to neither schema and whose shape differs
+// between the two generations.
+//
+// A field is a pointer or carries omitempty only where the ASF actually omits
+// it; members it always emits are required, so that a missing one is a decode
+// error rather than a silently zeroed value.
+
+// CVE4 is a record in the CVE JSON 4.0 schema, identified by data_version 4.0.
+type CVE4 struct {
+	DataType    string `json:"data_type"`
+	DataFormat  string `json:"data_format"`
+	DataVersion string `json:"data_version"`
+	Generator   struct {
+		Engine string `json:"engine"`
+	} `json:"generator"`
+	CVEDataMeta struct {
+		ID         string  `json:"ID"`
+		Assigner   string  `json:"ASSIGNER"`
+		State      string  `json:"STATE"`
+		Title      string  `json:"TITLE"`
+		AKA        *string `json:"AKA,omitempty"`
+		DatePublic *string `json:"DATE_PUBLIC,omitempty"`
+	} `json:"CVE_data_meta"`
+	Source struct {
+		Discovery string   `json:"discovery"`
+		Advisory  *string  `json:"advisory,omitempty"`
+		Defect    []string `json:"defect,omitempty"`
+	} `json:"source"`
+	Affects struct {
+		Vendor struct {
+			VendorData []struct {
+				VendorName string `json:"vendor_name"`
+				Product    struct {
+					ProductData []struct {
+						ProductName string `json:"product_name"`
+						Version     struct {
+							VersionData []Version4 `json:"version_data"`
+						} `json:"version"`
+					} `json:"product_data"`
+				} `json:"product"`
+			} `json:"vendor_data"`
+		} `json:"vendor"`
+	} `json:"affects"`
+	ProblemType struct {
+		ProblemTypeData []struct {
+			Description []LangValue4 `json:"description"`
+		} `json:"problemtype_data"`
+	} `json:"problemtype"`
+	Description struct {
+		DescriptionData []LangValue4 `json:"description_data"`
+	} `json:"description"`
+	References struct {
+		ReferenceData []Reference4 `json:"reference_data,omitempty"`
+	} `json:"references"`
+	Impact []struct {
+		Other string `json:"other"`
+	} `json:"impact"`
+	Timeline      []Timeline4  `json:"timeline"`
+	Credit        []LangValue4 `json:"credit,omitempty"`
+	Configuration []LangValue4 `json:"configuration,omitempty"`
+	Exploit       []LangValue4 `json:"exploit,omitempty"`
+	Solution      []LangValue4 `json:"solution,omitempty"`
+	WorkAround    []LangValue4 `json:"work_around,omitempty"`
+	CNAPrivate    *CNAPrivate4 `json:"CNA_private,omitempty"`
+}
+
+type Version4 struct {
+	VersionAffected string  `json:"version_affected"`
+	VersionValue    string  `json:"version_value"`
+	VersionName     *string `json:"version_name,omitempty"`
+	Platform        *string `json:"platform,omitempty"`
+}
+
+type LangValue4 struct {
+	Lang  string `json:"lang"`
+	Value string `json:"value"`
+}
+
+type Reference4 struct {
+	Refsource string  `json:"refsource"`
+	Name      *string `json:"name,omitempty"`
+	URL       *string `json:"url,omitempty"`
+}
+
+type Timeline4 struct {
+	Lang  string `json:"lang"`
+	Time  string `json:"time"`
+	Value string `json:"value"`
+}
+
+// CNAPrivate4 is the ASF-only extension as it appears in the CVE JSON 4.0
+// records. It tracks the security team's internal handling of the report and is
+// part of no CVE schema.
+type CNAPrivate4 struct {
+	Owner               string   `json:"owner"`
+	Userslist           *string  `json:"userslist,omitempty"`
+	Email               *string  `json:"email,omitempty"`
+	Emailed             *string  `json:"emailed,omitempty"`
+	InternalComments    *string  `json:"internal_comments,omitempty"`
+	ShareWithCVE        *bool    `json:"share_with_CVE,omitempty"`
+	CVEList             []string `json:"CVE_list,omitempty"`
+	CVETableDescription []string `json:"CVE_table_description,omitempty"`
+	Todo                []string `json:"todo,omitempty"`
+	Publish             *struct {
+		Month string `json:"month"`
+		Year  string `json:"year"`
+		YM    string `json:"ym"`
+	} `json:"publish,omitempty"`
+}
+
+// CVE5 is a record in the CVE Record Format, identified by dataVersion 5.x. It
+// is the same schema as pkg/fetch/mitre/cve/v5, narrowed to the members the ASF
+// emits and extended with CNA_private.
+type CVE5 struct {
+	DataType    string `json:"dataType"`
+	DataVersion string `json:"dataVersion"`
+	CVEMetadata struct {
+		CVEID         string `json:"cveId"`
+		AssignerOrgID string `json:"assignerOrgId"`
+		Serial        int    `json:"serial"`
+		State         string `json:"state"`
+	} `json:"cveMetadata"`
+	Containers struct {
+		CNA struct {
+			ProviderMetadata struct {
+				OrgID string `json:"orgId"`
+			} `json:"providerMetadata"`
+			Title        string         `json:"title"`
+			Descriptions []Description5 `json:"descriptions"`
+			Affected     []Affected5    `json:"affected"`
+			ProblemTypes []struct {
+				Descriptions []struct {
+					Lang        string  `json:"lang"`
+					Description string  `json:"description"`
+					CWEID       *string `json:"cweId,omitempty"`
+					Type        *string `json:"type,omitempty"`
+				} `json:"descriptions"`
+			} `json:"problemTypes"`
+			Metrics []struct {
+				Other struct {
+					Type    string `json:"type"`
+					Content struct {
+						Text string `json:"text"`
+					} `json:"content"`
+				} `json:"other"`
+			} `json:"metrics"`
+			Timeline []Timeline5 `json:"timeline"`
+			Source   struct {
+				Discovery string `json:"discovery"`
+			} `json:"source"`
+			XGenerator struct {
+				Engine string `json:"engine"`
+			} `json:"x_generator"`
+			References []Reference5 `json:"references,omitempty"`
+			Credits    []Credit5    `json:"credits,omitempty"`
+		} `json:"cna"`
+	} `json:"containers"`
+	CNAPrivate *CNAPrivate5 `json:"CNA_private,omitempty"`
+}
+
+type Description5 struct {
+	Lang            string `json:"lang"`
+	Value           string `json:"value"`
+	SupportingMedia []struct {
+		Type   string `json:"type"`
+		Base64 bool   `json:"base64"`
+		Value  string `json:"value"`
+	} `json:"supportingMedia"`
+}
+
+type Affected5 struct {
+	Vendor        string `json:"vendor"`
+	Product       string `json:"product"`
+	DefaultStatus string `json:"defaultStatus"`
+	Versions      []struct {
+		Status          string  `json:"status"`
+		Version         string  `json:"version"`
+		VersionType     *string `json:"versionType,omitempty"`
+		LessThan        *string `json:"lessThan,omitempty"`
+		LessThanOrEqual *string `json:"lessThanOrEqual,omitempty"`
+	} `json:"versions"`
+	CPEs []string `json:"cpes,omitempty"`
+}
+
+type Reference5 struct {
+	URL  string   `json:"url"`
+	Tags []string `json:"tags"`
+}
+
+type Credit5 struct {
+	Lang  string `json:"lang"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type Timeline5 struct {
+	Lang  string `json:"lang"`
+	Time  string `json:"time"`
+	Value string `json:"value"`
+}
+
+// CNAPrivate5 is the ASF-only extension as it appears in the CVE Record Format
+// records. Its member set differs from CNAPrivate4, so the two generations do
+// not share a type.
+type CNAPrivate5 struct {
+	Owner      string   `json:"owner"`
+	State      string   `json:"state"`
+	Type       string   `json:"type"`
+	Todo       []string `json:"todo"`
+	Emailed    *string  `json:"emailed,omitempty"`
+	ProjectURL *string  `json:"projecturl,omitempty"`
+	Userslist  *string  `json:"userslist,omitempty"`
+}


### PR DESCRIPTION
## What

Add Apache HTTP Server as a data source: a fetcher for the per-CVE JSON the ASF serves under `/security/json/`, and an extractor that maps it onto the canonical schema.

- `pkg/fetch/apache/httpd/json` → `vuls-data-update fetch apache-httpd-json`
- `pkg/extract/apache/httpd/json` → `vuls-data-update extract apache-httpd-json`
- `sourceTypes.ApacheHTTPDJSON` (`"apache-httpd-json"`)

## Why

The obvious entry point for this source is `vulnerabilities_22.html` / `vulnerabilities_24.html`, but those pages are generated. The generator input is published as JSON at `https://httpd.apache.org/security/json/`, and it covers the same set exactly:

| | count |
|---|---|
| unique CVE IDs across `vulnerabilities_13/20/22/24.html` | 268 |
| JSON files under `/security/json/` | 268 |
| in HTML but not JSON / in JSON but not HTML | 0 / 0 |

The JSON is also the better input for version matching. The HTML states affected versions as prose (`Affects: 2.0.35 through 2.2.19`), while the JSON enumerates them (43 entries for that record).

## How

**Two schema generations.** The directory mixes 208 records in CVE JSON 4.0 with 60 in the CVE Record Format. Records are routed by which version member they carry (`data_version` vs `dataVersion`); one carrying neither is an error rather than a wrong decode, so a future third generation surfaces instead of being silently mis-parsed.

`CNA_private` is an ASF-only member in neither schema, and its shape differs between the generations (v4 has `email`/`internal_comments`/`share_with_CVE`/`publish`, v5 has `projecturl`/`state`/`type`), so it needs two types rather than one.

**Detections.** Every record describes the one product, so detections use the `cpe` ecosystem with a fixed `cpe:2.3:a:apache:http_server:*:...` and only the version part varies — bounds (`lessThan`/`lessThanOrEqual`, and v4's `<=`/`>=`/`!<`) become a `Range`, versions the source enumerates one by one (`=`/`?=`, and v5 entries with no upper bound) become `CPEMatches`.

**Deliberate omissions**, each because the source does not actually carry the data:

- **CWE for v4** — `problemtype_data[].description[].value` holds the flaw's short name (`"Range header remote DoS"`), not a CWE identifier. v5's `cweId` is mapped normally.
- **Published for v5** — the CVE Record Format records the ASF serves have no `datePublished` and no `"public"` timeline entry (0 of 60). v4's `DATE_PUBLIC` is used where present (176 of 208).
- **`Fixed` versions** — derivable only from free-text `timeline` values, in 26 distinct shapes including `"2.2.35-never released"`, where a regex miss becomes a wrong fixed-version claim. Left for a follow-up that can pin the patterns under golden tests.

`?=` (141 entries, "listed but unverified" in the vulnerability page's own wording) is treated as affected. Happy to split it out if you want it distinguished.

## Points for review

- **`sourceTypes.ApacheHTTPDJSON` is a new source ID.** Additive only — no existing field changed — but downstream (`vuls2`) needs to know it to consume the output.
- **`cpe` ecosystem rather than a new `apache` one.** Follows `fortinet/cvrf`, and avoids an ecosystem constant that downstream matching would have to learn. Say the word if a dedicated ecosystem is preferred.
- **`affected[].cpes` entries without a concrete version are dropped.** One record (CVE-2026-29168) carries `cpe:2.3:a:apache:http_server:*:*:...`, which restates the criterion CPE. As a `CPEMatch` it would match every version and defeat that criterion's `Range` (2.4.30–2.4.66), so version-less entries are skipped — silently when they merely restate the product CPE, with a `slog.Warn` otherwise.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` — 413 packages ok, 0 failures
- `golangci-lint run` on both new packages — 0 issues
- Golden files generated through the real code path, not hand-written
- Fetcher fixtures cover `happy` (v4/v5 mixed), `notfound`, `unexpected`, `invalid-id`, `unknown-schema`; extractor fixtures cover every version-mapping branch (v4 `=` only / `=`+`?=` / `>=`+`<=`, v5 range / version-only / `cpes`)

End-to-end against the live site:

```
$ vuls-data-update fetch apache-httpd-json -d /tmp/e2e
268 records fetched
```

Diffing that output against the untouched upstream payloads: **0 value changes, 0 spurious fields**. Everything `omitempty` drops is a present-but-empty member (`"AKA": ""`, `"defect": []`, `"references": {}`) — the types are complete, verified by decoding all 268 with `json.RejectUnknownMembers(true)` (v4 208/208, v5 60/60).

```
$ vuls-data-update extract apache-httpd-json /tmp/e2e -d /tmp/e2e-extract
268 records extracted, 0 without a detection
exact affected versions: source 3470 = extracted 3470
```

The single record with no severity is the one whose `impact` is `"n/a"`.

## Checklist

- [x] Tests pass
- [x] Golden files updated
- [x] Deterministic output verified (if types changed) — the `types` change is one additive `SourceID` constant, so no `Sort()`/`Compare()` needed; golden tests pass
- [x] Backward compatibility maintained (if types/data changed) — additive constant only, no existing field touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
