### PR TITLE
fix(extract/redhat/vex/v1): skip pkg:luarocks purl

### DIFF
--- a/pkg/extract/redhat/vex/v1/testdata/fixtures/vex/2019/CVE-2019-14852.json
+++ b/pkg/extract/redhat/vex/v1/testdata/fixtures/vex/2019/CVE-2019-14852.json
@@ -1,0 +1,221 @@
+{
+	"document": {
+		"aggregate_severity": {
+			"namespace": "https://access.redhat.com/security/updates/classification/",
+			"text": "Moderate"
+		},
+		"category": "csaf_vex",
+		"csaf_version": "2.0",
+		"distribution": {
+			"text": "Copyright © Red Hat, Inc. All rights reserved.",
+			"tlp": {
+				"label": "WHITE",
+				"url": "https://www.first.org/tlp/"
+			}
+		},
+		"lang": "en",
+		"notes": [
+			{
+				"category": "legal_disclaimer",
+				"text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+				"title": "Terms of Use"
+			}
+		],
+		"publisher": {
+			"category": "vendor",
+			"contact_details": "https://access.redhat.com/security/team/contact/",
+			"issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+			"name": "Red Hat Product Security",
+			"namespace": "https://www.redhat.com"
+		},
+		"references": [
+			{
+				"category": "self",
+				"summary": "Canonical URL",
+				"url": "https://security.access.redhat.com/data/csaf/v2/vex/2019/cve-2019-14852.json"
+			}
+		],
+		"title": "apicast: deprecated protocol TLS 1.0 enabled in gateway",
+		"tracking": {
+			"current_release_date": "2026-08-04T05:02:37+00:00",
+			"generator": {
+				"date": "2026-08-04T05:02:37+00:00",
+				"engine": {
+					"name": "Red Hat SDEngine",
+					"version": "5.3.8"
+				}
+			},
+			"id": "CVE-2019-14852",
+			"initial_release_date": "2019-01-01T00:00:00+00:00",
+			"revision_history": [
+				{
+					"date": "2019-01-01T00:00:00+00:00",
+					"number": "1",
+					"summary": "Initial version"
+				},
+				{
+					"date": "2026-08-04T04:34:53+00:00",
+					"number": "2",
+					"summary": "Current version"
+				},
+				{
+					"date": "2026-08-04T05:02:37+00:00",
+					"number": "3",
+					"summary": "Last generated version"
+				}
+			],
+			"status": "final",
+			"version": "3"
+		}
+	},
+	"product_tree": {
+		"branches": [
+			{
+				"branches": [
+					{
+						"branches": [
+							{
+								"category": "product_name",
+								"name": "Red Hat 3scale API Management Platform 2",
+								"product": {
+									"name": "Red Hat 3scale API Management Platform 2",
+									"product_id": "red_hat_3scale_api_management_platform_2",
+									"product_identification_helper": {
+										"cpe": "cpe:/a:redhat:red_hat_3scale_amp:2"
+									}
+								}
+							}
+						],
+						"category": "product_family",
+						"name": "Red Hat 3scale API Management Platform 2"
+					},
+					{
+						"category": "product_version",
+						"name": "apicast",
+						"product": {
+							"name": "apicast",
+							"product_id": "apicast",
+							"product_identification_helper": {
+								"purl": "pkg:luarocks/apicast"
+							}
+						}
+					}
+				],
+				"category": "vendor",
+				"name": "Red Hat"
+			}
+		],
+		"relationships": [
+			{
+				"category": "default_component_of",
+				"full_product_name": {
+					"name": "apicast as a component of Red Hat 3scale API Management Platform 2",
+					"product_id": "red_hat_3scale_api_management_platform_2:apicast"
+				},
+				"product_reference": "apicast",
+				"relates_to_product_reference": "red_hat_3scale_api_management_platform_2"
+			}
+		]
+	},
+	"vulnerabilities": [
+		{
+			"cve": "CVE-2019-14852",
+			"cwe": {
+				"id": "CWE-327",
+				"name": "Use of a Broken or Risky Cryptographic Algorithm"
+			},
+			"discovery_date": "2019-10-03T00:00:00+00:00",
+			"ids": [
+				{
+					"system_name": "Red Hat Bugzilla ID",
+					"text": "1758208"
+				}
+			],
+			"notes": [
+				{
+					"category": "description",
+					"text": "A flaw was found in 3scale’s APIcast gateway that enabled the TLS 1.0 protocol. An attacker could target traffic using this weaker protocol and break its encryption, gaining access to unauthorized information.",
+					"title": "Vulnerability description"
+				},
+				{
+					"category": "summary",
+					"text": "apicast: deprecated protocol TLS 1.0 enabled in gateway",
+					"title": "Vulnerability summary"
+				},
+				{
+					"category": "general",
+					"text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+					"title": "CVSS score applicability"
+				}
+			],
+			"product_status": {
+				"known_affected": [
+					"red_hat_3scale_api_management_platform_2:apicast"
+				]
+			},
+			"references": [
+				{
+					"category": "self",
+					"summary": "Canonical URL",
+					"url": "https://access.redhat.com/security/cve/CVE-2019-14852"
+				},
+				{
+					"category": "external",
+					"summary": "RHBZ#1758208",
+					"url": "https://bugzilla.redhat.com/show_bug.cgi?id=1758208"
+				},
+				{
+					"category": "external",
+					"summary": "https://www.cve.org/CVERecord?id=CVE-2019-14852",
+					"url": "https://www.cve.org/CVERecord?id=CVE-2019-14852"
+				},
+				{
+					"category": "external",
+					"summary": "https://nvd.nist.gov/vuln/detail/CVE-2019-14852",
+					"url": "https://nvd.nist.gov/vuln/detail/CVE-2019-14852"
+				}
+			],
+			"release_date": "2021-03-17T00:00:00+00:00",
+			"remediations": [
+				{
+					"category": "none_available",
+					"details": "Affected",
+					"product_ids": [
+						"red_hat_3scale_api_management_platform_2:apicast"
+					]
+				}
+			],
+			"scores": [
+				{
+					"cvss_v3": {
+						"attackComplexity": "HIGH",
+						"attackVector": "NETWORK",
+						"availabilityImpact": "NONE",
+						"baseScore": 5.9,
+						"baseSeverity": "MEDIUM",
+						"confidentialityImpact": "HIGH",
+						"integrityImpact": "NONE",
+						"privilegesRequired": "NONE",
+						"scope": "UNCHANGED",
+						"userInteraction": "NONE",
+						"vectorString": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+						"version": "3.0"
+					},
+					"products": [
+						"red_hat_3scale_api_management_platform_2:apicast"
+					]
+				}
+			],
+			"threats": [
+				{
+					"category": "impact",
+					"details": "Moderate",
+					"product_ids": [
+						"red_hat_3scale_api_management_platform_2:apicast"
+					]
+				}
+			],
+			"title": "apicast: deprecated protocol TLS 1.0 enabled in gateway"
+		}
+	]
+}

--- a/pkg/extract/redhat/vex/v1/testdata/golden/data/2019/CVE-2019-14852.json
+++ b/pkg/extract/redhat/vex/v1/testdata/golden/data/2019/CVE-2019-14852.json
@@ -1,0 +1,10 @@
+{
+	"id": "CVE-2019-14852",
+	"data_source": {
+		"id": "redhat-vex",
+		"raws": [
+			"repository2cpe/repository-to-cpe.json",
+			"vex/2019/CVE-2019-14852.json"
+		]
+	}
+}

--- a/pkg/extract/redhat/vex/v1/v1.go
+++ b/pkg/extract/redhat/vex/v1/v1.go
@@ -442,7 +442,7 @@ func walkProductTree(trackingID string, pt v1.ProductTree, c2r map[string][]stri
 						// processed or just added to this skip list — silent
 						// data loss is worse than a loud failure.
 						for _, s := range []string{
-							"pkg:generic/", "pkg:golang/", "pkg:maven/", "pkg:npm/", "pkg:oci/", "pkg:pypi/",
+							"pkg:generic/", "pkg:golang/", "pkg:luarocks/", "pkg:maven/", "pkg:npm/", "pkg:oci/", "pkg:pypi/",
 						} {
 							if strings.HasPrefix(fpn.ProductIdentificationHelper.PURL, s) {
 								return nil, nil


### PR DESCRIPTION
## What
Add `pkg:luarocks/` to the non-RPM PURL skip list in the redhat vex/v1 extractor.

## Why
The legacy vex feed now contains `pkg:luarocks/apicast`, which made the vex/v1 extract fail loudly (by design) in vuls-data-db Extract All:
https://github.com/vulsio/vuls-data-db/actions/runs/30932679247/job/92075103337

```
unexpected purl prefix: "pkg:luarocks/apicast"
```

Same class of fix as #693 (skip a newly observed non-RPM PURL type until a proper handling strategy is decided).

## How
One-line addition to the skip list in `pkg/extract/redhat/vex/v1/v1.go`. Only vex/v1 failed — vex/v2 and csaf succeeded on the same day's data — so the list is extended only where the data was actually observed.

## Testing
```
GOEXPERIMENT=jsonv2 go build ./cmd/vuls-data-update
GOEXPERIMENT=jsonv2 go test ./pkg/extract/redhat/vex/...
```
Both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)