### PR TITLE
feat(microsoft/exchange): add exchange build numbers data source

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -65,6 +65,7 @@ import (
 	mavenOSV "github.com/MaineK00n/vuls-data-update/pkg/extract/maven/osv"
 	microsoftBulletin "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/bulletin"
 	microsoftCVRF "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/cvrf"
+	microsoftExchange "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/exchange"
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/msuc"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/servicing"
 	microsoftWSUSSCN2 "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/wsusscn2"
@@ -180,7 +181,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdJVNFeedDetail(), newCmdJVNFeedProduct(), newCmdJVNFeedRSS(),
 		newCmdLinuxOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftWSUSSCN2(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftExchange(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftWSUSSCN2(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
 		newCmdNetBSD(),
@@ -1631,6 +1632,31 @@ func newCmdMicrosoftCVRF() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := microsoftCVRF.Extract(args[0], microsoftCVRF.WithDir(options.dir)); err != nil {
 				return errors.Wrap(err, "failed to extract microsoft cvrf")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdMicrosoftExchange() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "exchange"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-exchange <Raw Microsoft Exchange Repository PATH>",
+		Short: "Extract Microsoft Exchange Build Numbers and Release Dates data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract microsoft-exchange vuls-data-raw-microsoft-exchange
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := microsoftExchange.Extract(args[0], microsoftExchange.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract microsoft exchange")
 			}
 			return nil
 		},

--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -89,6 +89,7 @@ import (
 	microsoftCSAF "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/csaf"
 	microsoftCVRF "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/cvrf"
 	microsoftDeployment "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/deployment"
+	microsoftExchange "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/exchange"
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/msuc"
 	microsoftProduct "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/product"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/servicing"
@@ -255,7 +256,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdLinuxOSV(),
 		newCmdMageiaOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftExchange(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
 		newCmdMinimOSOSV(), newCmdMinimOSSecDB(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreEMB3D(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
@@ -2629,6 +2630,51 @@ func newCmdMicrosoftCSAF() *cobra.Command {
 	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
 	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
 	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent http requests")
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
+
+	return cmd
+}
+
+func newCmdMicrosoftExchange() *cobra.Command {
+	options := &struct {
+		base
+		wait time.Duration
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "microsoft", "exchange"),
+			retry: 3,
+		},
+		wait: 1 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-exchange",
+		Short: "Fetch Microsoft Exchange Build Numbers and Release Dates data source",
+		Long: heredoc.Doc(`
+			Fetch the Exchange Server build numbers and release dates page as HTML into
+			<dir>/origin, and the tables it carries into <dir>/raw.
+
+			The page lists every build Exchange has shipped, from Exchange Server 4.0
+			to the Subscription Edition. The builds that name a KB are the security
+			updates; a cumulative update ships as a download and carries none.
+
+			The KB is not in a column -- it is the link on the product's name -- so the
+			link every cell carries is stored alongside its text.
+		`),
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch microsoft-exchange
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := microsoftExchange.Fetch(microsoftExchange.WithDir(options.dir), microsoftExchange.WithRetry(options.retry), microsoftExchange.WithWait(options.wait)); err != nil {
+				return errors.Wrap(err, "failed to fetch microsoft exchange")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
 	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
 
 	return cmd

--- a/pkg/extract/microsoft/exchange/exchange.go
+++ b/pkg/extract/microsoft/exchange/exchange.go
@@ -1,0 +1,394 @@
+// Package exchange extracts supersedence from Microsoft's Exchange Server build
+// numbers and release dates.
+//
+// The page carries no supersedence. What it carries is every build Exchange has
+// shipped, and the build number is the order -- but not in one line. Exchange
+// services every cumulative update level that is still supported, side by side,
+// and the build number says which:
+//
+//	Exchange Server 2019 CU15 Aug26SU   15.2.1748.49
+//	Exchange Server 2019 CU15 Jul26SU   15.2.1748.48
+//	Exchange Server 2019 CU14 Aug26SU   15.2.1544.44
+//
+// The third component is the cumulative update and the fourth is the security
+// update within it. A host on CU14 is not served by CU15's update and never
+// will be, so the lane is the chain: keyed on the table and the first three
+// components, ordered by the fourth. Thirty-seven of them run across the page,
+// and over their 121 edges the build order and the release dates never disagree.
+//
+// One KB is on many lanes. KB5000871, the March 2021 update, appears on
+// twenty-five rows -- every supported cumulative update level of Exchange 2013,
+// 2016 and 2019 got its own patched build of the one fix -- so it takes its
+// place in each of their chains and ends up with the edges of all of them.
+//
+// The table has to be part of the key rather than the build alone. Exchange
+// Server SE and Exchange Server 2019 are both 15.2, and only the table Microsoft
+// filed a row under says which product it is.
+//
+// Rows naming no KB are the cumulative updates themselves, which ship as
+// downloads rather than as KB articles, and every build of Exchange 2010 and
+// earlier. They are skipped: a chain of KBs has no place for them.
+package exchange
+
+import (
+	"cmp"
+	"encoding/json/v2"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
+	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/exchange"
+)
+
+// The columns a row is read out of, by name. The build is taken from the short
+// format; the long one is the same number with its parts zero-padded.
+const (
+	columnProduct = "Product name"
+	columnDate    = "Release date"
+	columnBuild   = "Build number (short format)"
+)
+
+var (
+	// kbPattern reads the KB out of the link on a product's name, that being
+	// where this page puts it.
+	kbPattern = regexp.MustCompile(`support\.microsoft\.com/(?:[a-z-]+/)?(?:help|kb)/(\d{6,})`)
+
+	// buildPattern is an Exchange build number. Four components on every row
+	// that names a KB; the older tables, which name none, use fewer.
+	buildPattern = regexp.MustCompile(`^\d+(?:\.\d+){3}$`)
+)
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+// update is one build, read for what decides its place in a chain.
+type update struct {
+	kbID string
+	url  string
+
+	// version is the heading the table sits under, e.g. "Exchange Server 2019".
+	// Exchange Server SE shares 15.2 with it, so the build number alone would
+	// not tell the two apart.
+	version string
+
+	// name is the product name as written, e.g. "Exchange Server 2019 CU15
+	// Aug26SU". Nothing is parsed out of it -- the build number says everything
+	// the name does, and says it the same way every time.
+	name string
+
+	build    []int
+	buildStr string
+
+	date time.Time
+
+	raw string
+}
+
+// lane is the cumulative update level an update patches: everything of the
+// build but its last component, which is the update's place within the lane.
+func (u update) lane() string {
+	parts := make([]string, 0, len(u.build)-1)
+	for _, p := range u.build[:len(u.build)-1] {
+		parts = append(parts, strconv.Itoa(p))
+	}
+	return strings.Join(parts, ".")
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "exchange"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract Microsoft Exchange Build Numbers and Release Dates")
+
+	us, err := read(args)
+	if err != nil {
+		return errors.Wrapf(err, "read %s", args)
+	}
+
+	kbs := chain(us)
+
+	for _, kb := range kbs {
+		if err := util.Write(filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)), kb, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)))
+		}
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.MicrosoftExchange,
+		Name: new("Microsoft Exchange Build Numbers and Release Dates"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{URL: u}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+// read walks the raw tree and returns the builds that name a KB.
+func read(args string) ([]update, error) {
+	root := filepath.Join(args, "raw")
+
+	var us []update
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".json" {
+			return nil
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", p)
+		}
+		defer f.Close()
+
+		var page exchange.Page
+		if err := json.UnmarshalRead(f, &page); err != nil {
+			return errors.Wrapf(err, "decode %s", p)
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+
+		us = append(us, parsePage(page, filepath.ToSlash(rel))...)
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrapf(err, "walk %s", root)
+	}
+
+	return us, nil
+}
+
+// parsePage reads a page's build histories.
+func parsePage(page exchange.Page, raw string) []update {
+	var us []update
+
+	for _, t := range page.Tables {
+		var missing []string
+		for _, c := range []string{columnProduct, columnDate, columnBuild} {
+			if !slices.Contains(t.Header, c) {
+				missing = append(missing, c)
+			}
+		}
+		if len(missing) > 0 {
+			// Exchange Server 2003 and earlier are listed with a single "Build
+			// number" column and name no KB, so there is nothing here to lose.
+			slog.Debug("not a build history this can read", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("missing", strings.Join(missing, ", ")))
+			continue
+		}
+
+		for _, row := range t.Rows {
+			u, ok := parseRow(t, row, raw)
+			if !ok {
+				continue
+			}
+			us = append(us, u)
+		}
+	}
+
+	return us
+}
+
+// parseRow reads one row, reporting false for the ones that are not updates.
+func parseRow(t exchange.Table, row []exchange.Cell, raw string) (update, bool) {
+	cell := func(column string) exchange.Cell {
+		i := slices.Index(t.Header, column)
+		if i < 0 || i >= len(row) {
+			return exchange.Cell{}
+		}
+		return row[i]
+	}
+
+	product := cell(columnProduct)
+
+	m := kbPattern.FindStringSubmatch(product.Href)
+	if m == nil {
+		// A cumulative update, a service pack or a build of Exchange 2010 and
+		// earlier. Those ship as downloads rather than as KB articles, so the
+		// name links to the Download Center or to nothing at all.
+		slog.Debug("build names no KB", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("product", product.Text))
+		return update{}, false
+	}
+
+	bs := cell(columnBuild).Text
+	if !buildPattern.MatchString(bs) {
+		// The build is the whole order, and its last component is the update's
+		// place in its lane. A row without one cannot be placed at all.
+		slog.Warn("unexpected build", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("kb", m[1]), slog.String("build", bs))
+		return update{}, false
+	}
+	build := make([]int, 0, 4)
+	for _, p := range strings.Split(bs, ".") {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			slog.Warn("unexpected build", slog.String("path", raw), slog.String("kb", m[1]), slog.String("build", bs))
+			return update{}, false
+		}
+		build = append(build, n)
+	}
+
+	// The date is a tiebreaker between two builds of one lane, not the order,
+	// so an unreadable one costs the tie and not the row.
+	var date time.Time
+	if d := cell(columnDate).Text; d != "" {
+		var err error
+		date, err = time.Parse("January 2, 2006", d)
+		if err != nil {
+			slog.Warn("unexpected release date", slog.String("path", raw), slog.String("kb", m[1]), slog.String("date", d))
+			date = time.Time{}
+		}
+	}
+
+	return update{
+		kbID:     m[1],
+		url:      product.Href,
+		version:  t.Heading,
+		name:     product.Text,
+		build:    build,
+		buildStr: bs,
+		date:     date,
+		raw:      raw,
+	}, true
+}
+
+// chain turns the builds into KB records, chained into supersedence.
+func chain(us []update) []microsoftkbTypes.KB {
+	type buildLane struct {
+		version string
+		lane    string
+	}
+
+	lanes := make(map[buildLane][]update)
+	for _, u := range us {
+		lanes[buildLane{version: u.version, lane: u.lane()}] = append(lanes[buildLane{version: u.version, lane: u.lane()}], u)
+	}
+
+	type link struct{ older, newer string }
+	var links []link
+	for bl, group := range lanes {
+		slices.SortFunc(group, func(x, y update) int {
+			return cmp.Or(slices.Compare(x.build, y.build), x.date.Compare(y.date), cmp.Compare(x.kbID, y.kbID))
+		})
+
+		for i := 1; i < len(group); i++ {
+			older, newer := group[i-1], group[i]
+
+			// The build is the order and the date is not, but where the two
+			// disagree the row is worth reading. Over the whole page they never
+			// have.
+			if !older.date.IsZero() && !newer.date.IsZero() && newer.date.Before(older.date) {
+				slog.Warn("a lane's builds and release dates disagree",
+					slog.String("version", bl.version), slog.String("lane", bl.lane),
+					slog.String("older", fmt.Sprintf("KB%s %s %s", older.kbID, older.buildStr, older.date.Format(time.DateOnly))),
+					slog.String("newer", fmt.Sprintf("KB%s %s %s", newer.kbID, newer.buildStr, newer.date.Format(time.DateOnly))))
+			}
+
+			links = append(links, link{older: older.kbID, newer: newer.kbID})
+		}
+	}
+
+	kbs := make(map[string]*microsoftkbTypes.KB, len(us))
+	for _, u := range us {
+		kb, ok := kbs[u.kbID]
+		if !ok {
+			kb = &microsoftkbTypes.KB{
+				KBID: u.kbID,
+				URL:  u.url,
+				DataSource: sourceTypes.Source{
+					ID: sourceTypes.MicrosoftExchange,
+				},
+			}
+			kbs[u.kbID] = kb
+		}
+		if !slices.Contains(kb.Products, u.version) {
+			kb.Products = append(kb.Products, u.version)
+		}
+		if !slices.Contains(kb.DataSource.Raws, u.raw) {
+			kb.DataSource.Raws = append(kb.DataSource.Raws, u.raw)
+		}
+	}
+
+	for _, l := range links {
+		// A KB is on many lanes and the lanes are patched in step, so one of
+		// them can name the next KB that another has already named. It is one
+		// edge either way.
+		if l.older == l.newer {
+			continue
+		}
+		if kb, ok := kbs[l.older]; ok {
+			s := microsoftkbSupersededByTypes.SupersededBy{KBID: l.newer}
+			if !slices.Contains(kb.SupersededBy, s) {
+				kb.SupersededBy = append(kb.SupersededBy, s)
+			}
+		}
+		if kb, ok := kbs[l.newer]; ok {
+			s := microsoftkbSupersedesTypes.Supersedes{KBID: l.older}
+			if !slices.Contains(kb.Supersedes, s) {
+				kb.Supersedes = append(kb.Supersedes, s)
+			}
+		}
+	}
+
+	out := make([]microsoftkbTypes.KB, 0, len(kbs))
+	for _, kb := range kbs {
+		out = append(out, *kb)
+	}
+	return out
+}

--- a/pkg/extract/microsoft/exchange/exchange_test.go
+++ b/pkg/extract/microsoft/exchange/exchange_test.go
@@ -1,0 +1,67 @@
+package exchange_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/exchange"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+// The fixture is the page as fetched, chosen for what decides a chain.
+//
+// Exchange services every supported cumulative update level side by side, and
+// the build number says which: KB5121574 at 15.2.1748.49 and KB5121575 at
+// 15.2.1544.44 shipped on one day for Exchange Server 2019, the first for hosts
+// on CU15 and the second for hosts on CU14, and neither reaches the other's.
+// Ordering the version's updates as one line by build number would have the
+// CU14 update replaced by a CU15 one that will never be offered to it.
+//
+// KB5000871 is on four rows across three product versions, which is what the
+// March 2021 update was: every supported cumulative update level got its own
+// patched build of the one fix. It takes its place in each of those lanes.
+//
+// Exchange Server SE and Exchange Server 2019 are both 15.2, so the table is
+// part of the key -- KB5121573 at 15.2.2562.46 has nothing to do with Exchange
+// 2019's chains.
+//
+// Rows that ship as downloads carry no KB: a cumulative update, and Exchange
+// Server SE's own release, link to the Download Center instead. Exchange Server
+// 2003 is listed with a column set of its own. None of them is an update this
+// can chain, and none is reported as a failure to read one.
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures/happy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := exchange.Extract(tt.args, exchange.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				return
+			default:
+				ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				gp, err := filepath.Abs(dir)
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}

--- a/pkg/extract/microsoft/exchange/testdata/fixtures/happy/raw/build-numbers-and-release-dates.json
+++ b/pkg/extract/microsoft/exchange/testdata/fixtures/happy/raw/build-numbers-and-release-dates.json
@@ -1,0 +1,295 @@
+{
+	"url": "https://learn.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates",
+	"tables": [
+		{
+			"heading": "Exchange Server SE",
+			"header": [
+				"Product name",
+				"Release date",
+				"Build number (short format)",
+				"Build number (long format)"
+			],
+			"rows": [
+				[
+					{
+						"text": "Exchange Server SE RTM Aug26SU",
+						"href": "https://support.microsoft.com/help/5121573"
+					},
+					{
+						"text": "August 11, 2026"
+					},
+					{
+						"text": "15.2.2562.46"
+					},
+					{
+						"text": "15.02.2562.046"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server SE RTM Jul26SU",
+						"href": "https://support.microsoft.com/help/5103212"
+					},
+					{
+						"text": "July 14, 2026"
+					},
+					{
+						"text": "15.2.2562.45"
+					},
+					{
+						"text": "15.02.2562.045"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server SE RTM",
+						"href": "https://www.microsoft.com/download/details.aspx?id=105683"
+					},
+					{
+						"text": "July 1, 2025"
+					},
+					{
+						"text": "15.2.2562.17"
+					},
+					{
+						"text": "15.02.2562.017"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Exchange Server 2019",
+			"header": [
+				"Product name",
+				"Release date",
+				"Build number (short format)",
+				"Build number (long format)"
+			],
+			"rows": [
+				[
+					{
+						"text": "Exchange Server 2019 CU15 Aug26SU",
+						"href": "https://support.microsoft.com/help/5121574"
+					},
+					{
+						"text": "August 11, 2026"
+					},
+					{
+						"text": "15.2.1748.49"
+					},
+					{
+						"text": "15.02.1748.049"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU14 Aug26SU",
+						"href": "https://support.microsoft.com/help/5121575"
+					},
+					{
+						"text": "August 11, 2026"
+					},
+					{
+						"text": "15.2.1544.44"
+					},
+					{
+						"text": "15.02.1544.044"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU15 Jul26SU",
+						"href": "https://support.microsoft.com/help/5103213"
+					},
+					{
+						"text": "July 14, 2026"
+					},
+					{
+						"text": "15.2.1748.48"
+					},
+					{
+						"text": "15.02.1748.048"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU14 Jul26SU",
+						"href": "https://support.microsoft.com/help/5103214"
+					},
+					{
+						"text": "July 14, 2026"
+					},
+					{
+						"text": "15.2.1544.43"
+					},
+					{
+						"text": "15.02.1544.043"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU15 (2025H1)",
+						"href": "https://www.microsoft.com/download/details.aspx?id=105682"
+					},
+					{
+						"text": "February 10, 2025"
+					},
+					{
+						"text": "15.2.1748.10"
+					},
+					{
+						"text": "15.02.1748.010"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU8 Mar21SU",
+						"href": "https://support.microsoft.com/help/5000871"
+					},
+					{
+						"text": "March 2, 2021"
+					},
+					{
+						"text": "15.2.792.10"
+					},
+					{
+						"text": "15.02.0792.010"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU7 Mar21SU",
+						"href": "https://support.microsoft.com/help/5000871"
+					},
+					{
+						"text": "March 2, 2021"
+					},
+					{
+						"text": "15.2.721.13"
+					},
+					{
+						"text": "15.02.0721.013"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Exchange Server 2016",
+			"header": [
+				"Product name",
+				"Release date",
+				"Build number (short format)",
+				"Build number (long format)"
+			],
+			"rows": [
+				[
+					{
+						"text": "Exchange Server 2016 CU23 Aug26SU",
+						"href": "https://support.microsoft.com/help/5121576"
+					},
+					{
+						"text": "August 11, 2026"
+					},
+					{
+						"text": "15.1.2507.72"
+					},
+					{
+						"text": "15.01.2507.072"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2016 CU19 Mar21SU",
+						"href": "https://support.microsoft.com/help/5000871"
+					},
+					{
+						"text": "March 2, 2021"
+					},
+					{
+						"text": "15.1.2176.9"
+					},
+					{
+						"text": "15.01.2176.009"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Exchange Server 2013",
+			"header": [
+				"Product name",
+				"Release date",
+				"Build number (short format)",
+				"Build number (long format)"
+			],
+			"rows": [
+				[
+					{
+						"text": "Exchange Server 2013 CU23 Mar23SU",
+						"href": "https://support.microsoft.com/help/5024296"
+					},
+					{
+						"text": "March 14, 2023"
+					},
+					{
+						"text": "15.0.1497.48"
+					},
+					{
+						"text": "15.00.1497.048"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2013 CU23 Mar21SU",
+						"href": "https://support.microsoft.com/help/5000871"
+					},
+					{
+						"text": "March 2, 2021"
+					},
+					{
+						"text": "15.0.1497.12"
+					},
+					{
+						"text": "15.00.1497.012"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2013 SP1 Mar21SU",
+						"href": "https://support.microsoft.com/help/5000871"
+					},
+					{
+						"text": "March 2, 2021"
+					},
+					{
+						"text": "15.0.847.64"
+					},
+					{
+						"text": "15.00.0847.064"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Exchange Server 2003",
+			"header": [
+				"Product name",
+				"Release date",
+				"Build number"
+			],
+			"rows": [
+				[
+					{
+						"text": "Exchange Server 2003 post-SP2"
+					},
+					{
+						"text": "August 2006"
+					},
+					{
+						"text": "6.5.7683.0"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/extract/microsoft/exchange/testdata/golden/datasource.json
+++ b/pkg/extract/microsoft/exchange/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "microsoft-exchange",
+	"name": "Microsoft Exchange Build Numbers and Release Dates"
+}

--- a/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5000xxx/5000871.json
+++ b/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5000xxx/5000871.json
@@ -1,0 +1,20 @@
+{
+	"kb_id": "5000871",
+	"url": "https://support.microsoft.com/help/5000871",
+	"products": [
+		"Exchange Server 2013",
+		"Exchange Server 2016",
+		"Exchange Server 2019"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5024296"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-exchange",
+		"raws": [
+			"build-numbers-and-release-dates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5024xxx/5024296.json
+++ b/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5024xxx/5024296.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5024296",
+	"url": "https://support.microsoft.com/help/5024296",
+	"products": [
+		"Exchange Server 2013"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5000871"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-exchange",
+		"raws": [
+			"build-numbers-and-release-dates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5103xxx/5103212.json
+++ b/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5103xxx/5103212.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5103212",
+	"url": "https://support.microsoft.com/help/5103212",
+	"products": [
+		"Exchange Server SE"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5121573"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-exchange",
+		"raws": [
+			"build-numbers-and-release-dates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5103xxx/5103213.json
+++ b/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5103xxx/5103213.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5103213",
+	"url": "https://support.microsoft.com/help/5103213",
+	"products": [
+		"Exchange Server 2019"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5121574"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-exchange",
+		"raws": [
+			"build-numbers-and-release-dates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5103xxx/5103214.json
+++ b/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5103xxx/5103214.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5103214",
+	"url": "https://support.microsoft.com/help/5103214",
+	"products": [
+		"Exchange Server 2019"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5121575"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-exchange",
+		"raws": [
+			"build-numbers-and-release-dates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5121xxx/5121573.json
+++ b/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5121xxx/5121573.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5121573",
+	"url": "https://support.microsoft.com/help/5121573",
+	"products": [
+		"Exchange Server SE"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5103212"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-exchange",
+		"raws": [
+			"build-numbers-and-release-dates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5121xxx/5121574.json
+++ b/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5121xxx/5121574.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5121574",
+	"url": "https://support.microsoft.com/help/5121574",
+	"products": [
+		"Exchange Server 2019"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5103213"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-exchange",
+		"raws": [
+			"build-numbers-and-release-dates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5121xxx/5121575.json
+++ b/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5121xxx/5121575.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "5121575",
+	"url": "https://support.microsoft.com/help/5121575",
+	"products": [
+		"Exchange Server 2019"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5103214"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-exchange",
+		"raws": [
+			"build-numbers-and-release-dates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5121xxx/5121576.json
+++ b/pkg/extract/microsoft/exchange/testdata/golden/microsoftkb/5121xxx/5121576.json
@@ -1,0 +1,13 @@
+{
+	"kb_id": "5121576",
+	"url": "https://support.microsoft.com/help/5121576",
+	"products": [
+		"Exchange Server 2016"
+	],
+	"data_source": {
+		"id": "microsoft-exchange",
+		"raws": [
+			"build-numbers-and-release-dates.json"
+		]
+	}
+}

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -87,6 +87,7 @@ const (
 	MicrosoftCSAF              SourceID = "microsoft-csaf"
 	MicrosoftCVRF              SourceID = "microsoft-cvrf"
 	MicrosoftDeployment        SourceID = "microsoft-deployment"
+	MicrosoftExchange          SourceID = "microsoft-exchange"
 	MicrosoftMSUC              SourceID = "microsoft-msuc"
 	MicrosoftProduct           SourceID = "microsoft-product"
 	MicrosoftServicing         SourceID = "microsoft-servicing"

--- a/pkg/fetch/microsoft/exchange/exchange.go
+++ b/pkg/fetch/microsoft/exchange/exchange.go
@@ -1,0 +1,376 @@
+// Package exchange fetches Microsoft's Exchange Server build numbers and
+// release dates -- the page listing every build Exchange has shipped.
+//
+// The page runs from Exchange Server 4.0 to the Subscription Edition, and 76 of
+// its builds name a KB. Those are the security and hotfix updates: a cumulative
+// update is a download and carries no KB, so the SUs are the only builds
+// addressable that way, and they are what a scanner has to reason about.
+//
+// The KB is not in a column. It is the link on the product's name --
+//
+//	<a href="https://support.microsoft.com/help/5121574">Exchange Server 2019 CU15 Aug26SU</a>
+//
+// so a cell read as text alone loses it entirely. This page is the only
+// structured record of several: four of eleven sampled answer "We did not find
+// any results" in the Update Catalog, the August, July and June 2026 updates
+// among them.
+//
+// One KB covers many builds. KB5000871, the March 2021 update, appears on
+// twenty-five rows -- every cumulative update level of Exchange 2013, 2016 and
+// 2019 that was still in support got its own patched build of the one fix. The
+// rows are stored as served and matched up in extract.
+//
+// fetch writes <dir>/origin verbatim and then produces <dir>/raw by reading it
+// back, never the HTTP response, so raw/ is reproducible from origin/ alone.
+package exchange
+
+import (
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+	"golang.org/x/net/html"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+const (
+	baseURL = "https://learn.microsoft.com"
+
+	// pagePath is the build numbers page. The name it is stored under is its
+	// last segment, so origin/ stays navigable against the site it came from.
+	pagePath = "/en-us/exchange/new-features/build-numbers-and-release-dates"
+)
+
+type options struct {
+	baseURL string
+	dir     string
+	retry   int
+	wait    time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type baseURLOption string
+
+func (u baseURLOption) apply(opts *options) {
+	opts.baseURL = string(u)
+}
+
+func WithBaseURL(url string) Option {
+	return baseURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+// Fetch stores the page under <dir>/origin and the tables it carries under
+// <dir>/raw.
+func Fetch(opts ...Option) error {
+	options := &options{
+		baseURL: baseURL,
+		dir:     filepath.Join(util.CacheDir(), "fetch", "microsoft", "exchange"),
+		retry:   3,
+		wait:    1 * time.Second,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	if err := options.fetch(); err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+
+	if err := options.convert(); err != nil {
+		return errors.Wrap(err, "convert")
+	}
+
+	return nil
+}
+
+// fetch stores the page as served.
+func (opts options) fetch() error {
+	slog.Info("Fetch Microsoft Exchange Build Numbers and Release Dates")
+
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
+
+	u, err := url.JoinPath(opts.baseURL, pagePath)
+	if err != nil {
+		return errors.Wrapf(err, "join %s and %s", opts.baseURL, pagePath)
+	}
+
+	if err := client.PipelineGet([]string{u}, 1, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, resp.Request.URL)
+		}
+
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", resp.Request.URL)
+		}
+
+		if err := writeOrigin(opts.dir, name(), bs); err != nil {
+			return errors.Wrapf(err, "write %s", name())
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "pipeline get")
+	}
+
+	return nil
+}
+
+// convert reads origin/ back and writes raw/, at the name its origin/
+// counterpart has. Going through the stored bytes rather than the response is
+// what lets the tree be re-derived after this parser changes.
+func (opts options) convert() error {
+	slog.Info("Convert origin to raw")
+
+	root := filepath.Join(opts.dir, "origin")
+
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".html" {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", p)
+		}
+		defer f.Close()
+
+		page, err := parsePage(f)
+		if err != nil {
+			return errors.Wrapf(err, "parse %s", p)
+		}
+
+		// The page is its tables. One that parses to none is not a page whose
+		// history has been retired -- it keeps Exchange Server 4.0, released in
+		// 1996, alongside the current release -- it is this parser having lost
+		// them, and it loses them all at once. Skipping would leave raw/ empty
+		// beside a full origin/ with the run green.
+		if len(page.Tables) == 0 {
+			return errors.Errorf("no table in %s", p)
+		}
+
+		if err := util.Write(filepath.Join(opts.dir, "raw", strings.TrimSuffix(filepath.ToSlash(rel), ".html")+".json"), page); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, "raw", strings.TrimSuffix(filepath.ToSlash(rel), ".html")+".json"))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", root)
+	}
+
+	return nil
+}
+
+// name is what the page is stored as: the last segment of its path, so origin/
+// stays navigable against the site it came from.
+func name() string {
+	segs := strings.Split(strings.Trim(pagePath, "/"), "/")
+	return segs[len(segs)-1] + ".html"
+}
+
+// writeOrigin stores content under <dir>/origin/<name> as served.
+//
+// Nothing derived from the response is recorded alongside it -- no fetch
+// timestamp, no ETag, no status line. Those change on every run even when the
+// page does not, and would turn every fetch into a diff, drowning the signal
+// this tree exists to carry: that Microsoft revised the page.
+func writeOrigin(dir, name string, content []byte) error {
+	p := filepath.Join(dir, "origin", name)
+
+	if err := os.MkdirAll(filepath.Dir(p), os.ModePerm); err != nil {
+		return errors.Wrapf(err, "mkdir %s", filepath.Dir(p))
+	}
+
+	if err := os.WriteFile(p, content, 0666); err != nil {
+		return errors.Wrapf(err, "write %s", p)
+	}
+
+	return nil
+}
+
+// parsePage reads a stored page for its canonical link and its tables.
+func parsePage(r io.Reader) (Page, error) {
+	doc, err := goquery.NewDocumentFromReader(r)
+	if err != nil {
+		return Page{}, errors.Wrap(err, "new document")
+	}
+
+	var page Page
+	var base *url.URL
+	if u, ok := doc.Find(`link[rel="canonical"]`).First().Attr("href"); ok {
+		page.URL = text(u)
+		base, _ = url.Parse(page.URL)
+	}
+
+	// Only the article body. The page chrome carries tables of its own, the
+	// locale picker among them, and a heading in a banner would otherwise
+	// become the heading of the first history.
+	root := doc.Find("main").First()
+	if root.Length() == 0 {
+		root = doc.Selection
+	}
+
+	// One pass in document order over the headings and the tables together,
+	// since a table's heading is its predecessor in the prose and not its
+	// ancestor. Headings inside a table are skipped: being visited after their
+	// own table's start tag they would otherwise be read as the next one's.
+	var heading string
+	root.Find("h1, h2, h3, h4, h5, h6, table").Each(func(_ int, s *goquery.Selection) {
+		if goquery.NodeName(s) != "table" {
+			if s.Closest("table").Length() == 0 {
+				heading = text(s.Text())
+			}
+			return
+		}
+
+		t, ok := parseTable(s, base)
+		if !ok {
+			return
+		}
+		t.Heading = heading
+
+		page.Tables = append(page.Tables, t)
+	})
+
+	return page, nil
+}
+
+// parseTable reads one table's column names and cells, reporting false for the
+// ones that carry neither.
+func parseTable(s *goquery.Selection, base *url.URL) (Table, bool) {
+	var rows [][]Cell
+	s.Find("tr").Each(func(_ int, tr *goquery.Selection) {
+		var cells []Cell
+		tr.Find("th, td").Each(func(_ int, c *goquery.Selection) {
+			cells = append(cells, parseCell(c, base))
+		})
+		if len(cells) == 0 {
+			return
+		}
+		rows = append(rows, cells)
+	})
+
+	if len(rows) < 2 {
+		return Table{}, false
+	}
+
+	header := make([]string, 0, len(rows[0]))
+	for _, c := range rows[0] {
+		header = append(header, c.Text)
+	}
+
+	return Table{Header: header, Rows: rows[1:]}, true
+}
+
+// parseCell reads a cell's text and the first link it carries.
+//
+// A line break is read as the space it stands for. Microsoft breaks two of this
+// page's column names across lines -- "Build number<br>(short format)" -- and
+// reading the text straight through runs them together as
+// "Build number(short format)", which is not a name any reader would look for.
+func parseCell(s *goquery.Selection, base *url.URL) Cell {
+	var b strings.Builder
+
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			switch {
+			case c.Type == html.TextNode:
+				b.WriteString(c.Data)
+			case c.Type == html.ElementNode && c.Data == "br":
+				b.WriteString(" ")
+			case c.Type == html.ElementNode:
+				walk(c)
+			}
+		}
+	}
+	for _, n := range s.Nodes {
+		walk(n)
+	}
+
+	cell := Cell{Text: text(b.String())}
+	if href, ok := s.Find("a[href]").First().Attr("href"); ok {
+		cell.Href = resolve(base, text(href))
+	}
+
+	return cell
+}
+
+// resolve turns a link into an address that works away from the page it was
+// read on. One that cannot be parsed is kept as served rather than dropped: it
+// is not this parser's to decide that Microsoft meant nothing by it.
+func resolve(base *url.URL, href string) string {
+	if href == "" || base == nil {
+		return href
+	}
+	ref, err := url.Parse(href)
+	if err != nil {
+		return href
+	}
+	return base.ResolveReference(ref).String()
+}
+
+// text normalizes the whitespace HTML is free to write however it likes.
+// goquery has already resolved the entities.
+func text(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/pkg/fetch/microsoft/exchange/exchange_test.go
+++ b/pkg/fetch/microsoft/exchange/exchange_test.go
@@ -1,0 +1,157 @@
+package exchange_test
+
+import (
+	"io/fs"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/exchange"
+)
+
+// The fixture is the page as served, cut down to the rows that decide what is
+// read out of it.
+//
+// Two of its column names are broken across lines -- "Build number<br>(short
+// format)" -- and a reader that takes a cell's text straight through gets
+// "Build number(short format)", which no lookup by name will find.
+//
+// The KB is the link on the product's name and nothing else on the page carries
+// it. Rows that ship as downloads rather than as KB articles link to the
+// Download Center instead, and Exchange Server 2003 is listed with a column set
+// of its own and no links at all.
+//
+// KB5000871 is on four rows across three product versions, which is what the
+// March 2021 update did: every supported cumulative update level got its own
+// patched build of the one fix.
+//
+// Exchange Server SE and Exchange Server 2019 are both 15.2, so the table a row
+// was filed under is the only thing that tells the two products apart.
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		golden   string
+		hasError bool
+	}{
+		{
+			name:    "happy",
+			fixture: "happy",
+			golden:  "happy",
+		},
+		{
+			// A page whose tables this cannot find is not a page that has lost
+			// them: it keeps Exchange Server 4.0, released in 1996, alongside
+			// the current release. So the run fails rather than committing an
+			// empty raw/ beside a full origin/.
+			name:     "page without tables",
+			fixture:  "tableless",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(handler(t, tt.fixture))
+			defer ts.Close()
+
+			dir := t.TempDir()
+			err := exchange.Fetch(
+				exchange.WithBaseURL(ts.URL),
+				exchange.WithDir(dir),
+				exchange.WithRetry(0),
+				exchange.WithWait(0),
+			)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Fatalf("unexpected error. err: %v", err)
+			case err == nil && tt.hasError:
+				t.Fatal("expected error has not occurred")
+			case err != nil:
+				return
+			}
+
+			diff(t, filepath.Join("testdata", "golden", tt.golden), dir)
+		})
+	}
+}
+
+// handler serves a fixture tree the way learn.microsoft.com serves the page:
+// one document per path, and nothing anywhere else.
+func handler(t *testing.T, fixture string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		bs, err := os.ReadFile(filepath.Join("testdata", "fixtures", fixture, filepath.Clean(r.URL.Path)+".html"))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(bs)
+	}
+}
+
+// diff compares the produced tree against golden byte for byte. Bytes rather
+// than parsed content: origin/ is only worth keeping if it reproduces exactly,
+// and raw/ is written deterministically, so any difference at all is a
+// regression.
+func diff(t *testing.T, golden, got string) {
+	t.Helper()
+
+	want := walk(t, golden)
+	have := walk(t, got)
+
+	if d := cmp.Diff(slices.Sorted(maps.Keys(want)), slices.Sorted(maps.Keys(have))); d != "" {
+		t.Errorf("files (-expected +got):\n%s", d)
+	}
+
+	for n, w := range want {
+		h, ok := have[n]
+		if !ok {
+			continue
+		}
+		if d := cmp.Diff(string(w), string(h)); d != "" {
+			t.Errorf("%s (-expected +got):\n%s", n, d)
+		}
+	}
+}
+
+func walk(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+
+	out := make(map[string][]byte)
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+
+		bs, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+
+		out[filepath.ToSlash(rel)] = bs
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walk %s. err: %v", root, err)
+	}
+
+	return out
+}

--- a/pkg/fetch/microsoft/exchange/testdata/fixtures/happy/en-us/exchange/new-features/build-numbers-and-release-dates.html
+++ b/pkg/fetch/microsoft/exchange/testdata/fixtures/happy/en-us/exchange/new-features/build-numbers-and-release-dates.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Exchange Server build numbers and release dates</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates" />
+</head>
+<body>
+<nav>
+<h2>Skip to main content</h2>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>Exchange Server SE</h2>
+<table>
+<tr> <th>Product name</th> <th>Release date</th> <th style="text-align: center;">Build number<br>(short format)</th> <th style="text-align: center;">Build number<br>(long format)</th> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5121573" data-linktype="external">Exchange Server SE RTM Aug26SU</a></td> <td>August 11, 2026</td> <td style="text-align: center;">15.2.2562.46</td> <td style="text-align: center;">15.02.2562.046</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5103212" data-linktype="external">Exchange Server SE RTM Jul26SU</a></td> <td>July 14, 2026</td> <td style="text-align: center;">15.2.2562.45</td> <td style="text-align: center;">15.02.2562.045</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://www.microsoft.com/download/details.aspx?id=105683" data-linktype="external">Exchange Server SE RTM</a></td> <td>July 1, 2025</td> <td style="text-align: center;">15.2.2562.17</td> <td style="text-align: center;">15.02.2562.017</td> </tr>
+</table>
+<h2>Exchange Server 2019</h2>
+<table>
+<tr> <th>Product name</th> <th>Release date</th> <th style="text-align: center;">Build number<br>(short format)</th> <th style="text-align: center;">Build number<br>(long format)</th> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5121574" data-linktype="external">Exchange Server 2019 CU15 Aug26SU</a></td> <td>August 11, 2026</td> <td style="text-align: center;">15.2.1748.49</td> <td style="text-align: center;">15.02.1748.049</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5121575" data-linktype="external">Exchange Server 2019 CU14 Aug26SU</a></td> <td>August 11, 2026</td> <td style="text-align: center;">15.2.1544.44</td> <td style="text-align: center;">15.02.1544.044</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5103213" data-linktype="external">Exchange Server 2019 CU15 Jul26SU</a></td> <td>July 14, 2026</td> <td style="text-align: center;">15.2.1748.48</td> <td style="text-align: center;">15.02.1748.048</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5103214" data-linktype="external">Exchange Server 2019 CU14 Jul26SU</a></td> <td>July 14, 2026</td> <td style="text-align: center;">15.2.1544.43</td> <td style="text-align: center;">15.02.1544.043</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://www.microsoft.com/download/details.aspx?id=105682" data-linktype="external">Exchange Server 2019 CU15 (2025H1)</a></td> <td>February 10, 2025</td> <td style="text-align: center;">15.2.1748.10</td> <td style="text-align: center;">15.02.1748.010</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5000871" data-linktype="external">Exchange Server 2019 CU8 Mar21SU</a></td> <td>March 2, 2021</td> <td style="text-align: center;">15.2.792.10</td> <td style="text-align: center;">15.02.0792.010</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5000871" data-linktype="external">Exchange Server 2019 CU7 Mar21SU</a></td> <td>March 2, 2021</td> <td style="text-align: center;">15.2.721.13</td> <td style="text-align: center;">15.02.0721.013</td> </tr>
+</table>
+<h2>Exchange Server 2016</h2>
+<table>
+<tr> <th>Product name</th> <th>Release date</th> <th style="text-align: center;">Build number<br>(short format)</th> <th style="text-align: center;">Build number<br>(long format)</th> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5121576" data-linktype="external">Exchange Server 2016 CU23 Aug26SU</a></td> <td>August 11, 2026</td> <td style="text-align: center;">15.1.2507.72</td> <td style="text-align: center;">15.01.2507.072</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5000871" data-linktype="external">Exchange Server 2016 CU19 Mar21SU</a></td> <td>March 2, 2021</td> <td style="text-align: center;">15.1.2176.9</td> <td style="text-align: center;">15.01.2176.009</td> </tr>
+</table>
+<h2>Exchange Server 2013</h2>
+<table>
+<tr> <th>Product name</th> <th>Release date</th> <th style="text-align: center;">Build number<br>(short format)</th> <th style="text-align: center;">Build number<br>(long format)</th> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5024296" data-linktype="external">Exchange Server 2013 CU23 Mar23SU</a></td> <td>March 14, 2023</td> <td style="text-align: center;">15.0.1497.48</td> <td style="text-align: center;">15.00.1497.048</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5000871" data-linktype="external">Exchange Server 2013 CU23 Mar21SU</a></td> <td>March 2, 2021</td> <td style="text-align: center;">15.0.1497.12</td> <td style="text-align: center;">15.00.1497.012</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5000871" data-linktype="external">Exchange Server 2013 SP1 Mar21SU</a></td> <td>March 2, 2021</td> <td style="text-align: center;">15.0.847.64</td> <td style="text-align: center;">15.00.0847.064</td> </tr>
+</table>
+<h2>Exchange Server 2003</h2>
+<table>
+<tr> <th>Product name</th> <th>Release date</th> <th>Build number</th> </tr>
+<tr> <td>Exchange Server 2003 post-SP2</td> <td>August 2006</td> <td>6.5.7683.0</td> </tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/exchange/testdata/fixtures/tableless/en-us/exchange/new-features/build-numbers-and-release-dates.html
+++ b/pkg/fetch/microsoft/exchange/testdata/fixtures/tableless/en-us/exchange/new-features/build-numbers-and-release-dates.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html lang="en-us"><head><meta charset="utf-8" /><title>Exchange Server build numbers and release dates</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates" /></head>
+<body><main><h2>Build numbers</h2><p>This content has moved.</p></main></body></html>

--- a/pkg/fetch/microsoft/exchange/testdata/golden/happy/origin/build-numbers-and-release-dates.html
+++ b/pkg/fetch/microsoft/exchange/testdata/golden/happy/origin/build-numbers-and-release-dates.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Exchange Server build numbers and release dates</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates" />
+</head>
+<body>
+<nav>
+<h2>Skip to main content</h2>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>Exchange Server SE</h2>
+<table>
+<tr> <th>Product name</th> <th>Release date</th> <th style="text-align: center;">Build number<br>(short format)</th> <th style="text-align: center;">Build number<br>(long format)</th> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5121573" data-linktype="external">Exchange Server SE RTM Aug26SU</a></td> <td>August 11, 2026</td> <td style="text-align: center;">15.2.2562.46</td> <td style="text-align: center;">15.02.2562.046</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5103212" data-linktype="external">Exchange Server SE RTM Jul26SU</a></td> <td>July 14, 2026</td> <td style="text-align: center;">15.2.2562.45</td> <td style="text-align: center;">15.02.2562.045</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://www.microsoft.com/download/details.aspx?id=105683" data-linktype="external">Exchange Server SE RTM</a></td> <td>July 1, 2025</td> <td style="text-align: center;">15.2.2562.17</td> <td style="text-align: center;">15.02.2562.017</td> </tr>
+</table>
+<h2>Exchange Server 2019</h2>
+<table>
+<tr> <th>Product name</th> <th>Release date</th> <th style="text-align: center;">Build number<br>(short format)</th> <th style="text-align: center;">Build number<br>(long format)</th> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5121574" data-linktype="external">Exchange Server 2019 CU15 Aug26SU</a></td> <td>August 11, 2026</td> <td style="text-align: center;">15.2.1748.49</td> <td style="text-align: center;">15.02.1748.049</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5121575" data-linktype="external">Exchange Server 2019 CU14 Aug26SU</a></td> <td>August 11, 2026</td> <td style="text-align: center;">15.2.1544.44</td> <td style="text-align: center;">15.02.1544.044</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5103213" data-linktype="external">Exchange Server 2019 CU15 Jul26SU</a></td> <td>July 14, 2026</td> <td style="text-align: center;">15.2.1748.48</td> <td style="text-align: center;">15.02.1748.048</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5103214" data-linktype="external">Exchange Server 2019 CU14 Jul26SU</a></td> <td>July 14, 2026</td> <td style="text-align: center;">15.2.1544.43</td> <td style="text-align: center;">15.02.1544.043</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://www.microsoft.com/download/details.aspx?id=105682" data-linktype="external">Exchange Server 2019 CU15 (2025H1)</a></td> <td>February 10, 2025</td> <td style="text-align: center;">15.2.1748.10</td> <td style="text-align: center;">15.02.1748.010</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5000871" data-linktype="external">Exchange Server 2019 CU8 Mar21SU</a></td> <td>March 2, 2021</td> <td style="text-align: center;">15.2.792.10</td> <td style="text-align: center;">15.02.0792.010</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5000871" data-linktype="external">Exchange Server 2019 CU7 Mar21SU</a></td> <td>March 2, 2021</td> <td style="text-align: center;">15.2.721.13</td> <td style="text-align: center;">15.02.0721.013</td> </tr>
+</table>
+<h2>Exchange Server 2016</h2>
+<table>
+<tr> <th>Product name</th> <th>Release date</th> <th style="text-align: center;">Build number<br>(short format)</th> <th style="text-align: center;">Build number<br>(long format)</th> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5121576" data-linktype="external">Exchange Server 2016 CU23 Aug26SU</a></td> <td>August 11, 2026</td> <td style="text-align: center;">15.1.2507.72</td> <td style="text-align: center;">15.01.2507.072</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5000871" data-linktype="external">Exchange Server 2016 CU19 Mar21SU</a></td> <td>March 2, 2021</td> <td style="text-align: center;">15.1.2176.9</td> <td style="text-align: center;">15.01.2176.009</td> </tr>
+</table>
+<h2>Exchange Server 2013</h2>
+<table>
+<tr> <th>Product name</th> <th>Release date</th> <th style="text-align: center;">Build number<br>(short format)</th> <th style="text-align: center;">Build number<br>(long format)</th> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5024296" data-linktype="external">Exchange Server 2013 CU23 Mar23SU</a></td> <td>March 14, 2023</td> <td style="text-align: center;">15.0.1497.48</td> <td style="text-align: center;">15.00.1497.048</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5000871" data-linktype="external">Exchange Server 2013 CU23 Mar21SU</a></td> <td>March 2, 2021</td> <td style="text-align: center;">15.0.1497.12</td> <td style="text-align: center;">15.00.1497.012</td> </tr>
+<tr> <td>&nbsp;&nbsp;&nbsp;<a href="https://support.microsoft.com/help/5000871" data-linktype="external">Exchange Server 2013 SP1 Mar21SU</a></td> <td>March 2, 2021</td> <td style="text-align: center;">15.0.847.64</td> <td style="text-align: center;">15.00.0847.064</td> </tr>
+</table>
+<h2>Exchange Server 2003</h2>
+<table>
+<tr> <th>Product name</th> <th>Release date</th> <th>Build number</th> </tr>
+<tr> <td>Exchange Server 2003 post-SP2</td> <td>August 2006</td> <td>6.5.7683.0</td> </tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/exchange/testdata/golden/happy/raw/build-numbers-and-release-dates.json
+++ b/pkg/fetch/microsoft/exchange/testdata/golden/happy/raw/build-numbers-and-release-dates.json
@@ -1,0 +1,295 @@
+{
+	"url": "https://learn.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates",
+	"tables": [
+		{
+			"heading": "Exchange Server SE",
+			"header": [
+				"Product name",
+				"Release date",
+				"Build number (short format)",
+				"Build number (long format)"
+			],
+			"rows": [
+				[
+					{
+						"text": "Exchange Server SE RTM Aug26SU",
+						"href": "https://support.microsoft.com/help/5121573"
+					},
+					{
+						"text": "August 11, 2026"
+					},
+					{
+						"text": "15.2.2562.46"
+					},
+					{
+						"text": "15.02.2562.046"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server SE RTM Jul26SU",
+						"href": "https://support.microsoft.com/help/5103212"
+					},
+					{
+						"text": "July 14, 2026"
+					},
+					{
+						"text": "15.2.2562.45"
+					},
+					{
+						"text": "15.02.2562.045"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server SE RTM",
+						"href": "https://www.microsoft.com/download/details.aspx?id=105683"
+					},
+					{
+						"text": "July 1, 2025"
+					},
+					{
+						"text": "15.2.2562.17"
+					},
+					{
+						"text": "15.02.2562.017"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Exchange Server 2019",
+			"header": [
+				"Product name",
+				"Release date",
+				"Build number (short format)",
+				"Build number (long format)"
+			],
+			"rows": [
+				[
+					{
+						"text": "Exchange Server 2019 CU15 Aug26SU",
+						"href": "https://support.microsoft.com/help/5121574"
+					},
+					{
+						"text": "August 11, 2026"
+					},
+					{
+						"text": "15.2.1748.49"
+					},
+					{
+						"text": "15.02.1748.049"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU14 Aug26SU",
+						"href": "https://support.microsoft.com/help/5121575"
+					},
+					{
+						"text": "August 11, 2026"
+					},
+					{
+						"text": "15.2.1544.44"
+					},
+					{
+						"text": "15.02.1544.044"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU15 Jul26SU",
+						"href": "https://support.microsoft.com/help/5103213"
+					},
+					{
+						"text": "July 14, 2026"
+					},
+					{
+						"text": "15.2.1748.48"
+					},
+					{
+						"text": "15.02.1748.048"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU14 Jul26SU",
+						"href": "https://support.microsoft.com/help/5103214"
+					},
+					{
+						"text": "July 14, 2026"
+					},
+					{
+						"text": "15.2.1544.43"
+					},
+					{
+						"text": "15.02.1544.043"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU15 (2025H1)",
+						"href": "https://www.microsoft.com/download/details.aspx?id=105682"
+					},
+					{
+						"text": "February 10, 2025"
+					},
+					{
+						"text": "15.2.1748.10"
+					},
+					{
+						"text": "15.02.1748.010"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU8 Mar21SU",
+						"href": "https://support.microsoft.com/help/5000871"
+					},
+					{
+						"text": "March 2, 2021"
+					},
+					{
+						"text": "15.2.792.10"
+					},
+					{
+						"text": "15.02.0792.010"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2019 CU7 Mar21SU",
+						"href": "https://support.microsoft.com/help/5000871"
+					},
+					{
+						"text": "March 2, 2021"
+					},
+					{
+						"text": "15.2.721.13"
+					},
+					{
+						"text": "15.02.0721.013"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Exchange Server 2016",
+			"header": [
+				"Product name",
+				"Release date",
+				"Build number (short format)",
+				"Build number (long format)"
+			],
+			"rows": [
+				[
+					{
+						"text": "Exchange Server 2016 CU23 Aug26SU",
+						"href": "https://support.microsoft.com/help/5121576"
+					},
+					{
+						"text": "August 11, 2026"
+					},
+					{
+						"text": "15.1.2507.72"
+					},
+					{
+						"text": "15.01.2507.072"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2016 CU19 Mar21SU",
+						"href": "https://support.microsoft.com/help/5000871"
+					},
+					{
+						"text": "March 2, 2021"
+					},
+					{
+						"text": "15.1.2176.9"
+					},
+					{
+						"text": "15.01.2176.009"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Exchange Server 2013",
+			"header": [
+				"Product name",
+				"Release date",
+				"Build number (short format)",
+				"Build number (long format)"
+			],
+			"rows": [
+				[
+					{
+						"text": "Exchange Server 2013 CU23 Mar23SU",
+						"href": "https://support.microsoft.com/help/5024296"
+					},
+					{
+						"text": "March 14, 2023"
+					},
+					{
+						"text": "15.0.1497.48"
+					},
+					{
+						"text": "15.00.1497.048"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2013 CU23 Mar21SU",
+						"href": "https://support.microsoft.com/help/5000871"
+					},
+					{
+						"text": "March 2, 2021"
+					},
+					{
+						"text": "15.0.1497.12"
+					},
+					{
+						"text": "15.00.1497.012"
+					}
+				],
+				[
+					{
+						"text": "Exchange Server 2013 SP1 Mar21SU",
+						"href": "https://support.microsoft.com/help/5000871"
+					},
+					{
+						"text": "March 2, 2021"
+					},
+					{
+						"text": "15.0.847.64"
+					},
+					{
+						"text": "15.00.0847.064"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Exchange Server 2003",
+			"header": [
+				"Product name",
+				"Release date",
+				"Build number"
+			],
+			"rows": [
+				[
+					{
+						"text": "Exchange Server 2003 post-SP2"
+					},
+					{
+						"text": "August 2006"
+					},
+					{
+						"text": "6.5.7683.0"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/fetch/microsoft/exchange/types.go
+++ b/pkg/fetch/microsoft/exchange/types.go
@@ -1,0 +1,35 @@
+package exchange
+
+// Page is the Exchange Server build numbers and release dates, as served.
+//
+// Nothing is read out of the cells here. The KB an update ships as is not in a
+// column at all -- it is the link on the product's name -- and what a build
+// number means is decided by the table it sits in, so reading that apart belongs
+// in extract, under golden tests.
+type Page struct {
+	// URL is the page's own canonical link, taken from the stored HTML rather
+	// than from the request, so raw/ stays derivable from origin/ alone.
+	URL    string  `json:"url,omitempty"`
+	Tables []Table `json:"tables,omitempty"`
+}
+
+// Table is one product version's build history, with the heading it sits under.
+//
+// The heading is what names the version: Exchange Server SE and Exchange Server
+// 2019 are both 15.2, so the build number does not tell them apart and the
+// tables have to be kept as Microsoft filed them.
+type Table struct {
+	Heading string   `json:"heading,omitempty"`
+	Header  []string `json:"header,omitempty"`
+	Rows    [][]Cell `json:"rows,omitempty"`
+}
+
+// Cell is one cell, with the link it carries.
+//
+// The link is the point of it. This page names no Knowledge Base column: the KB
+// an update ships as is the link on its product name, so a cell read as text
+// alone loses the only identifier the whole source is for.
+type Cell struct {
+	Text string `json:"text,omitempty"`
+	Href string `json:"href,omitempty"`
+}


### PR DESCRIPTION
## What

Adds `microsoft-exchange`, a fetcher and extractor for the Exchange Server build numbers and release dates page. **76 KBs** in 37 lanes and 121 edges.

## Why

Four of eleven sampled answer "We did not find any results" in the Update Catalog — the August, July and June 2026 updates among them. Those are recent, which suggests Exchange SUs are often not published to the catalog at all rather than expiring out of it. Either way this page is the only structured record of them.

## How

**The KB is not in a column.** It is the link on the product's name:

```html
<a href="https://support.microsoft.com/help/5121574">Exchange Server 2019 CU15 Aug26SU</a>
```

so a cell read as text alone loses it entirely and the page names no KB anywhere. `fetch` stores the link every cell carries alongside its text.

**A line break inside a cell is read as the space it stands for.** Two of the column names are broken across lines — `Build number<br>(short format)` — and reading the text straight through gives `Build number(short format)`, which no lookup by name will find. This one cost a debugging round: the first run extracted 0 KBs.

**Exchange services every supported cumulative update level side by side, and the build number says which.** The third component is the cumulative update and the fourth is the security update within it:

```
Exchange Server 2019 CU15 Aug26SU   15.2.1748.49
Exchange Server 2019 CU14 Aug26SU   15.2.1544.44
```

Both shipped on 2026-08-11. A host on CU14 is never offered CU15's update, so **the lane is the chain** — keyed on the table and the first three components, ordered by the fourth. Over the 121 edges that produces, the build order and the release dates never disagree.

**One KB is on many lanes.** KB5000871, the March 2021 update, appears on **twenty-five rows** across Exchange 2013, 2016 and 2019 — every supported cumulative update level got its own patched build of the one fix — and takes its place in each of their chains.

**The table is part of the key.** Exchange Server SE and Exchange Server 2019 are both 15.2, and only the table a row was filed under says which product it is.

Rows that ship as downloads carry no KB — cumulative updates, service packs, and every build of Exchange 2010 and earlier — and are skipped at Debug.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` — passes
- `golangci-lint run ./pkg/...` — 0 issues
- Golden tests for both packages
- End to end against the live page: **76 KBs, 0 unchained, no warnings**

```
$ vuls-data-update fetch   microsoft-exchange -d <raw>
$ vuls-data-update extract microsoft-exchange <raw> -d <out>
```

## Checklist

- [x] Tests pass
- [x] Golden files updated
- [x] Deterministic output verified (types changed)
- [x] Backward compatibility maintained (types/data changed)

`pkg/extract/types/source` gains one constant, `MicrosoftExchange`. Additive; it is the only file shared with the other Microsoft data-source branches.
