### PR TITLE
docs(github): make Copilot instructions effective on GitHub reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,35 @@
+# vuls-data-update
+
+CLI tool to **fetch** raw vulnerability data sources, **extract** them to canonical JSON datasets, and manage **dotgit** repositories for distribution.
+
+## Build & Test
+
+```sh
+GOEXPERIMENT=jsonv2 go build ./cmd/vuls-data-update
+GOEXPERIMENT=jsonv2 go test ./...
+```
+
+## Architecture
+
+- Cobra command tree: root in `pkg/cmd/root/root.go` → `fetch`, `extract`, `dotgit`
+- Data-source subcommands are registered in `pkg/cmd/fetch/fetch.go` and `pkg/cmd/extract/extract.go`
+- Fetchers live in `pkg/fetch/<domain>/<name>/`, extractors in `pkg/extract/<domain>/<name>/`
+
+## Key Principles
+
+- **Deterministic JSON output is the top priority**: `encoding/json/v2` with `json.Deterministic(true)`, tab indent, always via `util.Write()` — never ad-hoc `json.Marshal`
+- Types under `pkg/extract/types/data` are imported by external repos (`filter-vuls-data-extracted-redhat`, `vuls2`) — breaking changes require coordination
+- Golden tests: fixtures in `testdata/fixtures/`, expected output in `testdata/golden/`
+- Errors are wrapped with `github.com/pkg/errors` — never swallowed, never returned bare without context
+
+## Detailed Guidelines
+
+See `.github/instructions/` for path-scoped conventions:
+
+- `go-code.instructions.md` — Go code conventions
+- `golden-test.instructions.md` — test conventions
+- `review.instructions.md` — review checklist and severity classification
+- `commit-pr.instructions.md` — commit message and PR conventions
+- `security.instructions.md` — security guidelines
+
+These mirror `.claude/rules/` (for Claude Code); keep both sides in sync when editing either.

--- a/.github/instructions/commit-pr.instructions.md
+++ b/.github/instructions/commit-pr.instructions.md
@@ -1,5 +1,6 @@
 ---
 description: "Commit message format and PR workflow conventions — enriched from 100+ commit analysis"
+applyTo: "**"
 ---
 # Commit & PR Conventions
 

--- a/.github/instructions/go-code.instructions.md
+++ b/.github/instructions/go-code.instructions.md
@@ -1,5 +1,6 @@
 ---
 description: "Go code conventions for vuls-data-update: deterministic JSON, util.Write, Sort/Compare patterns, error handling"
+applyTo: "**/*.go"
 ---
 # Go Code Conventions
 
@@ -54,6 +55,7 @@ description: "Go code conventions for vuls-data-update: deterministic JSON, util
 - Sentinel errors (`errors.New`) are rare; check with `errors.Is()`
   - Use specific sentinel errors (e.g., `ErrNotFoundX`) rather than generic ones when callers need to distinguish error types
 - Non-fatal errors: `slog.Warn(...)` + skip (e.g., invalid CPE, unparseable score) — still log, never silently drop
+  - Exception — **types packages (`pkg/extract/types/**`) never log**: they are library code embedded in host applications (vuls2 / vuls0) whose logging they must not bypass. Record non-fatal evaluation events as structured data on the result instead (e.g. `FilteredCriterion.Warnings`); projecting them into logs or scan-result warnings is the caller's job
 
 ## Slice and Map Idioms
 

--- a/.github/instructions/golden-test.instructions.md
+++ b/.github/instructions/golden-test.instructions.md
@@ -1,5 +1,6 @@
 ---
 description: "Test conventions: golden tests (fixtures/golden), inline table-driven tests, cmp.Diff, httptest patterns"
+applyTo: "**/*.go"
 ---
 # Test Conventions
 

--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -1,5 +1,6 @@
 ---
 description: "Code review guidelines: checklist, severity classification, review focus areas"
+applyTo: "**"
 ---
 # Review Guidelines
 
@@ -27,6 +28,7 @@ description: "Code review guidelines: checklist, severity classification, review
 - Error messages: lowercase verb phrase in library code, `"failed to ..."` in `pkg/cmd/`
 - Validation errors: use `"unexpected X. expected: %q, actual: %q"` pattern
 - Non-fatal errors: `slog.Warn(...)` + skip, don't silently ignore
+  - Exception: types packages (`pkg/extract/types/**`) must NOT log — they record structured warnings on results (e.g. `FilteredCriterion.Warnings`) and leave projection to callers. Do not flag missing `slog.Warn` there; do flag logging added to types packages
 
 ### Code Idioms
 - Pre-allocate slices: `make([]T, 0, len(x))` — not `var s []T` when capacity is known

--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -1,5 +1,6 @@
 ---
 description: "Security guidelines: prompt injection defense, credential protection, Go security patterns"
+applyTo: "**"
 ---
 # Security Guidelines
 


### PR DESCRIPTION
## What

Three small fixes so the agent/LLM guidance under `.github/` actually takes effect on GitHub-side Copilot code reviews:

- Add `applyTo` frontmatter to all five `.github/instructions/*.instructions.md` files (`**/*.go` for `go-code` / `golden-test`, `**` for the rest)
- Sync content that had drifted from `.claude/rules/`: the "types packages (`pkg/extract/types/**`) never log" exception was missing on the Copilot side of `go-code` and `review` (also restore the trailing newline in `security`)
- Add `.github/copilot-instructions.md` with repo-wide context (build/test commands, determinism-first principle, external type consumers)

## Why

- Copilot's `.instructions.md` files are only auto-applied when they carry an `applyTo` glob; without it they were effectively inert on GitHub reviews
- The drifted "never log in types packages" rule would make Copilot review flag the *absence* of `slog.Warn` in `pkg/extract/types/**` — the opposite of the intended convention
- Copilot had no repo-wide context equivalent to `CLAUDE.md`

## How

Documentation-only change; no Go code touched. After the sync, each `.github/instructions/*` file is identical to its `.claude/rules/*` counterpart except for the frontmatter block.

## Testing

- Verified `diff <(tail -n +5 .github/instructions/<n>.instructions.md) .claude/rules/<n>.md` is empty for all five pairs
- `go build` / `go test` unaffected (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)