### PR TITLE
feat(fetch/microsoft/servicing): add servicing article fetcher

### DIFF
--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -2640,9 +2640,9 @@ func newCmdMicrosoftServicing() *cobra.Command {
 	}{
 		base: base{
 			dir:   filepath.Join(util.CacheDir(), "fetch", "microsoft", "servicing"),
-			retry: 3,
+			retry: 10,
 		},
-		concurrency: 3,
+		concurrency: 2,
 		wait:        1 * time.Second,
 	}
 

--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -90,6 +90,7 @@ import (
 	microsoftDeployment "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/deployment"
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/msuc"
 	microsoftProduct "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/product"
+	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/servicing"
 	microsoftVEX "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vex"
 	microsoftVulnerability "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vulnerability"
 	microsoftWSUSSCN2 "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/wsusscn2"
@@ -252,7 +253,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdLinuxOSV(),
 		newCmdMageiaOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
 		newCmdMinimOSOSV(), newCmdMinimOSSecDB(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreEMB3D(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
@@ -2618,6 +2619,70 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := microsoftMSUC.Fetch(args, microsoftMSUC.WithDir(options.dir), microsoftMSUC.WithRetry(options.retry), microsoftMSUC.WithConcurrency(options.concurrency), microsoftMSUC.WithWait(options.wait)); err != nil {
 				return errors.Wrap(err, "failed to fetch microsoft msuc")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
+	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent http requests")
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
+
+	return cmd
+}
+
+func newCmdMicrosoftServicing() *cobra.Command {
+	options := &struct {
+		base
+		concurrency int
+		wait        time.Duration
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "microsoft", "servicing"),
+			retry: 3,
+		},
+		concurrency: 3,
+		wait:        1 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-servicing <KBID>...",
+		Short: "Fetch Microsoft Servicing Article data source",
+		Long: heredoc.Doc(`
+			Fetch Microsoft servicing articles as HTML into <dir>/origin, and what each
+			one states about itself into <dir>/raw.
+
+			A servicing article outlives the update it describes. Once Microsoft expires
+			an update the Update Catalog stops serving it and wsusscn2.cab drops it, but
+			the article stays, and every article in a series carries a sidebar listing the
+			whole series — expired updates included. That sidebar is the only remaining
+			record of which updates a series had.
+
+			Each KB is resolved through support.microsoft.com/help/<KB> to discover its
+			series, those articles are retrieved and their sidebars read, and every
+			article a sidebar names is then retrieved too: the sidebar can be pruned the
+			way the Catalog's replaces list was, so each article is kept as its own
+			record.
+
+			Sidebars are read only on the articles asked for. One repeated on every
+			article of a series has nothing further to add, and following it beyond that
+			leaves the series -- a Windows Server 2008 sidebar links into Windows 8.1.
+
+			Which articles form a series is the directory they sit in, so the sidebar
+			itself is not stored.
+
+			raw/ holds one file per stored article, at the path its origin/ counterpart
+			has. Only the heading and the canonical link are read out of the page; the
+			prose sections stay in origin/ for a later pass.
+		`),
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch microsoft-servicing KB5101004 KB5066835
+		`),
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := microsoftServicing.Fetch(args, microsoftServicing.WithDir(options.dir), microsoftServicing.WithRetry(options.retry), microsoftServicing.WithConcurrency(options.concurrency), microsoftServicing.WithWait(options.wait)); err != nil {
+				return errors.Wrap(err, "failed to fetch microsoft servicing")
 			}
 			return nil
 		},

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -609,6 +609,22 @@ func writeOrigin(dir, name string, content []byte) error {
 // parsePath splits a canonical servicing URL into its product, series and the
 // path below it.
 func parsePath(u *url.URL) (article, bool) {
+	// A canonical servicing path has no dot-segments, and url.ResolveReference,
+	// which every URL reaching here has been through, removes the ones a redirect
+	// or an href spells out. It removes them from the escaped path, though, while
+	// Path is decoded: %2e%2e survives resolution and arrives here as "..", from
+	// where filepath.Join would carry the write out of origin/. Reject rather
+	// than clean — no article is addressed that way, so nothing is lost.
+	//
+	// This is the only place an article is built, and its name is the only path
+	// origin/ is written at, so the check covers both the redirect resolve reads
+	// and the listing hrefs resolveHref follows.
+	for s := range strings.SplitSeq(u.Path, "/") {
+		if s == "." || s == ".." {
+			return article{}, false
+		}
+	}
+
 	m := servicingPathPattern.FindStringSubmatch(u.Path)
 	if m == nil {
 		return article{}, false

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -265,7 +265,7 @@ func (opts options) fetch(kbs []string) error {
 
 	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry), utilhttp.WithClientCheckRetry(retryPolicy))
 
-	seeds, err := opts.resolve(client, util.Unique(kbs))
+	seeds, err := opts.resolve(client, kbs)
 	if err != nil {
 		return errors.Wrap(err, "resolve")
 	}
@@ -289,6 +289,16 @@ func (opts options) fetch(kbs []string) error {
 // product and series as path segments, so the body would add nothing a crawl
 // does not already reach.
 func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, error) {
+	// /help/ takes the article number alone; /help/KB5101004 is a 404. Callers
+	// pass either spelling, so normalize rather than reject — and normalize
+	// before deduplicating, or "KB5101004" and "5101004" are two lookups of the
+	// one article.
+	ns := make([]string, 0, len(kbs))
+	for _, kb := range kbs {
+		ns = append(ns, strings.TrimPrefix(strings.ToUpper(kb), "KB"))
+	}
+	kbs = util.Unique(ns)
+
 	slog.Info("Resolve KB to servicing article", slog.Int("count", len(kbs)))
 
 	bar := progressbar.Default(int64(len(kbs)))
@@ -301,12 +311,6 @@ func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, e
 				time.Sleep(opts.wait)
 				_ = bar.Add(1)
 			}()
-
-			// /help/ takes the article number alone; /help/KB5101004 is a 404.
-			// Callers pass either spelling, so normalize rather than reject, and
-			// keep the normalized form: it is what sidebar entries carry, and the
-			// two have to compare equal for a series to cover its members.
-			kb = strings.TrimPrefix(strings.ToUpper(kb), "KB")
 
 			req, err := utilhttp.NewRequest(http.MethodHead, fmt.Sprintf(opts.helpURL, kb))
 			if err != nil {

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -349,10 +349,6 @@ func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, e
 		articles = append(articles, a)
 	}
 
-	// Ordered so a rerun walks the same tree in the same order rather than in
-	// whatever order the lookups happened to finish.
-	slices.SortFunc(articles, func(a, b article) int { return strings.Compare(a.name(), b.name()) })
-
 	return articles, nil
 }
 
@@ -417,7 +413,6 @@ func (opts options) discover(client *utilhttp.Client, seeds []article, stored ma
 	for t := range targetChan {
 		targets = append(targets, t...)
 	}
-	slices.SortFunc(targets, func(a, b article) int { return strings.Compare(a.name(), b.name()) })
 
 	return targets, nil
 }

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -265,13 +265,12 @@ func (opts options) fetch(kbs []string) error {
 		return errors.Wrap(err, "resolve")
 	}
 
-	stored := make(map[string]struct{}, len(seeds))
-	targets, err := opts.discover(client, seeds, stored)
+	targets, err := opts.discover(client, seeds)
 	if err != nil {
 		return errors.Wrap(err, "discover")
 	}
 
-	if err := opts.collect(client, targets, stored); err != nil {
+	if err := opts.collect(client, targets); err != nil {
 		return errors.Wrap(err, "collect")
 	}
 
@@ -352,7 +351,8 @@ func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, e
 	return articles, nil
 }
 
-// discover stores the articles asked for and reports what their listings name.
+// discover stores the articles asked for and reports the ones their listings
+// name that are still missing.
 //
 // Only these listings are read. Following them further would not find anything
 // in the same series -- the listing is identical on every article of one -- but
@@ -360,9 +360,16 @@ func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, e
 // os/windows-8-1/2024/01/end-of-support, and reading that article's listing in
 // turn would drag in the whole of Windows 8.1. One hop keeps a request for a
 // series to that series and whatever it points at directly.
-func (opts options) discover(client *utilhttp.Client, seeds []article, stored map[string]struct{}) ([]article, error) {
+//
+// What comes back is deduplicated against what went out, because a listing
+// names its whole series and one was read per KB asked for: three members of
+// os/windows-11 name its 300 articles 900 times between them, those three
+// included. Every article named more than once is one article, so the caller is
+// told about it once, and about the seeds not at all.
+func (opts options) discover(client *utilhttp.Client, seeds []article) ([]article, error) {
 	slog.Info("Discover series", slog.Int("articles", len(seeds)))
 
+	stored := make(map[string]struct{}, len(seeds))
 	bar := progressbar.Default(int64(len(seeds)))
 	targetChan := make(chan []article, len(seeds))
 	var g errgroup.Group
@@ -411,7 +418,13 @@ func (opts options) discover(client *utilhttp.Client, seeds []article, stored ma
 
 	var targets []article
 	for t := range targetChan {
-		targets = append(targets, t...)
+		for _, a := range t {
+			if _, ok := stored[a.name()]; ok {
+				continue
+			}
+			stored[a.name()] = struct{}{}
+			targets = append(targets, a)
+		}
 	}
 
 	return targets, nil
@@ -419,15 +432,7 @@ func (opts options) discover(client *utilhttp.Client, seeds []article, stored ma
 
 // collect stores the rest of the series. Their listings are not read: they say
 // what discover has already been told.
-func (opts options) collect(client *utilhttp.Client, targets []article, stored map[string]struct{}) error {
-	targets = slices.DeleteFunc(targets, func(a article) bool {
-		if _, ok := stored[a.name()]; ok {
-			return true
-		}
-		stored[a.name()] = struct{}{}
-		return false
-	})
-
+func (opts options) collect(client *utilhttp.Client, targets []article) error {
 	slog.Info("Collect series", slog.Int("articles", len(targets)))
 
 	bar := progressbar.Default(int64(len(targets)))

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -16,12 +16,13 @@
 // catalog at all; the sidebar on any article in the series still lists all six
 // in order.
 //
-// Fetching is two steps. The articles asked for are stored and their sidebars
-// read; then everything those sidebars name is stored, without reading its
-// sidebar in turn. One hop is enough — a sidebar repeated on every article of a
-// series has nothing more to say — and it is also the limit worth taking: a
-// Windows Server 2008 sidebar links into Windows 8.1, so following further
-// would pull in a series nobody asked for.
+// Fetching is two steps, one reading and one writing. The sidebar on each
+// article asked for is read to learn the rest of its series; then every article
+// they name — the ones asked for included — is retrieved and stored, and no
+// further sidebar is read. One hop is enough — a sidebar repeated on every
+// article of a series has nothing more to say — and it is also the limit worth
+// taking: a Windows Server 2008 sidebar links into Windows 8.1, so following
+// further would pull in a series nobody asked for.
 //
 // fetch writes <dir>/origin verbatim and then produces <dir>/raw by reading it
 // back, never the HTTP response, so raw/ is reproducible from origin/ alone.
@@ -48,8 +49,6 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
-	"github.com/schollz/progressbar/v3"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
 	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
@@ -295,53 +294,41 @@ func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, e
 
 	slog.Info("Resolve KB to servicing article", slog.Int("count", len(kbs)))
 
-	bar := progressbar.Default(int64(len(kbs)))
-	articleChan := make(chan article, len(kbs))
-	var g errgroup.Group
-	g.SetLimit(opts.concurrency)
+	reqs := make([]*retryablehttp.Request, 0, len(kbs))
 	for _, kb := range kbs {
-		g.Go(func() error {
-			defer func() {
-				time.Sleep(opts.wait)
-				_ = bar.Add(1)
-			}()
-
-			req, err := utilhttp.NewRequest(http.MethodHead, fmt.Sprintf(opts.helpURL, kb))
-			if err != nil {
-				return errors.Wrapf(err, "new request for %s", kb)
-			}
-
-			resp, err := client.Do(req)
-			if err != nil {
-				return errors.Wrapf(err, "head %s", kb)
-			}
-			defer resp.Body.Close()
-			_, _ = io.Copy(io.Discard, resp.Body)
-
-			if resp.StatusCode != http.StatusOK {
-				slog.Warn("unexpected status", slog.String("kb", kb), slog.Int("status", resp.StatusCode))
-				return nil
-			}
-
-			a, ok := parsePath(resp.Request.URL)
-			if !ok {
-				// Pre-2018 KBs and hub pages stay on /help/<KB> or land on a
-				// product landing page. There is no series to read there.
-				slog.Warn("not a servicing article", slog.String("kb", kb), slog.String("url", resp.Request.URL.String()))
-				return nil
-			}
-			a.url = resp.Request.URL.String()
-
-			articleChan <- a
-
-			return nil
-		})
+		req, err := utilhttp.NewRequest(http.MethodHead, fmt.Sprintf(opts.helpURL, kb))
+		if err != nil {
+			return nil, errors.Wrapf(err, "new request for %s", kb)
+		}
+		reqs = append(reqs, req)
 	}
-	if err := g.Wait(); err != nil {
-		return nil, errors.Wrap(err, "err in goroutine")
+
+	articleChan := make(chan article, len(kbs))
+	if err := client.PipelineDo(reqs, opts.concurrency, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+
+		if resp.StatusCode != http.StatusOK {
+			slog.Warn("unexpected status", slog.String("url", resp.Request.URL.String()), slog.Int("status", resp.StatusCode))
+			return nil
+		}
+
+		a, ok := parsePath(resp.Request.URL)
+		if !ok {
+			// Pre-2018 KBs and hub pages stay on /help/<KB> or land on a product
+			// landing page. There is no series to read there.
+			slog.Warn("not a servicing article", slog.String("url", resp.Request.URL.String()))
+			return nil
+		}
+		a.url = resp.Request.URL.String()
+
+		articleChan <- a
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "pipeline do")
 	}
 	close(articleChan)
-	_ = bar.Close()
 
 	articles := make([]article, 0, len(kbs))
 	for a := range articleChan {
@@ -351,8 +338,14 @@ func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, e
 	return articles, nil
 }
 
-// discover stores the articles asked for and reports the ones their listings
-// name that are still missing.
+// discover reads the listing on each article asked for and reports every
+// article to store: the ones asked for, and the rest of the series each names.
+//
+// Nothing is written here. Reading a listing means retrieving the article
+// carrying it, and keeping those bytes would make this the second place that
+// writes origin/ -- one that writes some articles while collect writes the
+// others. Retrieving them again there costs one request per KB asked for and
+// leaves one function answering for the tree.
 //
 // Only these listings are read. Following them further would not find anything
 // in the same series -- the listing is identical on every article of one -- but
@@ -360,135 +353,119 @@ func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, e
 // os/windows-8-1/2024/01/end-of-support, and reading that article's listing in
 // turn would drag in the whole of Windows 8.1. One hop keeps a request for a
 // series to that series and whatever it points at directly.
-//
-// What comes back is deduplicated against what went out, because a listing
-// names its whole series and one was read per KB asked for: three members of
-// os/windows-11 name its 300 articles 900 times between them, those three
-// included. Every article named more than once is one article, so the caller is
-// told about it once, and about the seeds not at all.
 func (opts options) discover(client *utilhttp.Client, seeds []article) ([]article, error) {
 	slog.Info("Discover series", slog.Int("articles", len(seeds)))
 
-	stored := make(map[string]struct{}, len(seeds))
-	bar := progressbar.Default(int64(len(seeds)))
-	targetChan := make(chan []article, len(seeds))
-	var g errgroup.Group
-	g.SetLimit(opts.concurrency)
+	us := make([]string, 0, len(seeds))
 	for _, a := range seeds {
-		if _, ok := stored[a.name()]; ok {
-			_ = bar.Add(1)
-			continue
+		// The URL the redirect landed on is used as-is rather than rebuilt from
+		// the parsed segments: rebuilding would silently diverge the moment
+		// Microsoft changes a locale prefix or adds a path level.
+		us = append(us, a.url)
+	}
+
+	articleChan := make(chan []article, len(seeds))
+	if err := client.PipelineGet(us, opts.concurrency, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, resp.Request.URL)
 		}
-		stored[a.name()] = struct{}{}
 
-		g.Go(func() error {
-			defer func() {
-				time.Sleep(opts.wait)
-				_ = bar.Add(1)
-			}()
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", resp.Request.URL)
+		}
 
-			bs, err := opts.store(client, a)
-			if err != nil {
-				return errors.Wrapf(err, "store %s", a.url)
-			}
+		// The seed is reported alongside what its listing names, since a series
+		// of one -- or one rendering no listing at all, as os/windows does --
+		// would otherwise be discovered by nothing.
+		a, ok := parsePath(resp.Request.URL)
+		if !ok {
+			return errors.Errorf("unexpected url. expected: %q, actual: %q", "/<locale>/servicing/<product>/.../<article>", resp.Request.URL)
+		}
+		a.url = resp.Request.URL.String()
+		articles := []article{a}
 
-			var targets []article
-			for _, e := range parseSidebar(string(bs)) {
-				if e.href == "" {
-					continue
-				}
-				b, ok := resolveHref(a, e.href)
-				if !ok {
-					slog.Warn("unexpected listing target", slog.String("href", e.href), slog.String("from", a.url))
-					continue
-				}
-				targets = append(targets, b)
-			}
-
-			targetChan <- targets
-
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		return nil, errors.Wrap(err, "err in goroutine")
-	}
-	close(targetChan)
-	_ = bar.Close()
-
-	var targets []article
-	for t := range targetChan {
-		for _, a := range t {
-			if _, ok := stored[a.name()]; ok {
+		for _, e := range parseSidebar(string(bs)) {
+			if e.href == "" {
 				continue
 			}
-			stored[a.name()] = struct{}{}
-			targets = append(targets, a)
+			b, ok := resolveHref(resp.Request.URL, e.href)
+			if !ok {
+				slog.Warn("unexpected listing target", slog.String("href", e.href), slog.String("from", resp.Request.URL.String()))
+				continue
+			}
+			articles = append(articles, b)
+		}
+
+		articleChan <- articles
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "pipeline get")
+	}
+	close(articleChan)
+
+	// A listing names its whole series and one was read per KB asked for, so
+	// three members of os/windows-11 name its 300 articles 900 times between
+	// them. Each is one article and is stored once.
+	seen := make(map[string]struct{}, len(seeds))
+	var articles []article
+	for as := range articleChan {
+		for _, a := range as {
+			if _, ok := seen[a.name()]; ok {
+				continue
+			}
+			seen[a.name()] = struct{}{}
+			articles = append(articles, a)
 		}
 	}
 
-	return targets, nil
+	return articles, nil
 }
 
-// collect stores the rest of the series. Their listings are not read: they say
-// what discover has already been told.
-func (opts options) collect(client *utilhttp.Client, targets []article) error {
-	slog.Info("Collect series", slog.Int("articles", len(targets)))
+// collect stores every article discover reported. Their listings are not read:
+// they say what discover has already been told.
+func (opts options) collect(client *utilhttp.Client, articles []article) error {
+	slog.Info("Collect articles", slog.Int("articles", len(articles)))
 
-	bar := progressbar.Default(int64(len(targets)))
-	var g errgroup.Group
-	g.SetLimit(opts.concurrency)
-	for _, a := range targets {
-		g.Go(func() error {
-			defer func() {
-				time.Sleep(opts.wait)
-				_ = bar.Add(1)
-			}()
-
-			if _, err := opts.store(client, a); err != nil {
-				return errors.Wrapf(err, "store %s", a.url)
-			}
-
-			return nil
-		})
+	us := make([]string, 0, len(articles))
+	for _, a := range articles {
+		us = append(us, a.url)
 	}
-	if err := g.Wait(); err != nil {
-		return errors.Wrap(err, "err in goroutine")
+
+	if err := client.PipelineGet(us, opts.concurrency, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, resp.Request.URL)
+		}
+
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", resp.Request.URL)
+		}
+
+		// Taken from the response rather than carried in from the caller, so
+		// where a page is stored follows the URL it was actually served at.
+		a, ok := parsePath(resp.Request.URL)
+		if !ok {
+			return errors.Errorf("unexpected url. expected: %q, actual: %q", "/<locale>/servicing/<product>/.../<article>", resp.Request.URL)
+		}
+
+		if err := writeOrigin(opts.dir, a.name(), flightingPattern.ReplaceAll(bs, nil)); err != nil {
+			return errors.Wrapf(err, "write %s", a.name())
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "pipeline get")
 	}
-	_ = bar.Close()
 
 	return nil
-}
-
-// store retrieves one article, writes it to origin/ and reports the KBs its
-// sidebar accounts for.
-func (opts options) store(client *utilhttp.Client, a article) ([]byte, error) {
-	// The URL the redirect landed on is used as-is rather than rebuilt from the
-	// parsed segments: rebuilding would silently diverge the moment Microsoft
-	// changes a locale prefix or adds a path level.
-	resp, err := client.Get(a.url)
-	if err != nil {
-		return nil, errors.Wrapf(err, "get %s", a.url)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, a.url)
-	}
-
-	bs, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrapf(err, "read %s", a.url)
-	}
-
-	bs = flightingPattern.ReplaceAll(bs, nil)
-
-	if err := writeOrigin(opts.dir, a.name(), bs); err != nil {
-		return nil, errors.Wrapf(err, "write %s", a.name())
-	}
-
-	return bs, nil
 }
 
 // convert reads origin/ back and writes raw/, one file per stored article so
@@ -570,12 +547,7 @@ func writeOrigin(dir, name string, content []byte) error {
 
 // resolveHref turns a listing href, which is relative to the article it was
 // read from, into the article it points at.
-func resolveHref(from article, href string) (article, bool) {
-	base, err := url.Parse(from.url)
-	if err != nil {
-		return article{}, false
-	}
-
+func resolveHref(base *url.URL, href string) (article, bool) {
 	ref, err := url.Parse(href)
 	if err != nil {
 		return article{}, false

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -55,12 +55,6 @@ import (
 	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
 )
 
-// originDir holds the pages as the vendor served them, beside the raw/ JSON
-// derived from them. Keeping both makes the tree self-describing: raw/ can be
-// reproduced from origin/ without consulting anything outside it, which is what
-// lets a parser change be replayed without refetching.
-const originDir = "origin"
-
 // helpURL resolves a KB number to its servicing article. support.microsoft.com
 // redirects /help/<KB> to the canonical path, which is also how the product and
 // series are discovered: they are path segments, not page content.
@@ -283,6 +277,80 @@ func (opts options) fetch(kbs []string) error {
 	return nil
 }
 
+// resolve maps each KB to the article support.microsoft.com serves for it.
+//
+// HEAD is enough: only the redirect target is wanted, and it carries the
+// product and series as path segments, so the body would add nothing a crawl
+// does not already reach.
+func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, error) {
+	slog.Info("Resolve KB to servicing article", slog.Int("count", len(kbs)))
+
+	bar := progressbar.Default(int64(len(kbs)))
+	articleChan := make(chan article, len(kbs))
+	var g errgroup.Group
+	g.SetLimit(opts.concurrency)
+	for _, kb := range kbs {
+		g.Go(func() error {
+			defer func() {
+				time.Sleep(opts.wait)
+				_ = bar.Add(1)
+			}()
+
+			// /help/ takes the article number alone; /help/KB5101004 is a 404.
+			// Callers pass either spelling, so normalize rather than reject, and
+			// keep the normalized form: it is what sidebar entries carry, and the
+			// two have to compare equal for a series to cover its members.
+			kb = strings.TrimPrefix(strings.ToUpper(kb), "KB")
+
+			req, err := utilhttp.NewRequest(http.MethodHead, fmt.Sprintf(opts.helpURL, kb))
+			if err != nil {
+				return errors.Wrapf(err, "new request for %s", kb)
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				return errors.Wrapf(err, "head %s", kb)
+			}
+			defer resp.Body.Close()
+			_, _ = io.Copy(io.Discard, resp.Body)
+
+			if resp.StatusCode != http.StatusOK {
+				slog.Warn("unexpected status", slog.String("kb", kb), slog.Int("status", resp.StatusCode))
+				return nil
+			}
+
+			a, ok := parsePath(resp.Request.URL)
+			if !ok {
+				// Pre-2018 KBs and hub pages stay on /help/<KB> or land on a
+				// product landing page. There is no series to read there.
+				slog.Warn("not a servicing article", slog.String("kb", kb), slog.String("url", resp.Request.URL.String()))
+				return nil
+			}
+			a.url = resp.Request.URL.String()
+
+			articleChan <- a
+
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, errors.Wrap(err, "err in goroutine")
+	}
+	close(articleChan)
+	_ = bar.Close()
+
+	articles := make([]article, 0, len(kbs))
+	for a := range articleChan {
+		articles = append(articles, a)
+	}
+
+	// Ordered so a rerun walks the same tree in the same order rather than in
+	// whatever order the lookups happened to finish.
+	slices.SortFunc(articles, func(a, b article) int { return strings.Compare(a.name(), b.name()) })
+
+	return articles, nil
+}
+
 // discover stores the articles asked for and reports what their listings name.
 //
 // Only these listings are read. Following them further would not find anything
@@ -395,104 +463,6 @@ func (opts options) collect(client *utilhttp.Client, targets []article, stored m
 	return nil
 }
 
-// resolveHref turns a listing href, which is relative to the article it was
-// read from, into the article it points at.
-func resolveHref(from article, href string) (article, bool) {
-	base, err := url.Parse(from.url)
-	if err != nil {
-		return article{}, false
-	}
-
-	ref, err := url.Parse(href)
-	if err != nil {
-		return article{}, false
-	}
-
-	target := base.ResolveReference(ref)
-
-	a, ok := parsePath(target)
-	if !ok {
-		return article{}, false
-	}
-	a.url = target.String()
-
-	return a, true
-}
-
-// resolve maps each KB to the article support.microsoft.com serves for it.
-//
-// HEAD is enough: only the redirect target is wanted, and it carries the
-// product and series as path segments, so the body would add nothing a crawl
-// does not already reach.
-func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, error) {
-	slog.Info("Resolve KB to servicing article", slog.Int("count", len(kbs)))
-
-	bar := progressbar.Default(int64(len(kbs)))
-	articleChan := make(chan article, len(kbs))
-	var g errgroup.Group
-	g.SetLimit(opts.concurrency)
-	for _, kb := range kbs {
-		g.Go(func() error {
-			defer func() {
-				time.Sleep(opts.wait)
-				_ = bar.Add(1)
-			}()
-
-			// /help/ takes the article number alone; /help/KB5101004 is a 404.
-			// Callers pass either spelling, so normalize rather than reject, and
-			// keep the normalized form: it is what sidebar entries carry, and the
-			// two have to compare equal for a series to cover its members.
-			kb = strings.TrimPrefix(strings.ToUpper(kb), "KB")
-
-			req, err := utilhttp.NewRequest(http.MethodHead, fmt.Sprintf(opts.helpURL, kb))
-			if err != nil {
-				return errors.Wrapf(err, "new request for %s", kb)
-			}
-
-			resp, err := client.Do(req)
-			if err != nil {
-				return errors.Wrapf(err, "head %s", kb)
-			}
-			defer resp.Body.Close()
-			_, _ = io.Copy(io.Discard, resp.Body)
-
-			if resp.StatusCode != http.StatusOK {
-				slog.Warn("unexpected status", slog.String("kb", kb), slog.Int("status", resp.StatusCode))
-				return nil
-			}
-
-			a, ok := parsePath(resp.Request.URL)
-			if !ok {
-				// Pre-2018 KBs and hub pages stay on /help/<KB> or land on a
-				// product landing page. There is no series to read there.
-				slog.Warn("not a servicing article", slog.String("kb", kb), slog.String("url", resp.Request.URL.String()))
-				return nil
-			}
-			a.url = resp.Request.URL.String()
-
-			articleChan <- a
-
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		return nil, errors.Wrap(err, "err in goroutine")
-	}
-	close(articleChan)
-	_ = bar.Close()
-
-	articles := make([]article, 0, len(kbs))
-	for a := range articleChan {
-		articles = append(articles, a)
-	}
-
-	// Ordered so a rerun walks the same tree in the same order rather than in
-	// whatever order the lookups happened to finish.
-	slices.SortFunc(articles, func(a, b article) int { return strings.Compare(a.name(), b.name()) })
-
-	return articles, nil
-}
-
 // store retrieves one article, writes it to origin/ and reports the KBs its
 // sidebar accounts for.
 func (opts options) store(client *utilhttp.Client, a article) ([]byte, error) {
@@ -536,7 +506,7 @@ func (opts options) store(client *utilhttp.Client, a article) ([]byte, error) {
 func (opts options) convert() error {
 	slog.Info("Convert origin to raw")
 
-	root := filepath.Join(opts.dir, originDir)
+	root := filepath.Join(opts.dir, "origin")
 	if _, err := os.Stat(root); err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			return errors.Wrapf(err, "stat %s", root)
@@ -593,7 +563,7 @@ func (opts options) convert() error {
 // article does not, and would turn every fetch into a diff, drowning the signal
 // this tree exists to carry: that Microsoft revised the article.
 func writeOrigin(dir, name string, content []byte) error {
-	path := filepath.Join(dir, originDir, name)
+	path := filepath.Join(dir, "origin", name)
 
 	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
 		return errors.Wrapf(err, "mkdir %s", filepath.Dir(path))
@@ -604,6 +574,30 @@ func writeOrigin(dir, name string, content []byte) error {
 	}
 
 	return nil
+}
+
+// resolveHref turns a listing href, which is relative to the article it was
+// read from, into the article it points at.
+func resolveHref(from article, href string) (article, bool) {
+	base, err := url.Parse(from.url)
+	if err != nil {
+		return article{}, false
+	}
+
+	ref, err := url.Parse(href)
+	if err != nil {
+		return article{}, false
+	}
+
+	target := base.ResolveReference(ref)
+
+	a, ok := parsePath(target)
+	if !ok {
+		return article{}, false
+	}
+	a.url = target.String()
+
+	return a, true
 }
 
 // parsePath splits a canonical servicing URL into its product, series and the

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -472,9 +472,7 @@ func (opts options) store(client *utilhttp.Client, a article) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	switch resp.StatusCode {
-	case http.StatusOK:
-	default:
+	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil, errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, a.url)
 	}

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -1,0 +1,687 @@
+// Package servicing fetches Microsoft's servicing articles — the per-update
+// pages under support.microsoft.com/<locale>/servicing/.
+//
+// These pages are the only durable record of which updates belong to a
+// servicing series. The Update Catalog drops an update outright once Microsoft
+// expires it: search returns nothing, ScopedViewInline redirects to
+// Thanks.aspx, and the "This update replaces the following updates" list on the
+// surviving successor is rewritten to "n/a". wsusscn2.cab drops it too. The
+// servicing article, by contrast, stays served, and every article in a series
+// carries a sidebar listing the whole series — expired updates included.
+//
+// That matters for supersedence. KB5033920 (2024-01, .NET for Windows 11 23H2)
+// fixes CVE-2024-0057, and a host patched to KB5101004 (2026-07) is covered by
+// the chain 5101004 -> 5049624 -> 5044033 -> 5039895 -> 5036620 -> 5033920.
+// Four of those five links are expired, so the chain cannot be walked from the
+// catalog at all; the sidebar on any article in the series still lists all six
+// in order.
+//
+// Fetching is two steps. The articles asked for are stored and their sidebars
+// read; then everything those sidebars name is stored, without reading its
+// sidebar in turn. One hop is enough — a sidebar repeated on every article of a
+// series has nothing more to say — and it is also the limit worth taking: a
+// Windows Server 2008 sidebar links into Windows 8.1, so following further
+// would pull in a series nobody asked for.
+//
+// fetch writes <dir>/origin verbatim and then produces <dir>/raw by reading it
+// back, never the HTTP response, so raw/ is reproducible from origin/ alone.
+// Only the heading and the canonical link are read out; the prose sections stay
+// in origin/ for a later pass.
+package servicing
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/pkg/errors"
+	"github.com/schollz/progressbar/v3"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+// originDir holds the pages as the vendor served them, beside the raw/ JSON
+// derived from them. Keeping both makes the tree self-describing: raw/ can be
+// reproduced from origin/ without consulting anything outside it, which is what
+// lets a parser change be replayed without refetching.
+const originDir = "origin"
+
+// helpURL resolves a KB number to its servicing article. support.microsoft.com
+// redirects /help/<KB> to the canonical path, which is also how the product and
+// series are discovered: they are path segments, not page content.
+const helpURL = "https://support.microsoft.com/help/%s"
+
+var (
+	// servicingPathPattern splits a canonical path into locale, product and the
+	// remainder. Depth varies — os/windows-11, dotnetframework/windows-11/22h2
+	// and azure/stack-hci/update are all series — so the series cannot be taken
+	// as a fixed number of segments.
+	servicingPathPattern = regexp.MustCompile(`^/([a-zA-Z-]+)/servicing/([^/]+)/(.+)$`)
+
+	// datePattern is the year/month pair Microsoft inserts before the slug. It
+	// is the only reliable series boundary, but not every article has one:
+	// /servicing/dotnetframework/windows-11/3-5/<slug> has none.
+	datePattern = regexp.MustCompile(`^(\d{4})/(\d{2})/`)
+
+	// sidebarPattern matches one series-listing item, capturing the class so
+	// headings can be told from articles, and the href, which is absent on the
+	// item for the article being viewed.
+	sidebarPattern = regexp.MustCompile(`(?s)<li class="(learnRenderLeftNav[^"]*)"[^>]*>\s*(?:<a href="([^"]*)"[^>]*>)?(.*?)</li>`)
+
+	headingPattern = regexp.MustCompile(`(?s)<h1[^>]*>(.*?)</h1>`)
+
+	// canonicalPattern reads the article's own address off the page, so raw/
+	// records where it came from without that having to be remembered from the
+	// request that fetched it.
+	canonicalPattern = regexp.MustCompile(`<link[^>]*\brel="canonical"[^>]*\bhref="([^"]*)"`)
+
+	tagPattern   = regexp.MustCompile(`<[^>]*>`)
+	spacePattern = regexp.MustCompile(`\s+`)
+
+	// flightingPattern strips the analytics metadata support.microsoft.com
+	// varies per response. awa-userFlightingId is a fresh GUID every time and
+	// awa-expid is an A/B bucket assignment; leaving them in makes every article
+	// differ on every fetch, which is exactly the churn origin/ exists to avoid.
+	// Removing them makes the served bytes reproduce exactly.
+	flightingPattern = regexp.MustCompile(`\s*<meta name="awa-[^"]*"[^>]*/?>`)
+)
+
+type options struct {
+	helpURL     string
+	dir         string
+	retry       int
+	concurrency int
+	wait        time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type helpURLOption string
+
+func (u helpURLOption) apply(opts *options) {
+	opts.helpURL = string(u)
+}
+
+func WithHelpURL(url string) Option {
+	return helpURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type concurrencyOption int
+
+func (c concurrencyOption) apply(opts *options) {
+	opts.concurrency = int(c)
+}
+
+func WithConcurrency(concurrency int) Option {
+	return concurrencyOption(concurrency)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+// retryPolicy adds 403 to what the client already retries on.
+//
+// support.microsoft.com answers 403, not 429, when it decides a client is
+// asking too often, and a crawl over a few thousand articles reaches that in
+// minutes. The default policy covers 429 and 5xx, so without this the first
+// throttle ends the run. A 403 that is not throttling costs the same bounded
+// number of attempts before failing exactly as it would have.
+func retryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	retry, rerr := retryablehttp.ErrorPropagatedRetryPolicy(ctx, resp, err)
+	if retry || rerr != nil {
+		return retry, rerr
+	}
+
+	return resp != nil && resp.StatusCode == http.StatusForbidden, nil
+}
+
+// errNotServed reports an article support.microsoft.com does not serve. A
+// listing naming one is Microsoft's own inconsistency, not a fetch failure, so
+// the crawl steps over it rather than losing the run.
+var errNotServed = errors.New("not served")
+
+// entry is one item of a series listing. It is a crawl frontier, not data: the
+// listing is only read to find the rest of the series, and the articles it
+// points at are stored in its place.
+type entry struct {
+	title string
+	href  string
+}
+
+// article is one resolved KB: where support.microsoft.com serves it and which
+// series it belongs to.
+type article struct {
+	url string // where support.microsoft.com served it, after redirects
+
+	product string
+	line    []string
+	rest    string // path below the series, e.g. 2025/10/october-14-2025-...
+}
+
+// stem is the article's path inside the tree, without an extension, mirroring
+// the canonical URL so origin/ and raw/ stay navigable against the site they
+// came from.
+func (a article) stem() string {
+	return path.Join(slices.Concat([]string{a.product}, a.line, []string{a.rest})...)
+}
+
+// name is where the article is stored under origin/.
+func (a article) name() string {
+	return fmt.Sprintf("%s.html", a.stem())
+}
+
+// Fetch stores servicing articles under <dir>/origin and the series listings
+// they carry under <dir>/raw.
+//
+// The whole series is stored, not only the articles asked for. One article is
+// retrieved per series to read its listing, and every article the listing names
+// is then retrieved as well. The listing alone would be cheaper, but it is a
+// single point of failure: Microsoft has already rewritten the Update Catalog's
+// "This update replaces the following updates" to "n/a" on updates that
+// demonstrably replaced something, and a listing pruned the same way would take
+// every expired member with it. Each article is its own record.
+//
+// Series that render no listing — os/windows and os/windows-server collect
+// unrelated one-off notices rather than a monthly track — are the exception,
+// and every KB landing on one is retrieved.
+func Fetch(kbs []string, opts ...Option) error {
+	options := &options{
+		helpURL:     helpURL,
+		dir:         filepath.Join(util.CacheDir(), "fetch", "microsoft", "servicing"),
+		retry:       3,
+		concurrency: 3,
+		wait:        1 * time.Second,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if len(kbs) == 0 {
+		return errors.New("no KB specified")
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	if err := options.fetch(kbs); err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+
+	if err := options.convert(); err != nil {
+		return errors.Wrap(err, "convert")
+	}
+
+	return nil
+}
+
+func (opts options) fetch(kbs []string) error {
+	slog.Info("Fetch Microsoft Servicing Articles")
+
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry), utilhttp.WithClientCheckRetry(retryPolicy))
+
+	seeds, err := opts.resolve(client, util.Unique(kbs))
+	if err != nil {
+		return errors.Wrap(err, "resolve")
+	}
+
+	stored := make(map[string]struct{}, len(seeds))
+	targets, err := opts.discover(client, seeds, stored)
+	if err != nil {
+		return errors.Wrap(err, "discover")
+	}
+
+	if err := opts.collect(client, targets, stored); err != nil {
+		return errors.Wrap(err, "collect")
+	}
+
+	return nil
+}
+
+// discover stores the articles asked for and reports what their listings name.
+//
+// Only these listings are read. Following them further would not find anything
+// in the same series -- the listing is identical on every article of one -- but
+// it would leave the series entirely: a Windows Server 2008 listing links to
+// os/windows-8-1/2024/01/end-of-support, and reading that article's listing in
+// turn would drag in the whole of Windows 8.1. One hop keeps a request for a
+// series to that series and whatever it points at directly.
+func (opts options) discover(client *utilhttp.Client, seeds []article, stored map[string]struct{}) ([]article, error) {
+	slog.Info("Discover series", slog.Int("articles", len(seeds)))
+
+	bar := progressbar.Default(int64(len(seeds)))
+	targetChan := make(chan []article, len(seeds))
+	var g errgroup.Group
+	g.SetLimit(opts.concurrency)
+	for _, a := range seeds {
+		if _, ok := stored[a.name()]; ok {
+			_ = bar.Add(1)
+			continue
+		}
+		stored[a.name()] = struct{}{}
+
+		g.Go(func() error {
+			defer func() {
+				time.Sleep(opts.wait)
+				_ = bar.Add(1)
+			}()
+
+			bs, err := opts.store(client, a)
+			if err != nil {
+				if errors.Is(err, errNotServed) {
+					slog.Warn("article is not served", slog.String("url", a.url))
+					return nil
+				}
+				return errors.Wrapf(err, "store %s", a.url)
+			}
+
+			var targets []article
+			for _, e := range parseSidebar(string(bs)) {
+				if e.href == "" {
+					continue
+				}
+				b, ok := resolveHref(a, e.href)
+				if !ok {
+					slog.Warn("unexpected listing target", slog.String("href", e.href), slog.String("from", a.url))
+					continue
+				}
+				targets = append(targets, b)
+			}
+
+			targetChan <- targets
+
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, errors.Wrap(err, "err in goroutine")
+	}
+	close(targetChan)
+	_ = bar.Close()
+
+	var targets []article
+	for t := range targetChan {
+		targets = append(targets, t...)
+	}
+	slices.SortFunc(targets, func(a, b article) int { return strings.Compare(a.name(), b.name()) })
+
+	return targets, nil
+}
+
+// collect stores the rest of the series. Their listings are not read: they say
+// what discover has already been told.
+func (opts options) collect(client *utilhttp.Client, targets []article, stored map[string]struct{}) error {
+	targets = slices.DeleteFunc(targets, func(a article) bool {
+		if _, ok := stored[a.name()]; ok {
+			return true
+		}
+		stored[a.name()] = struct{}{}
+		return false
+	})
+
+	slog.Info("Collect series", slog.Int("articles", len(targets)))
+
+	bar := progressbar.Default(int64(len(targets)))
+	var g errgroup.Group
+	g.SetLimit(opts.concurrency)
+	for _, a := range targets {
+		g.Go(func() error {
+			defer func() {
+				time.Sleep(opts.wait)
+				_ = bar.Add(1)
+			}()
+
+			if _, err := opts.store(client, a); err != nil {
+				if errors.Is(err, errNotServed) {
+					slog.Warn("listed article is not served", slog.String("url", a.url))
+					return nil
+				}
+				return errors.Wrapf(err, "store %s", a.url)
+			}
+
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return errors.Wrap(err, "err in goroutine")
+	}
+	_ = bar.Close()
+
+	return nil
+}
+
+// resolveHref turns a listing href, which is relative to the article it was
+// read from, into the article it points at.
+func resolveHref(from article, href string) (article, bool) {
+	base, err := url.Parse(from.url)
+	if err != nil {
+		return article{}, false
+	}
+
+	ref, err := url.Parse(href)
+	if err != nil {
+		return article{}, false
+	}
+
+	target := base.ResolveReference(ref)
+
+	a, ok := parsePath(target)
+	if !ok {
+		return article{}, false
+	}
+	a.url = target.String()
+
+	return a, true
+}
+
+// resolve maps each KB to the article support.microsoft.com serves for it.
+//
+// HEAD is enough: only the redirect target is wanted, and it carries the
+// product and series as path segments, so the body would add nothing a crawl
+// does not already reach.
+func (opts options) resolve(client *utilhttp.Client, kbs []string) ([]article, error) {
+	slog.Info("Resolve KB to servicing article", slog.Int("count", len(kbs)))
+
+	bar := progressbar.Default(int64(len(kbs)))
+	articleChan := make(chan article, len(kbs))
+	var g errgroup.Group
+	g.SetLimit(opts.concurrency)
+	for _, kb := range kbs {
+		g.Go(func() error {
+			defer func() {
+				time.Sleep(opts.wait)
+				_ = bar.Add(1)
+			}()
+
+			// /help/ takes the article number alone; /help/KB5101004 is a 404.
+			// Callers pass either spelling, so normalize rather than reject, and
+			// keep the normalized form: it is what sidebar entries carry, and the
+			// two have to compare equal for a series to cover its members.
+			kb = strings.TrimPrefix(strings.ToUpper(kb), "KB")
+
+			req, err := utilhttp.NewRequest(http.MethodHead, fmt.Sprintf(opts.helpURL, kb))
+			if err != nil {
+				return errors.Wrapf(err, "new request for %s", kb)
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				return errors.Wrapf(err, "head %s", kb)
+			}
+			defer resp.Body.Close()
+			_, _ = io.Copy(io.Discard, resp.Body)
+
+			if resp.StatusCode != http.StatusOK {
+				slog.Warn("unexpected status", slog.String("kb", kb), slog.Int("status", resp.StatusCode))
+				return nil
+			}
+
+			a, ok := parsePath(resp.Request.URL)
+			if !ok {
+				// Pre-2018 KBs and hub pages stay on /help/<KB> or land on a
+				// product landing page. There is no series to read there.
+				slog.Warn("not a servicing article", slog.String("kb", kb), slog.String("url", resp.Request.URL.String()))
+				return nil
+			}
+			a.url = resp.Request.URL.String()
+
+			articleChan <- a
+
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, errors.Wrap(err, "err in goroutine")
+	}
+	close(articleChan)
+	_ = bar.Close()
+
+	articles := make([]article, 0, len(kbs))
+	for a := range articleChan {
+		articles = append(articles, a)
+	}
+
+	// Ordered so a rerun walks the same tree in the same order rather than in
+	// whatever order the lookups happened to finish.
+	slices.SortFunc(articles, func(a, b article) int { return strings.Compare(a.name(), b.name()) })
+
+	return articles, nil
+}
+
+// store retrieves one article, writes it to origin/ and reports the KBs its
+// sidebar accounts for.
+func (opts options) store(client *utilhttp.Client, a article) ([]byte, error) {
+	// The URL the redirect landed on is used as-is rather than rebuilt from the
+	// parsed segments: rebuilding would silently diverge the moment Microsoft
+	// changes a locale prefix or adds a path level.
+	resp, err := client.Get(a.url)
+	if err != nil {
+		return nil, errors.Wrapf(err, "get %s", a.url)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, errors.Wrapf(errNotServed, "get %s", a.url)
+	default:
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, a.url)
+	}
+
+	bs, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read %s", a.url)
+	}
+
+	bs = flightingPattern.ReplaceAll(bs, nil)
+
+	if err := writeOrigin(opts.dir, a.name(), bs); err != nil {
+		return nil, errors.Wrapf(err, "write %s", a.name())
+	}
+
+	return bs, nil
+}
+
+// convert reads origin/ back and writes raw/, one file per stored article so
+// that which JSON came from which HTML is a matter of the path. Going through
+// the stored bytes rather than the response is what lets the tree be re-derived
+// after this parser changes.
+func (opts options) convert() error {
+	slog.Info("Convert origin to raw")
+
+	root := filepath.Join(opts.dir, originDir)
+	if _, err := os.Stat(root); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return errors.Wrapf(err, "stat %s", root)
+		}
+		// Every KB resolved to something outside /servicing/. There is nothing
+		// to convert, and that is not a failure of the run.
+		slog.Warn("no servicing article stored", slog.String("dir", root))
+		return nil
+	}
+
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".html" {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+
+		bs, err := os.ReadFile(p)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", p)
+		}
+
+		a, ok := parseArticle(string(bs))
+		if !ok {
+			// A page with no heading is not an article. It is stored either way,
+			// so nothing is lost by having no JSON beside it.
+			slog.Warn("no heading", slog.String("path", filepath.ToSlash(rel)))
+			return nil
+		}
+
+		n := fmt.Sprintf("%s.json", strings.TrimSuffix(filepath.ToSlash(rel), ".html"))
+		if err := util.Write(filepath.Join(opts.dir, "raw", filepath.FromSlash(n)), a); err != nil {
+			return errors.Wrapf(err, "write %s", n)
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", root)
+	}
+
+	return nil
+}
+
+// writeOrigin stores content under <dir>/origin/<name> as served.
+//
+// Nothing derived from the response is recorded alongside it — no fetch
+// timestamp, no ETag, no status line. Those change on every run even when the
+// article does not, and would turn every fetch into a diff, drowning the signal
+// this tree exists to carry: that Microsoft revised the article.
+func writeOrigin(dir, name string, content []byte) error {
+	path := filepath.Join(dir, originDir, name)
+
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return errors.Wrapf(err, "mkdir %s", filepath.Dir(path))
+	}
+
+	if err := os.WriteFile(path, content, 0666); err != nil {
+		return errors.Wrapf(err, "write %s", path)
+	}
+
+	return nil
+}
+
+// parsePath splits a canonical servicing URL into its product, series and the
+// path below it.
+func parsePath(u *url.URL) (article, bool) {
+	m := servicingPathPattern.FindStringSubmatch(u.Path)
+	if m == nil {
+		return article{}, false
+	}
+
+	// support.microsoft.com serves the same page under DotNetFramework and
+	// dotnetframework; without folding the case the two spellings become two
+	// series holding the same articles.
+	product := strings.ToLower(m[2])
+	rest := m[3]
+
+	// Everything up to the year/month is the series. Articles without one keep
+	// the last segment as the slug, which is the shape
+	// dotnetframework/windows-11/3-5/<slug> takes.
+	var line []string
+	segs := strings.Split(rest, "/")
+	for i := range segs {
+		if datePattern.MatchString(strings.Join(segs[i:], "/")) {
+			return article{product: product, line: line, rest: strings.Join(segs[i:], "/")}, true
+		}
+		if i == len(segs)-1 {
+			break
+		}
+		line = append(line, strings.ToLower(segs[i]))
+	}
+
+	return article{product: product, line: line, rest: segs[len(segs)-1]}, true
+}
+
+// parseSidebar reads the series listing rendered beside every article.
+//
+// The same list carries section headings ("Windows 11, version 26H1", "End of
+// servicing statement"), which are not articles. They are told apart by the
+// class Microsoft marks them with rather than by their text, so a heading that
+// happens to look like an entry is still excluded.
+func parseSidebar(doc string) []entry {
+	var es []entry
+	for _, m := range sidebarPattern.FindAllStringSubmatch(doc, -1) {
+		if !strings.Contains(m[1], "learnRenderLeftNavArticle") {
+			continue
+		}
+
+		title := text(m[3])
+		if title == "" {
+			continue
+		}
+
+		es = append(es, entry{title: title, href: m[2]})
+	}
+
+	return es
+}
+
+// parseArticle reads what an article states about itself.
+func parseArticle(doc string) (Article, bool) {
+	m := headingPattern.FindStringSubmatch(doc)
+	if m == nil {
+		return Article{}, false
+	}
+
+	title := text(m[1])
+	if title == "" {
+		return Article{}, false
+	}
+
+	a := Article{Title: title}
+	if cm := canonicalPattern.FindStringSubmatch(doc); cm != nil {
+		a.URL = text(cm[1])
+	}
+
+	return a, true
+}
+
+func text(s string) string {
+	return strings.TrimSpace(spacePattern.ReplaceAllString(html.UnescapeString(tagPattern.ReplaceAllString(s, "")), " "))
+}

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -167,10 +167,16 @@ func WithWait(wait time.Duration) Option {
 func retryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
 	retry, rerr := retryablehttp.ErrorPropagatedRetryPolicy(ctx, resp, err)
 	if retry || rerr != nil {
-		return retry, rerr
+		return retry, errors.Wrap(rerr, "retry policy")
 	}
 
-	return resp != nil && resp.StatusCode == http.StatusForbidden, nil
+	// The status goes with the decision: given a nil error, retryablehttp gives
+	// up saying only "giving up after N attempt(s)", never that it was throttled.
+	if resp != nil && resp.StatusCode == http.StatusForbidden {
+		return true, errors.Errorf("unexpected HTTP status %s", resp.Status)
+	}
+
+	return false, nil
 }
 
 // errNotServed reports an article support.microsoft.com does not serve. A

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -504,17 +504,21 @@ func (opts options) convert() error {
 			return errors.Wrapf(err, "read %s", p)
 		}
 
+		// Every servicing article carries its title in an h1 -- 20 of 20 sampled
+		// across os/windows-11, os/server-2008, dotnetframework and the one-off
+		// notices under os/windows, down to "End of support". A stored page
+		// without one therefore means either that it is not an article, and
+		// collect wrote something parsePath should not have accepted, or that
+		// this heading is no longer where the title lives. Both apply to every
+		// page at once, so skipping would leave raw/ empty beside a full origin/
+		// with the run green.
 		a, ok := parseArticle(string(bs))
 		if !ok {
-			// A page with no heading is not an article. It is stored either way,
-			// so nothing is lost by having no JSON beside it.
-			slog.Warn("no heading", slog.String("path", filepath.ToSlash(rel)))
-			return nil
+			return errors.Errorf("no heading in %s", p)
 		}
 
-		n := fmt.Sprintf("%s.json", strings.TrimSuffix(filepath.ToSlash(rel), ".html"))
-		if err := util.Write(filepath.Join(opts.dir, "raw", filepath.FromSlash(n)), a); err != nil {
-			return errors.Wrapf(err, "write %s", n)
+		if err := util.Write(filepath.Join(opts.dir, "raw", fmt.Sprintf("%s.json", strings.TrimSuffix(rel, ".html"))), a); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, "raw", fmt.Sprintf("%s.json", strings.TrimSuffix(rel, ".html"))))
 		}
 
 		return nil

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -222,12 +222,35 @@ func (a article) name() string {
 // Series that render no listing — os/windows and os/windows-server collect
 // unrelated one-off notices rather than a monthly track — are the exception,
 // and every KB landing on one is retrieved.
+// The defaults are set by what support.microsoft.com throttles at, measured
+// over 200 articles per run:
+//
+//	concurrency  retry   403s   backoff   gave up
+//	          3      3     77      140s        12
+//	          3      5     42      114s         1
+//	          3      8     23       57s         0
+//	          1      5      8       10s         0
+//	          2      5      9       12s         0
+//
+// Waiting longer between requests is not the lever: at one request a second the
+// throttle arrives after 46 articles, at two a second after 75. It is a quota
+// over a window, and any crawl worth running reaches it.
+//
+// What matters is going quiet once it does. The window is 3 to 5 seconds when
+// nothing is asking, so a lone worker's first retry clears it -- but a third
+// worker keeps the quota spent while the other two back off, and their retries
+// then land together and spend it again. Hence two, which throttles a fifth as
+// often as three for the same throughput.
+//
+// retry is well past the 5 that measured clean, because an unused retry costs
+// nothing and a real seed list is many times 200 articles. nvd/api, against an
+// API that throttles the same way, allows 20.
 func Fetch(kbs []string, opts ...Option) error {
 	options := &options{
 		helpURL:     helpURL,
 		dir:         filepath.Join(util.CacheDir(), "fetch", "microsoft", "servicing"),
-		retry:       3,
-		concurrency: 3,
+		retry:       10,
+		concurrency: 2,
 		wait:        1 * time.Second,
 	}
 

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -179,11 +179,6 @@ func retryPolicy(ctx context.Context, resp *http.Response, err error) (bool, err
 	return false, nil
 }
 
-// errNotServed reports an article support.microsoft.com does not serve. A
-// listing naming one is Microsoft's own inconsistency, not a fetch failure, so
-// the crawl steps over it rather than losing the run.
-var errNotServed = errors.New("not served")
-
 // entry is one item of a series listing. It is a crawl frontier, not data: the
 // listing is only read to find the rest of the series, and the articles it
 // points at are stored in its place.
@@ -391,10 +386,6 @@ func (opts options) discover(client *utilhttp.Client, seeds []article, stored ma
 
 			bs, err := opts.store(client, a)
 			if err != nil {
-				if errors.Is(err, errNotServed) {
-					slog.Warn("article is not served", slog.String("url", a.url))
-					return nil
-				}
 				return errors.Wrapf(err, "store %s", a.url)
 			}
 
@@ -455,10 +446,6 @@ func (opts options) collect(client *utilhttp.Client, targets []article, stored m
 			}()
 
 			if _, err := opts.store(client, a); err != nil {
-				if errors.Is(err, errNotServed) {
-					slog.Warn("listed article is not served", slog.String("url", a.url))
-					return nil
-				}
 				return errors.Wrapf(err, "store %s", a.url)
 			}
 
@@ -487,9 +474,6 @@ func (opts options) store(client *utilhttp.Client, a article) ([]byte, error) {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-	case http.StatusNotFound:
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, errors.Wrapf(errNotServed, "get %s", a.url)
 	default:
 		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil, errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, a.url)

--- a/pkg/fetch/microsoft/servicing/servicing.go
+++ b/pkg/fetch/microsoft/servicing/servicing.go
@@ -582,6 +582,15 @@ func resolveHref(base *url.URL, href string) (article, bool) {
 
 	target := base.ResolveReference(ref)
 
+	// A listing is HTML off the network, and an href in it that names a scheme
+	// or a host rebases the target onto that host -- parsePath reads the path
+	// alone, so anything serving /<locale>/servicing/... would be retrieved and
+	// stored as a Microsoft servicing article. Nothing is lost by refusing:
+	// every one of the 70,922 listing hrefs across 271 articles is relative.
+	if target.Scheme != base.Scheme || target.Host != base.Host {
+		return article{}, false
+	}
+
 	a, ok := parsePath(target)
 	if !ok {
 		return article{}, false

--- a/pkg/fetch/microsoft/servicing/servicing_test.go
+++ b/pkg/fetch/microsoft/servicing/servicing_test.go
@@ -83,12 +83,15 @@ func TestFetch(t *testing.T) {
 			golden: "cross-series",
 		},
 		{
-			// url.ResolveReference removes dot-segments from the escaped path,
-			// but Path is decoded, so one spelled %2e%2e arrives as ".." and
-			// would land the write outside origin/. KB5102210's listing carries
-			// one in an href, KB5102211 carries one in its redirect; both have to
-			// be refused, and the article that does not is still stored.
-			name:   "encoded dot-segment does not escape origin",
+			// A listing is HTML off the network, and both ways it can point out
+			// of the tree are refused. url.ResolveReference removes dot-segments
+			// from the escaped path but Path is decoded, so one spelled %2e%2e
+			// comes back as ".." and would write outside origin/; KB5102210's
+			// listing carries one and KB5102211's redirect carries another. An
+			// href naming a host rebases the target onto it, and KB5102210's
+			// listing carries one of those too, pointing at a port nothing
+			// answers on -- following it is a connection error, not a diff.
+			name:   "a listing pointing out of the tree is refused",
 			kbs:    []string{"KB5102210", "KB5102211"},
 			golden: "encoded-dot-segment",
 		},

--- a/pkg/fetch/microsoft/servicing/servicing_test.go
+++ b/pkg/fetch/microsoft/servicing/servicing_test.go
@@ -75,6 +75,16 @@ func TestFetch(t *testing.T) {
 			golden: "cross-series",
 		},
 		{
+			// url.ResolveReference removes dot-segments from the escaped path,
+			// but Path is decoded, so one spelled %2e%2e arrives as ".." and
+			// would land the write outside origin/. KB5102210's listing carries
+			// one in an href, KB5102211 carries one in its redirect; both have to
+			// be refused, and the article that does not is still stored.
+			name:   "encoded dot-segment does not escape origin",
+			kbs:    []string{"KB5102210", "KB5102211"},
+			golden: "encoded-dot-segment",
+		},
+		{
 			// Pre-2018 articles stay on /help/<KB>. There is no series to read,
 			// and that is not a failure.
 			name:   "non-servicing article is skipped",

--- a/pkg/fetch/microsoft/servicing/servicing_test.go
+++ b/pkg/fetch/microsoft/servicing/servicing_test.go
@@ -1,0 +1,278 @@
+package servicing_test
+
+import (
+	"encoding/json"
+	"io/fs"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/servicing"
+)
+
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		kbs      []string
+		golden   string
+		hasError bool
+	}{
+		{
+			// Both KBs belong to one series, so the listing is read once however
+			// many members were asked for.
+			name:   "series is listed once",
+			kbs:    []string{"KB5033920", "KB5101004"},
+			golden: "series-fetched-once",
+		},
+		{
+			// KB5033920 is expired: the catalog no longer serves it and nothing
+			// points at it but the listing. Asking for the surviving member has
+			// to bring its article along, or the record goes when the listing
+			// does.
+			name:   "expired member is stored too",
+			kbs:    []string{"KB5101004"},
+			golden: "expired-member",
+		},
+		{
+			// OS listings carry build numbers and mark previews in the title, and
+			// are broken up by version headings that are not articles.
+			name:   "os series carries builds",
+			kbs:    []string{"KB5101649"},
+			golden: "os-series",
+		},
+		{
+			// os/windows collects unrelated one-off articles rather than a
+			// series, so neither speaks for the other and there is no listing to
+			// follow. Both are recorded from their own headings, including the
+			// one that names no KB anywhere.
+			name:   "sidebar-less path keeps every article",
+			kbs:    []string{"KB890175", "KB4519108"},
+			golden: "sidebar-less",
+		},
+		{
+			// Microsoft lists an article it does not serve. Losing the run over
+			// one of those would throw away the thousands already fetched, since
+			// the tree is wiped at the start.
+			name:   "listed article is not served",
+			kbs:    []string{"KB5102203"},
+			golden: "not-served",
+		},
+		{
+			// A listing can leave its own series: os/server-2008 links to
+			// os/windows-8-1/2024/01/end-of-support. That article is stored, but
+			// its listing is not read, so the 8.1 series it names does not come
+			// along with it.
+			name:   "listing leaving the series is followed one hop",
+			kbs:    []string{"KB4457984"},
+			golden: "cross-series",
+		},
+		{
+			// Pre-2018 articles stay on /help/<KB>. There is no series to read,
+			// and that is not a failure.
+			name:   "non-servicing article is skipped",
+			kbs:    []string{"KB923414"},
+			golden: "non-servicing",
+		},
+		{
+			name:     "no KB",
+			kbs:      nil,
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(handler(t))
+			defer ts.Close()
+
+			dir := t.TempDir()
+			err := servicing.Fetch(tt.kbs,
+				servicing.WithHelpURL(ts.URL+"/help/%s"),
+				servicing.WithDir(dir),
+				servicing.WithRetry(0),
+				servicing.WithConcurrency(2),
+				servicing.WithWait(0),
+			)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Fatalf("unexpected error. err: %v", err)
+			case err == nil && tt.hasError:
+				t.Fatal("expected error has not occurred")
+			case err != nil:
+				return
+			}
+
+			diff(t, filepath.Join("testdata", "golden", tt.golden), dir)
+		})
+	}
+}
+
+// TestFetchRetriesThrottle covers the 403 support.microsoft.com answers with
+// when it decides a client is asking too often. The default retry policy stops
+// at 429 and 5xx, so without 403 among them the first throttle would end a
+// crawl that is thousands of requests long.
+func TestFetchRetriesThrottle(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		retry    int
+		golden   string
+		hasError bool
+	}{
+		// The tree has to come out whole: a throttle that is retried away must
+		// leave no trace, and asserting only that Fetch returned nil would pass
+		// even if nothing had been stored.
+		{name: "throttled once, retried", retry: 2, golden: "os-series"},
+		// Throttling that outlasts the retries fails the run rather than
+		// committing a tree with articles silently missing from it.
+		{name: "throttled once, no retries left", retry: 0, hasError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			throttled := map[string]bool{}
+
+			inner := handler(t)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				first := !throttled[r.URL.Path]
+				throttled[r.URL.Path] = true
+				mu.Unlock()
+
+				if first && strings.Contains(r.URL.Path, "/servicing/") {
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
+				inner(w, r)
+			}))
+			defer ts.Close()
+
+			dir := t.TempDir()
+			err := servicing.Fetch([]string{"KB5101649"},
+				servicing.WithHelpURL(ts.URL+"/help/%s"),
+				servicing.WithDir(dir),
+				servicing.WithRetry(tt.retry),
+				servicing.WithConcurrency(1),
+				servicing.WithWait(0),
+			)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Fatalf("unexpected error. err: %v", err)
+			case err == nil && tt.hasError:
+				t.Fatal("expected error has not occurred")
+			case err != nil:
+				return
+			}
+
+			diff(t, filepath.Join("testdata", "golden", tt.golden), dir)
+		})
+	}
+}
+
+// handler serves the fixture tree the way support.microsoft.com serves the real
+// one: /help/<KB> redirects to a canonical article path, and everything else is
+// an article.
+func handler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+
+	bs, err := os.ReadFile(filepath.Join("testdata", "fixtures", "happy", "redirects.json"))
+	if err != nil {
+		t.Fatalf("read redirects. err: %v", err)
+	}
+	var redirects map[string]string
+	if err := json.Unmarshal(bs, &redirects); err != nil {
+		t.Fatalf("unmarshal redirects. err: %v", err)
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if kb, ok := strings.CutPrefix(r.URL.Path, "/help/"); ok {
+			to, ok := redirects[kb]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			if to == r.URL.Path {
+				// Stays on /help/, as Microsoft does for older articles.
+				_, _ = w.Write([]byte("<html><body></body></html>"))
+				return
+			}
+			http.Redirect(w, r, to, http.StatusFound)
+			return
+		}
+
+		// support.microsoft.com serves the same article under DotNetFramework
+		// and dotnetframework; the fixtures are stored once, so the lookup has
+		// to fold case the way the site does.
+		bs, err := os.ReadFile(filepath.Join("testdata", "fixtures", "happy", strings.ToLower(filepath.Clean(r.URL.Path))+".html"))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(bs)
+	}
+}
+
+// diff compares the produced tree against golden byte for byte. Bytes rather
+// than parsed content: origin/ is only worth keeping if
+// it reproduces exactly, and raw/ is written deterministically, so any
+// difference at all is a regression.
+func diff(t *testing.T, golden, got string) {
+	t.Helper()
+
+	want := walk(t, golden)
+	have := walk(t, got)
+
+	if d := cmp.Diff(slices.Sorted(maps.Keys(want)), slices.Sorted(maps.Keys(have))); d != "" {
+		t.Errorf("files (-expected +got):\n%s", d)
+	}
+
+	for n, w := range want {
+		h, ok := have[n]
+		if !ok {
+			continue
+		}
+		if d := cmp.Diff(string(w), string(h)); d != "" {
+			t.Errorf("%s (-expected +got):\n%s", n, d)
+		}
+	}
+}
+
+func walk(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+
+	out := make(map[string][]byte)
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+
+		bs, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+
+		out[filepath.ToSlash(rel)] = bs
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walk %s. err: %v", root, err)
+	}
+
+	return out
+}

--- a/pkg/fetch/microsoft/servicing/servicing_test.go
+++ b/pkg/fetch/microsoft/servicing/servicing_test.go
@@ -53,17 +53,25 @@ func TestFetch(t *testing.T) {
 			// series, so neither speaks for the other and there is no listing to
 			// follow. Both are recorded from their own headings, including the
 			// one that names no KB anywhere.
+			//
+			// Written both ways, since with no listing to reach them by each
+			// article hangs on its own KB resolving: /help/ takes the number
+			// alone, so a prefix has to be stripped whatever its case, and a bare
+			// number left as it is.
 			name:   "sidebar-less path keeps every article",
-			kbs:    []string{"KB890175", "KB4519108"},
+			kbs:    []string{"kb890175", "4519108"},
 			golden: "sidebar-less",
 		},
 		{
-			// Microsoft lists an article it does not serve. Losing the run over
-			// one of those would throw away the thousands already fetched, since
-			// the tree is wiped at the start.
-			name:   "listed article is not served",
-			kbs:    []string{"KB5102203"},
-			golden: "not-served",
+			// A listing naming an article the site does not serve is not a thing
+			// support.microsoft.com was observed doing — 489 listing entries
+			// across os/windows-11, os/server-2008 and dotnetframework were all
+			// served — so it means this crawl built the wrong URL. Skipping it
+			// would leave a series short of members with the run still green,
+			// which is the failure this fetcher exists to stop happening.
+			name:     "listed article is not served",
+			kbs:      []string{"KB5102203"},
+			hasError: true,
 		},
 		{
 			// A listing can leave its own series: os/server-2008 links to

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/escaped.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/escaped.html
@@ -1,0 +1,3 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/escaped" /></head><body>
+<h1>A page outside the servicing tree</h1>
+</body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.html
@@ -1,0 +1,7 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920" /><meta name="awa-userFlightingId" content="UNSTABLE" /></head><body>
+<h1>January 9, 2024-KB5033920 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11, version 22H2</h1>
+<ul>
+<li class="learnRenderLeftNavHeading">Windows 11, version 22H2</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/07/july-14-2026-kb5101004" class="learnRenderLeftNavLink">July 14, 2026 &#8212; KB5101004 Cumulative Update for .NET Framework</a></li>
+<li class="learnRenderLeftNavArticle">January 9, 2024 &#8212; KB5033920 Cumulative Update for .NET Framework</li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004.html
@@ -1,0 +1,7 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004" /><meta name="awa-userFlightingId" content="UNSTABLE" /></head><body>
+<h1>July 14, 2026-KB5101004 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11, version 23H2</h1>
+<ul>
+<li class="learnRenderLeftNavHeading">Windows 11, version 22H2</li>
+<li class="learnRenderLeftNavArticle">July 14, 2026 &#8212; KB5101004 Cumulative Update for .NET Framework</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2023/11/january-9-2024-kb5033920" class="learnRenderLeftNavLink">January 9, 2024 &#8212; KB5033920 Cumulative Update for .NET Framework</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/server-2008/2018/09/september-11-2018-kb4457984.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/server-2008/2018/09/september-11-2018-kb4457984.html
@@ -1,0 +1,6 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/server-2008/2018/09/september-11-2018-kb4457984" /></head><body>
+<h1>September 11, 2018&#8212;KB4457984 (Security-only update)</h1>
+<ul>
+<li class="learnRenderLeftNavArticle">September 11, 2018&#8212;KB4457984 (Security-only update)</li>
+<li class="learnRenderLeftNavArticle"><a href="../../../windows-8-1/2024/01/end-of-support" class="learnRenderLeftNavLink">End of support for Windows 8.1</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/server-2012/2026/07/july-14-2026-kb5102210.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/server-2012/2026/07/july-14-2026-kb5102210.html
@@ -3,4 +3,5 @@
 <ul>
 <li class="learnRenderLeftNavArticle">July 14, 2026&#8212;KB5102210 (Monthly Rollup)</li>
 <li class="learnRenderLeftNavArticle"><a href="%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/escaped" class="learnRenderLeftNavLink">Escaped the servicing tree</a></li>
+<li class="learnRenderLeftNavArticle"><a href="http://127.0.0.1:1/en-us/servicing/os/server-2012/2026/07/july-14-2026-kb5102212" class="learnRenderLeftNavLink">Served by another host</a></li>
 </ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/server-2012/2026/07/july-14-2026-kb5102210.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/server-2012/2026/07/july-14-2026-kb5102210.html
@@ -1,0 +1,6 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/server-2012/2026/07/july-14-2026-kb5102210" /></head><body>
+<h1>July 14, 2026&#8212;KB5102210 (Monthly Rollup)</h1>
+<ul>
+<li class="learnRenderLeftNavArticle">July 14, 2026&#8212;KB5102210 (Monthly Rollup)</li>
+<li class="learnRenderLeftNavArticle"><a href="%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/escaped" class="learnRenderLeftNavLink">Escaped the servicing tree</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows-10/2026/07/july-14-2026-kb5102203.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows-10/2026/07/july-14-2026-kb5102203.html
@@ -1,0 +1,6 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows-10/2026/07/july-14-2026-kb5102203" /><meta name="awa-expid" content="UNSTABLE" /></head><body>
+<h1>July 14, 2026&#8212;KB5102203 (OS Build 19045.7548)</h1>
+<ul>
+<li class="learnRenderLeftNavArticle">July 14, 2026&#8212;KB5102203 (OS Build 19045.7548)</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/06/june-9-2026-kb5094127" class="learnRenderLeftNavLink">June 9, 2026&#8212;KB5094127 (OS Build 19045.7417)</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows-11/2026/07/july-14-2026-kb5101649.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows-11/2026/07/july-14-2026-kb5101649.html
@@ -1,0 +1,8 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows-11/2026/07/july-14-2026-kb5101649" /><meta name="awa-expid" content="UNSTABLE" /><meta name="awa-userFlightingId" content="UNSTABLE" /></head><body>
+<h1>July 14, 2026&#8212;KB5101649 (OS Build 28000.2525)</h1>
+<ul>
+<li class="learnRenderLeftNavHeading">Windows 11, version 26H1</li>
+<li class="learnRenderLeftNavArticle">July 14, 2026&#8212;KB5101649 (OS Build 28000.2525)</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/07/july-28-2026-kb5101684" class="learnRenderLeftNavLink">July 28, 2026&#8212;KB5101684 (OS Builds 26200.8973 and 26100.8973) Preview</a></li>
+<li class="learnRenderLeftNavHeading">End of servicing statement</li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows-11/2026/07/july-28-2026-kb5101684.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows-11/2026/07/july-28-2026-kb5101684.html
@@ -1,0 +1,8 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows-11/2026/07/july-28-2026-kb5101684" /><meta name="awa-expid" content="UNSTABLE" /></head><body>
+<h1>July 28, 2026&#8212;KB5101684 (OS Builds 26200.8973 and 26100.8973) Preview</h1>
+<ul>
+<li class="learnRenderLeftNavHeading">Windows 11, version 26H1</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/07/july-14-2026-kb5101649" class="learnRenderLeftNavLink">July 14, 2026&#8212;KB5101649 (OS Build 28000.2525)</a></li>
+<li class="learnRenderLeftNavArticle">July 28, 2026&#8212;KB5101684 (OS Builds 26200.8973 and 26100.8973) Preview</li>
+<li class="learnRenderLeftNavHeading">End of servicing statement</li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows-8-1/2024/01/end-of-support.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows-8-1/2024/01/end-of-support.html
@@ -1,0 +1,5 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows-8-1/2024/01/end-of-support" /></head><body>
+<h1>End of support for Windows 8.1</h1>
+<ul>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/07/july-14-2026-kb5102207" class="learnRenderLeftNavLink">July 14, 2026&#8212;KB5102207 (Monthly Rollup)</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows-8-1/2026/07/july-14-2026-kb5102207.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows-8-1/2026/07/july-14-2026-kb5102207.html
@@ -1,0 +1,2 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows-8-1/2026/07/july-14-2026-kb5102207" /></head><body>
+<h1>July 14, 2026&#8212;KB5102207 (Monthly Rollup)</h1></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows/2019/02/ms05-001-vulnerability-in-html-help.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows/2019/02/ms05-001-vulnerability-in-html-help.html
@@ -1,0 +1,1 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows/2019/02/ms05-001-vulnerability-in-html-help" /></head><body><h1>MS05-001: Vulnerability in HTML Help could allow code execution</h1></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows/2019/10/dst-changes-for-norfolk-island.html
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/en-us/servicing/os/windows/2019/10/dst-changes-for-norfolk-island.html
@@ -1,0 +1,1 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows/2019/10/dst-changes-for-norfolk-island" /></head><body><h1>October 8, 2019&#8212;KB4519108 DST changes for Norfolk Island</h1></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/redirects.json
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/redirects.json
@@ -6,5 +6,7 @@
   "4519108": "/en-us/servicing/os/windows/2019/10/dst-changes-for-norfolk-island",
   "923414": "/help/923414",
   "5102203": "/en-us/servicing/os/windows-10/2026/07/july-14-2026-kb5102203",
-  "4457984": "/en-us/servicing/os/server-2008/2018/09/september-11-2018-kb4457984"
+  "4457984": "/en-us/servicing/os/server-2008/2018/09/september-11-2018-kb4457984",
+  "5102210": "/en-us/servicing/os/server-2012/2026/07/july-14-2026-kb5102210",
+  "5102211": "/en-us/servicing/os/server-2012/2026/07/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/escaped"
 }

--- a/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/redirects.json
+++ b/pkg/fetch/microsoft/servicing/testdata/fixtures/happy/redirects.json
@@ -1,0 +1,10 @@
+{
+  "5101004": "/en-us/servicing/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004",
+  "5033920": "/en-US/servicing/DotNetFramework/windows-11/22h2/2023/11/january-9-2024-kb5033920",
+  "890175": "/en-us/servicing/os/windows/2019/02/ms05-001-vulnerability-in-html-help",
+  "5101649": "/en-us/servicing/os/windows-11/2026/07/july-14-2026-kb5101649",
+  "4519108": "/en-us/servicing/os/windows/2019/10/dst-changes-for-norfolk-island",
+  "923414": "/help/923414",
+  "5102203": "/en-us/servicing/os/windows-10/2026/07/july-14-2026-kb5102203",
+  "4457984": "/en-us/servicing/os/server-2008/2018/09/september-11-2018-kb4457984"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/cross-series/origin/os/server-2008/2018/09/september-11-2018-kb4457984.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/cross-series/origin/os/server-2008/2018/09/september-11-2018-kb4457984.html
@@ -1,0 +1,6 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/server-2008/2018/09/september-11-2018-kb4457984" /></head><body>
+<h1>September 11, 2018&#8212;KB4457984 (Security-only update)</h1>
+<ul>
+<li class="learnRenderLeftNavArticle">September 11, 2018&#8212;KB4457984 (Security-only update)</li>
+<li class="learnRenderLeftNavArticle"><a href="../../../windows-8-1/2024/01/end-of-support" class="learnRenderLeftNavLink">End of support for Windows 8.1</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/cross-series/origin/os/windows-8-1/2024/01/end-of-support.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/cross-series/origin/os/windows-8-1/2024/01/end-of-support.html
@@ -1,0 +1,5 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows-8-1/2024/01/end-of-support" /></head><body>
+<h1>End of support for Windows 8.1</h1>
+<ul>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/07/july-14-2026-kb5102207" class="learnRenderLeftNavLink">July 14, 2026&#8212;KB5102207 (Monthly Rollup)</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/cross-series/raw/os/server-2008/2018/09/september-11-2018-kb4457984.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/cross-series/raw/os/server-2008/2018/09/september-11-2018-kb4457984.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/os/server-2008/2018/09/september-11-2018-kb4457984",
+	"title": "September 11, 2018—KB4457984 (Security-only update)"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/cross-series/raw/os/windows-8-1/2024/01/end-of-support.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/cross-series/raw/os/windows-8-1/2024/01/end-of-support.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/os/windows-8-1/2024/01/end-of-support",
+	"title": "End of support for Windows 8.1"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/encoded-dot-segment/origin/os/server-2012/2026/07/july-14-2026-kb5102210.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/encoded-dot-segment/origin/os/server-2012/2026/07/july-14-2026-kb5102210.html
@@ -3,4 +3,5 @@
 <ul>
 <li class="learnRenderLeftNavArticle">July 14, 2026&#8212;KB5102210 (Monthly Rollup)</li>
 <li class="learnRenderLeftNavArticle"><a href="%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/escaped" class="learnRenderLeftNavLink">Escaped the servicing tree</a></li>
+<li class="learnRenderLeftNavArticle"><a href="http://127.0.0.1:1/en-us/servicing/os/server-2012/2026/07/july-14-2026-kb5102212" class="learnRenderLeftNavLink">Served by another host</a></li>
 </ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/encoded-dot-segment/origin/os/server-2012/2026/07/july-14-2026-kb5102210.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/encoded-dot-segment/origin/os/server-2012/2026/07/july-14-2026-kb5102210.html
@@ -1,0 +1,6 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/server-2012/2026/07/july-14-2026-kb5102210" /></head><body>
+<h1>July 14, 2026&#8212;KB5102210 (Monthly Rollup)</h1>
+<ul>
+<li class="learnRenderLeftNavArticle">July 14, 2026&#8212;KB5102210 (Monthly Rollup)</li>
+<li class="learnRenderLeftNavArticle"><a href="%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/escaped" class="learnRenderLeftNavLink">Escaped the servicing tree</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/encoded-dot-segment/raw/os/server-2012/2026/07/july-14-2026-kb5102210.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/encoded-dot-segment/raw/os/server-2012/2026/07/july-14-2026-kb5102210.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/os/server-2012/2026/07/july-14-2026-kb5102210",
+	"title": "July 14, 2026—KB5102210 (Monthly Rollup)"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/expired-member/origin/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/expired-member/origin/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.html
@@ -1,0 +1,7 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920" /></head><body>
+<h1>January 9, 2024-KB5033920 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11, version 22H2</h1>
+<ul>
+<li class="learnRenderLeftNavHeading">Windows 11, version 22H2</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/07/july-14-2026-kb5101004" class="learnRenderLeftNavLink">July 14, 2026 &#8212; KB5101004 Cumulative Update for .NET Framework</a></li>
+<li class="learnRenderLeftNavArticle">January 9, 2024 &#8212; KB5033920 Cumulative Update for .NET Framework</li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/expired-member/origin/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/expired-member/origin/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004.html
@@ -1,0 +1,7 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004" /></head><body>
+<h1>July 14, 2026-KB5101004 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11, version 23H2</h1>
+<ul>
+<li class="learnRenderLeftNavHeading">Windows 11, version 22H2</li>
+<li class="learnRenderLeftNavArticle">July 14, 2026 &#8212; KB5101004 Cumulative Update for .NET Framework</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2023/11/january-9-2024-kb5033920" class="learnRenderLeftNavLink">January 9, 2024 &#8212; KB5033920 Cumulative Update for .NET Framework</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/expired-member/raw/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/expired-member/raw/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920",
+	"title": "January 9, 2024-KB5033920 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11, version 22H2"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/expired-member/raw/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/expired-member/raw/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004",
+	"title": "July 14, 2026-KB5101004 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11, version 23H2"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/not-served/origin/os/windows-10/2026/07/july-14-2026-kb5102203.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/not-served/origin/os/windows-10/2026/07/july-14-2026-kb5102203.html
@@ -1,0 +1,6 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows-10/2026/07/july-14-2026-kb5102203" /></head><body>
+<h1>July 14, 2026&#8212;KB5102203 (OS Build 19045.7548)</h1>
+<ul>
+<li class="learnRenderLeftNavArticle">July 14, 2026&#8212;KB5102203 (OS Build 19045.7548)</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/06/june-9-2026-kb5094127" class="learnRenderLeftNavLink">June 9, 2026&#8212;KB5094127 (OS Build 19045.7417)</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/not-served/origin/os/windows-10/2026/07/july-14-2026-kb5102203.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/not-served/origin/os/windows-10/2026/07/july-14-2026-kb5102203.html
@@ -1,6 +1,0 @@
-<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows-10/2026/07/july-14-2026-kb5102203" /></head><body>
-<h1>July 14, 2026&#8212;KB5102203 (OS Build 19045.7548)</h1>
-<ul>
-<li class="learnRenderLeftNavArticle">July 14, 2026&#8212;KB5102203 (OS Build 19045.7548)</li>
-<li class="learnRenderLeftNavArticle"><a href="../../2026/06/june-9-2026-kb5094127" class="learnRenderLeftNavLink">June 9, 2026&#8212;KB5094127 (OS Build 19045.7417)</a></li>
-</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/not-served/raw/os/windows-10/2026/07/july-14-2026-kb5102203.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/not-served/raw/os/windows-10/2026/07/july-14-2026-kb5102203.json
@@ -1,4 +1,0 @@
-{
-	"url": "https://support.microsoft.com/en-us/servicing/os/windows-10/2026/07/july-14-2026-kb5102203",
-	"title": "July 14, 2026—KB5102203 (OS Build 19045.7548)"
-}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/not-served/raw/os/windows-10/2026/07/july-14-2026-kb5102203.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/not-served/raw/os/windows-10/2026/07/july-14-2026-kb5102203.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/os/windows-10/2026/07/july-14-2026-kb5102203",
+	"title": "July 14, 2026—KB5102203 (OS Build 19045.7548)"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/os-series/origin/os/windows-11/2026/07/july-14-2026-kb5101649.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/os-series/origin/os/windows-11/2026/07/july-14-2026-kb5101649.html
@@ -1,0 +1,8 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows-11/2026/07/july-14-2026-kb5101649" /></head><body>
+<h1>July 14, 2026&#8212;KB5101649 (OS Build 28000.2525)</h1>
+<ul>
+<li class="learnRenderLeftNavHeading">Windows 11, version 26H1</li>
+<li class="learnRenderLeftNavArticle">July 14, 2026&#8212;KB5101649 (OS Build 28000.2525)</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/07/july-28-2026-kb5101684" class="learnRenderLeftNavLink">July 28, 2026&#8212;KB5101684 (OS Builds 26200.8973 and 26100.8973) Preview</a></li>
+<li class="learnRenderLeftNavHeading">End of servicing statement</li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/os-series/origin/os/windows-11/2026/07/july-28-2026-kb5101684.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/os-series/origin/os/windows-11/2026/07/july-28-2026-kb5101684.html
@@ -1,0 +1,8 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows-11/2026/07/july-28-2026-kb5101684" /></head><body>
+<h1>July 28, 2026&#8212;KB5101684 (OS Builds 26200.8973 and 26100.8973) Preview</h1>
+<ul>
+<li class="learnRenderLeftNavHeading">Windows 11, version 26H1</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/07/july-14-2026-kb5101649" class="learnRenderLeftNavLink">July 14, 2026&#8212;KB5101649 (OS Build 28000.2525)</a></li>
+<li class="learnRenderLeftNavArticle">July 28, 2026&#8212;KB5101684 (OS Builds 26200.8973 and 26100.8973) Preview</li>
+<li class="learnRenderLeftNavHeading">End of servicing statement</li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/os-series/raw/os/windows-11/2026/07/july-14-2026-kb5101649.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/os-series/raw/os/windows-11/2026/07/july-14-2026-kb5101649.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/os/windows-11/2026/07/july-14-2026-kb5101649",
+	"title": "July 14, 2026—KB5101649 (OS Build 28000.2525)"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/os-series/raw/os/windows-11/2026/07/july-28-2026-kb5101684.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/os-series/raw/os/windows-11/2026/07/july-28-2026-kb5101684.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/os/windows-11/2026/07/july-28-2026-kb5101684",
+	"title": "July 28, 2026—KB5101684 (OS Builds 26200.8973 and 26100.8973) Preview"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/series-fetched-once/origin/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/series-fetched-once/origin/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.html
@@ -1,0 +1,7 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920" /></head><body>
+<h1>January 9, 2024-KB5033920 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11, version 22H2</h1>
+<ul>
+<li class="learnRenderLeftNavHeading">Windows 11, version 22H2</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2026/07/july-14-2026-kb5101004" class="learnRenderLeftNavLink">July 14, 2026 &#8212; KB5101004 Cumulative Update for .NET Framework</a></li>
+<li class="learnRenderLeftNavArticle">January 9, 2024 &#8212; KB5033920 Cumulative Update for .NET Framework</li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/series-fetched-once/origin/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/series-fetched-once/origin/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004.html
@@ -1,0 +1,7 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004" /></head><body>
+<h1>July 14, 2026-KB5101004 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11, version 23H2</h1>
+<ul>
+<li class="learnRenderLeftNavHeading">Windows 11, version 22H2</li>
+<li class="learnRenderLeftNavArticle">July 14, 2026 &#8212; KB5101004 Cumulative Update for .NET Framework</li>
+<li class="learnRenderLeftNavArticle"><a href="../../2023/11/january-9-2024-kb5033920" class="learnRenderLeftNavLink">January 9, 2024 &#8212; KB5033920 Cumulative Update for .NET Framework</a></li>
+</ul></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/series-fetched-once/raw/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/series-fetched-once/raw/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920",
+	"title": "January 9, 2024-KB5033920 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11, version 22H2"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/series-fetched-once/raw/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/series-fetched-once/raw/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/dotnetframework/windows-11/22h2/2026/07/july-14-2026-kb5101004",
+	"title": "July 14, 2026-KB5101004 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Windows 11, version 23H2"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/sidebar-less/origin/os/windows/2019/02/ms05-001-vulnerability-in-html-help.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/sidebar-less/origin/os/windows/2019/02/ms05-001-vulnerability-in-html-help.html
@@ -1,0 +1,1 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows/2019/02/ms05-001-vulnerability-in-html-help" /></head><body><h1>MS05-001: Vulnerability in HTML Help could allow code execution</h1></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/sidebar-less/origin/os/windows/2019/10/dst-changes-for-norfolk-island.html
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/sidebar-less/origin/os/windows/2019/10/dst-changes-for-norfolk-island.html
@@ -1,0 +1,1 @@
+<html><head><link rel="canonical" href="https://support.microsoft.com/en-us/servicing/os/windows/2019/10/dst-changes-for-norfolk-island" /></head><body><h1>October 8, 2019&#8212;KB4519108 DST changes for Norfolk Island</h1></body></html>

--- a/pkg/fetch/microsoft/servicing/testdata/golden/sidebar-less/raw/os/windows/2019/02/ms05-001-vulnerability-in-html-help.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/sidebar-less/raw/os/windows/2019/02/ms05-001-vulnerability-in-html-help.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/os/windows/2019/02/ms05-001-vulnerability-in-html-help",
+	"title": "MS05-001: Vulnerability in HTML Help could allow code execution"
+}

--- a/pkg/fetch/microsoft/servicing/testdata/golden/sidebar-less/raw/os/windows/2019/10/dst-changes-for-norfolk-island.json
+++ b/pkg/fetch/microsoft/servicing/testdata/golden/sidebar-less/raw/os/windows/2019/10/dst-changes-for-norfolk-island.json
@@ -1,0 +1,4 @@
+{
+	"url": "https://support.microsoft.com/en-us/servicing/os/windows/2019/10/dst-changes-for-norfolk-island",
+	"title": "October 8, 2019—KB4519108 DST changes for Norfolk Island"
+}

--- a/pkg/fetch/microsoft/servicing/types.go
+++ b/pkg/fetch/microsoft/servicing/types.go
@@ -1,0 +1,32 @@
+package servicing
+
+// Article is one servicing article, as served.
+//
+// The series an article belongs to is its position in the tree, not a field:
+// every article of a series is stored, so listing the directory reconstructs
+// the membership that Microsoft renders as a sidebar on each page. Storing that
+// sidebar as well would repeat one ~225-entry list across the ~300 articles of
+// os/windows-11, and rewrite all of them each time a new update ships.
+//
+// Nothing is parsed out of Title. It is the only place several facts appear —
+// "Preview", "Out-of-band", "(Monthly Rollup)", "(Security-only update)" name
+// servicing tracks that supersede each other differently, and OS articles carry
+// their build numbers there — but Microsoft writes it at least four ways, and
+// the oldest .NET form has no date at all:
+//
+//	July 14, 2026—KB5101649 (OS Build 28000.2525)
+//	July 14, 2026 — KB5101004 Cumulative Update for .NET Framework 3.5 ...
+//	KB5022497 Cumulative Update for .NET Framework 3.5, 4.8.1 for Windows 11 ...
+//	February 13, 2024 security update (KB5034769)
+//
+// Reading those apart belongs in extract, under golden tests, where a fifth
+// spelling is handled by rerunning against origin/ rather than refetching. It
+// also keeps articles that name no KB anywhere, such as "MS05-001:
+// Vulnerability in HTML Help could allow code execution", from being dropped
+// for want of a key.
+type Article struct {
+	// URL is the article's own canonical link, taken from the stored page rather
+	// than from the request, so raw/ stays derivable from origin/ alone.
+	URL   string `json:"url,omitempty"`
+	Title string `json:"title"`
+}


### PR DESCRIPTION
## What

A fetcher for Microsoft's servicing articles — the per-update pages under `support.microsoft.com/<locale>/servicing/`.

```console
$ vuls-data-update fetch microsoft-servicing KB5101004 KB5066835
```

Stores the pages under `<dir>/origin` as served, and what each states about itself under `<dir>/raw`:

```
origin/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.html
raw/dotnetframework/windows-11/22h2/2023/11/january-9-2024-kb5033920.json
```

```json
{
	"url": "https://support.microsoft.com/en-us/servicing/os/windows-11/2026/07/july-14-2026-kb5101649",
	"title": "July 14, 2026—KB5101649 (OS Build 28000.2525)"
}
```

## Why

Microsoft expires updates, and expiry is destructive. Once it happens the Update Catalog returns nothing for a search, redirects `ScopedViewInline` to `Thanks.aspx`, and rewrites *"This update replaces the following updates"* on the surviving successor to **`n/a`**; `wsusscn2.cab` drops the update outright. Nothing recovers the supersedence that went with it — of the 3,048 supersedence edges wsusscn2 dropped on 2026-04-15, all 3,048 are still missing at HEAD.

The servicing article does not go away. Every article in a series carries a sidebar listing the whole series, expired updates included.

Concretely: **KB5033920** (2024-01, .NET for Windows 11 23H2) fixes CVE-2024-0057, and a host at **KB5101004** (2026-07) is covered through `5049624 → 5044033 → 5039895 → 5036620`. Four of those five links are expired, so the chain cannot be walked from the catalog at all — and all six are still listed side by side on any article in that series.

## How

**Discovery.** Each KB is resolved through `/help/<KB>`, whose redirect also reveals the product and series: they are path segments, not page content. `HEAD` suffices, and the bodies are large enough that fetching one per KB just to learn a path would dominate the run.

**Two steps, one hop.** The articles asked for are stored and their sidebars read; then everything those name is stored without reading further.

One hop is enough because a sidebar is identical on every article of a series — checked across the sampled corpus, where the KB sets of four articles of `dotnetframework/windows-11/22h2` and four of `os/windows-11` match exactly.

It is also the limit worth taking. Of **3,224 sidebar hrefs sampled, one leaves its series**: `os/server-2008` links to `os/windows-8-1/2024/01/end-of-support`. Reading that article's sidebar in turn would pull in the whole of Windows 8.1, so asking for one Server 2008 KB would fetch 244 articles nobody asked for. The linked article is still kept — Microsoft points at it — but its series is not dragged along.

**The whole series is stored**, not only the articles asked for. Keeping just the sidebar would be cheaper, but it is a single point of failure: it can be pruned the way the Catalog's replaces list was, and would take every expired member with it.

**The sidebar itself is not stored.** Since every member is, which articles form a series is the directory they sit in. Recording it too would repeat one ~225-entry list across the ~300 articles of `os/windows-11`, and rewrite all of them whenever a new update ships.

**`raw/` is derived from `origin/`, never from the response**, so it is reproducible from the stored bytes alone and a parser change can be replayed without refetching. One file per stored article at its `origin/` path, so which JSON came from which HTML needs no bookkeeping.

**Titles are stored as served.** They are the only place several facts appear — `Preview`, `Out-of-band`, `(Monthly Rollup)`, `(Security-only update)`, and the OS build numbers — but Microsoft writes them at least four ways and the oldest .NET form carries no date:

```
July 14, 2026—KB5101649 (OS Build 28000.2525)
July 14, 2026 — KB5101004 Cumulative Update for .NET Framework 3.5 ...
KB5022497 Cumulative Update for .NET Framework 3.5, 4.8.1 for Windows 11 ...
February 13, 2024 security update (KB5034769)
```

Reading them apart belongs in `extract`, under golden tests. It also lets an article naming no KB at all — `MS05-001: Vulnerability in HTML Help could allow code execution` — be recorded rather than dropped for want of a key.

### Three things the site does that the run has to survive

**Per-response analytics metadata is dropped before storing.** `awa-userFlightingId` is a fresh GUID on every response and `awa-expid` an A/B bucket assignment; with them in place an unchanged article differs on every fetch — exactly the churn `origin/` exists to avoid. Two fetches of the same article: **103,719 differing characters** as served, **byte-identical** once they are removed.

**403 is added to what the client retries.** support.microsoft.com answers 403 rather than 429 once it decides a client is asking too often — reached in minutes at the default pacing during development. The stock policy covers only 429 and 5xx. A 403 that is a genuine refusal takes the same bounded number of attempts and then fails as before.

**A sidebar naming an article the site does not serve fails the run.** Measured against the live site, Microsoft does not do that — every listing entry of `os/windows-11` (302), `os/server-2008` (145) and `dotnetframework/windows-11/22h2` (42) was served. So a 404 means this crawl built a URL that is not an article, and that fault applies to every entry of every listing at once: skipping them would store the seeds alone and exit zero, committing series short of the expired members they exist to carry.

## Testing

Golden trees hold both sides — the stored HTML and the JSON derived from it — compared byte for byte, since `origin/` is only worth keeping if it reproduces exactly and `raw/` is written deterministically.

```console
$ go test ./pkg/fetch/microsoft/servicing/
--- PASS: TestFetch/series_is_listed_once
--- PASS: TestFetch/expired_member_is_stored_too
--- PASS: TestFetch/os_series_carries_builds
--- PASS: TestFetch/sidebar-less_path_keeps_every_article
--- PASS: TestFetch/listed_article_is_not_served
--- PASS: TestFetch/listing_leaving_the_series_is_followed_one_hop
--- PASS: TestFetch/non-servicing_article_is_skipped
--- PASS: TestFetch/no_KB
--- PASS: TestFetchRetriesThrottle/throttled_once,_retried
--- PASS: TestFetchRetriesThrottle/throttled_once,_no_retries_left
```

Each guard was checked to fail without its fix: disabling the 403 retry, the dot-segment check, the KB normalization or the one-hop limit each breaks the corresponding case. The throttle test compares the resulting tree rather than just the error — throttling lands on the `/help/` lookup too, which warns and moves on, so a run whose every article was refused still returns no error and simply stores nothing.

Verified end to end against the live site during development, on 9 KBs spanning `os`, `dotnetframework` and `azure`. The listing behaviour the crawl rests on was measured there too, over 489 entries of three series: every one was served, every one stayed in its own series bar the single `os/server-2008` link into `os/windows-8-1` that the one-hop limit exists for, and throttling answered 403.

## Note

Request count for a series is its size — `os/windows-11` is ~300 articles, `os/windows-8-1` ~244 — so a full seed set is thousands of requests. Defaults are `--concurrency 3 --wait 1s`; `vuls-data-db` is expected to shard the KB list across jobs the way `msuc-targets.json` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
