### PR TITLE
fix(extract/cisco/json): skip newly observed unparseable product names

### DIFF
--- a/pkg/extract/cisco/json/json.go
+++ b/pkg/extract/cisco/json/json.go
@@ -520,8 +520,9 @@ var productConversions = []productConversion{
 
 // knownUnparseableProductNames lists product names whose version string the
 // go-cisco-version parsers reject but which are known, accepted artifacts of
-// the upstream data (a truncated version, or a letter-suffixed build that the
-// parser does not model). These are skipped silently. Any OTHER parse failure
+// the upstream data (a truncated version, a letter-suffixed build that the
+// parser does not model, or a misspelled family-level entry carrying no
+// version at all). These are skipped silently. Any OTHER parse failure
 // is treated as a hard error (see convertProductName) so that a newly
 // introduced malformed pattern surfaces loudly instead of being dropped.
 var knownUnparseableProductNames = map[string]struct{}{

--- a/pkg/extract/cisco/json/json.go
+++ b/pkg/extract/cisco/json/json.go
@@ -527,6 +527,13 @@ var productConversions = []productConversion{
 var knownUnparseableProductNames = map[string]struct{}{
 	"Cisco IOS XE Software .0":                   {}, // cisco-sa-20170201-cbr
 	"Cisco IOS XE Software .1":                   {}, // cisco-sa-20170201-cbr
+	"Cisco IOS XE Software (3)S":                 {}, // cisco-sa-hardening-iosxe-V8NMuMZJ
+	"Cisco IOS XE Software (3)S1":                {}, // cisco-sa-hardening-iosxe-V8NMuMZJ
+	"Cisco IOS XE Software (3)S2":                {}, // cisco-sa-hardening-iosxe-V8NMuMZJ
+	"Cisco IOS XE Software (3)S2.1":              {}, // cisco-sa-hardening-iosxe-V8NMuMZJ
+	"Cisco IOS XE Software 3)S":                  {}, // cisco-sa-hardening-iosxe-V8NMuMZJ
+	"Cisco IOS XE Software (1.14)T":              {}, // cisco-sa-hardening-iosxe-V8NMuMZJ
+	"Cisco IOS XG Software ":                     {}, // cisco-sa-webui-dos-qdc7qx3 ("IOS XG" is an upstream typo; family-level entry with no version)
 	"Cisco Wireless LAN Controller (WLC) 3.6.0E": {}, // cisco-sa-20181017-wlc-gui-privesc, cisco-sa-20160831-wlc-2, cisco-sa-20160831-wlc-1
 }
 

--- a/pkg/extract/cisco/json/json_test.go
+++ b/pkg/extract/cisco/json/json_test.go
@@ -89,6 +89,14 @@ func TestConvertProductName(t *testing.T) {
 			product: "Cisco Wireless LAN Controller (WLC) 3.6.0E",
 		},
 		{
+			name:    "known truncated IOS XE version is skipped",
+			product: "Cisco IOS XE Software (3)S2.1",
+		},
+		{
+			name:    "known IOS XG typo family is skipped",
+			product: "Cisco IOS XG Software ",
+		},
+		{
 			name:     "unknown unparseable version errors",
 			product:  "Cisco Wireless LAN Controller (WLC) 9.9.9Z",
 			hasError: true,


### PR DESCRIPTION
## What

Add seven newly observed unparseable product names to `knownUnparseableProductNames` so the cisco-json extract no longer aborts:

- `cisco-sa-hardening-iosxe-V8NMuMZJ` — six truncated IOS XE versions: `(3)S2.1`, `(3)S2`, `(3)S1`, `3)S`, `(3)S`, `(1.14)T`
- `cisco-sa-webui-dos-qdc7qx3` — `Cisco IOS XG Software ` ("IOS XG" is an upstream typo; family-level entry with no version)

## Why

The nightly extract in vuls-data-db fails with:

```
unexpected IOS XE version format. expected: ["(<release>-)<major>.<minor>.<maintenance>" "<major>.<minor>.<maintenance>(<release>)"], actual: "(3)S2.1"
```

https://github.com/vulsio/vuls-data-db/actions/runs/31335524249 (`Extract vuls-data-extracted-cisco-json@main` / `@nightly`)

The CI stops at the first failure; scanning the full raw dataset surfaced the remaining six names, including the second advisory.

## How

Follows the established pattern for known-bad upstream artifacts (`Cisco IOS XE Software .0` etc. from cisco-sa-20170201-cbr): register the exact product names in `knownUnparseableProductNames` so they are skipped silently, while any other parse failure still surfaces as a hard error.

## Testing

- Added table cases for a truncated IOS XE version and the IOS XG typo to `TestConvertProductName`
- `GOEXPERIMENT=jsonv2 go test ./pkg/extract/cisco/...` passes
- Ran `convertProductName` over every `productNames` entry in the current `ghcr.io/vulsio/vuls-data-db:vuls-data-raw-cisco-json` dataset: zero parse failures remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)