### PR TITLE
feat(microsoft/releaseinfo): add windows release information data source

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -66,6 +66,7 @@ import (
 	microsoftBulletin "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/bulletin"
 	microsoftCVRF "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/cvrf"
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/msuc"
+	microsoftReleaseInfo "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/releaseinfo"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/servicing"
 	microsoftWSUSSCN2 "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/wsusscn2"
 	mitreATTACK "github.com/MaineK00n/vuls-data-update/pkg/extract/mitre/attack"
@@ -180,7 +181,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdJVNFeedDetail(), newCmdJVNFeedProduct(), newCmdJVNFeedRSS(),
 		newCmdLinuxOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftWSUSSCN2(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftReleaseInfo(), newCmdMicrosoftServicing(), newCmdMicrosoftWSUSSCN2(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
 		newCmdNetBSD(),
@@ -1656,6 +1657,31 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := microsoftMSUC.Extract(args[0], microsoftMSUC.WithDir(options.dir)); err != nil {
 				return errors.Wrap(err, "failed to extract microsoft msuc")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdMicrosoftReleaseInfo() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "releaseinfo"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-releaseinfo <Raw Microsoft Release Information Repository PATH>",
+		Short: "Extract Microsoft Windows Release Information data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract microsoft-releaseinfo vuls-data-raw-microsoft-releaseinfo
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := microsoftReleaseInfo.Extract(args[0], microsoftReleaseInfo.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract microsoft releaseinfo")
 			}
 			return nil
 		},

--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -91,6 +91,7 @@ import (
 	microsoftDeployment "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/deployment"
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/msuc"
 	microsoftProduct "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/product"
+	microsoftReleaseInfo "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/releaseinfo"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/servicing"
 	microsoftVEX "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vex"
 	microsoftVulnerability "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vulnerability"
@@ -255,7 +256,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdLinuxOSV(),
 		newCmdMageiaOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftReleaseInfo(), newCmdMicrosoftServicing(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
 		newCmdMinimOSOSV(), newCmdMinimOSSecDB(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreEMB3D(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
@@ -2658,6 +2659,58 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := microsoftMSUC.Fetch(args, microsoftMSUC.WithDir(options.dir), microsoftMSUC.WithRetry(options.retry), microsoftMSUC.WithConcurrency(options.concurrency), microsoftMSUC.WithWait(options.wait)); err != nil {
 				return errors.Wrap(err, "failed to fetch microsoft msuc")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
+	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent http requests")
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
+
+	return cmd
+}
+
+func newCmdMicrosoftReleaseInfo() *cobra.Command {
+	options := &struct {
+		base
+		concurrency int
+		wait        time.Duration
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "microsoft", "releaseinfo"),
+			retry: 3,
+		},
+		concurrency: 1,
+		wait:        1 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-releaseinfo",
+		Short: "Fetch Microsoft Windows Release Information data source",
+		Long: heredoc.Doc(`
+			Fetch the Windows 10, Windows 11 and Windows Server release-information
+			pages as HTML into <dir>/origin, and the tables they carry into <dir>/raw.
+
+			Each page lists, per release, every monthly update it has shipped: the OS
+			build, the availability date, the release-cadence letter and the KB. The
+			Update Catalog drops an update outright once Microsoft expires it and
+			wsusscn2.cab drops it too; these tables keep it.
+
+			The tables are stored as served -- the label each sits under, its column
+			names and its cells, with the link every cell carries -- and are not read
+			apart here. Which column means what varies between a release history and a
+			hotpatch calendar, and the set is not fixed, so reading them belongs in
+			extract where a change is handled by rerunning against origin/.
+		`),
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch microsoft-releaseinfo
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := microsoftReleaseInfo.Fetch(microsoftReleaseInfo.WithDir(options.dir), microsoftReleaseInfo.WithRetry(options.retry), microsoftReleaseInfo.WithConcurrency(options.concurrency), microsoftReleaseInfo.WithWait(options.wait)); err != nil {
+				return errors.Wrap(err, "failed to fetch microsoft releaseinfo")
 			}
 			return nil
 		},

--- a/pkg/extract/microsoft/releaseinfo/export_test.go
+++ b/pkg/extract/microsoft/releaseinfo/export_test.go
@@ -1,0 +1,3 @@
+package releaseinfo
+
+var Release = release

--- a/pkg/extract/microsoft/releaseinfo/releaseinfo.go
+++ b/pkg/extract/microsoft/releaseinfo/releaseinfo.go
@@ -1,0 +1,548 @@
+// Package releaseinfo extracts supersedence from Microsoft's Windows
+// release-information tables.
+//
+// The tables carry no supersedence of their own. What they carry is a release's
+// whole update history in one place, and in columns rather than in prose: the OS
+// build, the availability date, the release-cadence letter and the KB. The order
+// of that history is the supersedence, and reading it out is this package's job.
+//
+// The order is the build number, within one release line. Revision order is
+// supersedence -- a cumulative update at .8973 contains .8894 -- and the date is
+// only a tiebreaker, for the two occasions Microsoft has shipped one build twice.
+//
+// Three things decide which line an update belongs to, and all three are needed:
+//
+//   - The page. A build number is not unique across products: 26100 is Windows
+//     Server 2025 on one page and Windows 11 24H2 on another, each shipping its
+//     own KBs at revisions the other also ships. Keyed on the build alone the
+//     two interleave into one chain and each claims to supersede the other's
+//     updates.
+//
+//   - The build's major part, which is the release: an update to 22621 has
+//     nothing to do with one to 26100.
+//
+//   - The cadence letter. A build line runs two lines at once and only one of
+//     them carries it. B is the second Tuesday, and is what the following month
+//     builds on; C and D are the optional previews of the weeks after it, and
+//     OOB is out-of-band. Those carry the same fixes to the same build without
+//     the next month's update ever taking them up, and Microsoft's revision
+//     numbers interleave the two, so ordering by revision alone threads them
+//     into one chain.
+//
+// The servicing source splits that last one by asking whether the release date
+// falls on a second Tuesday, which is a reading of the calendar rather than of
+// what Microsoft said. Over the 1,944 rows these three pages carry, the letter
+// and the calendar disagree 18 times: twelve B releases did not ship on a second
+// Tuesday, and three D and three OOB releases did. Reading the letter puts all
+// eighteen on the line Microsoft filed them under.
+//
+// A and E appear seven times between them, first-week and fifth-week releases
+// from 2015 and 2016, and none of the seven is a second Tuesday. They are
+// optional releases and are treated as such, which is also what an unrecognised
+// letter is treated as: a new letter is far likelier to be another optional
+// cadence than a second security line, and mistaking one for B would put a
+// stranger into the chain the rest of the estate is measured against, where
+// mistaking B for one leaves an update chained to nothing.
+//
+// Hotpatch updates are a line of their own and are never mixed with the
+// cumulative ones. A hotpatch quarter opens with a Baseline (Restart) and runs
+// two hotpatch months on top of it before the next baseline rebases it, so the
+// hotpatch of one month does not supersede the cumulative update of that month
+// and is not superseded by the next one. The baseline is the join: Microsoft
+// ships it as that month's ordinary cumulative update too, so its KB appears in
+// both tables -- 22 of the 54 hotpatch KBs on the Windows Server page -- and it
+// takes its place in both chains, which is what a baseline is.
+//
+// Rows naming no KB are the months a calendar has reached but Microsoft has not
+// shipped yet, and are skipped.
+package releaseinfo
+
+import (
+	"cmp"
+	"encoding/json/v2"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
+	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/releaseinfo"
+)
+
+// The column names the tables are read by. They are read by name and not by
+// position because the two shapes share most of them in a different order, and
+// because Microsoft has already changed the set once: "Update type" was added
+// after these pages had run for years without it.
+const (
+	columnKB           = "KB article"
+	columnBuild        = "Build"
+	columnDate         = "Availability date"
+	columnUpdateType   = "Update type"
+	columnHotpatchType = "Type"
+)
+
+var (
+	// kbPattern allows the space Microsoft leaves after KB elsewhere in this
+	// estate, though these tables have not used one.
+	kbPattern = regexp.MustCompile(`KB ?(\d{6,})`)
+
+	buildPattern = regexp.MustCompile(`^(\d+)\.(\d+)$`)
+
+	// updateTypePattern reads the cadence letter out of "2026-08 B", "2021-03
+	// OOB" and "2024.08 B *" alike: the month is one token however Microsoft
+	// punctuates it, the letter is the next, and the footnote marker appended to
+	// one row of one hotpatch calendar is not the letter.
+	updateTypePattern = regexp.MustCompile(`^\S+ ([A-Z]+)`)
+
+	// buildSuffixPattern is what every release-history label ends with, and the
+	// only part of one that is not the release name: "Version 22H2 (OS build
+	// 19045)", "Windows Server 2016 (OS build 14393)".
+	buildSuffixPattern = regexp.MustCompile(`\s*\(OS build (\d+)\)$`)
+)
+
+// The lines a build runs at once. Kept as strings because they are a grouping
+// key and appear in warnings, where "hotpatch" says what "2" does not.
+const (
+	kindMonthly  = "monthly"
+	kindOptional = "optional"
+	kindHotpatch = "hotpatch"
+)
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+// update is one row of a release history or a hotpatch calendar, read for what
+// decides its place in a chain.
+type update struct {
+	kbID string
+	url  string
+
+	// page is the file the row was read from -- windows-10, windows-11,
+	// windows-server -- which is the product, and which two releases sharing a
+	// build number are told apart by.
+	page string
+
+	// release is the label the table was filed under, e.g. "Windows 10 Version
+	// 22H2". It names the line for a reader; the chain is keyed on the build.
+	release string
+
+	major    int
+	revision int
+
+	date   time.Time
+	letter string
+
+	hotpatch bool
+
+	// raw is the path this was read from, recorded on the KB so a record can be
+	// traced back to the page it came from.
+	raw string
+}
+
+// kind is the line within a release that an update belongs to.
+func (u update) kind() string {
+	switch {
+	case u.hotpatch:
+		return kindHotpatch
+	case u.letter == "B":
+		return kindMonthly
+	default:
+		return kindOptional
+	}
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "releaseinfo"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract Microsoft Release Information")
+
+	us, err := read(args)
+	if err != nil {
+		return errors.Wrapf(err, "read %s", args)
+	}
+
+	// A release whose updates all landed on one line is a line that was not
+	// split. Every release Microsoft has run for a full month has both -- a
+	// second-Tuesday cumulative update and something optional after it -- so one
+	// with only monthly rows means the letters stopped being read, and one with
+	// no monthly rows means they stopped being read the other way. Neither shows
+	// in the output: the KBs are all there, chained into one long line that
+	// looks exactly like a right one.
+	//
+	// A release of fewer than three updates is not counted. 26H1 opened with
+	// two and was neither wrong nor finished.
+	kinds := make(map[string]map[string]int)
+	for _, u := range us {
+		if u.hotpatch {
+			continue
+		}
+		if kinds[u.release] == nil {
+			kinds[u.release] = make(map[string]int)
+		}
+		kinds[u.release][u.kind()]++
+	}
+	for _, release := range slices.Sorted(maps.Keys(kinds)) {
+		total := kinds[release][kindMonthly] + kinds[release][kindOptional]
+		if total < 3 || len(kinds[release]) > 1 {
+			continue
+		}
+		slog.Warn("a release ran every update on one line", slog.String("release", release), slog.String("line", slices.Collect(maps.Keys(kinds[release]))[0]), slog.Int("count", total))
+	}
+
+	kbs := chain(us)
+
+	for _, kb := range kbs {
+		if err := util.Write(filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)), kb, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)))
+		}
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.MicrosoftReleaseInfo,
+		Name: new("Microsoft Windows Release Information"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{URL: u}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+// read walks the raw tree and returns the rows that are updates.
+func read(args string) ([]update, error) {
+	root := filepath.Join(args, "raw")
+
+	var us []update
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".json" {
+			return nil
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", p)
+		}
+		defer f.Close()
+
+		var page releaseinfo.Page
+		if err := json.UnmarshalRead(f, &page); err != nil {
+			return errors.Wrapf(err, "decode %s", p)
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+		rel = filepath.ToSlash(rel)
+
+		us = append(us, parsePage(page, strings.TrimSuffix(rel, ".json"), rel)...)
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrapf(err, "walk %s", root)
+	}
+
+	return us, nil
+}
+
+// parsePage reads one page's tables for the rows that are updates.
+func parsePage(page releaseinfo.Page, name, raw string) []update {
+	var us []update
+
+	// The release name of a hotpatch calendar is not in its label -- Microsoft
+	// files those under "Calendar year 2026", which says the year and not the
+	// product, and a page runs two of them at once. It is taken from the release
+	// history covering the same build, which is on the same page and says it in
+	// full. The histories are read first for that reason.
+	releases := make(map[int]string)
+	for _, t := range page.Tables {
+		if !slices.Contains(t.Header, columnKB) || slices.Contains(t.Header, columnHotpatchType) {
+			continue
+		}
+		if m := buildSuffixPattern.FindStringSubmatch(t.Label); m != nil {
+			major, err := strconv.Atoi(m[1])
+			if err != nil {
+				continue
+			}
+			releases[major] = release(name, t.Label)
+		}
+	}
+
+	for _, t := range page.Tables {
+		if !slices.Contains(t.Header, columnKB) {
+			// A lifecycle table. It states support dates rather than a history,
+			// and names only the latest update of each release, which the
+			// history it sits above already carries.
+			slog.Debug("not an update table", slog.String("path", raw), slog.String("label", t.Label))
+			continue
+		}
+
+		hotpatch := slices.Contains(t.Header, columnHotpatchType)
+
+		// The columns an update is read out of. A table missing one of them
+		// cannot be read at all, and saying which is missing is the difference
+		// between a page to go and look at and a source that quietly halved.
+		var missing []string
+		for _, c := range []string{columnBuild, columnDate, columnUpdateType} {
+			if !slices.Contains(t.Header, c) {
+				missing = append(missing, c)
+			}
+		}
+		if len(missing) > 0 {
+			slog.Warn("update table is missing columns", slog.String("path", raw), slog.String("label", t.Label), slog.String("missing", strings.Join(missing, ", ")), slog.String("header", strings.Join(t.Header, ", ")))
+			continue
+		}
+
+		for _, row := range t.Rows {
+			u, ok := parseRow(t, row, name, raw)
+			if !ok {
+				continue
+			}
+			u.hotpatch = hotpatch
+			if hotpatch {
+				u.release = releases[u.major]
+			}
+			us = append(us, u)
+		}
+	}
+
+	return us
+}
+
+// parseRow reads one row, reporting false for the ones that are not updates.
+func parseRow(t releaseinfo.Table, row []releaseinfo.Cell, name, raw string) (update, bool) {
+	cell := func(column string) releaseinfo.Cell {
+		i := slices.Index(t.Header, column)
+		// A row is free to hold a cell more than its header names -- one
+		// hotpatch row does -- so its length is checked rather than assumed.
+		if i < 0 || i >= len(row) {
+			return releaseinfo.Cell{}
+		}
+		return row[i]
+	}
+
+	m := kbPattern.FindStringSubmatch(cell(columnKB).Text)
+	if m == nil {
+		// A month the calendar has reached and Microsoft has not shipped yet.
+		slog.Debug("row names no KB", slog.String("path", raw), slog.String("label", t.Label))
+		return update{}, false
+	}
+
+	bm := buildPattern.FindStringSubmatch(cell(columnBuild).Text)
+	if bm == nil {
+		// The build is the whole order. A row without one cannot be placed, and
+		// every one of the 1,944 rows that names a KB has had it.
+		slog.Warn("unexpected build", slog.String("path", raw), slog.String("label", t.Label), slog.String("kb", m[1]), slog.String("build", cell(columnBuild).Text))
+		return update{}, false
+	}
+	major, err := strconv.Atoi(bm[1])
+	if err != nil {
+		slog.Warn("unexpected build", slog.String("path", raw), slog.String("kb", m[1]), slog.String("build", cell(columnBuild).Text))
+		return update{}, false
+	}
+	revision, err := strconv.Atoi(bm[2])
+	if err != nil {
+		slog.Warn("unexpected build", slog.String("path", raw), slog.String("kb", m[1]), slog.String("build", cell(columnBuild).Text))
+		return update{}, false
+	}
+
+	// The date is a tiebreaker between two updates of one build, not the order,
+	// so an unreadable one costs the tie and not the row.
+	var date time.Time
+	if d := cell(columnDate).Text; d != "" {
+		date, err = time.Parse(time.DateOnly, d)
+		if err != nil {
+			slog.Warn("unexpected availability date", slog.String("path", raw), slog.String("kb", m[1]), slog.String("date", d))
+			date = time.Time{}
+		}
+	}
+
+	// An unreadable cadence leaves the update on the optional line, where it
+	// chains among updates that supersede nothing the estate is measured
+	// against. Putting it on the monthly line instead would let it claim to
+	// replace the cumulative updates.
+	var letter string
+	if lm := updateTypePattern.FindStringSubmatch(cell(columnUpdateType).Text); lm != nil {
+		letter = lm[1]
+	} else {
+		slog.Warn("unexpected update type", slog.String("path", raw), slog.String("kb", m[1]), slog.String("update_type", cell(columnUpdateType).Text))
+	}
+	switch letter {
+	case "A", "B", "C", "D", "E", "OOB":
+	default:
+		slog.Warn("unrecognised release cadence, update is left on the optional line", slog.String("path", raw), slog.String("kb", m[1]), slog.String("update_type", cell(columnUpdateType).Text))
+	}
+
+	return update{
+		kbID:     m[1],
+		url:      cell(columnKB).Href,
+		page:     name,
+		release:  release(name, t.Label),
+		major:    major,
+		revision: revision,
+		date:     date,
+		letter:   letter,
+		raw:      raw,
+	}, true
+}
+
+// release names the line a table covers, as a reader would say it.
+//
+// The Windows Server labels name their product in full; the Windows 10 and 11
+// ones say "Version 22H2" and leave the product to the page, so the page
+// supplies it. A label that is neither -- a hotpatch calendar's "Calendar year
+// 2026" -- is left alone here and replaced by the release history's, which
+// covers the same build.
+func release(page, label string) string {
+	name := buildSuffixPattern.ReplaceAllString(label, "")
+
+	after, ok := strings.CutPrefix(name, "Version ")
+	if !ok {
+		return name
+	}
+
+	switch page {
+	case "windows-10":
+		return fmt.Sprintf("Windows 10 Version %s", after)
+	case "windows-11":
+		return fmt.Sprintf("Windows 11 Version %s", after)
+	default:
+		return name
+	}
+}
+
+// chain turns the rows into KB records, chained into supersedence.
+//
+// An update ships to more than one release at a time -- KB5121003 is 26200.9168
+// on one line and 26100.9168 on another -- so it takes its place in each of
+// their chains and ends up with the edges of both.
+func chain(us []update) []microsoftkbTypes.KB {
+	type buildLine struct {
+		page  string
+		major int
+		kind  string
+	}
+
+	byLine := make(map[buildLine][]update)
+	for _, u := range us {
+		bl := buildLine{page: u.page, major: u.major, kind: u.kind()}
+		byLine[bl] = append(byLine[bl], u)
+	}
+
+	type link struct{ older, newer string }
+	var links []link
+	for _, group := range byLine {
+		// Two updates do share a revision, where Microsoft has shipped a build
+		// twice off the same cadence. The release date decides those, and the KB
+		// number only where even that ties -- ordering by the number alone would
+		// be right by the accident that Microsoft allocates them in order, and
+		// wrong the first time it does not.
+		slices.SortFunc(group, func(x, y update) int {
+			return cmp.Or(cmp.Compare(x.revision, y.revision), x.date.Compare(y.date), cmp.Compare(x.kbID, y.kbID))
+		})
+		for i := 1; i < len(group); i++ {
+			links = append(links, link{older: group[i-1].kbID, newer: group[i].kbID})
+		}
+	}
+
+	kbs := make(map[string]*microsoftkbTypes.KB, len(us))
+	for _, u := range us {
+		kb, ok := kbs[u.kbID]
+		if !ok {
+			kb = &microsoftkbTypes.KB{
+				KBID: u.kbID,
+				URL:  u.url,
+				DataSource: sourceTypes.Source{
+					ID: sourceTypes.MicrosoftReleaseInfo,
+				},
+			}
+			kbs[u.kbID] = kb
+		}
+		if u.release != "" && !slices.Contains(kb.Products, u.release) {
+			kb.Products = append(kb.Products, u.release)
+		}
+		if !slices.Contains(kb.DataSource.Raws, u.raw) {
+			kb.DataSource.Raws = append(kb.DataSource.Raws, u.raw)
+		}
+	}
+
+	for _, l := range links {
+		if l.older == l.newer {
+			continue
+		}
+		if kb, ok := kbs[l.older]; ok {
+			s := microsoftkbSupersededByTypes.SupersededBy{KBID: l.newer}
+			if !slices.Contains(kb.SupersededBy, s) {
+				kb.SupersededBy = append(kb.SupersededBy, s)
+			}
+		}
+		if kb, ok := kbs[l.newer]; ok {
+			s := microsoftkbSupersedesTypes.Supersedes{KBID: l.older}
+			if !slices.Contains(kb.Supersedes, s) {
+				kb.Supersedes = append(kb.Supersedes, s)
+			}
+		}
+	}
+
+	out := make([]microsoftkbTypes.KB, 0, len(kbs))
+	for _, kb := range kbs {
+		out = append(out, *kb)
+	}
+	return out
+}

--- a/pkg/extract/microsoft/releaseinfo/releaseinfo_test.go
+++ b/pkg/extract/microsoft/releaseinfo/releaseinfo_test.go
@@ -1,0 +1,146 @@
+package releaseinfo_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/releaseinfo"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+// The fixtures are the tables as fetched, chosen for what decides a chain.
+//
+// Windows 10 1507 is one month written out in full: A on the 5th, B on the
+// 11th, OOB on the 14th, C on the 18th, D on the 27th, then the B of September.
+// Microsoft's revisions run straight through the six, .16413 to .16487, so
+// ordering by revision alone threads them into one line and has the September
+// security update replacing an August preview that nothing ever took up. Split
+// by the letter it is two: .16430 to .16487, and .16413 to .16433 to .16445 to
+// .16463.
+//
+// 1709 is January 2018, where the security update shipped on the 3rd rather
+// than on a second Tuesday, and two out-of-band releases and a preview followed
+// it at revisions above it. Asking the calendar which line the 3rd belongs to
+// puts the month's security update among the optional ones and leaves the
+// December one superseded by a preview; asking Microsoft puts it where it
+// belongs.
+//
+// Windows 11 24H2 and Windows Server 2025 are both 26100, and neither their
+// release histories nor their hotpatch calendars have anything to do with each
+// other. KB5121003 is 26100.9168 on one page while KB5120233 is 26100.33296 on
+// the other, so a chain keyed on the build alone would have each superseding the
+// other's updates.
+//
+// The Server hotpatch calendar shares KB5094125 with its release history, being
+// the June baseline and the June cumulative update at once. It takes its place
+// in both chains, which is what a baseline is: it supersedes May's hotpatch and
+// May's cumulative update, and neither of those touches the other.
+//
+// Server 2025 also runs an optional line through the same builds, and it is not
+// the hotpatch one. KB5091157 is .32698, between April's baseline at .32690 and
+// May's hotpatch at .32772, so a chain that took "not the second Tuesday" for
+// one line would splice an out-of-band cumulative update into the middle of a
+// hotpatch quarter. Its predecessor is January's out-of-band release, 462
+// revisions below it.
+//
+// The Server 2025 RTM row names no KB, being the release rather than an update
+// to it. Rows like that are not the hotpatch calendars' alone.
+//
+// KB5101684 and KB5121767 are the pair whose KB numbers run backwards against
+// their builds -- the July 28th preview at .8973 supersedes the July 18th
+// out-of-band at .8894 -- so a chain that fell back on the number would invert
+// them.
+//
+// One hotpatch row names no KB, being a month the calendar has reached and
+// Microsoft has not shipped; one carries a cell more than its header names; one
+// carries an asterisk after its cadence letter. None of the three is an update
+// that can be dropped for being oddly written.
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures/happy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := releaseinfo.Extract(tt.args, releaseinfo.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				return
+			default:
+				ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				gp, err := filepath.Abs(dir)
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}
+
+// The release name is what a KB record says it is for, and the label it is read
+// off is written two ways: Windows Server names its product in full, Windows 10
+// and 11 say only the version and leave the product to the page. A hotpatch
+// calendar names neither, being filed under the year.
+func TestRelease(t *testing.T) {
+	tests := []struct {
+		name  string
+		page  string
+		label string
+		want  string
+	}{
+		{
+			name:  "a Windows 10 label leaves the product to the page",
+			page:  "windows-10",
+			label: "Version 22H2 (OS build 19045)",
+			want:  "Windows 10 Version 22H2",
+		},
+		{
+			name:  "as does a Windows 11 one",
+			page:  "windows-11",
+			label: "Version 24H2 (OS build 26100)",
+			want:  "Windows 11 Version 24H2",
+		},
+		{
+			name:  "the first release of all carries a parenthesis of its own",
+			page:  "windows-10",
+			label: "Version 1507 (RTM) (OS build 10240)",
+			want:  "Windows 10 Version 1507 (RTM)",
+		},
+		{
+			name:  "a Windows Server label names its product in full",
+			page:  "windows-server",
+			label: "Windows Server 2016 (OS build 14393)",
+			want:  "Windows Server 2016",
+		},
+		{
+			name:  "a hotpatch calendar names no release",
+			page:  "windows-server",
+			label: "Calendar year 2026",
+			want:  "Calendar year 2026",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, releaseinfo.Release(tt.page, tt.label)); diff != "" {
+				t.Errorf("release(). (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/fixtures/happy/raw/windows-10.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/fixtures/happy/raw/windows-10.json
@@ -1,0 +1,315 @@
+{
+	"url": "https://learn.microsoft.com/en-us/windows/release-health/release-information",
+	"tables": [
+		{
+			"label": "Servicing channels",
+			"header": [
+				"Version",
+				"Servicing option",
+				"Availability date",
+				"Latest update for ESU",
+				"Latest revision date",
+				"Latest build"
+			],
+			"rows": [
+				[
+					{
+						"text": "22H2"
+					},
+					{
+						"text": "General Availability Channel"
+					},
+					{
+						"text": "2022-10-18"
+					},
+					{
+						"text": "2026-08 B",
+						"href": "https://support.microsoft.com/help/5120249"
+					},
+					{
+						"text": "2026-08-11"
+					},
+					{
+						"text": "19045.7663"
+					}
+				]
+			]
+		},
+		{
+			"label": "Version 1709 (OS build 16299)",
+			"header": [
+				"Servicing option",
+				"Update type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "Semi-Annual Channel • Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2018-01 D"
+					},
+					{
+						"text": "2018-01-31"
+					},
+					{
+						"text": "16299.214"
+					},
+					{
+						"text": "KB4058258",
+						"href": "https://support.microsoft.com/help/4058258"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel • Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2018-01 OOB"
+					},
+					{
+						"text": "2018-01-18"
+					},
+					{
+						"text": "16299.201"
+					},
+					{
+						"text": "KB4073291",
+						"href": "https://support.microsoft.com/help/4073291"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel • Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2018-01 OOB"
+					},
+					{
+						"text": "2018-01-17"
+					},
+					{
+						"text": "16299.194"
+					},
+					{
+						"text": "KB4073290",
+						"href": "https://support.microsoft.com/help/4073290"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel • Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2018-01 B"
+					},
+					{
+						"text": "2018-01-03"
+					},
+					{
+						"text": "16299.192"
+					},
+					{
+						"text": "KB4056892",
+						"href": "https://support.microsoft.com/help/4056892"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel • Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2017-12 B"
+					},
+					{
+						"text": "2017-12-12"
+					},
+					{
+						"text": "16299.125"
+					},
+					{
+						"text": "KB4054517",
+						"href": "https://support.microsoft.com/help/4054517"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2017-11 D"
+					},
+					{
+						"text": "2017-11-30"
+					},
+					{
+						"text": "16299.98"
+					},
+					{
+						"text": "KB4051963",
+						"href": "https://support.microsoft.com/help/4051963"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2017-11 B"
+					},
+					{
+						"text": "2017-11-14"
+					},
+					{
+						"text": "16299.64"
+					},
+					{
+						"text": "KB4048955",
+						"href": "https://support.microsoft.com/help/4048955"
+					}
+				]
+			]
+		},
+		{
+			"label": "Version 1507 (RTM) (OS build 10240)",
+			"header": [
+				"Servicing option",
+				"Update type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-09 D"
+					},
+					{
+						"text": "2015-09-30"
+					},
+					{
+						"text": "10240.16520"
+					},
+					{
+						"text": "KB3093266",
+						"href": "https://support.microsoft.com/help/3093266"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-09 B"
+					},
+					{
+						"text": "2015-09-08"
+					},
+					{
+						"text": "10240.16487"
+					},
+					{
+						"text": "KB3081455",
+						"href": "https://support.microsoft.com/help/3081455"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-08 D"
+					},
+					{
+						"text": "2015-08-27"
+					},
+					{
+						"text": "10240.16463"
+					},
+					{
+						"text": "KB3081448",
+						"href": "https://support.microsoft.com/help/3081448"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-08 C"
+					},
+					{
+						"text": "2015-08-18"
+					},
+					{
+						"text": "10240.16445"
+					},
+					{
+						"text": "KB3081444",
+						"href": "https://support.microsoft.com/help/3081444"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-08 OOB"
+					},
+					{
+						"text": "2015-08-14"
+					},
+					{
+						"text": "10240.16433"
+					},
+					{
+						"text": "KB3081438",
+						"href": "https://support.microsoft.com/help/3081438"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-08 B"
+					},
+					{
+						"text": "2015-08-11"
+					},
+					{
+						"text": "10240.16430"
+					},
+					{
+						"text": "KB3081436",
+						"href": "https://support.microsoft.com/help/3081436"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-08 A"
+					},
+					{
+						"text": "2015-08-05"
+					},
+					{
+						"text": "10240.16413"
+					},
+					{
+						"text": "KB3081424",
+						"href": "https://support.microsoft.com/help/3081424"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/fixtures/happy/raw/windows-11.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/fixtures/happy/raw/windows-11.json
@@ -1,0 +1,231 @@
+{
+	"url": "https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information",
+	"tables": [
+		{
+			"label": "Version 25H2 (OS build 26200)",
+			"header": [
+				"Servicing option",
+				"Update type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "General Availability Channel"
+					},
+					{
+						"text": "2026-08 B"
+					},
+					{
+						"text": "2026-08-11"
+					},
+					{
+						"text": "26200.9168"
+					},
+					{
+						"text": "KB5121003",
+						"href": "https://support.microsoft.com/help/5121003"
+					}
+				],
+				[
+					{
+						"text": "General Availability Channel"
+					},
+					{
+						"text": "2026-07 D"
+					},
+					{
+						"text": "2026-07-28"
+					},
+					{
+						"text": "26200.8973"
+					},
+					{
+						"text": "KB5101684",
+						"href": "https://support.microsoft.com/help/5101684"
+					}
+				],
+				[
+					{
+						"text": "General Availability Channel"
+					},
+					{
+						"text": "2026-07 OOB"
+					},
+					{
+						"text": "2026-07-18"
+					},
+					{
+						"text": "26200.8894"
+					},
+					{
+						"text": "KB5121767",
+						"href": "https://support.microsoft.com/help/5121767"
+					}
+				],
+				[
+					{
+						"text": "General Availability Channel"
+					},
+					{
+						"text": "2026-07 B"
+					},
+					{
+						"text": "2026-07-14"
+					},
+					{
+						"text": "26200.8875"
+					},
+					{
+						"text": "KB5101650",
+						"href": "https://support.microsoft.com/help/5101650"
+					}
+				]
+			]
+		},
+		{
+			"label": "Version 24H2 (OS build 26100)",
+			"header": [
+				"Servicing option",
+				"Update type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "LTSC • General Availability Channel"
+					},
+					{
+						"text": "2026-08 B"
+					},
+					{
+						"text": "2026-08-11"
+					},
+					{
+						"text": "26100.9168"
+					},
+					{
+						"text": "KB5121003",
+						"href": "https://support.microsoft.com/help/5121003"
+					}
+				],
+				[
+					{
+						"text": "LTSC • General Availability Channel"
+					},
+					{
+						"text": "2026-07 D"
+					},
+					{
+						"text": "2026-07-28"
+					},
+					{
+						"text": "26100.8973"
+					},
+					{
+						"text": "KB5101684",
+						"href": "https://support.microsoft.com/help/5101684"
+					}
+				],
+				[
+					{
+						"text": "LTSC • General Availability Channel"
+					},
+					{
+						"text": "2026-07 OOB"
+					},
+					{
+						"text": "2026-07-18"
+					},
+					{
+						"text": "26100.8894"
+					},
+					{
+						"text": "KB5121767",
+						"href": "https://support.microsoft.com/help/5121767"
+					}
+				]
+			]
+		},
+		{
+			"label": "Calendar year 2026",
+			"header": [
+				"Month",
+				"Update type",
+				"Type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "January"
+					},
+					{
+						"text": "2026.01 B"
+					},
+					{
+						"text": "Baseline (Restart)"
+					},
+					{
+						"text": "2026-01-13"
+					},
+					{
+						"text": "26100.7623"
+					},
+					{
+						"text": "KB5074109",
+						"href": "https://support.microsoft.com/help/5074109"
+					}
+				],
+				[
+					{
+						"text": "February"
+					},
+					{
+						"text": "2026.02 B"
+					},
+					{
+						"text": "Hotpatch"
+					},
+					{
+						"text": "2026-02-10"
+					},
+					{
+						"text": "26100.7781"
+					},
+					{
+						"text": "KB5077212",
+						"href": "https://support.microsoft.com/help/5077212"
+					}
+				],
+				[
+					{
+						"text": "March"
+					},
+					{
+						"text": "2026.03 B"
+					},
+					{
+						"text": "Hotpatch"
+					},
+					{
+						"text": "2026-03-10"
+					},
+					{
+						"text": "26100.7979"
+					},
+					{
+						"text": "KB5079420",
+						"href": "https://support.microsoft.com/help/5079420"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/fixtures/happy/raw/windows-server.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/fixtures/happy/raw/windows-server.json
@@ -1,0 +1,293 @@
+{
+	"url": "https://learn.microsoft.com/en-us/windows/release-health/windows-server-release-info",
+	"tables": [
+		{
+			"label": "Windows Server 2025 (OS build 26100)",
+			"header": [
+				"Servicing option",
+				"Update type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2026-08 B"
+					},
+					{
+						"text": "2026-08-11"
+					},
+					{
+						"text": "26100.33296"
+					},
+					{
+						"text": "KB5120233",
+						"href": "https://support.microsoft.com/help/5120233"
+					}
+				],
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2026-07 B"
+					},
+					{
+						"text": "2026-07-14"
+					},
+					{
+						"text": "26100.33158"
+					},
+					{
+						"text": "KB5099536",
+						"href": "https://support.microsoft.com/help/5099536"
+					}
+				],
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2026-06 B"
+					},
+					{
+						"text": "2026-06-09"
+					},
+					{
+						"text": "26100.32995"
+					},
+					{
+						"text": "KB5094125",
+						"href": "https://support.microsoft.com/help/5094125"
+					}
+				],
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2026-04 OOB"
+					},
+					{
+						"text": "2026-04-19"
+					},
+					{
+						"text": "26100.32698"
+					},
+					{
+						"text": "KB5091157",
+						"href": "https://support.microsoft.com/help/5091157"
+					}
+				],
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2026-01 OOB"
+					},
+					{
+						"text": "2026-01-24"
+					},
+					{
+						"text": "26100.32236"
+					},
+					{
+						"text": "KB5078135",
+						"href": "https://support.microsoft.com/help/5078135"
+					}
+				],
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2024-10 A"
+					},
+					{
+						"text": "2024-11-01"
+					},
+					{
+						"text": "26100.1742"
+					},
+					{}
+				]
+			]
+		},
+		{
+			"label": "Calendar year 2026",
+			"header": [
+				"Month",
+				"Update type",
+				"Type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "April"
+					},
+					{
+						"text": "2026.04 B"
+					},
+					{
+						"text": "Baseline (Restart)"
+					},
+					{
+						"text": "2026-04-14"
+					},
+					{
+						"text": "26100.32690"
+					},
+					{
+						"text": "KB5082063",
+						"href": "https://support.microsoft.com/help/5082063"
+					}
+				],
+				[
+					{
+						"text": "May"
+					},
+					{
+						"text": "2026.05 B"
+					},
+					{
+						"text": "Hotpatch"
+					},
+					{
+						"text": "2026-05-12"
+					},
+					{
+						"text": "26100.32772"
+					},
+					{
+						"text": "KB5087423",
+						"href": "https://support.microsoft.com/help/5087423"
+					},
+					{}
+				],
+				[
+					{
+						"text": "June"
+					},
+					{
+						"text": "2026.06 B"
+					},
+					{
+						"text": "Baseline (Restart)"
+					},
+					{
+						"text": "2026-06-09"
+					},
+					{
+						"text": "26100.32995"
+					},
+					{
+						"text": "KB5094125",
+						"href": "https://support.microsoft.com/help/5094125"
+					}
+				],
+				[
+					{
+						"text": "July"
+					},
+					{
+						"text": "2026.07 B"
+					},
+					{
+						"text": "Hotpatch"
+					},
+					{
+						"text": "2026-07-14"
+					},
+					{
+						"text": "26100.32860"
+					},
+					{}
+				]
+			]
+		},
+		{
+			"label": "Calendar year 2024",
+			"header": [
+				"Month",
+				"Update type",
+				"Type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "July"
+					},
+					{
+						"text": "2024.07 B"
+					},
+					{
+						"text": "Baseline (Restart)"
+					},
+					{
+						"text": "2024-07-09"
+					},
+					{
+						"text": "20348.2582"
+					},
+					{
+						"text": "KB5040437",
+						"href": "https://support.microsoft.com/help/5040437"
+					}
+				],
+				[
+					{
+						"text": "August"
+					},
+					{
+						"text": "2024.08 B *"
+					},
+					{
+						"text": "Baseline (Restart)"
+					},
+					{
+						"text": "2024-08-13"
+					},
+					{
+						"text": "20348.2655"
+					},
+					{
+						"text": "KB5041160",
+						"href": "https://support.microsoft.com/help/5041160"
+					}
+				],
+				[
+					{
+						"text": "September"
+					},
+					{
+						"text": "2024.09 B"
+					},
+					{
+						"text": "Hotpatch"
+					},
+					{
+						"text": "2024-09-10"
+					},
+					{
+						"text": "20348.2695"
+					},
+					{
+						"text": "KB5042880",
+						"href": "https://support.microsoft.com/help/5042880"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/datasource.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "microsoft-releaseinfo",
+	"name": "Microsoft Windows Release Information"
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081424.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081424.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "3081424",
+	"url": "https://support.microsoft.com/help/3081424",
+	"products": [
+		"Windows 10 Version 1507 (RTM)"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "3081438"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081436.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081436.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "3081436",
+	"url": "https://support.microsoft.com/help/3081436",
+	"products": [
+		"Windows 10 Version 1507 (RTM)"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "3081455"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081438.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081438.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "3081438",
+	"url": "https://support.microsoft.com/help/3081438",
+	"products": [
+		"Windows 10 Version 1507 (RTM)"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "3081444"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "3081424"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081444.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081444.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "3081444",
+	"url": "https://support.microsoft.com/help/3081444",
+	"products": [
+		"Windows 10 Version 1507 (RTM)"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "3081448"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "3081438"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081448.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081448.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "3081448",
+	"url": "https://support.microsoft.com/help/3081448",
+	"products": [
+		"Windows 10 Version 1507 (RTM)"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "3093266"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "3081444"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081455.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3081xxx/3081455.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "3081455",
+	"url": "https://support.microsoft.com/help/3081455",
+	"products": [
+		"Windows 10 Version 1507 (RTM)"
+	],
+	"supersedes": [
+		{
+			"kb_id": "3081436"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3093xxx/3093266.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/3093xxx/3093266.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "3093266",
+	"url": "https://support.microsoft.com/help/3093266",
+	"products": [
+		"Windows 10 Version 1507 (RTM)"
+	],
+	"supersedes": [
+		{
+			"kb_id": "3081448"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4048xxx/4048955.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4048xxx/4048955.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "4048955",
+	"url": "https://support.microsoft.com/help/4048955",
+	"products": [
+		"Windows 10 Version 1709"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "4054517"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4051xxx/4051963.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4051xxx/4051963.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "4051963",
+	"url": "https://support.microsoft.com/help/4051963",
+	"products": [
+		"Windows 10 Version 1709"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "4073290"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4054xxx/4054517.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4054xxx/4054517.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "4054517",
+	"url": "https://support.microsoft.com/help/4054517",
+	"products": [
+		"Windows 10 Version 1709"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "4056892"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "4048955"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4056xxx/4056892.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4056xxx/4056892.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "4056892",
+	"url": "https://support.microsoft.com/help/4056892",
+	"products": [
+		"Windows 10 Version 1709"
+	],
+	"supersedes": [
+		{
+			"kb_id": "4054517"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4058xxx/4058258.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4058xxx/4058258.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "4058258",
+	"url": "https://support.microsoft.com/help/4058258",
+	"products": [
+		"Windows 10 Version 1709"
+	],
+	"supersedes": [
+		{
+			"kb_id": "4073291"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4073xxx/4073290.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4073xxx/4073290.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "4073290",
+	"url": "https://support.microsoft.com/help/4073290",
+	"products": [
+		"Windows 10 Version 1709"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "4073291"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "4051963"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4073xxx/4073291.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/4073xxx/4073291.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "4073291",
+	"url": "https://support.microsoft.com/help/4073291",
+	"products": [
+		"Windows 10 Version 1709"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "4058258"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "4073290"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-10.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5040xxx/5040437.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5040xxx/5040437.json
@@ -1,0 +1,15 @@
+{
+	"kb_id": "5040437",
+	"url": "https://support.microsoft.com/help/5040437",
+	"superseded_by": [
+		{
+			"kb_id": "5041160"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-server.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5041xxx/5041160.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5041xxx/5041160.json
@@ -1,0 +1,20 @@
+{
+	"kb_id": "5041160",
+	"url": "https://support.microsoft.com/help/5041160",
+	"superseded_by": [
+		{
+			"kb_id": "5042880"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "5040437"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-server.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5042xxx/5042880.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5042xxx/5042880.json
@@ -1,0 +1,15 @@
+{
+	"kb_id": "5042880",
+	"url": "https://support.microsoft.com/help/5042880",
+	"supersedes": [
+		{
+			"kb_id": "5041160"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-server.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5074xxx/5074109.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5074xxx/5074109.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5074109",
+	"url": "https://support.microsoft.com/help/5074109",
+	"products": [
+		"Windows 11 Version 24H2"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5077212"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-11.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5077xxx/5077212.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5077xxx/5077212.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "5077212",
+	"url": "https://support.microsoft.com/help/5077212",
+	"products": [
+		"Windows 11 Version 24H2"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5079420"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "5074109"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-11.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5078xxx/5078135.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5078xxx/5078135.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5078135",
+	"url": "https://support.microsoft.com/help/5078135",
+	"products": [
+		"Windows Server 2025"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5091157"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-server.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5079xxx/5079420.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5079xxx/5079420.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5079420",
+	"url": "https://support.microsoft.com/help/5079420",
+	"products": [
+		"Windows 11 Version 24H2"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5077212"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-11.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5082xxx/5082063.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5082xxx/5082063.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5082063",
+	"url": "https://support.microsoft.com/help/5082063",
+	"products": [
+		"Windows Server 2025"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5087423"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-server.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5087xxx/5087423.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5087xxx/5087423.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "5087423",
+	"url": "https://support.microsoft.com/help/5087423",
+	"products": [
+		"Windows Server 2025"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5094125"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "5082063"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-server.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5091xxx/5091157.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5091xxx/5091157.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5091157",
+	"url": "https://support.microsoft.com/help/5091157",
+	"products": [
+		"Windows Server 2025"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5078135"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-server.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5094xxx/5094125.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5094xxx/5094125.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "5094125",
+	"url": "https://support.microsoft.com/help/5094125",
+	"products": [
+		"Windows Server 2025"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5099536"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "5087423"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-server.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5099xxx/5099536.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5099xxx/5099536.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "5099536",
+	"url": "https://support.microsoft.com/help/5099536",
+	"products": [
+		"Windows Server 2025"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5120233"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "5094125"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-server.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5101xxx/5101650.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5101xxx/5101650.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5101650",
+	"url": "https://support.microsoft.com/help/5101650",
+	"products": [
+		"Windows 11 Version 25H2"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5121003"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-11.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5101xxx/5101684.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5101xxx/5101684.json
@@ -1,0 +1,19 @@
+{
+	"kb_id": "5101684",
+	"url": "https://support.microsoft.com/help/5101684",
+	"products": [
+		"Windows 11 Version 24H2",
+		"Windows 11 Version 25H2"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5121767"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-11.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5120xxx/5120233.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5120xxx/5120233.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5120233",
+	"url": "https://support.microsoft.com/help/5120233",
+	"products": [
+		"Windows Server 2025"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5099536"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-server.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5121xxx/5121003.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5121xxx/5121003.json
@@ -1,0 +1,19 @@
+{
+	"kb_id": "5121003",
+	"url": "https://support.microsoft.com/help/5121003",
+	"products": [
+		"Windows 11 Version 24H2",
+		"Windows 11 Version 25H2"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5101650"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-11.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5121xxx/5121767.json
+++ b/pkg/extract/microsoft/releaseinfo/testdata/golden/microsoftkb/5121xxx/5121767.json
@@ -1,0 +1,19 @@
+{
+	"kb_id": "5121767",
+	"url": "https://support.microsoft.com/help/5121767",
+	"products": [
+		"Windows 11 Version 24H2",
+		"Windows 11 Version 25H2"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5101684"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-releaseinfo",
+		"raws": [
+			"windows-11.json"
+		]
+	}
+}

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -89,6 +89,7 @@ const (
 	MicrosoftDeployment        SourceID = "microsoft-deployment"
 	MicrosoftMSUC              SourceID = "microsoft-msuc"
 	MicrosoftProduct           SourceID = "microsoft-product"
+	MicrosoftReleaseInfo       SourceID = "microsoft-releaseinfo"
 	MicrosoftServicing         SourceID = "microsoft-servicing"
 	MicrosoftVulnerability     SourceID = "microsoft-vulnerability"
 	MicrosoftWSUSSCN2          SourceID = "microsoft-wsusscn2"

--- a/pkg/fetch/microsoft/releaseinfo/releaseinfo.go
+++ b/pkg/fetch/microsoft/releaseinfo/releaseinfo.go
@@ -1,0 +1,401 @@
+// Package releaseinfo fetches Microsoft's Windows release-information pages --
+// the release-health tables on learn.microsoft.com for Windows 10, Windows 11
+// and Windows Server.
+//
+// Each page lists, per release, every monthly update it has shipped: the OS
+// build, the availability date, the release-cadence letter and the KB. The
+// Update Catalog drops an update outright once Microsoft expires it and
+// wsusscn2.cab drops it too; these tables keep it. KB3205386, KB5014710 and
+// KB4601331 all answer "We did not find any results" in the catalog and are all
+// still listed here.
+//
+// The servicing articles cover the same ground and are the fuller source -- 944
+// of the 974 KBs on the Windows 10 page are in the os/windows-10 sidebar. What
+// this adds is the 30 that are not, and what none of the articles carry:
+//
+//   - Twenty-one of the thirty are the updates from 2015-07-29 to 2016-01-27.
+//     Their articles exist, but are titled "Cumulative update for Windows 10
+//     Version 1511: December 8, 2015" and name no KB anywhere, so extract drops
+//     them for want of a key. This is where that key is.
+//
+//   - The release-cadence letter, as a column. B is the second Tuesday and is
+//     the line the following month builds on; C and D are the optional previews
+//     of the weeks after it, and OOB is out-of-band. The servicing extractor
+//     infers the same split from the release date falling on a second Tuesday,
+//     which is a reading of the calendar rather than of what Microsoft said.
+//
+//   - The hotpatch calendars, which say which update is a Baseline (Restart)
+//     and which is a Hotpatch. Nothing else states that, and it is not a detail:
+//     a hotpatch line rebases on its quarterly baseline instead of running on
+//     from the month before, so ordering those updates as one chain with the
+//     ordinary cumulative ones is wrong.
+//
+//   - The OS build in a column of its own, rather than in a title Microsoft
+//     writes at least four ways.
+//
+// fetch writes <dir>/origin verbatim and then produces <dir>/raw by reading it
+// back, never the HTTP response, so raw/ is reproducible from origin/ alone.
+// The tables are stored as served and are not read apart here; that is extract's
+// job.
+package releaseinfo
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+const baseURL = "https://learn.microsoft.com"
+
+// pages are the release-information pages, by the name each is stored under.
+//
+// Windows Server has a page of its own even though its builds are the ones the
+// Windows 10 and 11 pages already list -- 26100 is Windows Server 2025 here and
+// Windows 11 24H2 there, each shipping its own KBs at revisions the other also
+// ships. Storing them apart is what keeps the two from being read as one line.
+var pages = []struct {
+	name string
+	path string
+}{
+	{name: "windows-10", path: "/en-us/windows/release-health/release-information"},
+	{name: "windows-11", path: "/en-us/windows/release-health/windows11-release-information"},
+	{name: "windows-server", path: "/en-us/windows/release-health/windows-server-release-info"},
+}
+
+type options struct {
+	baseURL     string
+	dir         string
+	retry       int
+	concurrency int
+	wait        time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type baseURLOption string
+
+func (u baseURLOption) apply(opts *options) {
+	opts.baseURL = string(u)
+}
+
+func WithBaseURL(url string) Option {
+	return baseURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type concurrencyOption int
+
+func (c concurrencyOption) apply(opts *options) {
+	opts.concurrency = int(c)
+}
+
+func WithConcurrency(concurrency int) Option {
+	return concurrencyOption(concurrency)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+// Fetch stores the release-information pages under <dir>/origin and the tables
+// they carry under <dir>/raw.
+func Fetch(opts ...Option) error {
+	options := &options{
+		baseURL:     baseURL,
+		dir:         filepath.Join(util.CacheDir(), "fetch", "microsoft", "releaseinfo"),
+		retry:       3,
+		concurrency: 1,
+		wait:        1 * time.Second,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	if err := options.fetch(); err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+
+	if err := options.convert(); err != nil {
+		return errors.Wrap(err, "convert")
+	}
+
+	return nil
+}
+
+// fetch stores each page as served.
+//
+// Three requests to one host, so the pipeline runs one at a time: there is
+// nothing here for concurrency to shorten, and learn.microsoft.com has no
+// reason to be asked three times at once for it.
+func (opts options) fetch() error {
+	slog.Info("Fetch Microsoft Release Information")
+
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
+
+	names := make(map[string]string, len(pages))
+	us := make([]string, 0, len(pages))
+	for _, p := range pages {
+		u, err := url.JoinPath(opts.baseURL, p.path)
+		if err != nil {
+			return errors.Wrapf(err, "join %s and %s", opts.baseURL, p.path)
+		}
+		names[u] = p.name
+		us = append(us, u)
+	}
+
+	if err := client.PipelineGet(us, opts.concurrency, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, resp.Request.URL)
+		}
+
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", resp.Request.URL)
+		}
+
+		// The name is looked up by the URL the request was built with, not the
+		// one it landed on: learn.microsoft.com appends a ?view= to some paths
+		// on redirect, and a page stored under a name that moves with it would
+		// double the tree the first time it does.
+		name, ok := names[resp.Request.URL.String()]
+		if !ok {
+			return errors.Errorf("unexpected url. expected: one of %q, actual: %q", us, resp.Request.URL)
+		}
+
+		if err := writeOrigin(opts.dir, fmt.Sprintf("%s.html", name), bs); err != nil {
+			return errors.Wrapf(err, "write %s", fmt.Sprintf("%s.html", name))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "pipeline get")
+	}
+
+	return nil
+}
+
+// convert reads origin/ back and writes raw/, one file per stored page so that
+// which JSON came from which HTML is a matter of the name. Going through the
+// stored bytes rather than the response is what lets the tree be re-derived
+// after this parser changes.
+func (opts options) convert() error {
+	slog.Info("Convert origin to raw")
+
+	root := filepath.Join(opts.dir, "origin")
+
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".html" {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", p)
+		}
+		defer f.Close()
+
+		page, err := parsePage(f)
+		if err != nil {
+			return errors.Wrapf(err, "parse %s", p)
+		}
+
+		// A release-information page is its tables. One that parses to none is
+		// not a page whose tables have all been retired -- Microsoft has kept
+		// every Windows 10 release back to 1507 through the version's end of
+		// support and past it -- it is this parser having lost them, and it
+		// loses them for every page at once. Skipping would leave raw/ empty
+		// beside a full origin/ with the run green.
+		if len(page.Tables) == 0 {
+			return errors.Errorf("no table in %s", p)
+		}
+
+		if err := util.Write(filepath.Join(opts.dir, "raw", fmt.Sprintf("%s.json", strings.TrimSuffix(rel, ".html"))), page); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, "raw", fmt.Sprintf("%s.json", strings.TrimSuffix(rel, ".html"))))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", root)
+	}
+
+	return nil
+}
+
+// writeOrigin stores content under <dir>/origin/<name> as served.
+//
+// Nothing derived from the response is recorded alongside it -- no fetch
+// timestamp, no ETag, no status line. Those change on every run even when the
+// page does not, and would turn every fetch into a diff, drowning the signal
+// this tree exists to carry: that Microsoft revised the page.
+func writeOrigin(dir, name string, content []byte) error {
+	path := filepath.Join(dir, "origin", name)
+
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return errors.Wrapf(err, "mkdir %s", filepath.Dir(path))
+	}
+
+	if err := os.WriteFile(path, content, 0666); err != nil {
+		return errors.Wrapf(err, "write %s", path)
+	}
+
+	return nil
+}
+
+// parsePage reads a stored page for its canonical link and its tables.
+func parsePage(r io.Reader) (Page, error) {
+	doc, err := goquery.NewDocumentFromReader(r)
+	if err != nil {
+		return Page{}, errors.Wrap(err, "new document")
+	}
+
+	var page Page
+	var base *url.URL
+	if u, ok := doc.Find(`link[rel="canonical"]`).First().Attr("href"); ok {
+		page.URL = text(u)
+		base, _ = url.Parse(page.URL)
+	}
+
+	// Only the article body. The page chrome carries tables of its own -- the
+	// locale picker among them -- and a <strong> in a banner would otherwise
+	// become the label of the first release history.
+	root := doc.Find("main").First()
+	if root.Length() == 0 {
+		root = doc.Selection
+	}
+
+	// One pass in document order over the labels and the tables together, since
+	// a table's label is not its ancestor or its sibling: Microsoft leaves it a
+	// <strong> loose in the prose above. Labels inside a table are skipped --
+	// they are cell emphasis, and being visited after their own table's start
+	// tag they would otherwise be read as the next table's label.
+	var label string
+	root.Find("strong, h1, h2, h3, h4, h5, h6, table").Each(func(_ int, s *goquery.Selection) {
+		if goquery.NodeName(s) != "table" {
+			if s.Closest("table").Length() == 0 {
+				label = text(s.Text())
+			}
+			return
+		}
+
+		t, ok := parseTable(s, base)
+		if !ok {
+			return
+		}
+		t.Label = label
+
+		page.Tables = append(page.Tables, t)
+	})
+
+	return page, nil
+}
+
+// parseTable reads one table's column names and cells, reporting false for the
+// ones that carry neither.
+//
+// The header is the first row whatever it is marked up with. Microsoft writes
+// these tables both ways -- some open with a row of th, others with a thead --
+// and a table read as all body would put its column names in raw/ as data.
+func parseTable(s *goquery.Selection, base *url.URL) (Table, bool) {
+	var rows [][]Cell
+	s.Find("tr").Each(func(_ int, tr *goquery.Selection) {
+		var cells []Cell
+		tr.Find("th, td").Each(func(_ int, c *goquery.Selection) {
+			cell := Cell{Text: text(c.Text())}
+			if href, ok := c.Find("a[href]").First().Attr("href"); ok {
+				cell.Href = resolve(base, text(href))
+			}
+			cells = append(cells, cell)
+		})
+		if len(cells) == 0 {
+			return
+		}
+		rows = append(rows, cells)
+	})
+
+	if len(rows) < 2 {
+		return Table{}, false
+	}
+
+	header := make([]string, 0, len(rows[0]))
+	for _, c := range rows[0] {
+		header = append(header, c.Text)
+	}
+
+	return Table{Header: header, Rows: rows[1:]}, true
+}
+
+// resolve turns a cell's href into an address that works away from the page it
+// was read on. An href that cannot be parsed is kept as served rather than
+// dropped: it is not this parser's to decide that Microsoft meant nothing by it.
+func resolve(base *url.URL, href string) string {
+	if href == "" || base == nil {
+		return href
+	}
+	ref, err := url.Parse(href)
+	if err != nil {
+		return href
+	}
+	return base.ResolveReference(ref).String()
+}
+
+// text normalizes the whitespace HTML is free to write however it likes.
+// goquery has already resolved the entities.
+func text(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/pkg/fetch/microsoft/releaseinfo/releaseinfo_test.go
+++ b/pkg/fetch/microsoft/releaseinfo/releaseinfo_test.go
@@ -1,0 +1,165 @@
+package releaseinfo_test
+
+import (
+	"io/fs"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/releaseinfo"
+)
+
+// The fixtures are the pages as served, cut down to the tables that decide what
+// is read out of them.
+//
+// windows-10 carries a lifecycle table, which names no KB article column and
+// puts its link on a "Latest update for ESU" cell instead, so a reader keying
+// on "a table with a link in it" would take it for a history. Its 1709 table
+// holds a <strong> inside a cell, which is visited after its own table's start
+// tag and would be read as the 1507 table's label. Both pages also carry a
+// <strong> and a table outside <main>.
+//
+// The 1507 table is one month written out in full -- A, B, OOB, C and D, then
+// the B of the month after -- which is the whole of what a build line has to be
+// split into, and 1709 is January 2018, where the security release shipped on
+// the 3rd rather than on a second Tuesday.
+//
+// windows-11 and windows-server both carry a 26100 line, being Windows 11 24H2
+// and Windows Server 2025, each with its own KBs at its own revisions. Their
+// hotpatch calendars share a build number in the same way.
+//
+// One hotpatch row carries a cell more than the header names and another an
+// asterisk after its cadence letter, both as Microsoft has served them. Two
+// rows name no KB at all: a month a calendar has reached and Microsoft has not
+// shipped, and the Windows Server 2025 RTM row, which is the release rather
+// than an update to it.
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		golden   string
+		hasError bool
+	}{
+		{
+			name:    "happy",
+			fixture: "happy",
+			golden:  "happy",
+		},
+		{
+			// A page whose tables this cannot find is not a page that has lost
+			// them: Microsoft has kept every Windows 10 release back to 1507
+			// through its end of support and past it. It is this parser having
+			// lost them, and it loses them for every page at once, so the run
+			// fails rather than committing an empty raw/ beside a full origin/.
+			name:     "page without tables",
+			fixture:  "tableless",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(handler(t, tt.fixture))
+			defer ts.Close()
+
+			dir := t.TempDir()
+			err := releaseinfo.Fetch(
+				releaseinfo.WithBaseURL(ts.URL),
+				releaseinfo.WithDir(dir),
+				releaseinfo.WithRetry(0),
+				releaseinfo.WithConcurrency(1),
+				releaseinfo.WithWait(0),
+			)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Fatalf("unexpected error. err: %v", err)
+			case err == nil && tt.hasError:
+				t.Fatal("expected error has not occurred")
+			case err != nil:
+				return
+			}
+
+			diff(t, filepath.Join("testdata", "golden", tt.golden), dir)
+		})
+	}
+}
+
+// handler serves a fixture tree the way learn.microsoft.com serves the pages:
+// one document per path, and nothing anywhere else.
+func handler(t *testing.T, fixture string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		bs, err := os.ReadFile(filepath.Join("testdata", "fixtures", fixture, filepath.Clean(r.URL.Path)+".html"))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(bs)
+	}
+}
+
+// diff compares the produced tree against golden byte for byte. Bytes rather
+// than parsed content: origin/ is only worth keeping if it reproduces exactly,
+// and raw/ is written deterministically, so any difference at all is a
+// regression.
+func diff(t *testing.T, golden, got string) {
+	t.Helper()
+
+	want := walk(t, golden)
+	have := walk(t, got)
+
+	if d := cmp.Diff(slices.Sorted(maps.Keys(want)), slices.Sorted(maps.Keys(have))); d != "" {
+		t.Errorf("files (-expected +got):\n%s", d)
+	}
+
+	for n, w := range want {
+		h, ok := have[n]
+		if !ok {
+			continue
+		}
+		if d := cmp.Diff(string(w), string(h)); d != "" {
+			t.Errorf("%s (-expected +got):\n%s", n, d)
+		}
+	}
+}
+
+func walk(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+
+	out := make(map[string][]byte)
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+
+		bs, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+
+		out[filepath.ToSlash(rel)] = bs
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walk %s. err: %v", root, err)
+	}
+
+	return out
+}

--- a/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/happy/en-us/windows/release-health/release-information.html
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/happy/en-us/windows/release-health/release-information.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Windows 10 release information</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/windows/release-health/release-information" />
+</head>
+<body>
+<nav>
+<strong>Skip to main content</strong>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>Windows 10 current versions by servicing option</h2>
+<h4>Servicing channels</h4>
+<table>
+<tr><th>Version</th><th>Servicing option</th><th>Availability date</th><th>Latest update for ESU</th><th>Latest revision date</th><th>Latest build</th></tr>
+<tr><td nowrap="">22H2</td><td nowrap="">General Availability Channel</td><td nowrap="">2022-10-18</td><td nowrap=""><a href="https://support.microsoft.com/help/5120249" target="_blank" data-linktype="external">2026-08 B</a></td><td nowrap="">2026-08-11</td><td nowrap="">19045.7663</td></tr>
+</table>
+<h2>Windows 10 release history</h2>
+<p>Note that the Update type column references each monthly update by the year and the month of its release, followed by a letter indicating the week of the month.</p>
+<strong>Version 1709 (OS build 16299)</strong>
+<table>
+<tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">Semi-Annual Channel • Semi-Annual Channel (Targeted)</td><td nowrap="">2018-01 D</td><td nowrap="">2018-01-31</td><td nowrap="">16299.214</td><td><a href="https://support.microsoft.com/help/4058258" target="_blank" data-linktype="external">KB4058258</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel • Semi-Annual Channel (Targeted)</td><td nowrap="">2018-01 OOB</td><td nowrap="">2018-01-18</td><td nowrap="">16299.201</td><td><a href="https://support.microsoft.com/help/4073291" target="_blank" data-linktype="external">KB4073291</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel • Semi-Annual Channel (Targeted)</td><td nowrap="">2018-01 OOB</td><td nowrap="">2018-01-17</td><td nowrap="">16299.194</td><td><a href="https://support.microsoft.com/help/4073290" target="_blank" data-linktype="external">KB4073290</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel • Semi-Annual Channel (Targeted)</td><td nowrap=""><strong>2018-01 B</strong></td><td nowrap="">2018-01-03</td><td nowrap="">16299.192</td><td><a href="https://support.microsoft.com/help/4056892" target="_blank" data-linktype="external">KB4056892</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel • Semi-Annual Channel (Targeted)</td><td nowrap="">2017-12 B</td><td nowrap="">2017-12-12</td><td nowrap="">16299.125</td><td><a href="https://support.microsoft.com/help/4054517" target="_blank" data-linktype="external">KB4054517</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel (Targeted)</td><td nowrap="">2017-11 D</td><td nowrap="">2017-11-30</td><td nowrap="">16299.98</td><td><a href="https://support.microsoft.com/help/4051963" target="_blank" data-linktype="external">KB4051963</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel (Targeted)</td><td nowrap="">2017-11 B</td><td nowrap="">2017-11-14</td><td nowrap="">16299.64</td><td><a href="https://support.microsoft.com/help/4048955" target="_blank" data-linktype="external">KB4048955</a></td></tr>
+</table>
+<strong>Version 1507 (RTM) (OS build 10240)</strong>
+<table>
+<tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-09 D</td><td nowrap="">2015-09-30</td><td nowrap="">10240.16520</td><td><a href="https://support.microsoft.com/help/3093266" target="_blank" data-linktype="external">KB3093266</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-09 B</td><td nowrap="">2015-09-08</td><td nowrap="">10240.16487</td><td><a href="https://support.microsoft.com/help/3081455" target="_blank" data-linktype="external">KB3081455</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-08 D</td><td nowrap="">2015-08-27</td><td nowrap="">10240.16463</td><td><a href="https://support.microsoft.com/help/3081448" target="_blank" data-linktype="external">KB3081448</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-08 C</td><td nowrap="">2015-08-18</td><td nowrap="">10240.16445</td><td><a href="https://support.microsoft.com/help/3081444" target="_blank" data-linktype="external">KB3081444</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-08 OOB</td><td nowrap="">2015-08-14</td><td nowrap="">10240.16433</td><td><a href="https://support.microsoft.com/help/3081438" target="_blank" data-linktype="external">KB3081438</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-08 B</td><td nowrap="">2015-08-11</td><td nowrap="">10240.16430</td><td><a href="https://support.microsoft.com/help/3081436" target="_blank" data-linktype="external">KB3081436</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-08 A</td><td nowrap="">2015-08-05</td><td nowrap="">10240.16413</td><td><a href="https://support.microsoft.com/help/3081424" target="_blank" data-linktype="external">KB3081424</a></td></tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/happy/en-us/windows/release-health/windows-server-release-info.html
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/happy/en-us/windows/release-health/windows-server-release-info.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Windows Server release information</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/windows/release-health/windows-server-release-info" />
+</head>
+<body>
+<nav>
+<strong>Skip to main content</strong>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>Windows Server release history</h2>
+<strong>Windows Server 2025 (OS build 26100)</strong>
+<table>
+<tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2026-08 B</td><td nowrap="">2026-08-11</td><td nowrap="">26100.33296</td><td><a href="https://support.microsoft.com/help/5120233" target="_blank" data-linktype="external">KB5120233</a></td></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2026-07 B</td><td nowrap="">2026-07-14</td><td nowrap="">26100.33158</td><td><a href="https://support.microsoft.com/help/5099536" target="_blank" data-linktype="external">KB5099536</a></td></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2026-06 B</td><td nowrap="">2026-06-09</td><td nowrap="">26100.32995</td><td><a href="https://support.microsoft.com/help/5094125" target="_blank" data-linktype="external">KB5094125</a></td></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2026-04 OOB</td><td nowrap="">2026-04-19</td><td nowrap="">26100.32698</td><td><a href="https://support.microsoft.com/help/5091157" target="_blank" data-linktype="external">KB5091157</a></td></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2026-01 OOB</td><td nowrap="">2026-01-24</td><td nowrap="">26100.32236</td><td><a href="https://support.microsoft.com/help/5078135" target="_blank" data-linktype="external">KB5078135</a></td></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2024-10 A</td><td nowrap="">2024-11-01</td><td nowrap="">26100.1742</td><td nowrap=""></td></tr>
+</table>
+<h2>Windows Server hotpatch calendar</h2>
+<strong>Calendar year 2026</strong>
+<table>
+<tr><th>Month</th><th>Update type</th><th>Type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">April</td><td nowrap="">2026.04 B</td><td nowrap="">Baseline (Restart)</td><td nowrap="">2026-04-14</td><td nowrap="">26100.32690</td><td><a href="https://support.microsoft.com/help/5082063" target="_blank" data-linktype="external">KB5082063</a></td></tr>
+<tr><td nowrap="">May</td><td nowrap="">2026.05 B</td><td nowrap="">Hotpatch</td><td nowrap="">2026-05-12</td><td nowrap="">26100.32772</td><td><a href="https://support.microsoft.com/help/5087423" target="_blank" data-linktype="external">KB5087423</a></td><td nowrap=""></td></tr>
+<tr><td nowrap="">June</td><td nowrap="">2026.06 B</td><td nowrap="">Baseline (Restart)</td><td nowrap="">2026-06-09</td><td nowrap="">26100.32995</td><td><a href="https://support.microsoft.com/help/5094125" target="_blank" data-linktype="external">KB5094125</a></td></tr>
+<tr><td nowrap="">July</td><td nowrap="">2026.07 B</td><td nowrap="">Hotpatch</td><td nowrap="">2026-07-14</td><td nowrap="">26100.32860</td><td nowrap=""></td></tr>
+</table>
+<strong>Calendar year 2024</strong>
+<table>
+<tr><th>Month</th><th>Update type</th><th>Type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">July</td><td nowrap="">2024.07 B</td><td nowrap="">Baseline (Restart)</td><td nowrap="">2024-07-09</td><td nowrap="">20348.2582</td><td><a href="https://support.microsoft.com/help/5040437" target="_blank" data-linktype="external">KB5040437</a></td></tr>
+<tr><td nowrap="">August</td><td nowrap="">2024.08 B *</td><td nowrap="">Baseline (Restart)</td><td nowrap="">2024-08-13</td><td nowrap="">20348.2655</td><td><a href="https://support.microsoft.com/help/5041160" target="_blank" data-linktype="external">KB5041160</a></td></tr>
+<tr><td nowrap="">September</td><td nowrap="">2024.09 B</td><td nowrap="">Hotpatch</td><td nowrap="">2024-09-10</td><td nowrap="">20348.2695</td><td><a href="https://support.microsoft.com/help/5042880" target="_blank" data-linktype="external">KB5042880</a></td></tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/happy/en-us/windows/release-health/windows11-release-information.html
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/happy/en-us/windows/release-health/windows11-release-information.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Windows 11 release information</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information" />
+</head>
+<body>
+<nav>
+<strong>Skip to main content</strong>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>Windows 11 release history</h2>
+<strong>Version 25H2 (OS build 26200)</strong>
+<table>
+<tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">General Availability Channel</td><td nowrap="">2026-08 B</td><td nowrap="">2026-08-11</td><td nowrap="">26200.9168</td><td><a href="https://support.microsoft.com/help/5121003" target="_blank" data-linktype="external">KB5121003</a></td></tr>
+<tr><td nowrap="">General Availability Channel</td><td nowrap="">2026-07 D</td><td nowrap="">2026-07-28</td><td nowrap="">26200.8973</td><td><a href="https://support.microsoft.com/help/5101684" target="_blank" data-linktype="external">KB5101684</a></td></tr>
+<tr><td nowrap="">General Availability Channel</td><td nowrap="">2026-07 OOB</td><td nowrap="">2026-07-18</td><td nowrap="">26200.8894</td><td><a href="https://support.microsoft.com/help/5121767" target="_blank" data-linktype="external">KB5121767</a></td></tr>
+<tr><td nowrap="">General Availability Channel</td><td nowrap="">2026-07 B</td><td nowrap="">2026-07-14</td><td nowrap="">26200.8875</td><td><a href="https://support.microsoft.com/help/5101650" target="_blank" data-linktype="external">KB5101650</a></td></tr>
+</table>
+<strong>Version 24H2 (OS build 26100)</strong>
+<table>
+<tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">LTSC • General Availability Channel</td><td nowrap="">2026-08 B</td><td nowrap="">2026-08-11</td><td nowrap="">26100.9168</td><td><a href="https://support.microsoft.com/help/5121003" target="_blank" data-linktype="external">KB5121003</a></td></tr>
+<tr><td nowrap="">LTSC • General Availability Channel</td><td nowrap="">2026-07 D</td><td nowrap="">2026-07-28</td><td nowrap="">26100.8973</td><td><a href="https://support.microsoft.com/help/5101684" target="_blank" data-linktype="external">KB5101684</a></td></tr>
+<tr><td nowrap="">LTSC • General Availability Channel</td><td nowrap="">2026-07 OOB</td><td nowrap="">2026-07-18</td><td nowrap="">26100.8894</td><td><a href="https://support.microsoft.com/help/5121767" target="_blank" data-linktype="external">KB5121767</a></td></tr>
+</table>
+<h2>Windows 11 hotpatch calendar</h2>
+<strong>Calendar year 2026</strong>
+<table>
+<tr><th>Month</th><th>Update type</th><th>Type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">January</td><td nowrap="">2026.01 B</td><td nowrap="">Baseline (Restart)</td><td nowrap="">2026-01-13</td><td nowrap="">26100.7623</td><td><a href="https://support.microsoft.com/help/5074109" target="_blank" data-linktype="external">KB5074109</a></td></tr>
+<tr><td nowrap="">February</td><td nowrap="">2026.02 B</td><td nowrap="">Hotpatch</td><td nowrap="">2026-02-10</td><td nowrap="">26100.7781</td><td><a href="https://support.microsoft.com/help/5077212" target="_blank" data-linktype="external">KB5077212</a></td></tr>
+<tr><td nowrap="">March</td><td nowrap="">2026.03 B</td><td nowrap="">Hotpatch</td><td nowrap="">2026-03-10</td><td nowrap="">26100.7979</td><td><a href="https://support.microsoft.com/help/5079420" target="_blank" data-linktype="external">KB5079420</a></td></tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/tableless/en-us/windows/release-health/release-information.html
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/tableless/en-us/windows/release-health/release-information.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Release information</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/windows/release-health/release-information" />
+</head>
+<body>
+<main>
+<h2>Release history</h2>
+<p>This content has moved.</p>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/tableless/en-us/windows/release-health/windows-server-release-info.html
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/tableless/en-us/windows/release-health/windows-server-release-info.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Release information</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/windows/release-health/windows-server-release-info" />
+</head>
+<body>
+<main>
+<h2>Release history</h2>
+<p>This content has moved.</p>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/tableless/en-us/windows/release-health/windows11-release-information.html
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/fixtures/tableless/en-us/windows/release-health/windows11-release-information.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Release information</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information" />
+</head>
+<body>
+<main>
+<h2>Release history</h2>
+<p>This content has moved.</p>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/origin/windows-10.html
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/origin/windows-10.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Windows 10 release information</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/windows/release-health/release-information" />
+</head>
+<body>
+<nav>
+<strong>Skip to main content</strong>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>Windows 10 current versions by servicing option</h2>
+<h4>Servicing channels</h4>
+<table>
+<tr><th>Version</th><th>Servicing option</th><th>Availability date</th><th>Latest update for ESU</th><th>Latest revision date</th><th>Latest build</th></tr>
+<tr><td nowrap="">22H2</td><td nowrap="">General Availability Channel</td><td nowrap="">2022-10-18</td><td nowrap=""><a href="https://support.microsoft.com/help/5120249" target="_blank" data-linktype="external">2026-08 B</a></td><td nowrap="">2026-08-11</td><td nowrap="">19045.7663</td></tr>
+</table>
+<h2>Windows 10 release history</h2>
+<p>Note that the Update type column references each monthly update by the year and the month of its release, followed by a letter indicating the week of the month.</p>
+<strong>Version 1709 (OS build 16299)</strong>
+<table>
+<tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">Semi-Annual Channel • Semi-Annual Channel (Targeted)</td><td nowrap="">2018-01 D</td><td nowrap="">2018-01-31</td><td nowrap="">16299.214</td><td><a href="https://support.microsoft.com/help/4058258" target="_blank" data-linktype="external">KB4058258</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel • Semi-Annual Channel (Targeted)</td><td nowrap="">2018-01 OOB</td><td nowrap="">2018-01-18</td><td nowrap="">16299.201</td><td><a href="https://support.microsoft.com/help/4073291" target="_blank" data-linktype="external">KB4073291</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel • Semi-Annual Channel (Targeted)</td><td nowrap="">2018-01 OOB</td><td nowrap="">2018-01-17</td><td nowrap="">16299.194</td><td><a href="https://support.microsoft.com/help/4073290" target="_blank" data-linktype="external">KB4073290</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel • Semi-Annual Channel (Targeted)</td><td nowrap=""><strong>2018-01 B</strong></td><td nowrap="">2018-01-03</td><td nowrap="">16299.192</td><td><a href="https://support.microsoft.com/help/4056892" target="_blank" data-linktype="external">KB4056892</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel • Semi-Annual Channel (Targeted)</td><td nowrap="">2017-12 B</td><td nowrap="">2017-12-12</td><td nowrap="">16299.125</td><td><a href="https://support.microsoft.com/help/4054517" target="_blank" data-linktype="external">KB4054517</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel (Targeted)</td><td nowrap="">2017-11 D</td><td nowrap="">2017-11-30</td><td nowrap="">16299.98</td><td><a href="https://support.microsoft.com/help/4051963" target="_blank" data-linktype="external">KB4051963</a></td></tr>
+<tr><td nowrap="">Semi-Annual Channel (Targeted)</td><td nowrap="">2017-11 B</td><td nowrap="">2017-11-14</td><td nowrap="">16299.64</td><td><a href="https://support.microsoft.com/help/4048955" target="_blank" data-linktype="external">KB4048955</a></td></tr>
+</table>
+<strong>Version 1507 (RTM) (OS build 10240)</strong>
+<table>
+<tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-09 D</td><td nowrap="">2015-09-30</td><td nowrap="">10240.16520</td><td><a href="https://support.microsoft.com/help/3093266" target="_blank" data-linktype="external">KB3093266</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-09 B</td><td nowrap="">2015-09-08</td><td nowrap="">10240.16487</td><td><a href="https://support.microsoft.com/help/3081455" target="_blank" data-linktype="external">KB3081455</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-08 D</td><td nowrap="">2015-08-27</td><td nowrap="">10240.16463</td><td><a href="https://support.microsoft.com/help/3081448" target="_blank" data-linktype="external">KB3081448</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-08 C</td><td nowrap="">2015-08-18</td><td nowrap="">10240.16445</td><td><a href="https://support.microsoft.com/help/3081444" target="_blank" data-linktype="external">KB3081444</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-08 OOB</td><td nowrap="">2015-08-14</td><td nowrap="">10240.16433</td><td><a href="https://support.microsoft.com/help/3081438" target="_blank" data-linktype="external">KB3081438</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-08 B</td><td nowrap="">2015-08-11</td><td nowrap="">10240.16430</td><td><a href="https://support.microsoft.com/help/3081436" target="_blank" data-linktype="external">KB3081436</a></td></tr>
+<tr><td nowrap="">LTSB • CB • CBB</td><td nowrap="">2015-08 A</td><td nowrap="">2015-08-05</td><td nowrap="">10240.16413</td><td><a href="https://support.microsoft.com/help/3081424" target="_blank" data-linktype="external">KB3081424</a></td></tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/origin/windows-11.html
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/origin/windows-11.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Windows 11 release information</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information" />
+</head>
+<body>
+<nav>
+<strong>Skip to main content</strong>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>Windows 11 release history</h2>
+<strong>Version 25H2 (OS build 26200)</strong>
+<table>
+<tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">General Availability Channel</td><td nowrap="">2026-08 B</td><td nowrap="">2026-08-11</td><td nowrap="">26200.9168</td><td><a href="https://support.microsoft.com/help/5121003" target="_blank" data-linktype="external">KB5121003</a></td></tr>
+<tr><td nowrap="">General Availability Channel</td><td nowrap="">2026-07 D</td><td nowrap="">2026-07-28</td><td nowrap="">26200.8973</td><td><a href="https://support.microsoft.com/help/5101684" target="_blank" data-linktype="external">KB5101684</a></td></tr>
+<tr><td nowrap="">General Availability Channel</td><td nowrap="">2026-07 OOB</td><td nowrap="">2026-07-18</td><td nowrap="">26200.8894</td><td><a href="https://support.microsoft.com/help/5121767" target="_blank" data-linktype="external">KB5121767</a></td></tr>
+<tr><td nowrap="">General Availability Channel</td><td nowrap="">2026-07 B</td><td nowrap="">2026-07-14</td><td nowrap="">26200.8875</td><td><a href="https://support.microsoft.com/help/5101650" target="_blank" data-linktype="external">KB5101650</a></td></tr>
+</table>
+<strong>Version 24H2 (OS build 26100)</strong>
+<table>
+<tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">LTSC • General Availability Channel</td><td nowrap="">2026-08 B</td><td nowrap="">2026-08-11</td><td nowrap="">26100.9168</td><td><a href="https://support.microsoft.com/help/5121003" target="_blank" data-linktype="external">KB5121003</a></td></tr>
+<tr><td nowrap="">LTSC • General Availability Channel</td><td nowrap="">2026-07 D</td><td nowrap="">2026-07-28</td><td nowrap="">26100.8973</td><td><a href="https://support.microsoft.com/help/5101684" target="_blank" data-linktype="external">KB5101684</a></td></tr>
+<tr><td nowrap="">LTSC • General Availability Channel</td><td nowrap="">2026-07 OOB</td><td nowrap="">2026-07-18</td><td nowrap="">26100.8894</td><td><a href="https://support.microsoft.com/help/5121767" target="_blank" data-linktype="external">KB5121767</a></td></tr>
+</table>
+<h2>Windows 11 hotpatch calendar</h2>
+<strong>Calendar year 2026</strong>
+<table>
+<tr><th>Month</th><th>Update type</th><th>Type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">January</td><td nowrap="">2026.01 B</td><td nowrap="">Baseline (Restart)</td><td nowrap="">2026-01-13</td><td nowrap="">26100.7623</td><td><a href="https://support.microsoft.com/help/5074109" target="_blank" data-linktype="external">KB5074109</a></td></tr>
+<tr><td nowrap="">February</td><td nowrap="">2026.02 B</td><td nowrap="">Hotpatch</td><td nowrap="">2026-02-10</td><td nowrap="">26100.7781</td><td><a href="https://support.microsoft.com/help/5077212" target="_blank" data-linktype="external">KB5077212</a></td></tr>
+<tr><td nowrap="">March</td><td nowrap="">2026.03 B</td><td nowrap="">Hotpatch</td><td nowrap="">2026-03-10</td><td nowrap="">26100.7979</td><td><a href="https://support.microsoft.com/help/5079420" target="_blank" data-linktype="external">KB5079420</a></td></tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/origin/windows-server.html
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/origin/windows-server.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Windows Server release information</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/windows/release-health/windows-server-release-info" />
+</head>
+<body>
+<nav>
+<strong>Skip to main content</strong>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>Windows Server release history</h2>
+<strong>Windows Server 2025 (OS build 26100)</strong>
+<table>
+<tr><th>Servicing option</th><th>Update type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2026-08 B</td><td nowrap="">2026-08-11</td><td nowrap="">26100.33296</td><td><a href="https://support.microsoft.com/help/5120233" target="_blank" data-linktype="external">KB5120233</a></td></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2026-07 B</td><td nowrap="">2026-07-14</td><td nowrap="">26100.33158</td><td><a href="https://support.microsoft.com/help/5099536" target="_blank" data-linktype="external">KB5099536</a></td></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2026-06 B</td><td nowrap="">2026-06-09</td><td nowrap="">26100.32995</td><td><a href="https://support.microsoft.com/help/5094125" target="_blank" data-linktype="external">KB5094125</a></td></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2026-04 OOB</td><td nowrap="">2026-04-19</td><td nowrap="">26100.32698</td><td><a href="https://support.microsoft.com/help/5091157" target="_blank" data-linktype="external">KB5091157</a></td></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2026-01 OOB</td><td nowrap="">2026-01-24</td><td nowrap="">26100.32236</td><td><a href="https://support.microsoft.com/help/5078135" target="_blank" data-linktype="external">KB5078135</a></td></tr>
+<tr><td nowrap="">LTSC</td><td nowrap="">2024-10 A</td><td nowrap="">2024-11-01</td><td nowrap="">26100.1742</td><td nowrap=""></td></tr>
+</table>
+<h2>Windows Server hotpatch calendar</h2>
+<strong>Calendar year 2026</strong>
+<table>
+<tr><th>Month</th><th>Update type</th><th>Type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">April</td><td nowrap="">2026.04 B</td><td nowrap="">Baseline (Restart)</td><td nowrap="">2026-04-14</td><td nowrap="">26100.32690</td><td><a href="https://support.microsoft.com/help/5082063" target="_blank" data-linktype="external">KB5082063</a></td></tr>
+<tr><td nowrap="">May</td><td nowrap="">2026.05 B</td><td nowrap="">Hotpatch</td><td nowrap="">2026-05-12</td><td nowrap="">26100.32772</td><td><a href="https://support.microsoft.com/help/5087423" target="_blank" data-linktype="external">KB5087423</a></td><td nowrap=""></td></tr>
+<tr><td nowrap="">June</td><td nowrap="">2026.06 B</td><td nowrap="">Baseline (Restart)</td><td nowrap="">2026-06-09</td><td nowrap="">26100.32995</td><td><a href="https://support.microsoft.com/help/5094125" target="_blank" data-linktype="external">KB5094125</a></td></tr>
+<tr><td nowrap="">July</td><td nowrap="">2026.07 B</td><td nowrap="">Hotpatch</td><td nowrap="">2026-07-14</td><td nowrap="">26100.32860</td><td nowrap=""></td></tr>
+</table>
+<strong>Calendar year 2024</strong>
+<table>
+<tr><th>Month</th><th>Update type</th><th>Type</th><th>Availability date</th><th>Build</th><th>KB article</th></tr>
+<tr><td nowrap="">July</td><td nowrap="">2024.07 B</td><td nowrap="">Baseline (Restart)</td><td nowrap="">2024-07-09</td><td nowrap="">20348.2582</td><td><a href="https://support.microsoft.com/help/5040437" target="_blank" data-linktype="external">KB5040437</a></td></tr>
+<tr><td nowrap="">August</td><td nowrap="">2024.08 B *</td><td nowrap="">Baseline (Restart)</td><td nowrap="">2024-08-13</td><td nowrap="">20348.2655</td><td><a href="https://support.microsoft.com/help/5041160" target="_blank" data-linktype="external">KB5041160</a></td></tr>
+<tr><td nowrap="">September</td><td nowrap="">2024.09 B</td><td nowrap="">Hotpatch</td><td nowrap="">2024-09-10</td><td nowrap="">20348.2695</td><td><a href="https://support.microsoft.com/help/5042880" target="_blank" data-linktype="external">KB5042880</a></td></tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/raw/windows-10.json
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/raw/windows-10.json
@@ -1,0 +1,315 @@
+{
+	"url": "https://learn.microsoft.com/en-us/windows/release-health/release-information",
+	"tables": [
+		{
+			"label": "Servicing channels",
+			"header": [
+				"Version",
+				"Servicing option",
+				"Availability date",
+				"Latest update for ESU",
+				"Latest revision date",
+				"Latest build"
+			],
+			"rows": [
+				[
+					{
+						"text": "22H2"
+					},
+					{
+						"text": "General Availability Channel"
+					},
+					{
+						"text": "2022-10-18"
+					},
+					{
+						"text": "2026-08 B",
+						"href": "https://support.microsoft.com/help/5120249"
+					},
+					{
+						"text": "2026-08-11"
+					},
+					{
+						"text": "19045.7663"
+					}
+				]
+			]
+		},
+		{
+			"label": "Version 1709 (OS build 16299)",
+			"header": [
+				"Servicing option",
+				"Update type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "Semi-Annual Channel • Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2018-01 D"
+					},
+					{
+						"text": "2018-01-31"
+					},
+					{
+						"text": "16299.214"
+					},
+					{
+						"text": "KB4058258",
+						"href": "https://support.microsoft.com/help/4058258"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel • Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2018-01 OOB"
+					},
+					{
+						"text": "2018-01-18"
+					},
+					{
+						"text": "16299.201"
+					},
+					{
+						"text": "KB4073291",
+						"href": "https://support.microsoft.com/help/4073291"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel • Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2018-01 OOB"
+					},
+					{
+						"text": "2018-01-17"
+					},
+					{
+						"text": "16299.194"
+					},
+					{
+						"text": "KB4073290",
+						"href": "https://support.microsoft.com/help/4073290"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel • Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2018-01 B"
+					},
+					{
+						"text": "2018-01-03"
+					},
+					{
+						"text": "16299.192"
+					},
+					{
+						"text": "KB4056892",
+						"href": "https://support.microsoft.com/help/4056892"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel • Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2017-12 B"
+					},
+					{
+						"text": "2017-12-12"
+					},
+					{
+						"text": "16299.125"
+					},
+					{
+						"text": "KB4054517",
+						"href": "https://support.microsoft.com/help/4054517"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2017-11 D"
+					},
+					{
+						"text": "2017-11-30"
+					},
+					{
+						"text": "16299.98"
+					},
+					{
+						"text": "KB4051963",
+						"href": "https://support.microsoft.com/help/4051963"
+					}
+				],
+				[
+					{
+						"text": "Semi-Annual Channel (Targeted)"
+					},
+					{
+						"text": "2017-11 B"
+					},
+					{
+						"text": "2017-11-14"
+					},
+					{
+						"text": "16299.64"
+					},
+					{
+						"text": "KB4048955",
+						"href": "https://support.microsoft.com/help/4048955"
+					}
+				]
+			]
+		},
+		{
+			"label": "Version 1507 (RTM) (OS build 10240)",
+			"header": [
+				"Servicing option",
+				"Update type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-09 D"
+					},
+					{
+						"text": "2015-09-30"
+					},
+					{
+						"text": "10240.16520"
+					},
+					{
+						"text": "KB3093266",
+						"href": "https://support.microsoft.com/help/3093266"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-09 B"
+					},
+					{
+						"text": "2015-09-08"
+					},
+					{
+						"text": "10240.16487"
+					},
+					{
+						"text": "KB3081455",
+						"href": "https://support.microsoft.com/help/3081455"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-08 D"
+					},
+					{
+						"text": "2015-08-27"
+					},
+					{
+						"text": "10240.16463"
+					},
+					{
+						"text": "KB3081448",
+						"href": "https://support.microsoft.com/help/3081448"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-08 C"
+					},
+					{
+						"text": "2015-08-18"
+					},
+					{
+						"text": "10240.16445"
+					},
+					{
+						"text": "KB3081444",
+						"href": "https://support.microsoft.com/help/3081444"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-08 OOB"
+					},
+					{
+						"text": "2015-08-14"
+					},
+					{
+						"text": "10240.16433"
+					},
+					{
+						"text": "KB3081438",
+						"href": "https://support.microsoft.com/help/3081438"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-08 B"
+					},
+					{
+						"text": "2015-08-11"
+					},
+					{
+						"text": "10240.16430"
+					},
+					{
+						"text": "KB3081436",
+						"href": "https://support.microsoft.com/help/3081436"
+					}
+				],
+				[
+					{
+						"text": "LTSB • CB • CBB"
+					},
+					{
+						"text": "2015-08 A"
+					},
+					{
+						"text": "2015-08-05"
+					},
+					{
+						"text": "10240.16413"
+					},
+					{
+						"text": "KB3081424",
+						"href": "https://support.microsoft.com/help/3081424"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/raw/windows-11.json
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/raw/windows-11.json
@@ -1,0 +1,231 @@
+{
+	"url": "https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information",
+	"tables": [
+		{
+			"label": "Version 25H2 (OS build 26200)",
+			"header": [
+				"Servicing option",
+				"Update type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "General Availability Channel"
+					},
+					{
+						"text": "2026-08 B"
+					},
+					{
+						"text": "2026-08-11"
+					},
+					{
+						"text": "26200.9168"
+					},
+					{
+						"text": "KB5121003",
+						"href": "https://support.microsoft.com/help/5121003"
+					}
+				],
+				[
+					{
+						"text": "General Availability Channel"
+					},
+					{
+						"text": "2026-07 D"
+					},
+					{
+						"text": "2026-07-28"
+					},
+					{
+						"text": "26200.8973"
+					},
+					{
+						"text": "KB5101684",
+						"href": "https://support.microsoft.com/help/5101684"
+					}
+				],
+				[
+					{
+						"text": "General Availability Channel"
+					},
+					{
+						"text": "2026-07 OOB"
+					},
+					{
+						"text": "2026-07-18"
+					},
+					{
+						"text": "26200.8894"
+					},
+					{
+						"text": "KB5121767",
+						"href": "https://support.microsoft.com/help/5121767"
+					}
+				],
+				[
+					{
+						"text": "General Availability Channel"
+					},
+					{
+						"text": "2026-07 B"
+					},
+					{
+						"text": "2026-07-14"
+					},
+					{
+						"text": "26200.8875"
+					},
+					{
+						"text": "KB5101650",
+						"href": "https://support.microsoft.com/help/5101650"
+					}
+				]
+			]
+		},
+		{
+			"label": "Version 24H2 (OS build 26100)",
+			"header": [
+				"Servicing option",
+				"Update type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "LTSC • General Availability Channel"
+					},
+					{
+						"text": "2026-08 B"
+					},
+					{
+						"text": "2026-08-11"
+					},
+					{
+						"text": "26100.9168"
+					},
+					{
+						"text": "KB5121003",
+						"href": "https://support.microsoft.com/help/5121003"
+					}
+				],
+				[
+					{
+						"text": "LTSC • General Availability Channel"
+					},
+					{
+						"text": "2026-07 D"
+					},
+					{
+						"text": "2026-07-28"
+					},
+					{
+						"text": "26100.8973"
+					},
+					{
+						"text": "KB5101684",
+						"href": "https://support.microsoft.com/help/5101684"
+					}
+				],
+				[
+					{
+						"text": "LTSC • General Availability Channel"
+					},
+					{
+						"text": "2026-07 OOB"
+					},
+					{
+						"text": "2026-07-18"
+					},
+					{
+						"text": "26100.8894"
+					},
+					{
+						"text": "KB5121767",
+						"href": "https://support.microsoft.com/help/5121767"
+					}
+				]
+			]
+		},
+		{
+			"label": "Calendar year 2026",
+			"header": [
+				"Month",
+				"Update type",
+				"Type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "January"
+					},
+					{
+						"text": "2026.01 B"
+					},
+					{
+						"text": "Baseline (Restart)"
+					},
+					{
+						"text": "2026-01-13"
+					},
+					{
+						"text": "26100.7623"
+					},
+					{
+						"text": "KB5074109",
+						"href": "https://support.microsoft.com/help/5074109"
+					}
+				],
+				[
+					{
+						"text": "February"
+					},
+					{
+						"text": "2026.02 B"
+					},
+					{
+						"text": "Hotpatch"
+					},
+					{
+						"text": "2026-02-10"
+					},
+					{
+						"text": "26100.7781"
+					},
+					{
+						"text": "KB5077212",
+						"href": "https://support.microsoft.com/help/5077212"
+					}
+				],
+				[
+					{
+						"text": "March"
+					},
+					{
+						"text": "2026.03 B"
+					},
+					{
+						"text": "Hotpatch"
+					},
+					{
+						"text": "2026-03-10"
+					},
+					{
+						"text": "26100.7979"
+					},
+					{
+						"text": "KB5079420",
+						"href": "https://support.microsoft.com/help/5079420"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/raw/windows-server.json
+++ b/pkg/fetch/microsoft/releaseinfo/testdata/golden/happy/raw/windows-server.json
@@ -1,0 +1,293 @@
+{
+	"url": "https://learn.microsoft.com/en-us/windows/release-health/windows-server-release-info",
+	"tables": [
+		{
+			"label": "Windows Server 2025 (OS build 26100)",
+			"header": [
+				"Servicing option",
+				"Update type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2026-08 B"
+					},
+					{
+						"text": "2026-08-11"
+					},
+					{
+						"text": "26100.33296"
+					},
+					{
+						"text": "KB5120233",
+						"href": "https://support.microsoft.com/help/5120233"
+					}
+				],
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2026-07 B"
+					},
+					{
+						"text": "2026-07-14"
+					},
+					{
+						"text": "26100.33158"
+					},
+					{
+						"text": "KB5099536",
+						"href": "https://support.microsoft.com/help/5099536"
+					}
+				],
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2026-06 B"
+					},
+					{
+						"text": "2026-06-09"
+					},
+					{
+						"text": "26100.32995"
+					},
+					{
+						"text": "KB5094125",
+						"href": "https://support.microsoft.com/help/5094125"
+					}
+				],
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2026-04 OOB"
+					},
+					{
+						"text": "2026-04-19"
+					},
+					{
+						"text": "26100.32698"
+					},
+					{
+						"text": "KB5091157",
+						"href": "https://support.microsoft.com/help/5091157"
+					}
+				],
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2026-01 OOB"
+					},
+					{
+						"text": "2026-01-24"
+					},
+					{
+						"text": "26100.32236"
+					},
+					{
+						"text": "KB5078135",
+						"href": "https://support.microsoft.com/help/5078135"
+					}
+				],
+				[
+					{
+						"text": "LTSC"
+					},
+					{
+						"text": "2024-10 A"
+					},
+					{
+						"text": "2024-11-01"
+					},
+					{
+						"text": "26100.1742"
+					},
+					{}
+				]
+			]
+		},
+		{
+			"label": "Calendar year 2026",
+			"header": [
+				"Month",
+				"Update type",
+				"Type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "April"
+					},
+					{
+						"text": "2026.04 B"
+					},
+					{
+						"text": "Baseline (Restart)"
+					},
+					{
+						"text": "2026-04-14"
+					},
+					{
+						"text": "26100.32690"
+					},
+					{
+						"text": "KB5082063",
+						"href": "https://support.microsoft.com/help/5082063"
+					}
+				],
+				[
+					{
+						"text": "May"
+					},
+					{
+						"text": "2026.05 B"
+					},
+					{
+						"text": "Hotpatch"
+					},
+					{
+						"text": "2026-05-12"
+					},
+					{
+						"text": "26100.32772"
+					},
+					{
+						"text": "KB5087423",
+						"href": "https://support.microsoft.com/help/5087423"
+					},
+					{}
+				],
+				[
+					{
+						"text": "June"
+					},
+					{
+						"text": "2026.06 B"
+					},
+					{
+						"text": "Baseline (Restart)"
+					},
+					{
+						"text": "2026-06-09"
+					},
+					{
+						"text": "26100.32995"
+					},
+					{
+						"text": "KB5094125",
+						"href": "https://support.microsoft.com/help/5094125"
+					}
+				],
+				[
+					{
+						"text": "July"
+					},
+					{
+						"text": "2026.07 B"
+					},
+					{
+						"text": "Hotpatch"
+					},
+					{
+						"text": "2026-07-14"
+					},
+					{
+						"text": "26100.32860"
+					},
+					{}
+				]
+			]
+		},
+		{
+			"label": "Calendar year 2024",
+			"header": [
+				"Month",
+				"Update type",
+				"Type",
+				"Availability date",
+				"Build",
+				"KB article"
+			],
+			"rows": [
+				[
+					{
+						"text": "July"
+					},
+					{
+						"text": "2024.07 B"
+					},
+					{
+						"text": "Baseline (Restart)"
+					},
+					{
+						"text": "2024-07-09"
+					},
+					{
+						"text": "20348.2582"
+					},
+					{
+						"text": "KB5040437",
+						"href": "https://support.microsoft.com/help/5040437"
+					}
+				],
+				[
+					{
+						"text": "August"
+					},
+					{
+						"text": "2024.08 B *"
+					},
+					{
+						"text": "Baseline (Restart)"
+					},
+					{
+						"text": "2024-08-13"
+					},
+					{
+						"text": "20348.2655"
+					},
+					{
+						"text": "KB5041160",
+						"href": "https://support.microsoft.com/help/5041160"
+					}
+				],
+				[
+					{
+						"text": "September"
+					},
+					{
+						"text": "2024.09 B"
+					},
+					{
+						"text": "Hotpatch"
+					},
+					{
+						"text": "2024-09-10"
+					},
+					{
+						"text": "20348.2695"
+					},
+					{
+						"text": "KB5042880",
+						"href": "https://support.microsoft.com/help/5042880"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/fetch/microsoft/releaseinfo/types.go
+++ b/pkg/fetch/microsoft/releaseinfo/types.go
@@ -1,0 +1,53 @@
+package releaseinfo
+
+// Page is one release-information page, as served.
+//
+// Nothing is read out of the tables here. Which column carries what varies
+// between them -- a release history is keyed by Build, a hotpatch calendar by
+// Month -- and the set is not fixed: Microsoft added "Update type" after these
+// pages had run for years without it, and the same table has been served with a
+// row holding one cell more than its header. Reading the columns apart belongs
+// in extract, under golden tests, where a changed one is handled by rerunning
+// against origin/ rather than by refetching a page whose older revisions are
+// gone.
+type Page struct {
+	// URL is the page's own canonical link, taken from the stored HTML rather
+	// than from the request, so raw/ stays derivable from origin/ alone.
+	URL    string  `json:"url,omitempty"`
+	Tables []Table `json:"tables,omitempty"`
+}
+
+// Table is one table of a page, with the label it is filed under.
+//
+// The label is what names the release a table covers -- "Version 22H2 (OS build
+// 19045)", "Windows Server 2016 (OS build 14393)". Microsoft marks it with
+// <strong>, not a heading: all fourteen Windows 10 release histories sit under
+// the single "Windows 10 release history" h2, so the heading is the same for
+// every one of them and says nothing that tells them apart.
+//
+// It is stored for the release name, which nothing else on the page carries,
+// and for nothing else. The build a table covers is in the Build column of
+// every one of its rows, so a label Microsoft restyles costs the name and not
+// the chain.
+type Table struct {
+	Label  string   `json:"label,omitempty"`
+	Header []string `json:"header,omitempty"`
+	Rows   [][]Cell `json:"rows,omitempty"`
+}
+
+// Cell is one cell, with the link it carries.
+//
+// The link is kept because it is the only per-KB address these pages give: the
+// KB article cell is written <a href="https://support.microsoft.com/help/5120249">
+// KB5120249</a>, and reading the cell as text alone would leave a KB record
+// whose URL had to be built by hand from its number. It is resolved against the
+// page's own address, so a relative one stays usable away from the page it was
+// read on; the absolute ones these pages use are unchanged by that.
+//
+// Every cell carries it, not only the ones this source reads, because which
+// cell holds the link is the table's business and not the reader's -- on the
+// lifecycle tables it is the "Latest update" cell rather than a KB one.
+type Cell struct {
+	Text string `json:"text,omitempty"`
+	Href string `json:"href,omitempty"`
+}


### PR DESCRIPTION
## What

Adds `microsoft-releaseinfo`, a fetcher and extractor for the Windows release-health pages — Windows 10, Windows 11 and Windows Server. **1,334 KBs**, every one of them chained.

## Why

The Update Catalog drops an update outright once Microsoft expires it, and wsusscn2.cab drops it too. These tables keep it: KB3205386, KB5014710 and KB4601331 all answer "We did not find any results" in the catalog and are all still listed here.

Two things follow that no other source in this repo provides.

**The release-cadence letter, as a column.** `B` is the second Tuesday and is the line the following month builds on; `C` and `D` are the optional previews of the weeks after it, and `OOB` is out-of-band. `extract/microsoft/servicing` splits the same two lines by asking whether the release date falls on a second Tuesday, which is a reading of the calendar rather than of what Microsoft said. **Over the 1,944 rows these three pages carry, the letter and the calendar disagree 18 times** — twelve `B` releases did not ship on a second Tuesday (KB4056892, the January 2018 emergency release, among them) and three `D` and three `OOB` releases did.

**The hotpatch calendars,** which say which update is a `Baseline (Restart)` and which is a `Hotpatch`. A hotpatch line rebases on its quarterly baseline instead of running on from the month before, so ordering those with the ordinary cumulative updates is wrong. 22 of the Windows Server page's 54 hotpatch KBs are baselines, shipped as that month's ordinary cumulative update too, and they take their place in both chains.

It also covers 30 KBs that `servicing` cannot key. 21 of those are the updates from 2015-07-29 to 2016-01-27, whose articles are titled `Cumulative update for Windows 10 Version 1511: December 8, 2015` and name no KB anywhere, so `extract/microsoft/servicing` drops them.

## How

`fetch` stores the three pages under `origin/` and their tables under `raw/`, as served — label, column names, cells, and the link every cell carries. Nothing is read apart there: the column set is not fixed (Microsoft added `Update type` after the pages had run for years without it), so interpretation lives in `extract` where a change is handled by rerunning against `origin/`.

`extract` keys a chain on **(page, build major, line)** and orders by build revision:

- the **page**, because a build number is not unique across products — 26100 is Windows Server 2025 on one page and Windows 11 24H2 on another, each shipping its own KBs at revisions the other also ships;
- the **build's major part**, which is the release;
- the **line** — `monthly` for `B`, `optional` for the rest, `hotpatch` for the calendars.

An unrecognised letter lands on the optional line: a new letter is likelier to be another optional cadence than a second security line, and mistaking one for `B` would put a stranger into the chain the estate is measured against.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` — passes
- `golangci-lint run ./pkg/...` — 0 issues
- Golden tests for both packages, with fixtures built from the pages as served
- End to end against the live pages: 1,334 KBs, **0 unchained, 0 without a product name, 0 without a URL, no warnings**

```
$ vuls-data-update fetch   microsoft-releaseinfo -d <raw>
$ vuls-data-update extract microsoft-releaseinfo <raw> -d <out>
```

## Checklist

- [x] Tests pass
- [x] Golden files updated
- [x] Deterministic output verified (types changed)
- [x] Backward compatibility maintained (types/data changed)

`pkg/extract/types/source` gains one constant, `MicrosoftReleaseInfo`. Nothing existing changes shape, so this is additive. It is the only file this branch shares with the other Microsoft data-source branches, and the only place they will conflict.
