### PR TITLE
feat(microsoft/sqlbuild): add sql server build versions data source

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -67,6 +67,7 @@ import (
 	microsoftCVRF "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/cvrf"
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/msuc"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/servicing"
+	microsoftSQLBuild "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/sqlbuild"
 	microsoftWSUSSCN2 "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/wsusscn2"
 	mitreATTACK "github.com/MaineK00n/vuls-data-update/pkg/extract/mitre/attack"
 	mitreCAPEC "github.com/MaineK00n/vuls-data-update/pkg/extract/mitre/capec"
@@ -180,7 +181,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdJVNFeedDetail(), newCmdJVNFeedProduct(), newCmdJVNFeedRSS(),
 		newCmdLinuxOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftWSUSSCN2(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftSQLBuild(), newCmdMicrosoftWSUSSCN2(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
 		newCmdNetBSD(),
@@ -1656,6 +1657,31 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := microsoftMSUC.Extract(args[0], microsoftMSUC.WithDir(options.dir)); err != nil {
 				return errors.Wrap(err, "failed to extract microsoft msuc")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdMicrosoftSQLBuild() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "sqlbuild"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-sqlbuild <Raw Microsoft SQL Server Build Versions Repository PATH>",
+		Short: "Extract Microsoft SQL Server Build Versions data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract microsoft-sqlbuild vuls-data-raw-microsoft-sqlbuild
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := microsoftSQLBuild.Extract(args[0], microsoftSQLBuild.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract microsoft sqlbuild")
 			}
 			return nil
 		},

--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -92,6 +92,7 @@ import (
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/msuc"
 	microsoftProduct "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/product"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/servicing"
+	microsoftSQLBuild "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/sqlbuild"
 	microsoftVEX "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vex"
 	microsoftVulnerability "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vulnerability"
 	microsoftWSUSSCN2 "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/wsusscn2"
@@ -255,7 +256,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdLinuxOSV(),
 		newCmdMageiaOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftSQLBuild(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
 		newCmdMinimOSOSV(), newCmdMinimOSSecDB(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreEMB3D(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
@@ -2666,6 +2667,56 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
 	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
 	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent http requests")
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
+
+	return cmd
+}
+
+func newCmdMicrosoftSQLBuild() *cobra.Command {
+	options := &struct {
+		base
+		wait time.Duration
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "microsoft", "sqlbuild"),
+			retry: 3,
+		},
+		wait: 1 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-sqlbuild",
+		Short: "Fetch Microsoft SQL Server Build Versions data source",
+		Long: heredoc.Doc(`
+			Fetch the SQL Server build-versions article as Markdown into <dir>/origin,
+			and the tables it carries into <dir>/raw.
+
+			The article lists, per product version, every build SQL Server has shipped:
+			the build number, the service pack, the kind of update and the KB. It runs
+			from SQL Server 2005 to the current release, and the Update Catalog no
+			longer serves most of what it names.
+
+			It is fetched from MicrosoftDocs/SupportArticles-docs rather than from the
+			rendered page, because the repository is public and keeps the article's
+			history, so a row Microsoft removes stays recoverable afterwards.
+
+			The tables are stored as authored and are not read apart here; that belongs
+			in extract, where a change is handled by rerunning against origin/.
+		`),
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch microsoft-sqlbuild
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := microsoftSQLBuild.Fetch(microsoftSQLBuild.WithDir(options.dir), microsoftSQLBuild.WithRetry(options.retry), microsoftSQLBuild.WithWait(options.wait)); err != nil {
+				return errors.Wrap(err, "failed to fetch microsoft sqlbuild")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
 	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
 
 	return cmd

--- a/pkg/extract/microsoft/sqlbuild/export_test.go
+++ b/pkg/extract/microsoft/sqlbuild/export_test.go
@@ -1,0 +1,7 @@
+package sqlbuild
+
+var (
+	Line        = line
+	ServicePack = servicePack
+	ReleaseDate = releaseDate
+)

--- a/pkg/extract/microsoft/sqlbuild/sqlbuild.go
+++ b/pkg/extract/microsoft/sqlbuild/sqlbuild.go
@@ -1,0 +1,596 @@
+// Package sqlbuild extracts supersedence from Microsoft's SQL Server
+// build-versions article.
+//
+// The article carries no supersedence. What it carries is every build a product
+// version has shipped, and the build number is the order: a build contains the
+// one below it on the same line. Reading the lines apart is this package's job,
+// and SQL Server runs several at once.
+//
+// A product version services two or three lines in parallel, and they do not
+// supersede each other:
+//
+//   - CU, the cumulative updates. Each contains every fix before it.
+//   - GDR, the general distribution releases, which carry security fixes and
+//     nothing else. A host on GDR is not on CU and a CU does not reach it.
+//   - QFE, the older name for the hotfix line GDR ran beside, on SQL Server 2005
+//     through 2012.
+//   - Azure Connect Pack, an optional feature pack for SQL Server 2016 SP3 and
+//     2017 that is serviced on its own.
+//
+// The line is read from the Update column, which names it: "CU26", "CU25 + GDR",
+// "GDR Security Update", "MS15-058: QFE Security Update", "Azure Connect Pack +
+// GDR". A "CUn + GDR" is on the CU line -- it is that CU with a security fix on
+// top -- and only the rows naming no CU are on the GDR one.
+//
+// The service pack is the other divider, and it is needed. Microsoft services
+// the RTM line and the SP1 line side by side for as long as both are supported,
+// so a build number that is higher is not always a build that came later: SQL
+// Server 2008's RTM CU9 at 10.00.1835.0 shipped in March 2010, eleven months
+// after SP1 CU2 at 10.00.2710.0. Ordering a version's CUs as one line by build
+// number puts 41 such pairs the wrong way round; keying the service pack in as
+// well leaves 7, and every one of those is a row Microsoft filed under a service
+// pack its build number does not belong to.
+//
+// The service pack is not simply the Service pack column. Microsoft stopped
+// filling it in around 2023 and moved the fact into the Update column -- SQL
+// Server 2016's SP3 GDRs read "SP3 | GDR" up to February 2023 and "None | SP3 +
+// GDR" after it -- so the column is read first and the label second. Thirteen
+// rows state it in neither, all of them Azure Connect Pack releases, and they
+// take the service pack of the build below them on their own line, which is what
+// splitting them off it would otherwise cost: two chains where the article has
+// one.
+//
+// RTM and RTW/PCU rows are the baselines a service pack opens with, and they
+// belong to every line that runs on it: SQL Server 2016's SP1 baseline at
+// 13.0.4001.0 is what both the SP1 CUs and the SP1 GDRs are built on. A baseline
+// joins only the lines that exist -- a version that shipped no QFE gets no QFE
+// chain from having a baseline.
+//
+// Rows naming no KB are the product releases themselves, marked "NA" or left
+// empty, and are skipped. So are SQL Server 2000 and earlier, whose tables have
+// no Knowledge Base column at all.
+package sqlbuild
+
+import (
+	"cmp"
+	"encoding/json/v2"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
+	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/sqlbuild"
+)
+
+// The columns a row is read out of, by name. A table without the Knowledge Base
+// column is not a build history -- SQL Server 2000 and earlier are listed with
+// their KBs written into prose, and 7.0 and 6.5 with no KBs at all.
+const (
+	columnBuild       = "Build number or version"
+	columnServicePack = "Service pack"
+	columnUpdate      = "Update"
+	columnKB          = "Knowledge Base number"
+	columnDate        = "Release date"
+)
+
+// The lines a product version services in parallel.
+const (
+	lineCU       = "cu"
+	lineGDR      = "gdr"
+	lineQFE      = "qfe"
+	lineACP      = "azure-connect-pack"
+	lineBaseline = "baseline"
+	lineUnknown  = ""
+)
+
+var (
+	kbPattern = regexp.MustCompile(`KB ?(\d{6,})`)
+
+	// buildPattern is a SQL Server build number. Three components as well as
+	// four: SQL Server 2005 and 2000 are written 9.00.5324.
+	buildPattern = regexp.MustCompile(`^\d+\.\d+(?:\.\d+){1,2}$`)
+
+	// servicePackPattern is how a service pack is written wherever it appears --
+	// on its own in the Service pack column, and inside a label in the Update
+	// one, as "SP3 + GDR" and "SQL Server 2014 SP3 CU4 + GDR".
+	servicePackPattern = regexp.MustCompile(`(?i)\bSP(\d)\b`)
+
+	// cuPattern is a cumulative update's name. The space is allowed because
+	// Microsoft has written both "CU26" and, elsewhere in this estate, "CU 26".
+	cuPattern = regexp.MustCompile(`(?i)\bCU ?\d+`)
+
+	// baselinePattern is what a service pack's own release is called. Microsoft
+	// spells the PCU form five ways -- RTW/PCU1, RTW / PCU 1, RTW/PCU4 -- so the
+	// separator is not matched, only the two names.
+	baselinePattern = regexp.MustCompile(`(?i)\bRT[MW]\b|\bPCU\b|\bGA\b`)
+
+	// weekdayPattern is the day of the week one row opens its release date with.
+	weekdayPattern = regexp.MustCompile(`(?i)^(Mon|Tues|Wednes|Thurs|Fri|Satur|Sun)day,?\s*`)
+)
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+// update is one row of a build history, read for what decides its place in a
+// chain.
+type update struct {
+	kbID string
+	url  string
+
+	// version is the heading the table sits under, e.g. "SQL Server 2008 R2".
+	// It is the only place the article writes the product version out; the
+	// build number says 10.50, which is the same fact in a spelling nothing
+	// else uses.
+	version string
+
+	// servicePack divides the lines a version runs in parallel. Empty for the
+	// versions that have no service packs at all, which is every one since SQL
+	// Server 2016.
+	servicePack string
+
+	line string
+
+	build    []int
+	buildStr string
+
+	date  time.Time
+	label string
+
+	raw string
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "sqlbuild"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract Microsoft SQL Server Build Versions")
+
+	us, err := read(args)
+	if err != nil {
+		return errors.Wrapf(err, "read %s", args)
+	}
+
+	inherit(us)
+
+	kbs := chain(us)
+
+	for _, kb := range kbs {
+		if err := util.Write(filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)), kb, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)))
+		}
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.MicrosoftSQLBuild,
+		Name: new("Microsoft SQL Server Build Versions"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{URL: u}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+// read walks the raw tree and returns the rows that are updates.
+func read(args string) ([]update, error) {
+	root := filepath.Join(args, "raw")
+
+	var us []update
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".json" {
+			return nil
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", p)
+		}
+		defer f.Close()
+
+		var a sqlbuild.Article
+		if err := json.UnmarshalRead(f, &a); err != nil {
+			return errors.Wrapf(err, "decode %s", p)
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+
+		us = append(us, parseArticle(a, filepath.ToSlash(rel))...)
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrapf(err, "walk %s", root)
+	}
+
+	return us, nil
+}
+
+// parseArticle reads an article's build histories.
+func parseArticle(a sqlbuild.Article, raw string) []update {
+	var us []update
+
+	for _, t := range a.Tables {
+		if !slices.Contains(t.Header, columnKB) {
+			// A summary of the latest update per version, or SQL Server 2000
+			// and earlier, whose KBs are written into prose rather than given a
+			// column. The summary repeats rows the histories already carry;
+			// 2000 and earlier are two KBs in a shape of their own.
+			slog.Debug("not a build history", slog.String("path", raw), slog.String("heading", t.Heading))
+			continue
+		}
+
+		var missing []string
+		for _, c := range []string{columnBuild, columnServicePack, columnUpdate, columnDate} {
+			if !slices.Contains(t.Header, c) {
+				missing = append(missing, c)
+			}
+		}
+		if len(missing) > 0 {
+			slog.Warn("build history is missing columns", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("missing", strings.Join(missing, ", ")), slog.String("header", strings.Join(t.Header, ", ")))
+			continue
+		}
+
+		for _, row := range t.Rows {
+			u, ok := parseRow(t, row, raw)
+			if !ok {
+				continue
+			}
+			us = append(us, u)
+		}
+	}
+
+	return us
+}
+
+// parseRow reads one row, reporting false for the ones that are not updates.
+func parseRow(t sqlbuild.Table, row []sqlbuild.Cell, raw string) (update, bool) {
+	cell := func(column string) sqlbuild.Cell {
+		i := slices.Index(t.Header, column)
+		if i < 0 || i >= len(row) {
+			return sqlbuild.Cell{}
+		}
+		return row[i]
+	}
+
+	m := kbPattern.FindStringSubmatch(cell(columnKB).Text)
+	if m == nil {
+		// The product release itself, written "NA" or left empty. It ships no
+		// KB and takes no place in a chain of them.
+		slog.Debug("row names no KB", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("build", cell(columnBuild).Text))
+		return update{}, false
+	}
+
+	bs := cell(columnBuild).Text
+	if !buildPattern.MatchString(bs) {
+		// The build is the whole order. A row without one cannot be placed.
+		slog.Warn("unexpected build", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("kb", m[1]), slog.String("build", bs))
+		return update{}, false
+	}
+	build := make([]int, 0, 4)
+	for _, p := range strings.Split(bs, ".") {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			slog.Warn("unexpected build", slog.String("path", raw), slog.String("kb", m[1]), slog.String("build", bs))
+			return update{}, false
+		}
+		build = append(build, n)
+	}
+
+	// The date is a tiebreaker between two rows of one build, not the order, so
+	// an unreadable one costs the tie and not the row.
+	var date time.Time
+	if d := cell(columnDate).Text; d != "" {
+		var ok bool
+		date, ok = releaseDate(d)
+		if !ok {
+			slog.Warn("unexpected release date", slog.String("path", raw), slog.String("kb", m[1]), slog.String("date", d))
+		}
+	}
+
+	label := cell(columnUpdate).Text
+	line := line(label)
+	if line == lineUnknown {
+		// Two rows name no kind of update at all. They are recorded and left to
+		// a line of their own, where they chain to nothing: guessing one would
+		// put an edge into a line the estate is measured against.
+		slog.Warn("unrecognised kind of update, row is left unchained", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("kb", m[1]), slog.String("build", bs))
+	}
+
+	return update{
+		kbID:        m[1],
+		url:         absolute(cell(columnKB).Href),
+		version:     t.Heading,
+		servicePack: servicePack(cell(columnServicePack).Text, label),
+		line:        line,
+		build:       build,
+		buildStr:    bs,
+		date:        date,
+		label:       label,
+		raw:         raw,
+	}, true
+}
+
+// line is which of a version's parallel lines an update belongs to.
+//
+// The order the cases are asked in is the whole of it. "CU25 + GDR" is a
+// cumulative update carrying a security fix and belongs to the CU line, so a
+// label naming a CU is answered before one naming GDR is ever considered; and
+// "Azure Connect Pack + GDR" is neither, so it is answered before both.
+func line(label string) string {
+	switch {
+	case strings.Contains(strings.ToLower(label), "azure connect"):
+		return lineACP
+	case cuPattern.MatchString(label):
+		return lineCU
+	case strings.Contains(strings.ToUpper(label), "QFE"):
+		return lineQFE
+	case strings.Contains(strings.ToUpper(label), "GDR"):
+		return lineGDR
+	case baselinePattern.MatchString(label):
+		return lineBaseline
+	default:
+		return lineUnknown
+	}
+}
+
+// servicePack reads the service pack an update was built on, from the column
+// that names it or, where Microsoft has stopped filling that in, from the label.
+func servicePack(column, label string) string {
+	if m := servicePackPattern.FindStringSubmatch(column); m != nil {
+		return "SP" + m[1]
+	}
+	if strings.EqualFold(strings.TrimSpace(column), "RTM") {
+		return "RTM"
+	}
+	if m := servicePackPattern.FindStringSubmatch(label); m != nil {
+		return "SP" + m[1]
+	}
+	return ""
+}
+
+// releaseDate reads the date a row was released, in the four shapes Microsoft
+// has written across 586 of them.
+//
+// The article is hand-authored and the date is prose, so the comma is optional
+// ("July 16 2018"), the space after it is optional ("March 21,2016"), and one
+// row opens with the day of the week ("Friday, June 27, 2014"). Four rows in all,
+// and none of them is a date that cannot be read -- only one written by hand.
+func releaseDate(s string) (time.Time, bool) {
+	s = weekdayPattern.ReplaceAllString(strings.TrimSpace(s), "")
+	s = strings.Join(strings.Fields(strings.ReplaceAll(s, ",", ", ")), " ")
+
+	for _, layout := range []string{"January 2, 2006", "January 2 2006"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+
+	return time.Time{}, false
+}
+
+// absolute keeps a link only where it addresses the KB.
+//
+// Some Knowledge Base cells link to a sibling article in the docs repository
+// instead -- "[KB5093421](sqlserver-2025/cumulativeupdate6.md)" -- which is a
+// path in a repository and not an address for anything. Turning one into a
+// learn.microsoft.com URL means knowing how that docset is mounted, which the
+// path does not say, and building an address the article never gave.
+func absolute(href string) string {
+	if href == "" {
+		return ""
+	}
+	u, err := url.Parse(href)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return ""
+	}
+	return href
+}
+
+// inherit fills in the service pack of the rows that name none, from the build
+// below them on their own line.
+//
+// Thirteen rows name none, every one an Azure Connect Pack release from 2023 on,
+// by which time Microsoft had stopped filling the column in and the label had
+// never carried it. Left empty they are a second Azure Connect Pack line beside
+// the first, and the article's one chain of sixteen becomes two of thirteen and
+// three.
+//
+// A version whose rows all name none is not this case and is left alone: SQL
+// Server 2017 and later have no service packs to name, and there is nothing
+// below them to inherit.
+func inherit(us []update) {
+	type key struct{ version, line string }
+	byLine := make(map[key][]int)
+	for i, u := range us {
+		byLine[key{version: u.version, line: u.line}] = append(byLine[key{version: u.version, line: u.line}], i)
+	}
+
+	for _, is := range byLine {
+		slices.SortFunc(is, func(x, y int) int { return slices.Compare(us[x].build, us[y].build) })
+
+		var last string
+		for _, i := range is {
+			switch {
+			case us[i].servicePack != "":
+				last = us[i].servicePack
+			case last != "":
+				us[i].servicePack = last
+			}
+		}
+	}
+}
+
+// chain turns the rows into KB records, chained into supersedence.
+func chain(us []update) []microsoftkbTypes.KB {
+	type buildLine struct {
+		version     string
+		line        string
+		servicePack string
+	}
+
+	// Which lines a version actually runs, so that a baseline joins the ones
+	// there are rather than conjuring the ones there are not.
+	served := make(map[buildLine]struct{})
+	for _, u := range us {
+		if u.line == lineBaseline || u.line == lineUnknown {
+			continue
+		}
+		served[buildLine{version: u.version, line: u.line, servicePack: u.servicePack}] = struct{}{}
+	}
+
+	lines := make(map[buildLine][]update)
+	for _, u := range us {
+		switch u.line {
+		case lineBaseline:
+			// A service pack's own release is what every line running on it is
+			// built from, so it takes its place in each.
+			for _, l := range []string{lineCU, lineGDR, lineQFE} {
+				bl := buildLine{version: u.version, line: l, servicePack: u.servicePack}
+				if _, ok := served[bl]; !ok {
+					continue
+				}
+				lines[bl] = append(lines[bl], u)
+			}
+		case lineUnknown:
+			// Recorded, and left where nothing chains to it.
+		default:
+			lines[buildLine{version: u.version, line: u.line, servicePack: u.servicePack}] = append(lines[buildLine{version: u.version, line: u.line, servicePack: u.servicePack}], u)
+		}
+	}
+
+	type link struct{ older, newer string }
+	var links []link
+	for bl, group := range lines {
+		// Two rows do share a build, where Microsoft has listed one build under
+		// two labels. The release date decides those, and the KB number only
+		// where even that ties.
+		slices.SortFunc(group, func(x, y update) int {
+			return cmp.Or(slices.Compare(x.build, y.build), x.date.Compare(y.date), cmp.Compare(x.kbID, y.kbID))
+		})
+
+		for i := 1; i < len(group); i++ {
+			older, newer := group[i-1], group[i]
+
+			// The build is the order and the date is not, but where the two
+			// disagree the row is worth reading: seven pairs do, and every one
+			// is filed under a service pack its build number does not belong
+			// to -- SQL Server 2016's 13.0.4202.2 is listed under RTM while its
+			// build says SP1. The edge is kept, the build being the surer of
+			// the two, and the pair is named so it can be looked at.
+			if !older.date.IsZero() && !newer.date.IsZero() && newer.date.Before(older.date) {
+				slog.Warn("a line's builds and release dates disagree",
+					slog.String("version", bl.version), slog.String("line", bl.line), slog.String("service_pack", bl.servicePack),
+					slog.String("older", fmt.Sprintf("KB%s %s %s", older.kbID, older.buildStr, older.date.Format(time.DateOnly))),
+					slog.String("newer", fmt.Sprintf("KB%s %s %s", newer.kbID, newer.buildStr, newer.date.Format(time.DateOnly))))
+			}
+
+			links = append(links, link{older: older.kbID, newer: newer.kbID})
+		}
+	}
+
+	kbs := make(map[string]*microsoftkbTypes.KB, len(us))
+	for _, u := range us {
+		kb, ok := kbs[u.kbID]
+		if !ok {
+			kb = &microsoftkbTypes.KB{
+				KBID: u.kbID,
+				URL:  u.url,
+				DataSource: sourceTypes.Source{
+					ID: sourceTypes.MicrosoftSQLBuild,
+				},
+			}
+			kbs[u.kbID] = kb
+		}
+		if kb.URL == "" {
+			kb.URL = u.url
+		}
+		if !slices.Contains(kb.Products, u.version) {
+			kb.Products = append(kb.Products, u.version)
+		}
+		if !slices.Contains(kb.DataSource.Raws, u.raw) {
+			kb.DataSource.Raws = append(kb.DataSource.Raws, u.raw)
+		}
+	}
+
+	for _, l := range links {
+		if l.older == l.newer {
+			continue
+		}
+		if kb, ok := kbs[l.older]; ok {
+			s := microsoftkbSupersededByTypes.SupersededBy{KBID: l.newer}
+			if !slices.Contains(kb.SupersededBy, s) {
+				kb.SupersededBy = append(kb.SupersededBy, s)
+			}
+		}
+		if kb, ok := kbs[l.newer]; ok {
+			s := microsoftkbSupersedesTypes.Supersedes{KBID: l.older}
+			if !slices.Contains(kb.Supersedes, s) {
+				kb.Supersedes = append(kb.Supersedes, s)
+			}
+		}
+	}
+
+	out := make([]microsoftkbTypes.KB, 0, len(kbs))
+	for _, kb := range kbs {
+		out = append(out, *kb)
+	}
+	return out
+}

--- a/pkg/extract/microsoft/sqlbuild/sqlbuild_test.go
+++ b/pkg/extract/microsoft/sqlbuild/sqlbuild_test.go
@@ -1,0 +1,170 @@
+package sqlbuild_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/sqlbuild"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+// The fixture is the article as fetched, chosen for what decides a chain.
+//
+// SQL Server 2019 runs the two lines a modern version runs, and runs them
+// through the same months: KB5102335 at 15.0.4480.2 and KB5102336 at
+// 15.0.2180.2 shipped on one day and replace their own predecessors and not
+// each other.
+//
+// SQL Server 2016 is where the service pack has to be read twice over. Its
+// Azure Connect Pack line runs 13.0.7000.253 through 13.0.7085.1, and Microsoft
+// stopped filling the Service pack column in partway along it, so the last of
+// the four names no service pack anywhere and takes SP3 from the build below it.
+// Without that the article's one chain of four is two, of three and one.
+//
+// Its SP1 baseline at 13.0.4001.0 is what both SP1 lines are built on, and is
+// superseded by the SP1 CU and the SP1 GDR alike. Its RTM GDR pair is the shape
+// the build order has to be trusted through: 13.0.4202.2 is filed under RTM
+// while its build number says SP1, so it comes after 13.0.1745.2 by build and
+// thirteen months before it by date.
+//
+// SQL Server 2008 is why the service pack is in the key at all. Its RTM CU9 at
+// 10.00.1835.0 shipped in March 2010, eleven months after its SP1 CU2 at
+// 10.00.2710.0, so ordering the version's cumulative updates as one line by
+// build number has the older one replacing the newer.
+//
+// SQL Server 2005 carries the QFE line, which GDR ran beside rather than after.
+//
+// Three rows name a release date Microsoft wrote by hand -- "Friday, June 27,
+// 2014", "March 21,2016", "July 16 2018" -- and two name no kind of update at
+// all, which leaves them recorded and unchained rather than guessed at.
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures/happy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := sqlbuild.Extract(tt.args, sqlbuild.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				return
+			default:
+				ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				gp, err := filepath.Abs(dir)
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}
+
+// The line an update belongs to is the whole of what keeps SQL Server's parallel
+// servicing apart, and it is read from a label Microsoft writes many ways. The
+// order the cases are asked in decides most of these: "CU25 + GDR" names both a
+// cumulative update and a GDR, and is a cumulative update.
+func TestLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		label string
+		want  string
+	}{
+		{name: "a cumulative update", label: "CU26", want: "cu"},
+		{name: "a cumulative update carrying a security fix is still one", label: "CU25 + GDR", want: "cu"},
+		{name: "a cumulative update named in full", label: "SQL Server 2014 SP3 CU4 + GDR", want: "cu"},
+		{name: "a general distribution release", label: "GDR", want: "gdr"},
+		{name: "one named as a security update", label: "GDR Security Update", want: "gdr"},
+		{name: "one named after its bulletin", label: "MS15-058: GDR Security Update", want: "gdr"},
+		{name: "one whose bulletin has no colon", label: "MS16-136 GDR Security Update", want: "gdr"},
+		{name: "the hotfix line GDR ran beside", label: "MS12-070: QFE Security update", want: "qfe"},
+		{name: "the feature pack serviced on its own", label: "Azure Connect Pack + GDR", want: "azure-connect-pack"},
+		{name: "which Microsoft has also written in lower case", label: "Azure Connect pack", want: "azure-connect-pack"},
+		{name: "a product release", label: "RTM", want: "baseline"},
+		{name: "a service pack release", label: "RTW/PCU1", want: "baseline"},
+		{name: "the same, spaced", label: "RTW / PCU 1", want: "baseline"},
+		{name: "general availability", label: "RTM/GA", want: "baseline"},
+		{name: "a row naming no kind at all", label: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, sqlbuild.Line(tt.label)); diff != "" {
+				t.Errorf("line(). (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// The service pack is read from the column that names it, and from the label
+// where Microsoft has stopped filling that column in.
+func TestServicePack(t *testing.T) {
+	tests := []struct {
+		name   string
+		column string
+		label  string
+		want   string
+	}{
+		{name: "the column names it", column: "SP3", label: "GDR", want: "SP3"},
+		{name: "the column names the product release", column: "RTM", label: "CU9", want: "RTM"},
+		{name: "the column is empty and the label names it", column: "None", label: "SP3 + GDR", want: "SP3"},
+		{name: "the label names it in full", column: "None", label: "SQL Server 2014 SP3 CU4 + GDR", want: "SP3"},
+		{name: "neither names one", column: "None", label: "Azure Connect Pack + GDR", want: ""},
+		{name: "a version that has no service packs", column: "None", label: "CU32 + GDR", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, sqlbuild.ServicePack(tt.column, tt.label)); diff != "" {
+				t.Errorf("servicePack(). (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// The release date is prose in a hand-authored article, and Microsoft has
+// written it four ways across 586 rows.
+func TestReleaseDate(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want time.Time
+		ok   bool
+	}{
+		{name: "as written almost everywhere", s: "July 16, 2026", want: time.Date(2026, time.July, 16, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "with the day zero-padded", s: "October 09, 2012", want: time.Date(2012, time.October, 9, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "with no comma", s: "July 16 2018", want: time.Date(2018, time.July, 16, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "with no space after the comma", s: "March 21,2016", want: time.Date(2016, time.March, 21, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "opening with the day of the week", s: "Friday, June 27, 2014", want: time.Date(2014, time.June, 27, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "not a date", s: "n/a", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := sqlbuild.ReleaseDate(tt.s)
+			if ok != tt.ok {
+				t.Fatalf("releaseDate() ok = %v, want %v", ok, tt.ok)
+			}
+			if !tt.ok {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("releaseDate(). (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/fixtures/happy/raw/support/sql/releases/download-and-install-latest-updates.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/fixtures/happy/raw/support/sql/releases/download-and-install-latest-updates.json
@@ -1,0 +1,679 @@
+{
+	"path": "support/sql/releases/download-and-install-latest-updates.md",
+	"tables": [
+		{
+			"heading": "Latest updates for Microsoft SQL Server",
+			"header": [
+				"Version",
+				"Latest service pack",
+				"Latest GDR",
+				"Latest cumulative update"
+			],
+			"rows": [
+				[
+					{
+						"text": "SQL Server 2025"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "GDR",
+						"href": "https://support.microsoft.com/help/5102333"
+					},
+					{
+						"text": "CU7 for 2025",
+						"href": "https://support.microsoft.com/help/5096981"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2025",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "17.0.4065.4"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "CU7"
+					},
+					{
+						"text": "KB5096981",
+						"href": "https://support.microsoft.com/help/5096981"
+					},
+					{
+						"text": "July 16, 2026"
+					}
+				],
+				[
+					{
+						"text": "17.0.4055.5"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "CU6"
+					},
+					{
+						"text": "KB5093421",
+						"href": "sqlserver-2025/cumulativeupdate6.md"
+					},
+					{
+						"text": "June 17, 2026"
+					}
+				],
+				[
+					{
+						"text": "17.0.1000.7"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "RTM/GA"
+					},
+					{
+						"text": "NA"
+					},
+					{
+						"text": "November 05, 2025"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2019",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "15.0.4480.2"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "CU32 + GDR"
+					},
+					{
+						"text": "KB5102335",
+						"href": "https://support.microsoft.com/help/5102335"
+					},
+					{
+						"text": "July 14, 2026"
+					}
+				],
+				[
+					{
+						"text": "15.0.2180.2"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "GDR"
+					},
+					{
+						"text": "KB5102336",
+						"href": "https://support.microsoft.com/help/5102336"
+					},
+					{
+						"text": "July 14, 2026"
+					}
+				],
+				[
+					{
+						"text": "15.0.4470.1"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "CU32 + GDR"
+					},
+					{
+						"text": "KB5090407",
+						"href": "https://support.microsoft.com/help/5090407"
+					},
+					{
+						"text": "May 12, 2026"
+					}
+				],
+				[
+					{
+						"text": "15.0.2170.1"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "GDR"
+					},
+					{
+						"text": "KB5090408",
+						"href": "https://support.microsoft.com/help/5090408"
+					},
+					{
+						"text": "May 12, 2026"
+					}
+				],
+				[
+					{
+						"text": "15.0.2000.5"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "NA"
+					},
+					{
+						"text": "November 04, 2019"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2016",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "13.0.7085.1"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "Azure Connect Pack + GDR"
+					},
+					{
+						"text": "KB5089270",
+						"href": "https://support.microsoft.com/help/5089270"
+					},
+					{
+						"text": "May 12, 2026"
+					}
+				],
+				[
+					{
+						"text": "13.0.7024.30"
+					},
+					{
+						"text": "SP3"
+					},
+					{
+						"text": "Azure Connect pack + GDR"
+					},
+					{
+						"text": "KB5021128",
+						"href": "https://support.microsoft.com/help/5021128"
+					},
+					{
+						"text": "February 14, 2023"
+					}
+				],
+				[
+					{
+						"text": "13.0.7016.1"
+					},
+					{
+						"text": "SP3"
+					},
+					{
+						"text": "Azure Connect pack + GDR"
+					},
+					{
+						"text": "KB5015371",
+						"href": "https://support.microsoft.com/help/5015371"
+					},
+					{
+						"text": "June 14, 2022"
+					}
+				],
+				[
+					{
+						"text": "13.0.7000.253"
+					},
+					{
+						"text": "SP3"
+					},
+					{
+						"text": "Azure Connect pack"
+					},
+					{
+						"text": "KB5014242",
+						"href": "sqlserver-2016/servicepack3-azureconnect.md"
+					},
+					{
+						"text": "May 19, 2022"
+					}
+				],
+				[
+					{
+						"text": "13.0.5153.0"
+					},
+					{
+						"text": "SP2"
+					},
+					{
+						"text": "CU2"
+					},
+					{
+						"text": "KB4340355",
+						"href": "sqlserver-2016/servicepack2-cumulativeupdate2.md"
+					},
+					{
+						"text": "July 16 2018"
+					}
+				],
+				[
+					{
+						"text": "13.0.4411.0"
+					},
+					{
+						"text": "SP1"
+					},
+					{
+						"text": "CU1"
+					},
+					{
+						"text": "KB3208177",
+						"href": "sqlserver-2016/servicepack1-cumulativeupdate1.md"
+					},
+					{
+						"text": "January 17, 2017"
+					}
+				],
+				[
+					{
+						"text": "13.0.4206.0"
+					},
+					{
+						"text": "SP1"
+					},
+					{
+						"text": "GDR"
+					},
+					{
+						"text": "KB4019089",
+						"href": "https://support.microsoft.com/help/4019089"
+					},
+					{
+						"text": "August 08, 2017"
+					}
+				],
+				[
+					{
+						"text": "13.0.4001.0"
+					},
+					{
+						"text": "SP1"
+					},
+					{
+						"text": "RTW/PCU1"
+					},
+					{
+						"text": "KB3182545",
+						"href": "sqlserver-2016/servicepack1.md"
+					},
+					{
+						"text": "November 16, 2016"
+					}
+				],
+				[
+					{
+						"text": "13.0.4202.2"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "GDR"
+					},
+					{
+						"text": "KB3210089",
+						"href": "https://support.microsoft.com/help/3210089"
+					},
+					{
+						"text": "December 16, 2016"
+					}
+				],
+				[
+					{
+						"text": "13.0.1745.2"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "GDR"
+					},
+					{
+						"text": "KB4058560",
+						"href": "https://support.microsoft.com/help/4058560"
+					},
+					{
+						"text": "January 06, 2018"
+					}
+				],
+				[
+					{
+						"text": "13.0.1601.5"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "NA"
+					},
+					{
+						"text": "June 01, 2016"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2014",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "12.0.2370.0"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "CU2"
+					},
+					{
+						"text": "KB2967546",
+						"href": "https://support.microsoft.com/help/2967546"
+					},
+					{
+						"text": "Friday, June 27, 2014"
+					}
+				],
+				[
+					{
+						"text": "12.0.2342.0"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "CU1"
+					},
+					{
+						"text": "KB2931693",
+						"href": "https://support.microsoft.com/help/2931693"
+					},
+					{
+						"text": "April 21, 2014"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2012",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "11.0.6523.0"
+					},
+					{
+						"text": "SP3"
+					},
+					{
+						"text": "CU2"
+					},
+					{
+						"text": "KB3137746",
+						"href": "https://support.microsoft.com/help/3137746"
+					},
+					{
+						"text": "March 21,2016"
+					}
+				],
+				[
+					{
+						"text": "11.0.6518.0"
+					},
+					{
+						"text": "SP3"
+					},
+					{
+						"text": "CU1"
+					},
+					{
+						"text": "KB3123299",
+						"href": "https://support.microsoft.com/help/3123299"
+					},
+					{
+						"text": "January 19, 2016"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2008",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "10.00.5867.0"
+					},
+					{
+						"text": "(on-demand update package)"
+					},
+					{},
+					{
+						"text": "KB2877204",
+						"href": "https://support.microsoft.com/help/2877204"
+					},
+					{
+						"text": "October 16, 2013"
+					}
+				],
+				[
+					{
+						"text": "10.00.2710.0"
+					},
+					{
+						"text": "SP1"
+					},
+					{
+						"text": "CU2"
+					},
+					{
+						"text": "KB970315",
+						"href": "https://support.microsoft.com/help/970315"
+					},
+					{
+						"text": "April 16, 2009"
+					}
+				],
+				[
+					{
+						"text": "10.00.2531.0"
+					},
+					{
+						"text": "SP1"
+					},
+					{
+						"text": "RTW / PCU 1"
+					},
+					{},
+					{
+						"text": "April 07, 2009"
+					}
+				],
+				[
+					{
+						"text": "10.00.1835.0"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "CU9"
+					},
+					{
+						"text": "KB2083921",
+						"href": "https://support.microsoft.com/help/2083921"
+					},
+					{
+						"text": "March 15, 2010"
+					}
+				],
+				[
+					{
+						"text": "10.00.1798.0"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "CU5"
+					},
+					{
+						"text": "KB975977",
+						"href": "https://support.microsoft.com/help/975977"
+					},
+					{
+						"text": "July 20, 2009"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2005",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "9.00.5324"
+					},
+					{
+						"text": "SP4"
+					},
+					{
+						"text": "MS12-070: QFE Security update"
+					},
+					{
+						"text": "KB2716427",
+						"href": "https://support.microsoft.com/help/2716427"
+					},
+					{
+						"text": "October 09, 2012"
+					}
+				],
+				[
+					{
+						"text": "9.00.5292"
+					},
+					{
+						"text": "SP4"
+					},
+					{
+						"text": "MS11-049: QFE Security update"
+					},
+					{
+						"text": "KB2494123",
+						"href": "https://support.microsoft.com/help/2494123"
+					},
+					{
+						"text": "June 14, 2011"
+					}
+				],
+				[
+					{
+						"text": "9.00.3042"
+					},
+					{
+						"text": "SP2"
+					},
+					{},
+					{
+						"text": "KB937137",
+						"href": "https://support.microsoft.com/help/937137"
+					},
+					{}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2000",
+			"header": [
+				"Build number or version",
+				"Version description, (KB number for that update), release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "8.00.2283"
+					},
+					{
+						"text": "Post-SP4 hotfix for MS09-004 (971524)"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/datasource.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "microsoft-sqlbuild",
+	"name": "Microsoft SQL Server Build Versions"
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2083xxx/2083921.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2083xxx/2083921.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "2083921",
+	"url": "https://support.microsoft.com/help/2083921",
+	"products": [
+		"SQL Server 2008"
+	],
+	"supersedes": [
+		{
+			"kb_id": "975977"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2494xxx/2494123.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2494xxx/2494123.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "2494123",
+	"url": "https://support.microsoft.com/help/2494123",
+	"products": [
+		"SQL Server 2005"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "2716427"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2716xxx/2716427.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2716xxx/2716427.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "2716427",
+	"url": "https://support.microsoft.com/help/2716427",
+	"products": [
+		"SQL Server 2005"
+	],
+	"supersedes": [
+		{
+			"kb_id": "2494123"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2877xxx/2877204.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2877xxx/2877204.json
@@ -1,0 +1,13 @@
+{
+	"kb_id": "2877204",
+	"url": "https://support.microsoft.com/help/2877204",
+	"products": [
+		"SQL Server 2008"
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2931xxx/2931693.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2931xxx/2931693.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "2931693",
+	"url": "https://support.microsoft.com/help/2931693",
+	"products": [
+		"SQL Server 2014"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "2967546"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2967xxx/2967546.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/2967xxx/2967546.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "2967546",
+	"url": "https://support.microsoft.com/help/2967546",
+	"products": [
+		"SQL Server 2014"
+	],
+	"supersedes": [
+		{
+			"kb_id": "2931693"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/3123xxx/3123299.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/3123xxx/3123299.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "3123299",
+	"url": "https://support.microsoft.com/help/3123299",
+	"products": [
+		"SQL Server 2012"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "3137746"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/3137xxx/3137746.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/3137xxx/3137746.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "3137746",
+	"url": "https://support.microsoft.com/help/3137746",
+	"products": [
+		"SQL Server 2012"
+	],
+	"supersedes": [
+		{
+			"kb_id": "3123299"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/3182xxx/3182545.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/3182xxx/3182545.json
@@ -1,0 +1,20 @@
+{
+	"kb_id": "3182545",
+	"products": [
+		"SQL Server 2016"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "3208177"
+		},
+		{
+			"kb_id": "4019089"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/3208xxx/3208177.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/3208xxx/3208177.json
@@ -1,0 +1,17 @@
+{
+	"kb_id": "3208177",
+	"products": [
+		"SQL Server 2016"
+	],
+	"supersedes": [
+		{
+			"kb_id": "3182545"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/3210xxx/3210089.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/3210xxx/3210089.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "3210089",
+	"url": "https://support.microsoft.com/help/3210089",
+	"products": [
+		"SQL Server 2016"
+	],
+	"supersedes": [
+		{
+			"kb_id": "4058560"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/4019xxx/4019089.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/4019xxx/4019089.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "4019089",
+	"url": "https://support.microsoft.com/help/4019089",
+	"products": [
+		"SQL Server 2016"
+	],
+	"supersedes": [
+		{
+			"kb_id": "3182545"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/4058xxx/4058560.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/4058xxx/4058560.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "4058560",
+	"url": "https://support.microsoft.com/help/4058560",
+	"products": [
+		"SQL Server 2016"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "3210089"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/4340xxx/4340355.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/4340xxx/4340355.json
@@ -1,0 +1,12 @@
+{
+	"kb_id": "4340355",
+	"products": [
+		"SQL Server 2016"
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5014xxx/5014242.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5014xxx/5014242.json
@@ -1,0 +1,17 @@
+{
+	"kb_id": "5014242",
+	"products": [
+		"SQL Server 2016"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5015371"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5015xxx/5015371.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5015xxx/5015371.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "5015371",
+	"url": "https://support.microsoft.com/help/5015371",
+	"products": [
+		"SQL Server 2016"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5021128"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "5014242"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5021xxx/5021128.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5021xxx/5021128.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "5021128",
+	"url": "https://support.microsoft.com/help/5021128",
+	"products": [
+		"SQL Server 2016"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5089270"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "5015371"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5089xxx/5089270.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5089xxx/5089270.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5089270",
+	"url": "https://support.microsoft.com/help/5089270",
+	"products": [
+		"SQL Server 2016"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5021128"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5090xxx/5090407.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5090xxx/5090407.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5090407",
+	"url": "https://support.microsoft.com/help/5090407",
+	"products": [
+		"SQL Server 2019"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5102335"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5090xxx/5090408.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5090xxx/5090408.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5090408",
+	"url": "https://support.microsoft.com/help/5090408",
+	"products": [
+		"SQL Server 2019"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5102336"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5093xxx/5093421.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5093xxx/5093421.json
@@ -1,0 +1,17 @@
+{
+	"kb_id": "5093421",
+	"products": [
+		"SQL Server 2025"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5096981"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5096xxx/5096981.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5096xxx/5096981.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5096981",
+	"url": "https://support.microsoft.com/help/5096981",
+	"products": [
+		"SQL Server 2025"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5093421"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5102xxx/5102335.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5102xxx/5102335.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5102335",
+	"url": "https://support.microsoft.com/help/5102335",
+	"products": [
+		"SQL Server 2019"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5090407"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5102xxx/5102336.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/5102xxx/5102336.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5102336",
+	"url": "https://support.microsoft.com/help/5102336",
+	"products": [
+		"SQL Server 2019"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5090408"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/937xxx/937137.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/937xxx/937137.json
@@ -1,0 +1,13 @@
+{
+	"kb_id": "937137",
+	"url": "https://support.microsoft.com/help/937137",
+	"products": [
+		"SQL Server 2005"
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/970xxx/970315.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/970xxx/970315.json
@@ -1,0 +1,13 @@
+{
+	"kb_id": "970315",
+	"url": "https://support.microsoft.com/help/970315",
+	"products": [
+		"SQL Server 2008"
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/975xxx/975977.json
+++ b/pkg/extract/microsoft/sqlbuild/testdata/golden/microsoftkb/975xxx/975977.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "975977",
+	"url": "https://support.microsoft.com/help/975977",
+	"products": [
+		"SQL Server 2008"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "2083921"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sqlbuild",
+		"raws": [
+			"support/sql/releases/download-and-install-latest-updates.json"
+		]
+	}
+}

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -90,6 +90,7 @@ const (
 	MicrosoftMSUC              SourceID = "microsoft-msuc"
 	MicrosoftProduct           SourceID = "microsoft-product"
 	MicrosoftServicing         SourceID = "microsoft-servicing"
+	MicrosoftSQLBuild          SourceID = "microsoft-sqlbuild"
 	MicrosoftVulnerability     SourceID = "microsoft-vulnerability"
 	MicrosoftWSUSSCN2          SourceID = "microsoft-wsusscn2"
 	MinimosSecDB               SourceID = "minimos-secdb"

--- a/pkg/fetch/microsoft/sqlbuild/sqlbuild.go
+++ b/pkg/fetch/microsoft/sqlbuild/sqlbuild.go
@@ -1,0 +1,371 @@
+// Package sqlbuild fetches Microsoft's SQL Server build-versions article --
+// "Download and install the latest updates for SQL Server" -- from the docs
+// repository it is authored in.
+//
+// The article lists, per product version, every build SQL Server has shipped:
+// the build number, the service pack it belongs to, what kind of update it is
+// and the KB. It runs from SQL Server 2005 to the current release, 584 KBs, and
+// the Update Catalog no longer serves most of them.
+//
+// It is fetched as Markdown from MicrosoftDocs/SupportArticles-docs rather than
+// as the rendered page, because the repository is public and keeps the article's
+// history. A row Microsoft removes is recoverable from git afterwards, which the
+// rendered page cannot offer at all -- and recovering what has been removed is
+// the whole reason this source exists.
+//
+// The per-version articles under sqlserver-<year>/build-versions.md were
+// measured against this one and add nothing: their KB sets are identical to it,
+// version for version, all six of them, and what they carry beyond it is the
+// sqlservr.exe and msmdsrv.exe file versions, which no chain is ordered by. This
+// article also covers SQL Server 2012, 2008 R2, 2008 and 2005, which have no
+// per-version article at all -- 197 KBs that exist nowhere else in the set.
+//
+// Being hand-authored Markdown, it is not always well formed: one row of the
+// 2016 article has lost its leading pipe, and the rendered page shows the row
+// because the docs pipeline forgives it. The table reader forgives it too, and
+// says so, so that a row held together by leniency is a thing someone can go and
+// look at rather than a silent repair.
+//
+// fetch writes <dir>/origin verbatim and then produces <dir>/raw by reading it
+// back, never the HTTP response, so raw/ is reproducible from origin/ alone.
+package sqlbuild
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+const (
+	baseURL = "https://raw.githubusercontent.com/MicrosoftDocs/SupportArticles-docs/main"
+
+	// articlePath is the article's path in the docs repository, which is both
+	// where it is fetched from and where its history is read.
+	articlePath = "support/sql/releases/download-and-install-latest-updates.md"
+)
+
+var (
+	// separatorPattern is the row of dashes under a Markdown table's header. It
+	// is the only row that is not content.
+	separatorPattern = regexp.MustCompile(`^:?-{2,}:?$`)
+
+	headingPattern = regexp.MustCompile(`^#{1,6}\s+(.*)$`)
+
+	// linkPattern is a Markdown link. Only the first of a cell is taken: a cell
+	// naming two links names two things, and which of them is the cell's own
+	// address is not this parser's to decide.
+	linkPattern = regexp.MustCompile(`\[([^\]]*)\]\(([^)]*)\)`)
+
+	// markupPattern is the emphasis and the line breaks Microsoft writes inside
+	// cells, which are presentation and not content.
+	markupPattern = regexp.MustCompile(`\*\*|<br\s*/?>|__`)
+)
+
+type options struct {
+	baseURL string
+	dir     string
+	retry   int
+	wait    time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type baseURLOption string
+
+func (u baseURLOption) apply(opts *options) {
+	opts.baseURL = string(u)
+}
+
+func WithBaseURL(url string) Option {
+	return baseURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+// Fetch stores the article under <dir>/origin and the tables it carries under
+// <dir>/raw.
+func Fetch(opts ...Option) error {
+	options := &options{
+		baseURL: baseURL,
+		dir:     filepath.Join(util.CacheDir(), "fetch", "microsoft", "sqlbuild"),
+		retry:   3,
+		wait:    1 * time.Second,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	if err := options.fetch(); err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+
+	if err := options.convert(); err != nil {
+		return errors.Wrap(err, "convert")
+	}
+
+	return nil
+}
+
+// fetch stores the article as served.
+func (opts options) fetch() error {
+	slog.Info("Fetch Microsoft SQL Server Build Versions")
+
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
+
+	u, err := url.JoinPath(opts.baseURL, articlePath)
+	if err != nil {
+		return errors.Wrapf(err, "join %s and %s", opts.baseURL, articlePath)
+	}
+
+	if err := client.PipelineGet([]string{u}, 1, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, resp.Request.URL)
+		}
+
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", resp.Request.URL)
+		}
+
+		if err := writeOrigin(opts.dir, articlePath, bs); err != nil {
+			return errors.Wrapf(err, "write %s", articlePath)
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "pipeline get")
+	}
+
+	return nil
+}
+
+// convert reads origin/ back and writes raw/, at the path its origin/
+// counterpart has. Going through the stored bytes rather than the response is
+// what lets the tree be re-derived after this parser changes.
+func (opts options) convert() error {
+	slog.Info("Convert origin to raw")
+
+	root := filepath.Join(opts.dir, "origin")
+
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".md" {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+		rel = filepath.ToSlash(rel)
+
+		bs, err := os.ReadFile(p)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", p)
+		}
+
+		a := parseArticle(string(bs), rel)
+
+		// The article is its tables. One that parses to none is not an article
+		// whose tables have been retired -- it lists builds back to SQL Server
+		// 6.5, released in 1996 -- it is this parser having lost them, and it
+		// loses them all at once. Skipping would leave raw/ empty beside a full
+		// origin/ with the run green.
+		if len(a.Tables) == 0 {
+			return errors.Errorf("no table in %s", p)
+		}
+
+		if err := util.Write(filepath.Join(opts.dir, "raw", fmt.Sprintf("%s.json", strings.TrimSuffix(rel, ".md"))), a); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, "raw", fmt.Sprintf("%s.json", strings.TrimSuffix(rel, ".md"))))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", root)
+	}
+
+	return nil
+}
+
+// writeOrigin stores content under <dir>/origin/<name> as served.
+//
+// Nothing derived from the response is recorded alongside it -- no fetch
+// timestamp, no ETag, no commit. Those change on every run even when the article
+// does not, and would turn every fetch into a diff, drowning the signal this
+// tree exists to carry: that Microsoft revised the article.
+func writeOrigin(dir, name string, content []byte) error {
+	path := filepath.Join(dir, "origin", filepath.FromSlash(name))
+
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return errors.Wrapf(err, "mkdir %s", filepath.Dir(path))
+	}
+
+	if err := os.WriteFile(path, content, 0666); err != nil {
+		return errors.Wrapf(err, "write %s", path)
+	}
+
+	return nil
+}
+
+// parseArticle reads an article's tables, each under the heading it follows.
+func parseArticle(doc, path string) Article {
+	a := Article{Path: path}
+
+	var heading string
+	// The table being read, as an index rather than a pointer: appending the
+	// next one may move the slice out from under a pointer into it.
+	table := -1
+	for _, line := range strings.Split(doc, "\n") {
+		line = strings.TrimRight(line, "\r")
+
+		if m := headingPattern.FindStringSubmatch(line); m != nil {
+			heading = strings.TrimSpace(m[1])
+			table = -1
+			continue
+		}
+
+		cells, ok := parseRow(line, table >= 0)
+		if !ok {
+			table = -1
+			continue
+		}
+		if cells == nil {
+			// The dashes under a header. They say how the columns align and
+			// nothing about what is in them.
+			continue
+		}
+
+		if table < 0 {
+			a.Tables = append(a.Tables, Table{Heading: heading, Header: texts(cells)})
+			table = len(a.Tables) - 1
+			continue
+		}
+		a.Tables[table].Rows = append(a.Tables[table].Rows, cells)
+	}
+
+	// A table of nothing but a header is not a table. The article carries one:
+	// its opening summary is a header row Microsoft never filled in.
+	a.Tables = slices.DeleteFunc(a.Tables, func(t Table) bool { return len(t.Rows) == 0 })
+
+	return a
+}
+
+// parseRow reads one line as a table row, reporting false for the lines that
+// are not one and a nil row for the separator under a header.
+//
+// A row is recognised by its leading pipe, except inside a table, where a line
+// carrying pipes is taken as a row without one. Microsoft has served such a row
+// -- the SQL Server 2016 article has one that lost its leading pipe -- and the
+// docs pipeline renders it as part of the table, so a reader that stopped there
+// would end the table early and read the rest of it as a new one, header and
+// all. Being inside a table is what makes it safe: the prose between tables is
+// never taken this way.
+func parseRow(line string, inTable bool) ([]Cell, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return nil, false
+	}
+
+	if !strings.HasPrefix(trimmed, "|") {
+		if !inTable || !strings.Contains(trimmed, "|") {
+			return nil, false
+		}
+		slog.Warn("table row without a leading pipe", slog.String("row", trimmed))
+	}
+
+	fields := strings.Split(strings.Trim(trimmed, "|"), "|")
+
+	separator := true
+	for _, f := range fields {
+		if !separatorPattern.MatchString(strings.TrimSpace(f)) {
+			separator = false
+			break
+		}
+	}
+	if separator {
+		return nil, true
+	}
+
+	cells := make([]Cell, 0, len(fields))
+	for _, f := range fields {
+		cells = append(cells, parseCell(f))
+	}
+
+	return cells, true
+}
+
+// parseCell reads a cell's text and the first link it carries.
+func parseCell(s string) Cell {
+	var href string
+	if m := linkPattern.FindStringSubmatch(s); m != nil {
+		href = strings.TrimSpace(m[2])
+	}
+
+	// The link's text stands in for the link, which is what the cell reads as.
+	text := linkPattern.ReplaceAllString(s, "$1")
+	text = markupPattern.ReplaceAllString(text, " ")
+
+	return Cell{Text: strings.Join(strings.Fields(text), " "), Href: href}
+}
+
+func texts(cells []Cell) []string {
+	out := make([]string, 0, len(cells))
+	for _, c := range cells {
+		out = append(out, c.Text)
+	}
+	return out
+}

--- a/pkg/fetch/microsoft/sqlbuild/sqlbuild_test.go
+++ b/pkg/fetch/microsoft/sqlbuild/sqlbuild_test.go
@@ -1,0 +1,155 @@
+package sqlbuild_test
+
+import (
+	"io/fs"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/sqlbuild"
+)
+
+// The fixture is the article as authored, cut down to the rows that decide what
+// is read out of it.
+//
+// It opens with a summary table that names no Knowledge Base column, and closes
+// with SQL Server 2000, whose table has a column set of its own. Neither is a
+// build history and both sit among the ones that are.
+//
+// One SQL Server 2016 row has lost its leading pipe, as Microsoft has served it.
+// The docs pipeline renders it inside the table, so a reader that stopped there
+// would end the table early and read the rest of it as a second one, header and
+// all -- turning fifteen rows into one table of one and another of thirteen.
+//
+// Knowledge Base cells are written both ways: as an address for the KB, and as a
+// path to a sibling article in the repository, which is not one. Three rows name
+// no KB at all, being the product release rather than an update to it, and one
+// of those has an empty cell rather than the "NA" the others use.
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		golden   string
+		hasError bool
+	}{
+		{
+			name:    "happy",
+			fixture: "happy",
+			golden:  "happy",
+		},
+		{
+			// An article whose tables this cannot find is not an article that
+			// has lost them: it lists builds back to SQL Server 6.5, released
+			// in 1996. It is this parser having lost them, so the run fails
+			// rather than committing an empty raw/ beside a full origin/.
+			name:     "article without tables",
+			fixture:  "tableless",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(handler(t, tt.fixture))
+			defer ts.Close()
+
+			dir := t.TempDir()
+			err := sqlbuild.Fetch(
+				sqlbuild.WithBaseURL(ts.URL),
+				sqlbuild.WithDir(dir),
+				sqlbuild.WithRetry(0),
+				sqlbuild.WithWait(0),
+			)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Fatalf("unexpected error. err: %v", err)
+			case err == nil && tt.hasError:
+				t.Fatal("expected error has not occurred")
+			case err != nil:
+				return
+			}
+
+			diff(t, filepath.Join("testdata", "golden", tt.golden), dir)
+		})
+	}
+}
+
+// handler serves a fixture tree the way raw.githubusercontent.com serves the
+// repository: one document per path, and nothing anywhere else.
+func handler(t *testing.T, fixture string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		bs, err := os.ReadFile(filepath.Join("testdata", "fixtures", fixture, filepath.Clean(r.URL.Path)))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(bs)
+	}
+}
+
+// diff compares the produced tree against golden byte for byte. Bytes rather
+// than parsed content: origin/ is only worth keeping if it reproduces exactly,
+// and raw/ is written deterministically, so any difference at all is a
+// regression.
+func diff(t *testing.T, golden, got string) {
+	t.Helper()
+
+	want := walk(t, golden)
+	have := walk(t, got)
+
+	if d := cmp.Diff(slices.Sorted(maps.Keys(want)), slices.Sorted(maps.Keys(have))); d != "" {
+		t.Errorf("files (-expected +got):\n%s", d)
+	}
+
+	for n, w := range want {
+		h, ok := have[n]
+		if !ok {
+			continue
+		}
+		if d := cmp.Diff(string(w), string(h)); d != "" {
+			t.Errorf("%s (-expected +got):\n%s", n, d)
+		}
+	}
+}
+
+func walk(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+
+	out := make(map[string][]byte)
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+
+		bs, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+
+		out[filepath.ToSlash(rel)] = bs
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walk %s. err: %v", root, err)
+	}
+
+	return out
+}

--- a/pkg/fetch/microsoft/sqlbuild/testdata/fixtures/happy/support/sql/releases/download-and-install-latest-updates.md
+++ b/pkg/fetch/microsoft/sqlbuild/testdata/fixtures/happy/support/sql/releases/download-and-install-latest-updates.md
@@ -1,0 +1,88 @@
+---
+title: Latest updates for SQL Server
+description: This article lists the latest updates for SQL Server.
+ms.date: 07/16/2026
+---
+# Latest updates for Microsoft SQL Server
+
+The following table lists the latest builds for each supported version.
+
+| Version | Latest service pack | Latest GDR | Latest cumulative update |
+|---------|---------------------|------------|--------------------------|
+| **SQL Server 2025** | None | [GDR](https://support.microsoft.com/help/5102333) | [CU7 for 2025](https://support.microsoft.com/help/5096981) |
+
+## SQL Server 2025
+
+| Build number or version | Service pack | Update | Knowledge Base number | Release date |
+|-------------------------|--------------|--------|-----------------------|--------------|
+| 17.0.4065.4             | None         | CU7    | [KB5096981](https://support.microsoft.com/help/5096981) | July 16, 2026 |
+| 17.0.4055.5             | None         | CU6    | [KB5093421](sqlserver-2025/cumulativeupdate6.md)        | June 17, 2026 |
+| 17.0.1000.7             | None         | RTM/GA | NA                                                      | November 05, 2025 |
+
+## SQL Server 2019
+
+| Build number or version | Service pack | Update     | Knowledge Base number | Release date |
+|-------------------------|--------------|------------|-----------------------|--------------|
+| 15.0.4480.2             | None         | CU32 + GDR | [KB5102335](https://support.microsoft.com/help/5102335) | July 14, 2026 |
+| 15.0.2180.2             | None         | GDR        | [KB5102336](https://support.microsoft.com/help/5102336) | July 14, 2026 |
+| 15.0.4470.1             | None         | CU32 + GDR | [KB5090407](https://support.microsoft.com/help/5090407) | May 12, 2026 |
+| 15.0.2170.1             | None         | GDR        | [KB5090408](https://support.microsoft.com/help/5090408) | May 12, 2026 |
+| 15.0.2000.5             | None         | RTM        | NA                                                      | November 04, 2019 |
+
+## SQL Server 2016
+
+| Build number or version | Service pack | Update                   | Knowledge Base number | Release date |
+|-------------------------|--------------|--------------------------|-----------------------|--------------|
+| 13.0.7085.1             | None         | Azure Connect Pack + GDR | [KB5089270](https://support.microsoft.com/help/5089270) | May 12, 2026 |
+ 13.0.7024.30            | SP3          | Azure Connect pack + GDR | [KB5021128](https://support.microsoft.com/help/5021128) | February 14, 2023 |
+| 13.0.7016.1             | SP3          | Azure Connect pack + GDR | [KB5015371](https://support.microsoft.com/help/5015371) | June 14, 2022 |
+| 13.0.7000.253           | SP3          | Azure Connect pack       | [KB5014242](sqlserver-2016/servicepack3-azureconnect.md) | May 19, 2022 |
+| 13.0.5153.0             | SP2          | CU2                      | [KB4340355](sqlserver-2016/servicepack2-cumulativeupdate2.md) | July 16 2018 |
+| 13.0.4411.0             | SP1          | CU1                      | [KB3208177](sqlserver-2016/servicepack1-cumulativeupdate1.md) | January 17, 2017 |
+| 13.0.4206.0             | SP1          | GDR                      | [KB4019089](https://support.microsoft.com/help/4019089) | August 08, 2017 |
+| 13.0.4001.0             | SP1          | RTW/PCU1                 | [KB3182545](sqlserver-2016/servicepack1.md) | November 16, 2016 |
+| 13.0.4202.2             | RTM          | GDR                      | [KB3210089](https://support.microsoft.com/help/3210089) | December 16, 2016 |
+| 13.0.1745.2             | RTM          | GDR                      | [KB4058560](https://support.microsoft.com/help/4058560) | January 06, 2018 |
+| 13.0.1601.5             | None         | RTM                      | NA                                                      | June 01, 2016 |
+
+## SQL Server 2014
+
+| Build number or version | Service pack | Update | Knowledge Base number | Release date |
+|-------------------------|--------------|--------|-----------------------|--------------|
+| 12.0.2370.0             | RTM          | CU2    | [KB2967546](https://support.microsoft.com/help/2967546) | Friday, June 27, 2014 |
+| 12.0.2342.0             | RTM          | CU1    | [KB2931693](https://support.microsoft.com/help/2931693) | April 21, 2014 |
+
+## SQL Server 2012
+
+| Build number or version | Service pack | Update | Knowledge Base number | Release date |
+|-------------------------|--------------|--------|-----------------------|--------------|
+| 11.0.6523.0             | SP3          | CU2    | [KB3137746](https://support.microsoft.com/help/3137746) | March 21,2016 |
+| 11.0.6518.0             | SP3          | CU1    | [KB3123299](https://support.microsoft.com/help/3123299) | January 19, 2016 |
+
+## SQL Server 2008
+
+| Build number or version | Service pack | Update | Knowledge Base number | Release date |
+|-------------------------|--------------|--------|-----------------------|--------------|
+| 10.00.5867.0            | (on-demand update package) |  | [KB2877204](https://support.microsoft.com/help/2877204) | October 16, 2013 |
+| 10.00.2710.0            | SP1          | CU2    | [KB970315](https://support.microsoft.com/help/970315) | April 16, 2009 |
+| 10.00.2531.0            | SP1          | RTW / PCU 1 |  | April 07, 2009 |
+| 10.00.1835.0            | RTM          | CU9    | [KB2083921](https://support.microsoft.com/help/2083921) | March 15, 2010 |
+| 10.00.1798.0            | RTM          | CU5    | [KB975977](https://support.microsoft.com/help/975977) | July 20, 2009 |
+
+## SQL Server 2005
+
+| Build number or version | Service pack | Update | Knowledge Base number | Release date |
+|-------------------------|--------------|--------|-----------------------|--------------|
+| 9.00.5324               | SP4          | MS12-070: QFE Security update | [KB2716427](https://support.microsoft.com/help/2716427) | October 09, 2012 |
+| 9.00.5292               | SP4          | MS11-049: QFE Security update | [KB2494123](https://support.microsoft.com/help/2494123) | June 14, 2011 |
+| 9.00.3042               | SP2          |  | [KB937137](https://support.microsoft.com/help/937137) |  |
+
+## SQL Server 2000
+
+| Build number or version | Version description, (KB number for that update), release date |
+|-------------------------|----------------------------------------------------------------|
+| 8.00.2283               | Post-SP4 hotfix for MS09-004 (971524) |
+
+## References
+
+- [SQL Server servicing models](servicing-models-sql-server.md)

--- a/pkg/fetch/microsoft/sqlbuild/testdata/fixtures/tableless/support/sql/releases/download-and-install-latest-updates.md
+++ b/pkg/fetch/microsoft/sqlbuild/testdata/fixtures/tableless/support/sql/releases/download-and-install-latest-updates.md
@@ -1,0 +1,7 @@
+---
+title: Latest updates for SQL Server
+ms.date: 07/16/2026
+---
+# Latest updates for Microsoft SQL Server
+
+This content has moved.

--- a/pkg/fetch/microsoft/sqlbuild/testdata/golden/happy/origin/support/sql/releases/download-and-install-latest-updates.md
+++ b/pkg/fetch/microsoft/sqlbuild/testdata/golden/happy/origin/support/sql/releases/download-and-install-latest-updates.md
@@ -1,0 +1,88 @@
+---
+title: Latest updates for SQL Server
+description: This article lists the latest updates for SQL Server.
+ms.date: 07/16/2026
+---
+# Latest updates for Microsoft SQL Server
+
+The following table lists the latest builds for each supported version.
+
+| Version | Latest service pack | Latest GDR | Latest cumulative update |
+|---------|---------------------|------------|--------------------------|
+| **SQL Server 2025** | None | [GDR](https://support.microsoft.com/help/5102333) | [CU7 for 2025](https://support.microsoft.com/help/5096981) |
+
+## SQL Server 2025
+
+| Build number or version | Service pack | Update | Knowledge Base number | Release date |
+|-------------------------|--------------|--------|-----------------------|--------------|
+| 17.0.4065.4             | None         | CU7    | [KB5096981](https://support.microsoft.com/help/5096981) | July 16, 2026 |
+| 17.0.4055.5             | None         | CU6    | [KB5093421](sqlserver-2025/cumulativeupdate6.md)        | June 17, 2026 |
+| 17.0.1000.7             | None         | RTM/GA | NA                                                      | November 05, 2025 |
+
+## SQL Server 2019
+
+| Build number or version | Service pack | Update     | Knowledge Base number | Release date |
+|-------------------------|--------------|------------|-----------------------|--------------|
+| 15.0.4480.2             | None         | CU32 + GDR | [KB5102335](https://support.microsoft.com/help/5102335) | July 14, 2026 |
+| 15.0.2180.2             | None         | GDR        | [KB5102336](https://support.microsoft.com/help/5102336) | July 14, 2026 |
+| 15.0.4470.1             | None         | CU32 + GDR | [KB5090407](https://support.microsoft.com/help/5090407) | May 12, 2026 |
+| 15.0.2170.1             | None         | GDR        | [KB5090408](https://support.microsoft.com/help/5090408) | May 12, 2026 |
+| 15.0.2000.5             | None         | RTM        | NA                                                      | November 04, 2019 |
+
+## SQL Server 2016
+
+| Build number or version | Service pack | Update                   | Knowledge Base number | Release date |
+|-------------------------|--------------|--------------------------|-----------------------|--------------|
+| 13.0.7085.1             | None         | Azure Connect Pack + GDR | [KB5089270](https://support.microsoft.com/help/5089270) | May 12, 2026 |
+ 13.0.7024.30            | SP3          | Azure Connect pack + GDR | [KB5021128](https://support.microsoft.com/help/5021128) | February 14, 2023 |
+| 13.0.7016.1             | SP3          | Azure Connect pack + GDR | [KB5015371](https://support.microsoft.com/help/5015371) | June 14, 2022 |
+| 13.0.7000.253           | SP3          | Azure Connect pack       | [KB5014242](sqlserver-2016/servicepack3-azureconnect.md) | May 19, 2022 |
+| 13.0.5153.0             | SP2          | CU2                      | [KB4340355](sqlserver-2016/servicepack2-cumulativeupdate2.md) | July 16 2018 |
+| 13.0.4411.0             | SP1          | CU1                      | [KB3208177](sqlserver-2016/servicepack1-cumulativeupdate1.md) | January 17, 2017 |
+| 13.0.4206.0             | SP1          | GDR                      | [KB4019089](https://support.microsoft.com/help/4019089) | August 08, 2017 |
+| 13.0.4001.0             | SP1          | RTW/PCU1                 | [KB3182545](sqlserver-2016/servicepack1.md) | November 16, 2016 |
+| 13.0.4202.2             | RTM          | GDR                      | [KB3210089](https://support.microsoft.com/help/3210089) | December 16, 2016 |
+| 13.0.1745.2             | RTM          | GDR                      | [KB4058560](https://support.microsoft.com/help/4058560) | January 06, 2018 |
+| 13.0.1601.5             | None         | RTM                      | NA                                                      | June 01, 2016 |
+
+## SQL Server 2014
+
+| Build number or version | Service pack | Update | Knowledge Base number | Release date |
+|-------------------------|--------------|--------|-----------------------|--------------|
+| 12.0.2370.0             | RTM          | CU2    | [KB2967546](https://support.microsoft.com/help/2967546) | Friday, June 27, 2014 |
+| 12.0.2342.0             | RTM          | CU1    | [KB2931693](https://support.microsoft.com/help/2931693) | April 21, 2014 |
+
+## SQL Server 2012
+
+| Build number or version | Service pack | Update | Knowledge Base number | Release date |
+|-------------------------|--------------|--------|-----------------------|--------------|
+| 11.0.6523.0             | SP3          | CU2    | [KB3137746](https://support.microsoft.com/help/3137746) | March 21,2016 |
+| 11.0.6518.0             | SP3          | CU1    | [KB3123299](https://support.microsoft.com/help/3123299) | January 19, 2016 |
+
+## SQL Server 2008
+
+| Build number or version | Service pack | Update | Knowledge Base number | Release date |
+|-------------------------|--------------|--------|-----------------------|--------------|
+| 10.00.5867.0            | (on-demand update package) |  | [KB2877204](https://support.microsoft.com/help/2877204) | October 16, 2013 |
+| 10.00.2710.0            | SP1          | CU2    | [KB970315](https://support.microsoft.com/help/970315) | April 16, 2009 |
+| 10.00.2531.0            | SP1          | RTW / PCU 1 |  | April 07, 2009 |
+| 10.00.1835.0            | RTM          | CU9    | [KB2083921](https://support.microsoft.com/help/2083921) | March 15, 2010 |
+| 10.00.1798.0            | RTM          | CU5    | [KB975977](https://support.microsoft.com/help/975977) | July 20, 2009 |
+
+## SQL Server 2005
+
+| Build number or version | Service pack | Update | Knowledge Base number | Release date |
+|-------------------------|--------------|--------|-----------------------|--------------|
+| 9.00.5324               | SP4          | MS12-070: QFE Security update | [KB2716427](https://support.microsoft.com/help/2716427) | October 09, 2012 |
+| 9.00.5292               | SP4          | MS11-049: QFE Security update | [KB2494123](https://support.microsoft.com/help/2494123) | June 14, 2011 |
+| 9.00.3042               | SP2          |  | [KB937137](https://support.microsoft.com/help/937137) |  |
+
+## SQL Server 2000
+
+| Build number or version | Version description, (KB number for that update), release date |
+|-------------------------|----------------------------------------------------------------|
+| 8.00.2283               | Post-SP4 hotfix for MS09-004 (971524) |
+
+## References
+
+- [SQL Server servicing models](servicing-models-sql-server.md)

--- a/pkg/fetch/microsoft/sqlbuild/testdata/golden/happy/raw/support/sql/releases/download-and-install-latest-updates.json
+++ b/pkg/fetch/microsoft/sqlbuild/testdata/golden/happy/raw/support/sql/releases/download-and-install-latest-updates.json
@@ -1,0 +1,679 @@
+{
+	"path": "support/sql/releases/download-and-install-latest-updates.md",
+	"tables": [
+		{
+			"heading": "Latest updates for Microsoft SQL Server",
+			"header": [
+				"Version",
+				"Latest service pack",
+				"Latest GDR",
+				"Latest cumulative update"
+			],
+			"rows": [
+				[
+					{
+						"text": "SQL Server 2025"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "GDR",
+						"href": "https://support.microsoft.com/help/5102333"
+					},
+					{
+						"text": "CU7 for 2025",
+						"href": "https://support.microsoft.com/help/5096981"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2025",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "17.0.4065.4"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "CU7"
+					},
+					{
+						"text": "KB5096981",
+						"href": "https://support.microsoft.com/help/5096981"
+					},
+					{
+						"text": "July 16, 2026"
+					}
+				],
+				[
+					{
+						"text": "17.0.4055.5"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "CU6"
+					},
+					{
+						"text": "KB5093421",
+						"href": "sqlserver-2025/cumulativeupdate6.md"
+					},
+					{
+						"text": "June 17, 2026"
+					}
+				],
+				[
+					{
+						"text": "17.0.1000.7"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "RTM/GA"
+					},
+					{
+						"text": "NA"
+					},
+					{
+						"text": "November 05, 2025"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2019",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "15.0.4480.2"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "CU32 + GDR"
+					},
+					{
+						"text": "KB5102335",
+						"href": "https://support.microsoft.com/help/5102335"
+					},
+					{
+						"text": "July 14, 2026"
+					}
+				],
+				[
+					{
+						"text": "15.0.2180.2"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "GDR"
+					},
+					{
+						"text": "KB5102336",
+						"href": "https://support.microsoft.com/help/5102336"
+					},
+					{
+						"text": "July 14, 2026"
+					}
+				],
+				[
+					{
+						"text": "15.0.4470.1"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "CU32 + GDR"
+					},
+					{
+						"text": "KB5090407",
+						"href": "https://support.microsoft.com/help/5090407"
+					},
+					{
+						"text": "May 12, 2026"
+					}
+				],
+				[
+					{
+						"text": "15.0.2170.1"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "GDR"
+					},
+					{
+						"text": "KB5090408",
+						"href": "https://support.microsoft.com/help/5090408"
+					},
+					{
+						"text": "May 12, 2026"
+					}
+				],
+				[
+					{
+						"text": "15.0.2000.5"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "NA"
+					},
+					{
+						"text": "November 04, 2019"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2016",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "13.0.7085.1"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "Azure Connect Pack + GDR"
+					},
+					{
+						"text": "KB5089270",
+						"href": "https://support.microsoft.com/help/5089270"
+					},
+					{
+						"text": "May 12, 2026"
+					}
+				],
+				[
+					{
+						"text": "13.0.7024.30"
+					},
+					{
+						"text": "SP3"
+					},
+					{
+						"text": "Azure Connect pack + GDR"
+					},
+					{
+						"text": "KB5021128",
+						"href": "https://support.microsoft.com/help/5021128"
+					},
+					{
+						"text": "February 14, 2023"
+					}
+				],
+				[
+					{
+						"text": "13.0.7016.1"
+					},
+					{
+						"text": "SP3"
+					},
+					{
+						"text": "Azure Connect pack + GDR"
+					},
+					{
+						"text": "KB5015371",
+						"href": "https://support.microsoft.com/help/5015371"
+					},
+					{
+						"text": "June 14, 2022"
+					}
+				],
+				[
+					{
+						"text": "13.0.7000.253"
+					},
+					{
+						"text": "SP3"
+					},
+					{
+						"text": "Azure Connect pack"
+					},
+					{
+						"text": "KB5014242",
+						"href": "sqlserver-2016/servicepack3-azureconnect.md"
+					},
+					{
+						"text": "May 19, 2022"
+					}
+				],
+				[
+					{
+						"text": "13.0.5153.0"
+					},
+					{
+						"text": "SP2"
+					},
+					{
+						"text": "CU2"
+					},
+					{
+						"text": "KB4340355",
+						"href": "sqlserver-2016/servicepack2-cumulativeupdate2.md"
+					},
+					{
+						"text": "July 16 2018"
+					}
+				],
+				[
+					{
+						"text": "13.0.4411.0"
+					},
+					{
+						"text": "SP1"
+					},
+					{
+						"text": "CU1"
+					},
+					{
+						"text": "KB3208177",
+						"href": "sqlserver-2016/servicepack1-cumulativeupdate1.md"
+					},
+					{
+						"text": "January 17, 2017"
+					}
+				],
+				[
+					{
+						"text": "13.0.4206.0"
+					},
+					{
+						"text": "SP1"
+					},
+					{
+						"text": "GDR"
+					},
+					{
+						"text": "KB4019089",
+						"href": "https://support.microsoft.com/help/4019089"
+					},
+					{
+						"text": "August 08, 2017"
+					}
+				],
+				[
+					{
+						"text": "13.0.4001.0"
+					},
+					{
+						"text": "SP1"
+					},
+					{
+						"text": "RTW/PCU1"
+					},
+					{
+						"text": "KB3182545",
+						"href": "sqlserver-2016/servicepack1.md"
+					},
+					{
+						"text": "November 16, 2016"
+					}
+				],
+				[
+					{
+						"text": "13.0.4202.2"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "GDR"
+					},
+					{
+						"text": "KB3210089",
+						"href": "https://support.microsoft.com/help/3210089"
+					},
+					{
+						"text": "December 16, 2016"
+					}
+				],
+				[
+					{
+						"text": "13.0.1745.2"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "GDR"
+					},
+					{
+						"text": "KB4058560",
+						"href": "https://support.microsoft.com/help/4058560"
+					},
+					{
+						"text": "January 06, 2018"
+					}
+				],
+				[
+					{
+						"text": "13.0.1601.5"
+					},
+					{
+						"text": "None"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "NA"
+					},
+					{
+						"text": "June 01, 2016"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2014",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "12.0.2370.0"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "CU2"
+					},
+					{
+						"text": "KB2967546",
+						"href": "https://support.microsoft.com/help/2967546"
+					},
+					{
+						"text": "Friday, June 27, 2014"
+					}
+				],
+				[
+					{
+						"text": "12.0.2342.0"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "CU1"
+					},
+					{
+						"text": "KB2931693",
+						"href": "https://support.microsoft.com/help/2931693"
+					},
+					{
+						"text": "April 21, 2014"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2012",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "11.0.6523.0"
+					},
+					{
+						"text": "SP3"
+					},
+					{
+						"text": "CU2"
+					},
+					{
+						"text": "KB3137746",
+						"href": "https://support.microsoft.com/help/3137746"
+					},
+					{
+						"text": "March 21,2016"
+					}
+				],
+				[
+					{
+						"text": "11.0.6518.0"
+					},
+					{
+						"text": "SP3"
+					},
+					{
+						"text": "CU1"
+					},
+					{
+						"text": "KB3123299",
+						"href": "https://support.microsoft.com/help/3123299"
+					},
+					{
+						"text": "January 19, 2016"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2008",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "10.00.5867.0"
+					},
+					{
+						"text": "(on-demand update package)"
+					},
+					{},
+					{
+						"text": "KB2877204",
+						"href": "https://support.microsoft.com/help/2877204"
+					},
+					{
+						"text": "October 16, 2013"
+					}
+				],
+				[
+					{
+						"text": "10.00.2710.0"
+					},
+					{
+						"text": "SP1"
+					},
+					{
+						"text": "CU2"
+					},
+					{
+						"text": "KB970315",
+						"href": "https://support.microsoft.com/help/970315"
+					},
+					{
+						"text": "April 16, 2009"
+					}
+				],
+				[
+					{
+						"text": "10.00.2531.0"
+					},
+					{
+						"text": "SP1"
+					},
+					{
+						"text": "RTW / PCU 1"
+					},
+					{},
+					{
+						"text": "April 07, 2009"
+					}
+				],
+				[
+					{
+						"text": "10.00.1835.0"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "CU9"
+					},
+					{
+						"text": "KB2083921",
+						"href": "https://support.microsoft.com/help/2083921"
+					},
+					{
+						"text": "March 15, 2010"
+					}
+				],
+				[
+					{
+						"text": "10.00.1798.0"
+					},
+					{
+						"text": "RTM"
+					},
+					{
+						"text": "CU5"
+					},
+					{
+						"text": "KB975977",
+						"href": "https://support.microsoft.com/help/975977"
+					},
+					{
+						"text": "July 20, 2009"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2005",
+			"header": [
+				"Build number or version",
+				"Service pack",
+				"Update",
+				"Knowledge Base number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "9.00.5324"
+					},
+					{
+						"text": "SP4"
+					},
+					{
+						"text": "MS12-070: QFE Security update"
+					},
+					{
+						"text": "KB2716427",
+						"href": "https://support.microsoft.com/help/2716427"
+					},
+					{
+						"text": "October 09, 2012"
+					}
+				],
+				[
+					{
+						"text": "9.00.5292"
+					},
+					{
+						"text": "SP4"
+					},
+					{
+						"text": "MS11-049: QFE Security update"
+					},
+					{
+						"text": "KB2494123",
+						"href": "https://support.microsoft.com/help/2494123"
+					},
+					{
+						"text": "June 14, 2011"
+					}
+				],
+				[
+					{
+						"text": "9.00.3042"
+					},
+					{
+						"text": "SP2"
+					},
+					{},
+					{
+						"text": "KB937137",
+						"href": "https://support.microsoft.com/help/937137"
+					},
+					{}
+				]
+			]
+		},
+		{
+			"heading": "SQL Server 2000",
+			"header": [
+				"Build number or version",
+				"Version description, (KB number for that update), release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "8.00.2283"
+					},
+					{
+						"text": "Post-SP4 hotfix for MS09-004 (971524)"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/fetch/microsoft/sqlbuild/types.go
+++ b/pkg/fetch/microsoft/sqlbuild/types.go
@@ -1,0 +1,42 @@
+package sqlbuild
+
+// Article is one support article, as served, with the tables read out of it.
+//
+// Nothing is read out of the cells here. Which column carries what is the
+// table's business, and Microsoft writes the same fact several ways across the
+// eleven this article holds -- a service pack lives in the Service pack column
+// on the older versions and in the Update column on the newer ones. Reading
+// that apart belongs in extract, under golden tests, where a change is handled
+// by rerunning against origin/ rather than by refetching an article whose older
+// revisions are only in git.
+type Article struct {
+	// Path is where the article lives in the docs repository, which is also
+	// where its history is. It is taken from the request rather than from the
+	// document, the document naming only its rendered address.
+	Path   string  `json:"path,omitempty"`
+	Tables []Table `json:"tables,omitempty"`
+}
+
+// Table is one table of an article, with the heading it sits under.
+//
+// The heading is the product version -- "SQL Server 2019", "SQL Server 2008 R2"
+// -- and is the only place the article states it: the build number's first two
+// components say 15.0 and 10.50, which is the same fact in a spelling nothing
+// else uses.
+type Table struct {
+	Heading string   `json:"heading,omitempty"`
+	Header  []string `json:"header,omitempty"`
+	Rows    [][]Cell `json:"rows,omitempty"`
+}
+
+// Cell is one cell, with the link it carries.
+//
+// The link is kept because it is the only per-KB address the article gives: a
+// Knowledge Base number is written [KB5102335](https://support.microsoft.com/help/5102335),
+// and some are written [KB5054833](cumulativeupdate32.md) instead, pointing at
+// a sibling article rather than at the KB. Both are stored as written; which of
+// them is an address for the KB is extract's to decide.
+type Cell struct {
+	Text string `json:"text,omitempty"`
+	Href string `json:"href,omitempty"`
+}


### PR DESCRIPTION
## What

Adds `microsoft-sqlbuild`, a fetcher and extractor for the SQL Server build-versions article. **586 KBs**, SQL Server 2005 to 2025, in 59 chains.

## Why

The Update Catalog no longer serves most of what this article names.

It is fetched as **Markdown from `MicrosoftDocs/SupportArticles-docs`** rather than as the rendered page, because that repository is public and keeps the article's history: a row Microsoft removes stays recoverable afterwards, which is the whole point of reading this source.

The per-version articles under `sqlserver-<year>/build-versions.md` are **not** fetched. Their KB sets were measured against this one and are identical, version for version, all six of them; what they carry beyond it is the `sqlservr.exe` and `msmdsrv.exe` file versions, which no chain is ordered by. This article also covers SQL Server 2012, 2008 R2, 2008 and 2005, which have no per-version article at all — 197 KBs that exist nowhere else in the set.

## How

**The build number is the order, but not in one line.** SQL Server runs several in parallel and they do not supersede each other: CU, GDR, the older QFE, and the Azure Connect Pack. The line is read from the `Update` column, which names it. A `CUn + GDR` is on the CU line — it is that CU with a security fix on top — so a label naming a CU is answered before one naming GDR is considered.

**The service pack is the other divider, and it is needed.** Microsoft services the RTM line and the SP1 line side by side, so a higher build is not always a later one: SQL Server 2008's RTM CU9 at `10.00.1835.0` shipped in March 2010, **eleven months after** SP1 CU2 at `10.00.2710.0`. Ordering a version's cumulative updates as one line by build number puts **41 such pairs the wrong way round; keying the service pack in leaves 7**, and every one of those is a row Microsoft filed under a service pack its build number does not belong to. Those seven are reported rather than quietly kept.

**The service pack is not simply the `Service pack` column.** Microsoft stopped filling it in around 2023 and moved the fact into the `Update` column — SQL Server 2016's SP3 GDRs read `SP3 | GDR` up to February 2023 and `None | SP3 + GDR` after it — so the column is read first and the label second. Thirteen rows state it in neither, all Azure Connect Pack releases, and they take the service pack of the build below them on their own line; without that the article's one chain of sixteen becomes two, of thirteen and three.

**RTM and RTW/PCU rows are the baselines** a service pack opens with, and belong to every line running on it. A baseline joins only the lines that exist.

One note on the source: the article is hand-authored and not always well formed. The table reader accepts a row that has lost its leading pipe, as Microsoft has served one and the docs pipeline renders it, and **says so** rather than repairing it silently. That row is fixed upstream in MicrosoftDocs/SupportArticles-docs#2105.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` — passes
- `golangci-lint run ./pkg/...` — 0 issues
- Golden tests for both packages
- End to end against the live repository: **586 KBs**, 9 warnings — 2 rows naming no kind of update, 7 build/date disagreements, all of them expected and all named

```
$ vuls-data-update fetch   microsoft-sqlbuild -d <raw>
$ vuls-data-update extract microsoft-sqlbuild <raw> -d <out>
```

## Checklist

- [x] Tests pass
- [x] Golden files updated
- [x] Deterministic output verified (types changed)
- [x] Backward compatibility maintained (types/data changed)

`pkg/extract/types/source` gains one constant, `MicrosoftSQLBuild`. Additive; it is the only file shared with the other Microsoft data-source branches.

**Known limitation.** 140 of the 586 records carry no URL. Their Knowledge Base cells link to a sibling article in the docs repository — `[KB5093421](sqlserver-2025/cumulativeupdate6.md)` — which is a path in a repository and not an address. Building a learn.microsoft.com URL from one means knowing how that docset is mounted, which the path does not say, so no URL is recorded rather than a made-up one. Happy to synthesise `support.microsoft.com/help/<KB>` instead if that is preferred.
