### PR TITLE
fix(extract/suse/oval): report actual check value in unexpected evr operation error

### DIFF
--- a/pkg/extract/suse/oval/oval.go
+++ b/pkg/extract/suse/oval/oval.go
@@ -1010,6 +1010,6 @@ func (e extractor) translateEVRCriterion(oc oval.Criterion, t oval.RpminfoTest, 
 			return translated{}, errors.Errorf("unexpected rpminfo_test check. test: %s, expected: %q, actual: %q", oc.TestRef, []string{"at least one", "all", "none satisfy"}, t.Check)
 		}
 	default:
-		return translated{}, errors.Errorf("unexpected evr operation. test: %s, check: %q, expected: %q, actual: %q", oc.TestRef, "at least one", []string{"less than", "equals", "greater than", "greater than or equal"}, s.Evr.Operation)
+		return translated{}, errors.Errorf("unexpected evr operation. test: %s, check: %q, expected: %q, actual: %q", oc.TestRef, t.Check, []string{"less than", "equals", "greater than", "greater than or equal"}, s.Evr.Operation)
 	}
 }


### PR DESCRIPTION
## What

Use the actual `t.Check` value instead of a hardcoded `"at least one"` in the error message of the rpminfo_state EVR operation switch's default case.

## Why

The `unexpected evr operation` error exists so a human can inspect the input data when SUSE introduces an encoding the extractor does not know. The message reported `check: "at least one"` regardless of the rpminfo_test's actual check attribute (which can also be `"all"` or `"none satisfy"`), misleading that inspection. Originally pointed out by Copilot review on #905; that PR was closed because upstream removed the data that motivated it, but this message fix is data-independent and worth keeping.

## Testing

`GOEXPERIMENT=jsonv2 go test ./pkg/extract/suse/oval/` passes (message-only change, no behavior change on handled data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)