### PR TITLE
feat(microsoft/sharepoint): add sharepoint update history data source

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -67,6 +67,7 @@ import (
 	microsoftCVRF "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/cvrf"
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/msuc"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/servicing"
+	microsoftSharePoint "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/sharepoint"
 	microsoftWSUSSCN2 "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/wsusscn2"
 	mitreATTACK "github.com/MaineK00n/vuls-data-update/pkg/extract/mitre/attack"
 	mitreCAPEC "github.com/MaineK00n/vuls-data-update/pkg/extract/mitre/capec"
@@ -180,7 +181,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdJVNFeedDetail(), newCmdJVNFeedProduct(), newCmdJVNFeedRSS(),
 		newCmdLinuxOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftWSUSSCN2(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftSharePoint(), newCmdMicrosoftWSUSSCN2(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
 		newCmdNetBSD(),
@@ -1656,6 +1657,31 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := microsoftMSUC.Extract(args[0], microsoftMSUC.WithDir(options.dir)); err != nil {
 				return errors.Wrap(err, "failed to extract microsoft msuc")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdMicrosoftSharePoint() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "sharepoint"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-sharepoint <Raw Microsoft SharePoint Update History Repository PATH>",
+		Short: "Extract Microsoft SharePoint Update History data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract microsoft-sharepoint vuls-data-raw-microsoft-sharepoint
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := microsoftSharePoint.Extract(args[0], microsoftSharePoint.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract microsoft sharepoint")
 			}
 			return nil
 		},

--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -92,6 +92,7 @@ import (
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/msuc"
 	microsoftProduct "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/product"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/servicing"
+	microsoftSharePoint "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/sharepoint"
 	microsoftVEX "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vex"
 	microsoftVulnerability "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vulnerability"
 	microsoftWSUSSCN2 "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/wsusscn2"
@@ -255,7 +256,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdLinuxOSV(),
 		newCmdMageiaOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftSharePoint(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
 		newCmdMinimOSOSV(), newCmdMinimOSSecDB(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreEMB3D(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
@@ -2666,6 +2667,54 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
 	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
 	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent http requests")
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
+
+	return cmd
+}
+
+func newCmdMicrosoftSharePoint() *cobra.Command {
+	options := &struct {
+		base
+		wait time.Duration
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "microsoft", "sharepoint"),
+			retry: 3,
+		},
+		wait: 1 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-sharepoint",
+		Short: "Fetch Microsoft SharePoint Update History data source",
+		Long: heredoc.Doc(`
+			Fetch the SharePoint Server update history as HTML into <dir>/origin, and
+			the tables it carries into <dir>/raw.
+
+			The page lists every public update SharePoint has shipped, from SharePoint
+			2010 to the Subscription Edition, and the Update Catalog no longer serves
+			all of them.
+
+			A row describes more than one package: a server and its language pack, or
+			SharePoint Foundation beside SharePoint Server, named one per line with
+			their KBs one per line beside them. The lines are kept apart in raw/ so
+			that extract can match them by position; read as one string they would run
+			together with nothing to say which KB belongs to which package.
+		`),
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch microsoft-sharepoint
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := microsoftSharePoint.Fetch(microsoftSharePoint.WithDir(options.dir), microsoftSharePoint.WithRetry(options.retry), microsoftSharePoint.WithWait(options.wait)); err != nil {
+				return errors.Wrap(err, "failed to fetch microsoft sharepoint")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
 	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
 
 	return cmd

--- a/pkg/extract/microsoft/sharepoint/export_test.go
+++ b/pkg/extract/microsoft/sharepoint/export_test.go
@@ -1,0 +1,3 @@
+package sharepoint
+
+var ReleaseDate = releaseDate

--- a/pkg/extract/microsoft/sharepoint/sharepoint.go
+++ b/pkg/extract/microsoft/sharepoint/sharepoint.go
@@ -1,0 +1,443 @@
+// Package sharepoint extracts supersedence from Microsoft's SharePoint Server
+// update history.
+//
+// The page carries no supersedence. What it carries is every public update a
+// package has shipped, and the version number is the order: a cumulative update
+// contains the one below it. Reading the packages apart is this package's job.
+//
+// A row is not one update. It describes two at once, naming the packages one
+// per line and their KBs one per line beside them, matched by position:
+//
+//	SharePoint Server 2019                     KB 5002894
+//	SharePoint Server 2019 MUI/language patch   KB 5002896
+//
+// and the two are separate chains. On the Subscription Edition, 2019 and 2016
+// the second is the language pack of the first; on 2013 and 2010 it is
+// SharePoint Foundation beside SharePoint Server, a different product
+// altogether. Either way they ship their own KBs at their own versions and
+// neither replaces the other, so the package name is what a chain is keyed on.
+// Ten of them run across the page, from SharePoint Foundation 2010 to the
+// Subscription Edition's language pack.
+//
+// The version orders them and the release date does not, because most of the
+// page has no day in it: 411 of the 769 rows are dated by month alone, "April
+// 2026", against 45 written out in full. The two never disagree -- over all 759
+// edges there is not one pair whose versions and dates run opposite ways, and no
+// two updates of a package share a version -- so the date is kept as a
+// tiebreaker it has never had to break.
+package sharepoint
+
+import (
+	"cmp"
+	"encoding/json/v2"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
+	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/sharepoint"
+)
+
+// The columns a row is read out of, by name.
+const (
+	columnPackage = "Package Name"
+	columnKB      = "KB Number"
+	columnVersion = "Version"
+	columnDate    = "Release Date"
+)
+
+var (
+	// kbPattern allows the space Microsoft writes on this page and nowhere else
+	// in the estate: every one of the 769 is written "KB 5002893".
+	kbPattern = regexp.MustCompile(`KB ?(\d{6,})`)
+
+	versionPattern = regexp.MustCompile(`^\d+(?:\.\d+){2,3}$`)
+
+	// datePattern is the release date, with the day Microsoft writes on the
+	// newer rows and without it on the older ones. A row dated by month alone
+	// is taken as its first, which orders it against the months around it and
+	// against nothing within its own -- which is all the date is ever asked to
+	// do here.
+	//
+	// It is searched rather than anchored because two rows open with the
+	// service pack instead: "Service Pack 2 July 2013".
+	datePattern = regexp.MustCompile(`([A-Z][a-z]+) (?:(\d{1,2}), )?(\d{4})`)
+
+	// noUpdatePattern is how Microsoft writes a month one package of a row
+	// shipped nothing in, rather than leaving the cell blank.
+	noUpdatePattern = regexp.MustCompile(`(?i)^No update for\b`)
+)
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+// update is one package's release, read for what decides its place in a chain.
+type update struct {
+	kbID string
+	url  string
+
+	// pkg is the package the update is for, e.g. "SharePoint Server 2019" or
+	// "SharePoint Foundation 2013". It is the chain.
+	pkg string
+
+	version    []int
+	versionStr string
+
+	date time.Time
+
+	raw string
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "sharepoint"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract Microsoft SharePoint Update History")
+
+	us, err := read(args)
+	if err != nil {
+		return errors.Wrapf(err, "read %s", args)
+	}
+
+	kbs := chain(us)
+
+	for _, kb := range kbs {
+		if err := util.Write(filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)), kb, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)))
+		}
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.MicrosoftSharePoint,
+		Name: new("Microsoft SharePoint Update History"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{URL: u}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+// read walks the raw tree and returns the releases it holds.
+func read(args string) ([]update, error) {
+	root := filepath.Join(args, "raw")
+
+	var us []update
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".json" {
+			return nil
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", p)
+		}
+		defer f.Close()
+
+		var page sharepoint.Page
+		if err := json.UnmarshalRead(f, &page); err != nil {
+			return errors.Wrapf(err, "decode %s", p)
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+
+		us = append(us, parsePage(page, filepath.ToSlash(rel))...)
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrapf(err, "walk %s", root)
+	}
+
+	return us, nil
+}
+
+// parsePage reads a page's update histories.
+func parsePage(page sharepoint.Page, raw string) []update {
+	var us []update
+
+	for _, t := range page.Tables {
+		var missing []string
+		for _, c := range []string{columnPackage, columnKB, columnVersion, columnDate} {
+			if !slices.Contains(t.Header, c) {
+				missing = append(missing, c)
+			}
+		}
+		if len(missing) > 0 {
+			slog.Debug("not an update history", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("missing", strings.Join(missing, ", ")))
+			continue
+		}
+
+		for _, row := range t.Rows {
+			us = append(us, parseRow(t, row, raw)...)
+		}
+	}
+
+	return us
+}
+
+// parseRow reads one row into the releases it describes, one per package named.
+func parseRow(t sharepoint.Table, row []sharepoint.Cell, raw string) []update {
+	cell := func(column string) sharepoint.Cell {
+		i := slices.Index(t.Header, column)
+		if i < 0 || i >= len(row) {
+			return sharepoint.Cell{}
+		}
+		return row[i]
+	}
+
+	pkgs, kbs, versions := cell(columnPackage).Lines, cell(columnKB).Lines, cell(columnVersion).Lines
+
+	// The packages and their KBs are matched by position, so a row naming more
+	// of one than the other cannot be matched at all: pairing what there is
+	// would attach a KB to whichever package happened to line up with it. Every
+	// one of the 769 releases on the page pairs one to one.
+	if len(pkgs) != len(kbs) {
+		slog.Warn("row names a different number of packages and KBs", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("packages", strings.Join(texts(pkgs), " / ")), slog.String("kbs", strings.Join(texts(kbs), " / ")))
+		return nil
+	}
+
+	// The date is one for the whole row -- the packages of a row ship together
+	// -- so it is read once.
+	var date time.Time
+	if lines := cell(columnDate).Lines; len(lines) > 0 {
+		var ok bool
+		date, ok = releaseDate(lines[0].Text)
+		if !ok {
+			slog.Warn("unexpected release date", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("date", lines[0].Text))
+		}
+	}
+
+	out := make([]update, 0, len(pkgs))
+	for i, pkg := range pkgs {
+		m := kbPattern.FindStringSubmatch(kbs[i].Text)
+		if m == nil {
+			// A month one package of a row shipped nothing in, which Microsoft
+			// writes out rather than leaving blank: SharePoint Foundation 2010
+			// says "No update for June." beside SharePoint Server 2010's KB
+			// three times in 2015. It is a release that did not happen, not a
+			// release this failed to read, so it is not reported as one.
+			if noUpdatePattern.MatchString(kbs[i].Text) {
+				slog.Debug("package shipped no update", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("package", pkg.Text), slog.String("kb", kbs[i].Text))
+				continue
+			}
+			slog.Warn("package names no KB", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("package", pkg.Text), slog.String("kb", kbs[i].Text))
+			continue
+		}
+
+		// The version is written once where the packages share it and once each
+		// where they do not, which is how Microsoft has written both.
+		var vs string
+		switch {
+		case i < len(versions):
+			vs = versions[i].Text
+		case len(versions) > 0:
+			vs = versions[0].Text
+		}
+		if !versionPattern.MatchString(vs) {
+			// The version is the whole order. A release without one cannot be
+			// placed, and every one of the 769 has had it.
+			slog.Warn("unexpected version", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("kb", m[1]), slog.String("version", vs))
+			continue
+		}
+		version := make([]int, 0, 4)
+		bad := false
+		for _, p := range strings.Split(vs, ".") {
+			n, err := strconv.Atoi(p)
+			if err != nil {
+				bad = true
+				break
+			}
+			version = append(version, n)
+		}
+		if bad {
+			slog.Warn("unexpected version", slog.String("path", raw), slog.String("kb", m[1]), slog.String("version", vs))
+			continue
+		}
+
+		out = append(out, update{
+			kbID:       m[1],
+			url:        kbs[i].Href,
+			pkg:        pkg.Text,
+			version:    version,
+			versionStr: vs,
+			date:       date,
+			raw:        raw,
+		})
+	}
+
+	return out
+}
+
+// releaseDate reads the date a row was released.
+//
+// Most of the page is dated by month alone, and a month is taken as its first
+// day: the date only ever orders a release against other months, the version
+// having already ordered it within its own.
+func releaseDate(s string) (time.Time, bool) {
+	m := datePattern.FindStringSubmatch(s)
+	if m == nil {
+		return time.Time{}, false
+	}
+
+	day := m[2]
+	if day == "" {
+		day = "1"
+	}
+
+	t, err := time.Parse("January 2 2006", fmt.Sprintf("%s %s %s", m[1], day, m[3]))
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return t, true
+}
+
+func texts(lines []sharepoint.Line) []string {
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, l.Text)
+	}
+	return out
+}
+
+// chain turns the releases into KB records, chained into supersedence.
+func chain(us []update) []microsoftkbTypes.KB {
+	packages := make(map[string][]update)
+	for _, u := range us {
+		packages[u.pkg] = append(packages[u.pkg], u)
+	}
+
+	type link struct{ older, newer string }
+	var links []link
+	for _, group := range packages {
+		// No two releases of a package share a version, so the date and the KB
+		// number are tiebreakers that have never had to break one. They are
+		// there because the first time Microsoft ships one twice, the order
+		// should not fall to whichever the walk reached first.
+		slices.SortFunc(group, func(x, y update) int {
+			return cmp.Or(slices.Compare(x.version, y.version), x.date.Compare(y.date), cmp.Compare(x.kbID, y.kbID))
+		})
+
+		for i := 1; i < len(group); i++ {
+			older, newer := group[i-1], group[i]
+
+			// The version is the order and the date is not, but where the two
+			// disagree the row is worth reading. Over the whole page they never
+			// have.
+			if !older.date.IsZero() && !newer.date.IsZero() && newer.date.Before(older.date) {
+				slog.Warn("a package's versions and release dates disagree",
+					slog.String("package", older.pkg),
+					slog.String("older", fmt.Sprintf("KB%s %s %s", older.kbID, older.versionStr, older.date.Format(time.DateOnly))),
+					slog.String("newer", fmt.Sprintf("KB%s %s %s", newer.kbID, newer.versionStr, newer.date.Format(time.DateOnly))))
+			}
+
+			links = append(links, link{older: older.kbID, newer: newer.kbID})
+		}
+	}
+
+	kbs := make(map[string]*microsoftkbTypes.KB, len(us))
+	for _, u := range us {
+		kb, ok := kbs[u.kbID]
+		if !ok {
+			kb = &microsoftkbTypes.KB{
+				KBID: u.kbID,
+				URL:  u.url,
+				DataSource: sourceTypes.Source{
+					ID: sourceTypes.MicrosoftSharePoint,
+				},
+			}
+			kbs[u.kbID] = kb
+		}
+		if kb.URL == "" {
+			kb.URL = u.url
+		}
+		if !slices.Contains(kb.Products, u.pkg) {
+			kb.Products = append(kb.Products, u.pkg)
+		}
+		if !slices.Contains(kb.DataSource.Raws, u.raw) {
+			kb.DataSource.Raws = append(kb.DataSource.Raws, u.raw)
+		}
+	}
+
+	for _, l := range links {
+		if l.older == l.newer {
+			continue
+		}
+		if kb, ok := kbs[l.older]; ok {
+			s := microsoftkbSupersededByTypes.SupersededBy{KBID: l.newer}
+			if !slices.Contains(kb.SupersededBy, s) {
+				kb.SupersededBy = append(kb.SupersededBy, s)
+			}
+		}
+		if kb, ok := kbs[l.newer]; ok {
+			s := microsoftkbSupersedesTypes.Supersedes{KBID: l.older}
+			if !slices.Contains(kb.Supersedes, s) {
+				kb.Supersedes = append(kb.Supersedes, s)
+			}
+		}
+	}
+
+	out := make([]microsoftkbTypes.KB, 0, len(kbs))
+	for _, kb := range kbs {
+		out = append(out, *kb)
+	}
+	return out
+}

--- a/pkg/extract/microsoft/sharepoint/sharepoint_test.go
+++ b/pkg/extract/microsoft/sharepoint/sharepoint_test.go
@@ -1,0 +1,103 @@
+package sharepoint_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/sharepoint"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+// The fixture is the page as fetched, chosen for what decides a chain.
+//
+// A row is two updates wherever it names two packages, and the two are not one
+// line: KB5002894 and KB5002896 shipped on the same day in the same row, one
+// for SharePoint Server 2019 and one for its language pack, and neither
+// replaces the other. On 2013 the pair is SharePoint Foundation beside
+// SharePoint Server, a different product again.
+//
+// SharePoint Foundation 2010 is where that matters most. Its row for June 2015
+// reads "No update for June." beside SharePoint Server 2010's KB3054880, so the
+// Foundation chain runs straight from April 2015 to April 2021 while the Server
+// chain takes the June release in between. Reading the row as one update would
+// hand Foundation a KB it never shipped.
+//
+// The 2016 rows write the version once per package and the others once for the
+// row, so the version has to be taken per package where there is one and shared
+// where there is not.
+//
+// Dates come three ways -- "August 11, 2026", "April 2023" and "Service Pack 2
+// July 2013" -- and most of the page has no day at all, which is why the
+// version orders these and the date does not. Several 2010 KBs are written as
+// text with no link, and those records carry no URL rather than a made-up one.
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures/happy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := sharepoint.Extract(tt.args, sharepoint.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				return
+			default:
+				ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				gp, err := filepath.Abs(dir)
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}
+
+// Most of the page is dated by month alone, so a month has to read as a date at
+// all, and two rows put a service pack in front of one.
+func TestReleaseDate(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want time.Time
+		ok   bool
+	}{
+		{name: "a full date", s: "August 11, 2026", want: time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "a single-digit day", s: "June 9, 2026", want: time.Date(2026, time.June, 9, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "a month with no day, which is most of the page", s: "April 2023", want: time.Date(2023, time.April, 1, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "a month behind a service pack", s: "Service Pack 2 July 2013", want: time.Date(2013, time.July, 1, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "not a date", s: "No update for June.", ok: false},
+		{name: "nothing", s: "", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := sharepoint.ReleaseDate(tt.s)
+			if ok != tt.ok {
+				t.Fatalf("releaseDate() ok = %v, want %v", ok, tt.ok)
+			}
+			if !tt.ok {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("releaseDate(). (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/fixtures/happy/raw/sharepoint-updates.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/fixtures/happy/raw/sharepoint-updates.json
@@ -1,0 +1,531 @@
+{
+	"url": "https://learn.microsoft.com/en-us/officeupdates/sharepoint-updates",
+	"tables": [
+		{
+			"heading": "SharePoint Server Subscription Edition update history",
+			"header": [
+				"Package Name",
+				"KB Number",
+				"Version",
+				"Release Date"
+			],
+			"rows": [
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server Subscription Edition"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002893",
+								"href": "https://support.microsoft.com/help/5002893"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.19725.20522"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "August 11, 2026"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server Subscription Edition"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002882",
+								"href": "https://support.microsoft.com/help/5002882"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.19725.20434"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "July 14, 2026"
+							}
+						]
+					}
+				]
+			]
+		},
+		{
+			"heading": "SharePoint 2019 update history",
+			"header": [
+				"Package Name",
+				"KB Number",
+				"Version",
+				"Release Date"
+			],
+			"rows": [
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server 2019"
+							},
+							{
+								"text": "SharePoint Server 2019 MUI/language patch"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002894",
+								"href": "https://support.microsoft.com/help/5002894"
+							},
+							{
+								"text": "KB 5002896",
+								"href": "https://support.microsoft.com/help/5002896"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.10417.20198"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "August 11, 2026"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server 2019"
+							},
+							{
+								"text": "SharePoint Server 2019 MUI/language patch"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002883",
+								"href": "https://support.microsoft.com/help/5002883"
+							},
+							{
+								"text": "KB 5002885",
+								"href": "https://support.microsoft.com/help/5002885"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.10417.20175"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "July 14, 2026"
+							}
+						]
+					}
+				]
+			]
+		},
+		{
+			"heading": "SharePoint 2016 update history",
+			"header": [
+				"Package Name",
+				"KB Number",
+				"Version",
+				"Release Date"
+			],
+			"rows": [
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server 2016"
+							},
+							{
+								"text": "SharePoint Server 2016 MUI/language patch"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002905",
+								"href": "https://support.microsoft.com/help/5002905"
+							},
+							{
+								"text": "KB 5002906",
+								"href": "https://support.microsoft.com/help/5002906"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.5565.1001"
+							},
+							{
+								"text": "16.0.5565.1001"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "August 11, 2026"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server 2016"
+							},
+							{
+								"text": "SharePoint Server 2016 MUI/language patch"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002891",
+								"href": "https://support.microsoft.com/help/5002891"
+							},
+							{
+								"text": "KB 5002892",
+								"href": "https://support.microsoft.com/help/5002892"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.5561.1001"
+							},
+							{
+								"text": "16.0.5561.1001"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "July 14, 2026"
+							}
+						]
+					}
+				]
+			]
+		},
+		{
+			"heading": "SharePoint 2013 update history",
+			"header": [
+				"Package Name",
+				"KB Number",
+				"Version",
+				"Release Date"
+			],
+			"rows": [
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2013"
+							},
+							{
+								"text": "SharePoint Server 2013"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002379",
+								"href": "https://support.microsoft.com/help/5002379"
+							},
+							{
+								"text": "KB 5002381",
+								"href": "https://support.microsoft.com/help/5002381"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "15.0.5545.1000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "April 2023"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2013"
+							},
+							{
+								"text": "SharePoint Server 2013"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002363",
+								"href": "https://support.microsoft.com/help/5002363"
+							},
+							{
+								"text": "KB 5002366",
+								"href": "https://support.microsoft.com/help/5002366"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "15.0.5537.1000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "March 2023"
+							}
+						]
+					}
+				]
+			]
+		},
+		{
+			"heading": "SharePoint 2010 update history",
+			"header": [
+				"Package Name",
+				"KB Number",
+				"Version",
+				"Release Date"
+			],
+			"rows": [
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2010"
+							},
+							{
+								"text": "SharePoint Server 2010"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 4504709",
+								"href": "https://support.microsoft.com/help/4504709"
+							},
+							{
+								"text": "KB 4504742"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "14.0.7268.5000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "April 2021"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server 2010"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 4504706"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "14.0.7267.5000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "March 2021"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2010"
+							},
+							{
+								"text": "SharePoint Server 2010"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "No update for June."
+							},
+							{
+								"text": "KB 3054880"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "14.0.7151.5001"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "June 2015"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2010"
+							},
+							{
+								"text": "SharePoint Server 2010"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 2965293"
+							},
+							{
+								"text": "KB 2965294"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "14.0.7147.5000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "April 2015"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2010"
+							},
+							{
+								"text": "SharePoint Server 2010"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 2687453"
+							},
+							{
+								"text": "KB 2687464"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "14.0.7015.1000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "Service Pack 2 July 2013"
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/datasource.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "microsoft-sharepoint",
+	"name": "Microsoft SharePoint Update History"
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/2687xxx/2687453.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/2687xxx/2687453.json
@@ -1,0 +1,17 @@
+{
+	"kb_id": "2687453",
+	"products": [
+		"SharePoint Foundation 2010"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "2965293"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/2687xxx/2687464.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/2687xxx/2687464.json
@@ -1,0 +1,17 @@
+{
+	"kb_id": "2687464",
+	"products": [
+		"SharePoint Server 2010"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "2965294"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/2965xxx/2965293.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/2965xxx/2965293.json
@@ -1,0 +1,22 @@
+{
+	"kb_id": "2965293",
+	"products": [
+		"SharePoint Foundation 2010"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "4504709"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "2687453"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/2965xxx/2965294.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/2965xxx/2965294.json
@@ -1,0 +1,22 @@
+{
+	"kb_id": "2965294",
+	"products": [
+		"SharePoint Server 2010"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "3054880"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "2687464"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/3054xxx/3054880.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/3054xxx/3054880.json
@@ -1,0 +1,22 @@
+{
+	"kb_id": "3054880",
+	"products": [
+		"SharePoint Server 2010"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "4504706"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "2965294"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/4504xxx/4504706.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/4504xxx/4504706.json
@@ -1,0 +1,22 @@
+{
+	"kb_id": "4504706",
+	"products": [
+		"SharePoint Server 2010"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "4504742"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "3054880"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/4504xxx/4504709.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/4504xxx/4504709.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "4504709",
+	"url": "https://support.microsoft.com/help/4504709",
+	"products": [
+		"SharePoint Foundation 2010"
+	],
+	"supersedes": [
+		{
+			"kb_id": "2965293"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/4504xxx/4504742.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/4504xxx/4504742.json
@@ -1,0 +1,17 @@
+{
+	"kb_id": "4504742",
+	"products": [
+		"SharePoint Server 2010"
+	],
+	"supersedes": [
+		{
+			"kb_id": "4504706"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002363.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002363.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002363",
+	"url": "https://support.microsoft.com/help/5002363",
+	"products": [
+		"SharePoint Foundation 2013"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5002379"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002366.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002366.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002366",
+	"url": "https://support.microsoft.com/help/5002366",
+	"products": [
+		"SharePoint Server 2013"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5002381"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002379.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002379.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002379",
+	"url": "https://support.microsoft.com/help/5002379",
+	"products": [
+		"SharePoint Foundation 2013"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5002363"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002381.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002381.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002381",
+	"url": "https://support.microsoft.com/help/5002381",
+	"products": [
+		"SharePoint Server 2013"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5002366"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002882.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002882.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002882",
+	"url": "https://support.microsoft.com/help/5002882",
+	"products": [
+		"SharePoint Server Subscription Edition"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5002893"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002883.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002883.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002883",
+	"url": "https://support.microsoft.com/help/5002883",
+	"products": [
+		"SharePoint Server 2019"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5002894"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002885.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002885.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002885",
+	"url": "https://support.microsoft.com/help/5002885",
+	"products": [
+		"SharePoint Server 2019 MUI/language patch"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5002896"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002891.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002891.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002891",
+	"url": "https://support.microsoft.com/help/5002891",
+	"products": [
+		"SharePoint Server 2016"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5002905"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002892.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002892.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002892",
+	"url": "https://support.microsoft.com/help/5002892",
+	"products": [
+		"SharePoint Server 2016 MUI/language patch"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5002906"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002893.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002893.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002893",
+	"url": "https://support.microsoft.com/help/5002893",
+	"products": [
+		"SharePoint Server Subscription Edition"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5002882"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002894.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002894.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002894",
+	"url": "https://support.microsoft.com/help/5002894",
+	"products": [
+		"SharePoint Server 2019"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5002883"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002896.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002896.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002896",
+	"url": "https://support.microsoft.com/help/5002896",
+	"products": [
+		"SharePoint Server 2019 MUI/language patch"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5002885"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002905.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002905.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002905",
+	"url": "https://support.microsoft.com/help/5002905",
+	"products": [
+		"SharePoint Server 2016"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5002891"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002906.json
+++ b/pkg/extract/microsoft/sharepoint/testdata/golden/microsoftkb/5002xxx/5002906.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5002906",
+	"url": "https://support.microsoft.com/help/5002906",
+	"products": [
+		"SharePoint Server 2016 MUI/language patch"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5002892"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sharepoint",
+		"raws": [
+			"sharepoint-updates.json"
+		]
+	}
+}

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -90,6 +90,7 @@ const (
 	MicrosoftMSUC              SourceID = "microsoft-msuc"
 	MicrosoftProduct           SourceID = "microsoft-product"
 	MicrosoftServicing         SourceID = "microsoft-servicing"
+	MicrosoftSharePoint        SourceID = "microsoft-sharepoint"
 	MicrosoftVulnerability     SourceID = "microsoft-vulnerability"
 	MicrosoftWSUSSCN2          SourceID = "microsoft-wsusscn2"
 	MinimosSecDB               SourceID = "minimos-secdb"

--- a/pkg/fetch/microsoft/sharepoint/sharepoint.go
+++ b/pkg/fetch/microsoft/sharepoint/sharepoint.go
@@ -1,0 +1,398 @@
+// Package sharepoint fetches Microsoft's SharePoint Server update history --
+// the officeupdates page listing every public update SharePoint has shipped.
+//
+// The page runs from SharePoint 2010 to the Subscription Edition, 769 KBs, and
+// the Update Catalog no longer serves all of them: of ten sampled across the
+// page's fifteen years, three answer "We did not find any results".
+//
+// It is the rendered page rather than the Markdown it is authored in, because
+// the docs repository behind officeupdates is private -- learn.microsoft.com
+// names MicrosoftDocs/OfficeDocs-OfficeUpdates-pr as the source and there is no
+// public counterpart, unlike the SQL Server article.
+//
+// The rows are lists. One row describes two packages at once, naming them one
+// per line and their KBs one per line beside them:
+//
+//	SharePoint Server 2019            | KB 5002894 | 16.0.10417.20198 | August 11, 2026
+//	SharePoint Server 2019 MUI/langua… | KB 5002896 |                  |
+//
+// which is one <td> per column with a <br> between the lines. On SharePoint
+// 2013 and 2010 the two are not a server and its language pack but Foundation
+// and Server, separate products with separate KBs. Either way the columns line
+// up by position, so the lines are kept apart here and matched in extract.
+//
+// fetch writes <dir>/origin verbatim and then produces <dir>/raw by reading it
+// back, never the HTTP response, so raw/ is reproducible from origin/ alone.
+package sharepoint
+
+import (
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+	"golang.org/x/net/html"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+const (
+	baseURL = "https://learn.microsoft.com"
+
+	// pagePath is the update history. The name it is stored under is its last
+	// segment, so origin/ stays navigable against the site it came from.
+	pagePath = "/en-us/officeupdates/sharepoint-updates"
+)
+
+type options struct {
+	baseURL string
+	dir     string
+	retry   int
+	wait    time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type baseURLOption string
+
+func (u baseURLOption) apply(opts *options) {
+	opts.baseURL = string(u)
+}
+
+func WithBaseURL(url string) Option {
+	return baseURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+// Fetch stores the update history under <dir>/origin and the tables it carries
+// under <dir>/raw.
+func Fetch(opts ...Option) error {
+	options := &options{
+		baseURL: baseURL,
+		dir:     filepath.Join(util.CacheDir(), "fetch", "microsoft", "sharepoint"),
+		retry:   3,
+		wait:    1 * time.Second,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	if err := options.fetch(); err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+
+	if err := options.convert(); err != nil {
+		return errors.Wrap(err, "convert")
+	}
+
+	return nil
+}
+
+// fetch stores the page as served.
+func (opts options) fetch() error {
+	slog.Info("Fetch Microsoft SharePoint Update History")
+
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
+
+	u, err := url.JoinPath(opts.baseURL, pagePath)
+	if err != nil {
+		return errors.Wrapf(err, "join %s and %s", opts.baseURL, pagePath)
+	}
+
+	if err := client.PipelineGet([]string{u}, 1, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, resp.Request.URL)
+		}
+
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", resp.Request.URL)
+		}
+
+		if err := writeOrigin(opts.dir, name(), bs); err != nil {
+			return errors.Wrapf(err, "write %s", name())
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "pipeline get")
+	}
+
+	return nil
+}
+
+// convert reads origin/ back and writes raw/, at the name its origin/
+// counterpart has. Going through the stored bytes rather than the response is
+// what lets the tree be re-derived after this parser changes.
+func (opts options) convert() error {
+	slog.Info("Convert origin to raw")
+
+	root := filepath.Join(opts.dir, "origin")
+
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".html" {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", p)
+		}
+		defer f.Close()
+
+		page, err := parsePage(f)
+		if err != nil {
+			return errors.Wrapf(err, "parse %s", p)
+		}
+
+		// The page is its tables. One that parses to none is not a page whose
+		// history has been retired -- it keeps SharePoint 2010, out of support
+		// since 2021, alongside the current release -- it is this parser having
+		// lost them, and it loses them all at once. Skipping would leave raw/
+		// empty beside a full origin/ with the run green.
+		if len(page.Tables) == 0 {
+			return errors.Errorf("no table in %s", p)
+		}
+
+		if err := util.Write(filepath.Join(opts.dir, "raw", strings.TrimSuffix(filepath.ToSlash(rel), ".html")+".json"), page); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, "raw", strings.TrimSuffix(filepath.ToSlash(rel), ".html")+".json"))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", root)
+	}
+
+	return nil
+}
+
+// name is what the page is stored as: the last segment of its path, so origin/
+// stays navigable against the site it came from.
+func name() string {
+	segs := strings.Split(strings.Trim(pagePath, "/"), "/")
+	return segs[len(segs)-1] + ".html"
+}
+
+// writeOrigin stores content under <dir>/origin/<name> as served.
+//
+// Nothing derived from the response is recorded alongside it -- no fetch
+// timestamp, no ETag, no status line. Those change on every run even when the
+// page does not, and would turn every fetch into a diff, drowning the signal
+// this tree exists to carry: that Microsoft revised the page.
+func writeOrigin(dir, name string, content []byte) error {
+	p := filepath.Join(dir, "origin", name)
+
+	if err := os.MkdirAll(filepath.Dir(p), os.ModePerm); err != nil {
+		return errors.Wrapf(err, "mkdir %s", filepath.Dir(p))
+	}
+
+	if err := os.WriteFile(p, content, 0666); err != nil {
+		return errors.Wrapf(err, "write %s", p)
+	}
+
+	return nil
+}
+
+// parsePage reads a stored page for its canonical link and its tables.
+func parsePage(r io.Reader) (Page, error) {
+	doc, err := goquery.NewDocumentFromReader(r)
+	if err != nil {
+		return Page{}, errors.Wrap(err, "new document")
+	}
+
+	var page Page
+	var base *url.URL
+	if u, ok := doc.Find(`link[rel="canonical"]`).First().Attr("href"); ok {
+		page.URL = text(u)
+		base, _ = url.Parse(page.URL)
+	}
+
+	// Only the article body. The page chrome carries tables of its own, the
+	// locale picker among them, and a heading in a banner would otherwise
+	// become the heading of the first history.
+	root := doc.Find("main").First()
+	if root.Length() == 0 {
+		root = doc.Selection
+	}
+
+	// One pass in document order over the headings and the tables together,
+	// since a table's heading is its predecessor in the prose and not its
+	// ancestor. Headings inside a table are skipped: being visited after their
+	// own table's start tag they would otherwise be read as the next one's.
+	var heading string
+	root.Find("h1, h2, h3, h4, h5, h6, table").Each(func(_ int, s *goquery.Selection) {
+		if goquery.NodeName(s) != "table" {
+			if s.Closest("table").Length() == 0 {
+				heading = text(s.Text())
+			}
+			return
+		}
+
+		t, ok := parseTable(s, base)
+		if !ok {
+			return
+		}
+		t.Heading = heading
+
+		page.Tables = append(page.Tables, t)
+	})
+
+	return page, nil
+}
+
+// parseTable reads one table's column names and cells, reporting false for the
+// ones that carry neither.
+func parseTable(s *goquery.Selection, base *url.URL) (Table, bool) {
+	var rows [][]Cell
+	s.Find("tr").Each(func(_ int, tr *goquery.Selection) {
+		var cells []Cell
+		tr.Find("th, td").Each(func(_ int, c *goquery.Selection) {
+			cells = append(cells, parseCell(c, base))
+		})
+		if len(cells) == 0 {
+			return
+		}
+		rows = append(rows, cells)
+	})
+
+	if len(rows) < 2 {
+		return Table{}, false
+	}
+
+	header := make([]string, 0, len(rows[0]))
+	for _, c := range rows[0] {
+		header = append(header, strings.Join(c.texts(), " "))
+	}
+
+	return Table{Header: header, Rows: rows[1:]}, true
+}
+
+// parseCell splits a cell at its line breaks, keeping the link each line
+// carries.
+//
+// The split is on <br> rather than on the text, because the text of two lines
+// runs together the moment it is read as one string -- "KB 5002894KB 5002896"
+// -- and no separator can be recovered from it afterwards.
+func parseCell(s *goquery.Selection, base *url.URL) Cell {
+	var cell Cell
+
+	line := Line{}
+	flush := func() {
+		line.Text = text(line.Text)
+		if line.Text != "" || line.Href != "" {
+			cell.Lines = append(cell.Lines, line)
+		}
+		line = Line{}
+	}
+
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			switch {
+			case c.Type == html.TextNode:
+				line.Text += c.Data
+			case c.Type == html.ElementNode && c.Data == "br":
+				flush()
+			case c.Type == html.ElementNode:
+				if c.Data == "a" && line.Href == "" {
+					for _, a := range c.Attr {
+						if a.Key == "href" {
+							line.Href = resolve(base, text(a.Val))
+							break
+						}
+					}
+				}
+				walk(c)
+			}
+		}
+	}
+	for _, n := range s.Nodes {
+		walk(n)
+	}
+	flush()
+
+	return cell
+}
+
+func (c Cell) texts() []string {
+	out := make([]string, 0, len(c.Lines))
+	for _, l := range c.Lines {
+		out = append(out, l.Text)
+	}
+	return out
+}
+
+// resolve turns a link into an address that works away from the page it was
+// read on. One that cannot be parsed is kept as served rather than dropped: it
+// is not this parser's to decide that Microsoft meant nothing by it.
+func resolve(base *url.URL, href string) string {
+	if href == "" || base == nil {
+		return href
+	}
+	ref, err := url.Parse(href)
+	if err != nil {
+		return href
+	}
+	return base.ResolveReference(ref).String()
+}
+
+// text normalizes the whitespace HTML is free to write however it likes.
+// goquery has already resolved the entities.
+func text(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/pkg/fetch/microsoft/sharepoint/sharepoint_test.go
+++ b/pkg/fetch/microsoft/sharepoint/sharepoint_test.go
@@ -1,0 +1,157 @@
+package sharepoint_test
+
+import (
+	"io/fs"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/sharepoint"
+)
+
+// The fixture is the page as served, cut down to the row shapes that decide
+// what is read out of it.
+//
+// A row describes one package or two, and where it describes two, the second is
+// a language pack on the Subscription Edition, 2019 and 2016 and SharePoint
+// Foundation on 2013 and 2010 -- a different product with its own KBs. The
+// packages and their KBs are matched by the <br> between them, so a reader that
+// took a cell as one string would be left with "KB 5002894KB 5002896" and
+// nothing to say which package either belongs to.
+//
+// The 2016 rows write the version once per package and the others write it once
+// for the row. One 2010 row names a package that shipped nothing that month,
+// which Microsoft writes out as "No update for June." rather than leaving the
+// cell empty, and several 2010 KBs are written as text with no link at all.
+//
+// Dates are written both ways, "August 11, 2026" and "April 2023", and one row
+// opens with a service pack instead. The page also carries a heading and a table
+// outside <main>.
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		golden   string
+		hasError bool
+	}{
+		{
+			name:    "happy",
+			fixture: "happy",
+			golden:  "happy",
+		},
+		{
+			// A page whose tables this cannot find is not a page that has lost
+			// them: it keeps SharePoint 2010, out of support since 2021,
+			// alongside the current release. So the run fails rather than
+			// committing an empty raw/ beside a full origin/.
+			name:     "page without tables",
+			fixture:  "tableless",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(handler(t, tt.fixture))
+			defer ts.Close()
+
+			dir := t.TempDir()
+			err := sharepoint.Fetch(
+				sharepoint.WithBaseURL(ts.URL),
+				sharepoint.WithDir(dir),
+				sharepoint.WithRetry(0),
+				sharepoint.WithWait(0),
+			)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Fatalf("unexpected error. err: %v", err)
+			case err == nil && tt.hasError:
+				t.Fatal("expected error has not occurred")
+			case err != nil:
+				return
+			}
+
+			diff(t, filepath.Join("testdata", "golden", tt.golden), dir)
+		})
+	}
+}
+
+// handler serves a fixture tree the way learn.microsoft.com serves the page:
+// one document per path, and nothing anywhere else.
+func handler(t *testing.T, fixture string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		bs, err := os.ReadFile(filepath.Join("testdata", "fixtures", fixture, filepath.Clean(r.URL.Path)+".html"))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(bs)
+	}
+}
+
+// diff compares the produced tree against golden byte for byte. Bytes rather
+// than parsed content: origin/ is only worth keeping if it reproduces exactly,
+// and raw/ is written deterministically, so any difference at all is a
+// regression.
+func diff(t *testing.T, golden, got string) {
+	t.Helper()
+
+	want := walk(t, golden)
+	have := walk(t, got)
+
+	if d := cmp.Diff(slices.Sorted(maps.Keys(want)), slices.Sorted(maps.Keys(have))); d != "" {
+		t.Errorf("files (-expected +got):\n%s", d)
+	}
+
+	for n, w := range want {
+		h, ok := have[n]
+		if !ok {
+			continue
+		}
+		if d := cmp.Diff(string(w), string(h)); d != "" {
+			t.Errorf("%s (-expected +got):\n%s", n, d)
+		}
+	}
+}
+
+func walk(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+
+	out := make(map[string][]byte)
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+
+		bs, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+
+		out[filepath.ToSlash(rel)] = bs
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walk %s. err: %v", root, err)
+	}
+
+	return out
+}

--- a/pkg/fetch/microsoft/sharepoint/testdata/fixtures/happy/en-us/officeupdates/sharepoint-updates.html
+++ b/pkg/fetch/microsoft/sharepoint/testdata/fixtures/happy/en-us/officeupdates/sharepoint-updates.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>SharePoint Server update history</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/officeupdates/sharepoint-updates" />
+</head>
+<body>
+<nav>
+<h2>Skip to main content</h2>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>SharePoint Server Subscription Edition update history</h2>
+<table>
+<tr> <th style="text-align: left;"><strong>Package Name</strong></th> <th style="text-align: left;"><strong>KB Number</strong></th> <th style="text-align: left;"><strong>Version</strong></th> <th style="text-align: left;"><strong>Release Date</strong></th> </tr>
+<tr> <td style="text-align: left;">SharePoint Server Subscription Edition <br></td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002893" data-linktype="external">KB 5002893</a></td> <td style="text-align: left;">16.0.19725.20522</td> <td style="text-align: left;">August 11, 2026</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Server Subscription Edition <br></td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002882" data-linktype="external">KB 5002882</a></td> <td style="text-align: left;">16.0.19725.20434</td> <td style="text-align: left;">July 14, 2026</td> </tr>
+</table>
+<h2>SharePoint 2019 update history</h2>
+<table>
+<tr> <th style="text-align: left;"><strong>Package Name</strong></th> <th style="text-align: left;"><strong>KB Number</strong></th> <th style="text-align: left;"><strong>Version</strong></th> <th style="text-align: left;"><strong>Release Date</strong></th> </tr>
+<tr> <td style="text-align: left;">SharePoint Server 2019 <br> SharePoint Server 2019 MUI/language patch</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002894" data-linktype="external">KB 5002894</a><br><a href="https://support.microsoft.com/help/5002896" data-linktype="external">KB 5002896</a></td> <td style="text-align: left;">16.0.10417.20198</td> <td style="text-align: left;">August 11, 2026</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Server 2019 <br> SharePoint Server 2019 MUI/language patch</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002883" data-linktype="external">KB 5002883</a><br><a href="https://support.microsoft.com/help/5002885" data-linktype="external">KB 5002885</a></td> <td style="text-align: left;">16.0.10417.20175</td> <td style="text-align: left;">July 14, 2026</td> </tr>
+</table>
+<h2>SharePoint 2016 update history</h2>
+<table>
+<tr> <th style="text-align: left;"><strong>Package Name</strong></th> <th style="text-align: left;"><strong>KB Number</strong></th> <th style="text-align: left;"><strong>Version</strong></th> <th style="text-align: left;"><strong>Release Date</strong></th> </tr>
+<tr> <td style="text-align: left;">SharePoint Server 2016 <br> SharePoint Server 2016 MUI/language patch <br></td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002905" data-linktype="external">KB 5002905</a><br><a href="https://support.microsoft.com/help/5002906" data-linktype="external">KB 5002906</a> <br></td> <td style="text-align: left;">16.0.5565.1001 <br> 16.0.5565.1001</td> <td style="text-align: left;">August 11, 2026</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Server 2016 <br> SharePoint Server 2016 MUI/language patch <br></td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002891" data-linktype="external">KB 5002891</a><br><a href="https://support.microsoft.com/help/5002892" data-linktype="external">KB 5002892</a> <br></td> <td style="text-align: left;">16.0.5561.1001 <br> 16.0.5561.1001</td> <td style="text-align: left;">July 14, 2026</td> </tr>
+</table>
+<h2>SharePoint 2013 update history</h2>
+<table>
+<tr> <th style="text-align: left;"><strong>Package Name</strong></th> <th style="text-align: left;"><strong>KB Number</strong></th> <th style="text-align: left;"><strong>Version</strong></th> <th style="text-align: left;"><strong>Release Date</strong></th> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2013<br>SharePoint Server 2013</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002379" data-linktype="external">KB 5002379</a><br><a href="https://support.microsoft.com/help/5002381" data-linktype="external">KB 5002381</a><br></td> <td style="text-align: left;">15.0.5545.1000</td> <td style="text-align: left;">April 2023</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2013<br>SharePoint Server 2013</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002363" data-linktype="external">KB 5002363</a><br><a href="https://support.microsoft.com/help/5002366" data-linktype="external">KB 5002366</a><br></td> <td style="text-align: left;">15.0.5537.1000</td> <td style="text-align: left;">March 2023</td> </tr>
+</table>
+<h2>SharePoint 2010 update history</h2>
+<table>
+<tr> <th style="text-align: left;"><strong>Package Name</strong></th> <th style="text-align: left;"><strong>KB Number</strong></th> <th style="text-align: left;"><strong>Version</strong></th> <th style="text-align: left;"><strong>Release Date</strong></th> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2010<br>SharePoint Server 2010<br></td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/4504709" data-linktype="external">KB 4504709</a><br>KB 4504742<br></td> <td style="text-align: left;">14.0.7268.5000</td> <td style="text-align: left;">April 2021</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Server 2010<br></td> <td style="text-align: left;">KB 4504706<br></td> <td style="text-align: left;">14.0.7267.5000</td> <td style="text-align: left;">March 2021</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2010<br>SharePoint Server 2010<br></td> <td style="text-align: left;">No update for June.<br>KB 3054880<br></td> <td style="text-align: left;">14.0.7151.5001</td> <td style="text-align: left;">June 2015</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2010<br>SharePoint Server 2010<br></td> <td style="text-align: left;">KB 2965293<br>KB 2965294<br></td> <td style="text-align: left;">14.0.7147.5000</td> <td style="text-align: left;">April 2015</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2010<br>SharePoint Server 2010<br></td> <td style="text-align: left;">KB 2687453<br>KB 2687464<br></td> <td style="text-align: left;">14.0.7015.1000</td> <td style="text-align: left;">Service Pack 2 July 2013</td> </tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/sharepoint/testdata/fixtures/tableless/en-us/officeupdates/sharepoint-updates.html
+++ b/pkg/fetch/microsoft/sharepoint/testdata/fixtures/tableless/en-us/officeupdates/sharepoint-updates.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head><meta charset="utf-8" /><title>SharePoint Server update history</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/officeupdates/sharepoint-updates" /></head>
+<body><main><h2>SharePoint update history</h2><p>This content has moved.</p></main></body>
+</html>

--- a/pkg/fetch/microsoft/sharepoint/testdata/golden/happy/origin/sharepoint-updates.html
+++ b/pkg/fetch/microsoft/sharepoint/testdata/golden/happy/origin/sharepoint-updates.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>SharePoint Server update history</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/officeupdates/sharepoint-updates" />
+</head>
+<body>
+<nav>
+<h2>Skip to main content</h2>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>SharePoint Server Subscription Edition update history</h2>
+<table>
+<tr> <th style="text-align: left;"><strong>Package Name</strong></th> <th style="text-align: left;"><strong>KB Number</strong></th> <th style="text-align: left;"><strong>Version</strong></th> <th style="text-align: left;"><strong>Release Date</strong></th> </tr>
+<tr> <td style="text-align: left;">SharePoint Server Subscription Edition <br></td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002893" data-linktype="external">KB 5002893</a></td> <td style="text-align: left;">16.0.19725.20522</td> <td style="text-align: left;">August 11, 2026</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Server Subscription Edition <br></td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002882" data-linktype="external">KB 5002882</a></td> <td style="text-align: left;">16.0.19725.20434</td> <td style="text-align: left;">July 14, 2026</td> </tr>
+</table>
+<h2>SharePoint 2019 update history</h2>
+<table>
+<tr> <th style="text-align: left;"><strong>Package Name</strong></th> <th style="text-align: left;"><strong>KB Number</strong></th> <th style="text-align: left;"><strong>Version</strong></th> <th style="text-align: left;"><strong>Release Date</strong></th> </tr>
+<tr> <td style="text-align: left;">SharePoint Server 2019 <br> SharePoint Server 2019 MUI/language patch</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002894" data-linktype="external">KB 5002894</a><br><a href="https://support.microsoft.com/help/5002896" data-linktype="external">KB 5002896</a></td> <td style="text-align: left;">16.0.10417.20198</td> <td style="text-align: left;">August 11, 2026</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Server 2019 <br> SharePoint Server 2019 MUI/language patch</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002883" data-linktype="external">KB 5002883</a><br><a href="https://support.microsoft.com/help/5002885" data-linktype="external">KB 5002885</a></td> <td style="text-align: left;">16.0.10417.20175</td> <td style="text-align: left;">July 14, 2026</td> </tr>
+</table>
+<h2>SharePoint 2016 update history</h2>
+<table>
+<tr> <th style="text-align: left;"><strong>Package Name</strong></th> <th style="text-align: left;"><strong>KB Number</strong></th> <th style="text-align: left;"><strong>Version</strong></th> <th style="text-align: left;"><strong>Release Date</strong></th> </tr>
+<tr> <td style="text-align: left;">SharePoint Server 2016 <br> SharePoint Server 2016 MUI/language patch <br></td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002905" data-linktype="external">KB 5002905</a><br><a href="https://support.microsoft.com/help/5002906" data-linktype="external">KB 5002906</a> <br></td> <td style="text-align: left;">16.0.5565.1001 <br> 16.0.5565.1001</td> <td style="text-align: left;">August 11, 2026</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Server 2016 <br> SharePoint Server 2016 MUI/language patch <br></td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002891" data-linktype="external">KB 5002891</a><br><a href="https://support.microsoft.com/help/5002892" data-linktype="external">KB 5002892</a> <br></td> <td style="text-align: left;">16.0.5561.1001 <br> 16.0.5561.1001</td> <td style="text-align: left;">July 14, 2026</td> </tr>
+</table>
+<h2>SharePoint 2013 update history</h2>
+<table>
+<tr> <th style="text-align: left;"><strong>Package Name</strong></th> <th style="text-align: left;"><strong>KB Number</strong></th> <th style="text-align: left;"><strong>Version</strong></th> <th style="text-align: left;"><strong>Release Date</strong></th> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2013<br>SharePoint Server 2013</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002379" data-linktype="external">KB 5002379</a><br><a href="https://support.microsoft.com/help/5002381" data-linktype="external">KB 5002381</a><br></td> <td style="text-align: left;">15.0.5545.1000</td> <td style="text-align: left;">April 2023</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2013<br>SharePoint Server 2013</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5002363" data-linktype="external">KB 5002363</a><br><a href="https://support.microsoft.com/help/5002366" data-linktype="external">KB 5002366</a><br></td> <td style="text-align: left;">15.0.5537.1000</td> <td style="text-align: left;">March 2023</td> </tr>
+</table>
+<h2>SharePoint 2010 update history</h2>
+<table>
+<tr> <th style="text-align: left;"><strong>Package Name</strong></th> <th style="text-align: left;"><strong>KB Number</strong></th> <th style="text-align: left;"><strong>Version</strong></th> <th style="text-align: left;"><strong>Release Date</strong></th> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2010<br>SharePoint Server 2010<br></td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/4504709" data-linktype="external">KB 4504709</a><br>KB 4504742<br></td> <td style="text-align: left;">14.0.7268.5000</td> <td style="text-align: left;">April 2021</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Server 2010<br></td> <td style="text-align: left;">KB 4504706<br></td> <td style="text-align: left;">14.0.7267.5000</td> <td style="text-align: left;">March 2021</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2010<br>SharePoint Server 2010<br></td> <td style="text-align: left;">No update for June.<br>KB 3054880<br></td> <td style="text-align: left;">14.0.7151.5001</td> <td style="text-align: left;">June 2015</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2010<br>SharePoint Server 2010<br></td> <td style="text-align: left;">KB 2965293<br>KB 2965294<br></td> <td style="text-align: left;">14.0.7147.5000</td> <td style="text-align: left;">April 2015</td> </tr>
+<tr> <td style="text-align: left;">SharePoint Foundation 2010<br>SharePoint Server 2010<br></td> <td style="text-align: left;">KB 2687453<br>KB 2687464<br></td> <td style="text-align: left;">14.0.7015.1000</td> <td style="text-align: left;">Service Pack 2 July 2013</td> </tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/sharepoint/testdata/golden/happy/raw/sharepoint-updates.json
+++ b/pkg/fetch/microsoft/sharepoint/testdata/golden/happy/raw/sharepoint-updates.json
@@ -1,0 +1,531 @@
+{
+	"url": "https://learn.microsoft.com/en-us/officeupdates/sharepoint-updates",
+	"tables": [
+		{
+			"heading": "SharePoint Server Subscription Edition update history",
+			"header": [
+				"Package Name",
+				"KB Number",
+				"Version",
+				"Release Date"
+			],
+			"rows": [
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server Subscription Edition"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002893",
+								"href": "https://support.microsoft.com/help/5002893"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.19725.20522"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "August 11, 2026"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server Subscription Edition"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002882",
+								"href": "https://support.microsoft.com/help/5002882"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.19725.20434"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "July 14, 2026"
+							}
+						]
+					}
+				]
+			]
+		},
+		{
+			"heading": "SharePoint 2019 update history",
+			"header": [
+				"Package Name",
+				"KB Number",
+				"Version",
+				"Release Date"
+			],
+			"rows": [
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server 2019"
+							},
+							{
+								"text": "SharePoint Server 2019 MUI/language patch"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002894",
+								"href": "https://support.microsoft.com/help/5002894"
+							},
+							{
+								"text": "KB 5002896",
+								"href": "https://support.microsoft.com/help/5002896"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.10417.20198"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "August 11, 2026"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server 2019"
+							},
+							{
+								"text": "SharePoint Server 2019 MUI/language patch"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002883",
+								"href": "https://support.microsoft.com/help/5002883"
+							},
+							{
+								"text": "KB 5002885",
+								"href": "https://support.microsoft.com/help/5002885"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.10417.20175"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "July 14, 2026"
+							}
+						]
+					}
+				]
+			]
+		},
+		{
+			"heading": "SharePoint 2016 update history",
+			"header": [
+				"Package Name",
+				"KB Number",
+				"Version",
+				"Release Date"
+			],
+			"rows": [
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server 2016"
+							},
+							{
+								"text": "SharePoint Server 2016 MUI/language patch"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002905",
+								"href": "https://support.microsoft.com/help/5002905"
+							},
+							{
+								"text": "KB 5002906",
+								"href": "https://support.microsoft.com/help/5002906"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.5565.1001"
+							},
+							{
+								"text": "16.0.5565.1001"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "August 11, 2026"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server 2016"
+							},
+							{
+								"text": "SharePoint Server 2016 MUI/language patch"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002891",
+								"href": "https://support.microsoft.com/help/5002891"
+							},
+							{
+								"text": "KB 5002892",
+								"href": "https://support.microsoft.com/help/5002892"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "16.0.5561.1001"
+							},
+							{
+								"text": "16.0.5561.1001"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "July 14, 2026"
+							}
+						]
+					}
+				]
+			]
+		},
+		{
+			"heading": "SharePoint 2013 update history",
+			"header": [
+				"Package Name",
+				"KB Number",
+				"Version",
+				"Release Date"
+			],
+			"rows": [
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2013"
+							},
+							{
+								"text": "SharePoint Server 2013"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002379",
+								"href": "https://support.microsoft.com/help/5002379"
+							},
+							{
+								"text": "KB 5002381",
+								"href": "https://support.microsoft.com/help/5002381"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "15.0.5545.1000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "April 2023"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2013"
+							},
+							{
+								"text": "SharePoint Server 2013"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 5002363",
+								"href": "https://support.microsoft.com/help/5002363"
+							},
+							{
+								"text": "KB 5002366",
+								"href": "https://support.microsoft.com/help/5002366"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "15.0.5537.1000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "March 2023"
+							}
+						]
+					}
+				]
+			]
+		},
+		{
+			"heading": "SharePoint 2010 update history",
+			"header": [
+				"Package Name",
+				"KB Number",
+				"Version",
+				"Release Date"
+			],
+			"rows": [
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2010"
+							},
+							{
+								"text": "SharePoint Server 2010"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 4504709",
+								"href": "https://support.microsoft.com/help/4504709"
+							},
+							{
+								"text": "KB 4504742"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "14.0.7268.5000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "April 2021"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Server 2010"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 4504706"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "14.0.7267.5000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "March 2021"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2010"
+							},
+							{
+								"text": "SharePoint Server 2010"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "No update for June."
+							},
+							{
+								"text": "KB 3054880"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "14.0.7151.5001"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "June 2015"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2010"
+							},
+							{
+								"text": "SharePoint Server 2010"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 2965293"
+							},
+							{
+								"text": "KB 2965294"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "14.0.7147.5000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "April 2015"
+							}
+						]
+					}
+				],
+				[
+					{
+						"lines": [
+							{
+								"text": "SharePoint Foundation 2010"
+							},
+							{
+								"text": "SharePoint Server 2010"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "KB 2687453"
+							},
+							{
+								"text": "KB 2687464"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "14.0.7015.1000"
+							}
+						]
+					},
+					{
+						"lines": [
+							{
+								"text": "Service Pack 2 July 2013"
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/fetch/microsoft/sharepoint/types.go
+++ b/pkg/fetch/microsoft/sharepoint/types.go
@@ -1,0 +1,42 @@
+package sharepoint
+
+// Page is the SharePoint Server update history, as served.
+//
+// Nothing is read out of the cells here. What a cell means depends on the
+// column it is in and on the other cells of its row -- the packages a row
+// describes are named in one cell and their KBs in another, matched by
+// position -- and reading that apart belongs in extract, under golden tests,
+// where a change is handled by rerunning against origin/.
+type Page struct {
+	// URL is the page's own canonical link, taken from the stored HTML rather
+	// than from the request, so raw/ stays derivable from origin/ alone.
+	URL    string  `json:"url,omitempty"`
+	Tables []Table `json:"tables,omitempty"`
+}
+
+// Table is one product version's update history, with the heading it sits
+// under. The heading is the only place the page names the version a table
+// covers.
+type Table struct {
+	Heading string   `json:"heading,omitempty"`
+	Header  []string `json:"header,omitempty"`
+	Rows    [][]Cell `json:"rows,omitempty"`
+}
+
+// Cell is one cell, as a list of lines.
+//
+// A SharePoint cell holds a list, and it is not presentation: one row
+// describes two packages at once -- a server and its language pack, or
+// Foundation and Server on the older versions -- naming them one per line and
+// their KBs one per line beside them, so that the two columns line up by
+// position. Reading the cell as one string would leave "KB 5002894 KB 5002896"
+// with nothing to say which package either belongs to.
+type Cell struct {
+	Lines []Line `json:"lines,omitempty"`
+}
+
+// Line is one line of a cell, with the link it carries.
+type Line struct {
+	Text string `json:"text,omitempty"`
+	Href string `json:"href,omitempty"`
+}


### PR DESCRIPTION
## What

Adds `microsoft-sharepoint`, a fetcher and extractor for the SharePoint Server update history. **769 KBs**, SharePoint 2010 to the Subscription Edition, in 10 chains and 759 edges.

## Why

The Update Catalog no longer serves all of them: of ten sampled across the page's fifteen years, three answer "We did not find any results".

It is the rendered page rather than the Markdown it is authored in, because the docs repository behind `officeupdates` is private — learn.microsoft.com names `MicrosoftDocs/OfficeDocs-OfficeUpdates-pr` as the source and there is no public counterpart, unlike the SQL Server article.

## How

**A row is not one update.** It describes two at once, naming the packages one per line and their KBs one per line beside them, matched by position:

```
SharePoint Server 2019                     KB 5002894
SharePoint Server 2019 MUI/language patch  KB 5002896
```

which is one `<td>` per column with a `<br>` between the lines. On 2013 and 2010 the second is not a language pack but SharePoint Foundation beside SharePoint Server — a different product with its own KBs. Either way they ship at their own versions and neither replaces the other, so **the package name is the chain**.

`fetch` therefore stores a cell as a **list of lines** rather than a string. Read as one string a cell becomes `KB 5002894KB 5002896`, from which no separator can be recovered.

**Where that matters most is SharePoint Foundation 2010.** Three of its rows read `No update for June.` beside SharePoint Server 2010's KB, so the Foundation chain skips those months while the Server chain takes them. Reading a row as one update would hand Foundation a KB it never shipped. Those rows are recognised and logged at Debug, not Warn — a release that did not happen is not a failure to read one.

**The version orders these and the date does not.** 411 of the 769 rows are dated by month alone (`April 2026`) against 45 written out in full, so the date is kept as a tiebreaker — and over all 759 edges it has not once had to break one, no two updates of a package sharing a version.

This is the cleanest of the Microsoft sources measured so far: no version collisions, no date inversions, no unreadable rows.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` — passes
- `golangci-lint run ./pkg/...` — 0 issues
- Golden tests for both packages
- End to end against the live page: **769 KBs, 0 unchained, no warnings**

```
$ vuls-data-update fetch   microsoft-sharepoint -d <raw>
$ vuls-data-update extract microsoft-sharepoint <raw> -d <out>
```

## Checklist

- [x] Tests pass
- [x] Golden files updated
- [x] Deterministic output verified (types changed)
- [x] Backward compatibility maintained (types/data changed)

`pkg/extract/types/source` gains one constant, `MicrosoftSharePoint`. Additive; it is the only file shared with the other Microsoft data-source branches.

**Known limitation.** 235 records carry no URL: the older rows write their KB as plain text (`KB 4504742`) rather than as a link, and no URL is synthesised from the number.
