### PR TITLE
feat(fetch/util,extract/util): let RemoveAll be told what to keep

### DIFF
--- a/.claude/rules/go-code.md
+++ b/.claude/rules/go-code.md
@@ -80,7 +80,9 @@
 
 ## Cleanup Helpers
 
-- Use `util.RemoveAll(dir)` when cleaning output trees — it preserves `README.md` and `.git` directories
+- Use `util.RemoveAll(dir)` when cleaning output trees — it preserves `.git`
+- Pass `util.WithKeep(...)` when part of the tree is not produced by the step doing the cleaning and cannot be rebuilt by it. It states the whole keep set rather than adding to the default, so name `.git` alongside whatever else is kept: `util.RemoveAll(dir, util.WithKeep(".git", "raw"))`. Names match an entry's own name, not a suffix of the path
+- Prefer that over narrowing the call to a subdirectory. Narrowing spares the rest of the tree from being swept at all, so a file an older version of the step wrote and the current one does not will sit there indefinitely
 - `util.CacheDir()` defaults to `<os.UserCacheDir()>/vuls-data-update` (with a temp-dir fallback if the user cache directory is unavailable)
 
 ## Consistency With Surrounding Code

--- a/.github/instructions/go-code.instructions.md
+++ b/.github/instructions/go-code.instructions.md
@@ -84,7 +84,9 @@ applyTo: "**/*.go"
 
 ## Cleanup Helpers
 
-- Use `util.RemoveAll(dir)` when cleaning output trees — it preserves `README.md` and `.git` directories
+- Use `util.RemoveAll(dir)` when cleaning output trees — it preserves `.git`
+- Pass `util.WithKeep(...)` when part of the tree is not produced by the step doing the cleaning and cannot be rebuilt by it. It states the whole keep set rather than adding to the default, so name `.git` alongside whatever else is kept: `util.RemoveAll(dir, util.WithKeep(".git", "raw"))`. Names match an entry's own name, not a suffix of the path
+- Prefer that over narrowing the call to a subdirectory. Narrowing spares the rest of the tree from being swept at all, so a file an older version of the step wrote and the current one does not will sit there indefinitely
 - `util.CacheDir()` defaults to `<os.UserCacheDir()>/vuls-data-update` (with a temp-dir fallback if the user cache directory is unavailable)
 
 ## Consistency With Surrounding Code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ GOEXPERIMENT=jsonv2 go test ./...
 - **Deterministic JSON**: Use `encoding/json/v2` with `json.Deterministic(true)` and tab indent via `util.Write()`
 - **Sort/Compare**: `Sort()` recursively normalizes nested slices; map key ordering is provided by `json.Deterministic(true)` during encoding
 - **Golden tests**: Fixtures in `testdata/fixtures/`, golden output in `testdata/golden/`. Use `pkg/extract/util/test` helpers
-- **Cleanup**: Use `util.RemoveAll(dir)` — preserves `README.md` and `.git`
+- **Cleanup**: Use `util.RemoveAll(dir)` — preserves `.git`. Pass `util.WithKeep(...)` to state a different keep set; it replaces the default rather than adding to it, so name `.git` to retain it
 - **Cache**: `util.CacheDir()` defaults to `<os.UserCacheDir()>/vuls-data-update` (with a temp-dir fallback)
 
 ## Rules & Docs

--- a/pkg/extract/util/util.go
+++ b/pkg/extract/util/util.go
@@ -111,13 +111,67 @@ func Write(path string, content any, doSort bool) error {
 	return nil
 }
 
-func RemoveAll(root string) error {
+type removeOption struct {
+	keeps []string
+}
+
+type RemoveOption interface {
+	apply(*removeOption)
+}
+
+type keepOption []string
+
+func (o keepOption) apply(opts *removeOption) {
+	opts.keeps = o
+}
+
+// WithKeep sets which entries directly under root RemoveAll leaves alone. It
+// states the whole set rather than adding to the default, so that every set is
+// reachable -- including the empty one, which is how a tree is emptied
+// completely:
+//
+//	RemoveAll(dir)                            // .git
+//	RemoveAll(dir, WithKeep(".git", "raw"))   // .git and raw
+//	RemoveAll(dir, WithKeep("raw"))           // raw ALONE -- .git is deleted
+//	RemoveAll(dir, WithKeep())                // nothing; empties dir
+//
+// Note the third line. .git carries the history the tree is distributed as, so
+// a call meaning to widen the default has to name it: WithKeep(".git", ...).
+// Passing the option repeatedly replaces rather than accumulates, the last one
+// winning, as with every other option here.
+//
+// It exists for trees that are only partly extract-generated -- where some of
+// the tree is produced by another step and cannot be rebuilt by an extract.
+// Naming what to keep, rather than narrowing the call to the subdirectory the
+// extract does own, is what keeps the rest of the tree swept: a file an older
+// version of an extractor wrote and the current one does not is still removed.
+//
+// Names are matched against the entry's own name, so WithKeep("raw") keeps
+// "raw" and not "rawdata".
+func WithKeep(names ...string) RemoveOption {
+	return keepOption(names)
+}
+
+// RemoveAll empties root, keeping whatever WithKeep names -- .git when the
+// option is not given.
+//
+// That default is .git because it carries the history the tree is distributed
+// as, which no extract writes and every extract would otherwise destroy.
+func RemoveAll(root string, opts ...RemoveOption) error {
+	options := &removeOption{
+		keeps: []string{".git"},
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
 	ds, err := filepath.Glob(filepath.Join(root, "*"))
 	if err != nil {
 		return errors.Wrapf(err, "glob %s", filepath.Join(root, "*"))
 	}
 	for _, d := range ds {
-		if strings.HasSuffix(d, "README.md") || strings.HasSuffix(d, ".git") {
+		if slices.Contains(options.keeps, filepath.Base(d)) {
 			continue
 		}
 		if err := os.RemoveAll(d); err != nil {

--- a/pkg/extract/util/util_test.go
+++ b/pkg/extract/util/util_test.go
@@ -2,15 +2,14 @@ package util_test
 
 import (
 	"encoding/json/v2"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 
 	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
 	microsoftkbUpdateTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/update"
@@ -44,56 +43,109 @@ func TestUnique(t *testing.T) {
 func TestRemoveAll(t *testing.T) {
 	type args struct {
 		root string
+		opts []util.RemoveOption
 	}
 	tests := []struct {
-		name    string
-		args    args
+		name string
+		args args
+		// entries are created directly under root before the call; each is a
+		// directory when it ends in "/" and a file otherwise.
+		entries []string
+		want    []string
 		wantErr bool
 	}{
 		{
+			// README.md is no longer spared. The two extractors that publish
+			// one write it immediately after this call, so keeping it only ever
+			// preserved a copy about to be overwritten.
 			name: "happy",
 			args: args{
 				root: "happy",
 			},
+			entries: []string{".git/", "README.md", "test.json"},
+			want:    []string{".git"},
+		},
+		{
+			// The option states the whole set, so .git has to be named to
+			// survive alongside what the call adds.
+			name: "keep",
+			args: args{
+				root: "keep",
+				opts: []util.RemoveOption{util.WithKeep(".git", "README.md")},
+			},
+			entries: []string{".git/", "README.md", "data/", "test.json"},
+			want:    []string{".git", "README.md"},
+		},
+		{
+			// Which is also what makes .git droppable, the one way to empty a
+			// tree completely.
+			name: "keep nothing",
+			args: args{
+				root: "nothing",
+				opts: []util.RemoveOption{util.WithKeep()},
+			},
+			entries: []string{".git/", "README.md", "data/", "test.json"},
+			want:    []string{},
+		},
+		{
+			// Repeating the option replaces rather than accumulates.
+			name: "last option wins",
+			args: args{
+				root: "last",
+				opts: []util.RemoveOption{util.WithKeep(".git"), util.WithKeep("README.md")},
+			},
+			entries: []string{".git/", "README.md", "test.json"},
+			want:    []string{"README.md"},
+		},
+		{
+			// A kept name is the entry's own name, not a suffix of it: keeping
+			// "README.md" must not spare "OLD-README.md", nor ".git" spare
+			// "bare.git".
+			name: "keeps are not suffix matches",
+			args: args{
+				root: "exact",
+				opts: []util.RemoveOption{util.WithKeep(".git", "README.md")},
+			},
+			entries: []string{".git/", "bare.git/", "README.md", "OLD-README.md"},
+			want:    []string{".git", "README.md"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := filepath.Join(t.TempDir(), tt.args.root)
 			if err := os.MkdirAll(d, 0750); err != nil {
-				t.Error("unexpected error:", err)
+				t.Fatal("unexpected error:", err)
 			}
 
-			if err := os.Mkdir(filepath.Join(d, ".git"), 0750); err != nil {
-				t.Error("unexpected error:", err)
+			for _, e := range tt.entries {
+				if name, ok := strings.CutSuffix(e, "/"); ok {
+					if err := os.Mkdir(filepath.Join(d, name), 0750); err != nil {
+						t.Fatal("unexpected error:", err)
+					}
+					continue
+				}
+				f, err := os.Create(filepath.Join(d, e))
+				if err != nil {
+					t.Fatal("unexpected error:", err)
+				}
+				f.Close()
 			}
 
-			f, err := os.Create(filepath.Join(d, "README.md"))
-			if err != nil {
-				t.Error("unexpected error:", err)
-			}
-			defer f.Close()
-
-			f, err = os.Create(filepath.Join(d, "test.json"))
-			if err != nil {
-				t.Error("unexpected error:", err)
-			}
-			defer f.Close()
-
-			if err := util.RemoveAll(d); (err != nil) != tt.wantErr {
+			if err := util.RemoveAll(d, tt.args.opts...); (err != nil) != tt.wantErr {
 				t.Errorf("RemoveAll() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if _, err := os.Stat(filepath.Join(d, ".git")); errors.Is(err, fs.ErrNotExist) {
-				t.Error(".git is not exist")
+			es, err := os.ReadDir(d)
+			if err != nil {
+				t.Fatal("unexpected error:", err)
+			}
+			got := make([]string, 0, len(es))
+			for _, e := range es {
+				got = append(got, e.Name())
 			}
 
-			if _, err := os.Stat(filepath.Join(d, "README.md")); errors.Is(err, fs.ErrNotExist) {
-				t.Error("README.md is not exist")
-			}
-
-			if _, err := os.Stat(filepath.Join(d, "test.json")); err == nil {
-				t.Error("test.json is exist")
+			if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(func(x, y string) bool { return x < y })); diff != "" {
+				t.Errorf("RemoveAll(). (-expected +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/fetch/util/util.go
+++ b/pkg/fetch/util/util.go
@@ -95,13 +95,67 @@ func Write(path string, content any, opts ...WriteOption) error {
 	return nil
 }
 
-func RemoveAll(root string) error {
+type removeOption struct {
+	keeps []string
+}
+
+type RemoveOption interface {
+	apply(*removeOption)
+}
+
+type keepOption []string
+
+func (o keepOption) apply(opts *removeOption) {
+	opts.keeps = o
+}
+
+// WithKeep sets which entries directly under root RemoveAll leaves alone. It
+// states the whole set rather than adding to the default, so that every set is
+// reachable -- including the empty one, which is how a tree is emptied
+// completely:
+//
+//	RemoveAll(dir)                            // .git
+//	RemoveAll(dir, WithKeep(".git", "raw"))   // .git and raw
+//	RemoveAll(dir, WithKeep("raw"))           // raw ALONE -- .git is deleted
+//	RemoveAll(dir, WithKeep())                // nothing; empties dir
+//
+// Note the third line. .git carries the history the tree is distributed as, so
+// a call meaning to widen the default has to name it: WithKeep(".git", ...).
+// Passing the option repeatedly replaces rather than accumulates, the last one
+// winning, as with every other option here.
+//
+// It exists for sources whose tree is only partly fetch-generated -- where some
+// of it is produced by another step and cannot be rebuilt by a fetch. Naming
+// what to keep, rather than narrowing the call to the subdirectory the fetch
+// does own, is what keeps the rest of the tree swept: a file an older version
+// of a fetcher wrote and the current one does not is still removed.
+//
+// Names are matched against the entry's own name, so WithKeep("raw") keeps
+// "raw" and not "rawdata".
+func WithKeep(names ...string) RemoveOption {
+	return keepOption(names)
+}
+
+// RemoveAll empties root, keeping whatever WithKeep names -- .git when the
+// option is not given.
+//
+// That default is .git because it carries the history the tree is distributed
+// as, which no fetch writes and every fetch would otherwise destroy.
+func RemoveAll(root string, opts ...RemoveOption) error {
+	options := &removeOption{
+		keeps: []string{".git"},
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
 	ds, err := filepath.Glob(filepath.Join(root, "*"))
 	if err != nil {
 		return errors.Wrapf(err, "glob %s", filepath.Join(root, "*"))
 	}
 	for _, d := range ds {
-		if strings.HasSuffix(d, ".git") {
+		if slices.Contains(options.keeps, filepath.Base(d)) {
 			continue
 		}
 		if err := os.RemoveAll(d); err != nil {

--- a/pkg/fetch/util/util_test.go
+++ b/pkg/fetch/util/util_test.go
@@ -2,14 +2,13 @@ package util_test
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 
 	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
 )
@@ -39,10 +38,15 @@ func TestUnique(t *testing.T) {
 func TestRemoveAll(t *testing.T) {
 	type args struct {
 		root string
+		opts []util.RemoveOption
 	}
 	tests := []struct {
-		name    string
-		args    args
+		name string
+		args args
+		// entries are created directly under root before the call; each is a
+		// directory when it ends in "/" and a file otherwise.
+		entries []string
+		want    []string
 		wantErr bool
 	}{
 		{
@@ -50,35 +54,98 @@ func TestRemoveAll(t *testing.T) {
 			args: args{
 				root: "happy",
 			},
+			entries: []string{".git/", "test.json"},
+			want:    []string{".git"},
+		},
+		{
+			// The option states the whole set, so .git has to be named to
+			// survive alongside what the call adds.
+			name: "keep",
+			args: args{
+				root: "keep",
+				opts: []util.RemoveOption{util.WithKeep(".git", "raw")},
+			},
+			entries: []string{".git/", "raw/", "origin/", ".claude/", "test.json"},
+			want:    []string{".git", "raw"},
+		},
+		{
+			// Which is also what makes .git droppable, the one way to empty a
+			// tree completely.
+			name: "keep nothing",
+			args: args{
+				root: "nothing",
+				opts: []util.RemoveOption{util.WithKeep()},
+			},
+			entries: []string{".git/", "raw/", "test.json"},
+			want:    []string{},
+		},
+		{
+			// Repeating the option replaces rather than accumulates.
+			name: "last option wins",
+			args: args{
+				root: "last",
+				opts: []util.RemoveOption{util.WithKeep(".git"), util.WithKeep("raw")},
+			},
+			entries: []string{".git/", "raw/", "test.json"},
+			want:    []string{"raw"},
+		},
+		{
+			// A kept name is the entry's own name, not a suffix of it: keeping
+			// "raw" must not spare "rawdata".
+			name: "keep is not a suffix match",
+			args: args{
+				root: "keep-exact",
+				opts: []util.RemoveOption{util.WithKeep("raw")},
+			},
+			entries: []string{"raw/", "rawdata/", "vuls-data-raw/"},
+			want:    []string{"raw"},
+		},
+		{
+			// Same for the implicit .git.
+			name: "git is not a suffix match",
+			args: args{
+				root: "git-exact",
+			},
+			entries: []string{".git/", "bare.git/"},
+			want:    []string{".git"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := filepath.Join(t.TempDir(), tt.args.root)
 			if err := os.MkdirAll(d, 0750); err != nil {
-				t.Error("unexpected error:", err)
+				t.Fatal("unexpected error:", err)
 			}
 
-			if err := os.Mkdir(filepath.Join(d, ".git"), 0750); err != nil {
-				t.Error("unexpected error:", err)
+			for _, e := range tt.entries {
+				if name, ok := strings.CutSuffix(e, "/"); ok {
+					if err := os.Mkdir(filepath.Join(d, name), 0750); err != nil {
+						t.Fatal("unexpected error:", err)
+					}
+					continue
+				}
+				f, err := os.Create(filepath.Join(d, e))
+				if err != nil {
+					t.Fatal("unexpected error:", err)
+				}
+				f.Close()
 			}
 
-			f, err := os.Create(filepath.Join(d, "test.json"))
-			if err != nil {
-				t.Error("unexpected error:", err)
-			}
-			defer f.Close()
-
-			if err := util.RemoveAll(d); (err != nil) != tt.wantErr {
+			if err := util.RemoveAll(d, tt.args.opts...); (err != nil) != tt.wantErr {
 				t.Errorf("RemoveAll() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if _, err := os.Stat(filepath.Join(d, ".git")); errors.Is(err, fs.ErrNotExist) {
-				t.Error(".git is not exist")
+			es, err := os.ReadDir(d)
+			if err != nil {
+				t.Fatal("unexpected error:", err)
+			}
+			got := make([]string, 0, len(es))
+			for _, e := range es {
+				got = append(got, e.Name())
 			}
 
-			if _, err := os.Stat(filepath.Join(d, "test.json")); err == nil {
-				t.Error("test.json is exist")
+			if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(func(x, y string) bool { return x < y })); diff != "" {
+				t.Errorf("RemoveAll(). (-expected +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Gives `RemoveAll` a `WithKeep` option in both util packages, makes the implicit `.git` skip explicit, and drops the `README.md` that `extract/util` kept.

```go
util.RemoveAll(dir)                            // .git
util.RemoveAll(dir, util.WithKeep(".git", "raw"))   // .git and raw
util.RemoveAll(dir, util.WithKeep("raw"))           // raw ALONE — .git is deleted
util.RemoveAll(dir, util.WithKeep())                // nothing; empties dir
```

No call site changes — the option is variadic, and after the `README.md` removal the two packages keep the same set.

## Why

**The option.** A tree that is only partly generated by the step clearing it has no way to say so. The workaround is to call `RemoveAll` on the subdirectory the step does own, which spares the rest — and stops sweeping it, so a file an older version of a fetcher or extractor wrote and the current one does not sits there forever. #928 needs this for a source whose `raw/` is produced by hand.

**`WithKeep` states the whole set** rather than adding to the default. That is what makes every set reachable, the empty one included, so a caller that wants the tree genuinely emptied — `.git` and all — can say so. The cost is the third line above: a call meaning to *widen* the default has to name `.git` itself, and dropping it discards the history the tree is distributed as. The doc comment leads with that. Repeating the option replaces rather than accumulates, the last one winning, as with every other option in these packages.

**`README.md`.** It was kept by an implicit condition, and the keep turns out to be vestigial:

```go
// pkg/extract/vulncheck/kev/kev.go
util.RemoveAll(options.dir)                                  // :56  — kept README.md
os.MkdirAll(options.dir, 0755)                               // :62
os.WriteFile(filepath.Join(options.dir, "README.md"), ...)   // :65  — overwrote it
```

`vulncheck/kev` and `vulncheck/nist-nvd2` are the only two extractors with a `README.md`, and both write their own (a VulnCheck attribution notice their terms require) immediately after the call that spared the previous copy. Nothing else puts one in an extracted tree — `vuls-data-db` initializes those repositories with a `git init` and an empty commit.

So keeping it never preserved anything, and with it gone the two `RemoveAll`s agree.

## How

Options follow the `WriteOption` pattern already in these packages. Matching also tightens from path-suffix to entry name, so `WithKeep("raw")` keeps `raw` and not `rawdata`. That narrows the two implicit skips as a side effect — the old condition spared any entry ending in `.git` or `README.md` (`bare.git`, `OLD-README.md`). Nothing in these trees is named that way, and sparing one was never the intent.

## Testing

`go build ./...`, `go test ./...`, `go vet ./...`, `golangci-lint` (0 issues) and `gofmt` all clean.

`TestRemoveAll` in both packages covers the keep list, the implicit `.git`, the empty set, that repeating the option replaces, and that no keep is a suffix match.

The `README.md` removal is covered by the existing golden tests rather than by assertion: `pkg/extract/util/test.Diff` compares `README.md` when the output has one, and both vulncheck extractors have `README.md` committed in their golden trees. They pass, which is what shows the file is regenerated rather than preserved.

## Related

#928 stacks on this branch and is its first caller (`WithKeep(".git", "raw")`). It will retarget to `nightly` when this merges.