### PR TITLE
feat(microsoft/sfb): add skype for business server updates data source

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -67,6 +67,7 @@ import (
 	microsoftCVRF "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/cvrf"
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/msuc"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/servicing"
+	microsoftSfB "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/sfb"
 	microsoftWSUSSCN2 "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/wsusscn2"
 	mitreATTACK "github.com/MaineK00n/vuls-data-update/pkg/extract/mitre/attack"
 	mitreCAPEC "github.com/MaineK00n/vuls-data-update/pkg/extract/mitre/capec"
@@ -180,7 +181,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdJVNFeedDetail(), newCmdJVNFeedProduct(), newCmdJVNFeedRSS(),
 		newCmdLinuxOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftWSUSSCN2(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftSfB(), newCmdMicrosoftWSUSSCN2(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
 		newCmdNetBSD(),
@@ -1656,6 +1657,31 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := microsoftMSUC.Extract(args[0], microsoftMSUC.WithDir(options.dir)); err != nil {
 				return errors.Wrap(err, "failed to extract microsoft msuc")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdMicrosoftSfB() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "sfb"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-sfb <Raw Microsoft Skype for Business Repository PATH>",
+		Short: "Extract Microsoft Skype for Business Server Updates data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract microsoft-sfb vuls-data-raw-microsoft-sfb
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := microsoftSfB.Extract(args[0], microsoftSfB.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract microsoft sfb")
 			}
 			return nil
 		},

--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -92,6 +92,7 @@ import (
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/msuc"
 	microsoftProduct "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/product"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/servicing"
+	microsoftSfB "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/sfb"
 	microsoftVEX "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vex"
 	microsoftVulnerability "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vulnerability"
 	microsoftWSUSSCN2 "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/wsusscn2"
@@ -255,7 +256,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdLinuxOSV(),
 		newCmdMageiaOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftSfB(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
 		newCmdMinimOSOSV(), newCmdMinimOSSecDB(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreEMB3D(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
@@ -2666,6 +2667,49 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
 	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
 	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent http requests")
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
+
+	return cmd
+}
+
+func newCmdMicrosoftSfB() *cobra.Command {
+	options := &struct {
+		base
+		wait time.Duration
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "microsoft", "sfb"),
+			retry: 3,
+		},
+		wait: 1 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-sfb",
+		Short: "Fetch Microsoft Skype for Business Server Updates data source",
+		Long: heredoc.Doc(`
+			Fetch the Skype for Business Server update history as HTML into
+			<dir>/origin, and the tables it carries into <dir>/raw.
+
+			The page lists every cumulative update and hotfix the product line has
+			shipped, back through Lync Server 2010. The Update Catalog has dropped most
+			of them: eight of eleven sampled answer "We did not find any results", one
+			as recent as 2021, which is the highest rate of the pages read here.
+		`),
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch microsoft-sfb
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := microsoftSfB.Fetch(microsoftSfB.WithDir(options.dir), microsoftSfB.WithRetry(options.retry), microsoftSfB.WithWait(options.wait)); err != nil {
+				return errors.Wrap(err, "failed to fetch microsoft sfb")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
 	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
 
 	return cmd

--- a/pkg/extract/microsoft/sfb/export_test.go
+++ b/pkg/extract/microsoft/sfb/export_test.go
@@ -1,0 +1,3 @@
+package sfb
+
+var ReleaseDate = releaseDate

--- a/pkg/extract/microsoft/sfb/sfb.go
+++ b/pkg/extract/microsoft/sfb/sfb.go
@@ -1,0 +1,451 @@
+// Package sfb extracts supersedence from Microsoft's Skype for Business Server
+// update history.
+//
+// The page carries no supersedence and no build numbers to derive one from --
+// the Subscription Edition's table has a Build number column and no other table
+// does. What every row has is a release date, so the date is the order, within
+// the product a table is filed under. Six products run across the page, from
+// Lync Server 2010 to the Subscription Edition.
+//
+// The date is a month. 100 of the page's 104 rows are dated "August 2025" with
+// no day in them, so two updates of one month cannot be told apart and are not
+// ordered against each other: a month links to the month before it, all of one
+// to all of the other, which is what the servicing source does with the dates it
+// cannot split either. Four rows do carry a day, and one of those writes its
+// month as "Sept".
+//
+// Four KBs are not updates but articles. Microsoft revises one KB in place for
+// every hotfix of a cumulative update line -- KB4470124 is fifteen rows of
+// Skype for Business Server 2019, from Cumulative Update 5 in 2020 to Cumulative
+// Update 8 Hotfix 2 in 2025, and KB3061064 is twelve of Server 2015 -- so
+// "KB4470124 is installed" does not say which of the fifteen a host has. A KB
+// like that cannot be placed in a chain at all: an edge into it would claim a
+// patch level it does not name. They are recorded for their products and left
+// unchained, and reported so that a fifth is noticed.
+//
+// A KB on several rows of one month is a different thing and is chained
+// normally: KB5016714 is one July 2022 update listed under the three products
+// it was released for.
+package sfb
+
+import (
+	"cmp"
+	"encoding/json/v2"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
+	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/sfb"
+)
+
+// The columns a row is read out of, by name. A table without a KB number column
+// lists tools, virtual machines or documentation rather than updates.
+const (
+	columnPackage = "Package name"
+	columnKB      = "KB number"
+	columnDate    = "Release date"
+)
+
+var (
+	// kbPattern allows the space this page writes after KB, as every one of its
+	// 104 rows does.
+	kbPattern = regexp.MustCompile(`KB ?(\d{6,})`)
+
+	// datePattern is the release date. The day is optional because four rows in
+	// 104 have one, and the month is matched loosely because one of those four
+	// writes September as "Sept".
+	datePattern = regexp.MustCompile(`^([A-Za-z]+)\.? (?:(\d{1,2}), )?(\d{4})$`)
+)
+
+// months are the names this page writes, in the two lengths it writes them.
+var months = map[string]time.Month{
+	"jan": time.January, "feb": time.February, "mar": time.March,
+	"apr": time.April, "may": time.May, "jun": time.June,
+	"jul": time.July, "aug": time.August, "sep": time.September,
+	"oct": time.October, "nov": time.November, "dec": time.December,
+}
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+// update is one row of an update history.
+type update struct {
+	kbID string
+	url  string
+
+	// product is the heading the table sits under, e.g. "Lync Server 2013
+	// update history". It is the only place a row's product is named.
+	product string
+
+	// name is the package as written, e.g. "Skype for Business Server 2019
+	// Cumulative Update 8, Hotfix 2". Nothing is parsed out of it: Microsoft
+	// writes cumulative updates, hotfixes and security updates into the one
+	// column in prose, and the date says what the order is without it.
+	name string
+
+	date time.Time
+
+	raw string
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "sfb"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract Microsoft Skype for Business Server Updates")
+
+	us, err := read(args)
+	if err != nil {
+		return errors.Wrapf(err, "read %s", args)
+	}
+
+	kbs := chain(us)
+
+	for _, kb := range kbs {
+		if err := util.Write(filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)), kb, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)))
+		}
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.MicrosoftSfB,
+		Name: new("Microsoft Skype for Business Server Updates"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{URL: u}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+// read walks the raw tree and returns the rows that are updates.
+func read(args string) ([]update, error) {
+	root := filepath.Join(args, "raw")
+
+	var us []update
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".json" {
+			return nil
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", p)
+		}
+		defer f.Close()
+
+		var page sfb.Page
+		if err := json.UnmarshalRead(f, &page); err != nil {
+			return errors.Wrapf(err, "decode %s", p)
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+
+		us = append(us, parsePage(page, filepath.ToSlash(rel))...)
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrapf(err, "walk %s", root)
+	}
+
+	return us, nil
+}
+
+// parsePage reads a page's update histories.
+func parsePage(page sfb.Page, raw string) []update {
+	var us []update
+
+	for _, t := range page.Tables {
+		if !slices.Contains(t.Header, columnKB) {
+			// Tools, pre-configured virtual machines, developer kits and
+			// documentation. Ten of the page's sixteen tables are these, and
+			// none of them ships a KB.
+			slog.Debug("not an update history", slog.String("path", raw), slog.String("heading", t.Heading))
+			continue
+		}
+
+		var missing []string
+		for _, c := range []string{columnPackage, columnDate} {
+			if !slices.Contains(t.Header, c) {
+				missing = append(missing, c)
+			}
+		}
+		if len(missing) > 0 {
+			slog.Warn("update history is missing columns", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("missing", strings.Join(missing, ", ")), slog.String("header", strings.Join(t.Header, ", ")))
+			continue
+		}
+
+		for _, row := range t.Rows {
+			us = append(us, parseRow(t, row, raw)...)
+		}
+	}
+
+	return us
+}
+
+// parseRow reads one row into the updates it names, which is usually one.
+//
+// Two rows name two KBs, comma-separated on one and merely spaced on the other:
+// a release that shipped an update for the server and another for a component
+// beside it. Both are updates of that product and that month, so both are read.
+func parseRow(t sfb.Table, row []sfb.Cell, raw string) []update {
+	cell := func(column string) sfb.Cell {
+		i := slices.Index(t.Header, column)
+		if i < 0 || i >= len(row) {
+			return sfb.Cell{}
+		}
+		return row[i]
+	}
+
+	kb := cell(columnKB)
+
+	ms := kbPattern.FindAllStringSubmatch(kb.Text, -1)
+	if ms == nil {
+		slog.Debug("row names no KB", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("package", cell(columnPackage).Text))
+		return nil
+	}
+
+	// The date is the whole order here, there being no build number to fall
+	// back on, so a row without a readable one cannot be placed at all.
+	date, ok := releaseDate(cell(columnDate).Text)
+	if !ok {
+		slog.Warn("unexpected release date", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("kb", ms[0][1]), slog.String("date", cell(columnDate).Text))
+		return nil
+	}
+
+	out := make([]update, 0, len(ms))
+	for i, m := range ms {
+		// The cell links its first KB and leaves the rest as text, so a second
+		// KB is recorded without a URL rather than given the first's.
+		var href string
+		if i == 0 {
+			href = kb.Href
+		}
+
+		out = append(out, update{
+			kbID:    m[1],
+			url:     href,
+			product: t.Heading,
+			name:    cell(columnPackage).Text,
+			date:    date,
+			raw:     raw,
+		})
+	}
+
+	return out
+}
+
+// releaseDate reads the month a row was released, and the day where Microsoft
+// gave one.
+//
+// A month with no day is taken as its first, which orders it against the months
+// around it and against nothing within its own -- and within its own is exactly
+// where this source cannot tell two updates apart, so the chain does not try.
+func releaseDate(s string) (time.Time, bool) {
+	m := datePattern.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return time.Time{}, false
+	}
+
+	name := strings.ToLower(m[1])
+	if len(name) < 3 {
+		return time.Time{}, false
+	}
+	month, ok := months[name[:3]]
+	if !ok {
+		return time.Time{}, false
+	}
+
+	year, err := strconv.Atoi(m[3])
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	day := 1
+	if m[2] != "" {
+		day, err = strconv.Atoi(m[2])
+		if err != nil {
+			return time.Time{}, false
+		}
+	}
+
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC), true
+}
+
+// chain turns the rows into KB records, chained into supersedence.
+func chain(us []update) []microsoftkbTypes.KB {
+	// A KB written across more than one month is an article Microsoft revises
+	// in place rather than an update, and has no one place in a chain. It is
+	// recorded and left out of the ordering.
+	months := make(map[string]map[time.Time]struct{})
+	for _, u := range us {
+		if months[u.kbID] == nil {
+			months[u.kbID] = make(map[time.Time]struct{})
+		}
+		months[u.kbID][time.Date(u.date.Year(), u.date.Month(), 1, 0, 0, 0, 0, time.UTC)] = struct{}{}
+	}
+	revised := make(map[string]struct{})
+	for kbID, ms := range months {
+		if len(ms) > 1 {
+			revised[kbID] = struct{}{}
+		}
+	}
+	for _, kbID := range slices.Sorted(maps.Keys(revised)) {
+		var names []string
+		for _, u := range us {
+			if u.kbID == kbID {
+				names = append(names, fmt.Sprintf("%s (%s)", u.name, u.date.Format("January 2006")))
+			}
+		}
+		slog.Warn("a KB is revised in place across releases and is left unchained", slog.String("kb", kbID), slog.Int("releases", len(names)), slog.String("example", names[0]))
+	}
+
+	products := make(map[string][]update)
+	for _, u := range us {
+		if _, ok := revised[u.kbID]; ok {
+			continue
+		}
+		products[u.product] = append(products[u.product], u)
+	}
+
+	type link struct{ older, newer string }
+	var links []link
+	for _, group := range products {
+		slices.SortFunc(group, func(x, y update) int {
+			return cmp.Or(x.date.Compare(y.date), cmp.Compare(x.kbID, y.kbID))
+		})
+
+		// It is the date that links, not the row. Two updates of one month are
+		// releases beside each other -- the page gives no day to tell them
+		// apart by -- so each month links to the month before it rather than
+		// its rows being threaded into a line.
+		for i := 0; i < len(group); {
+			j := i + 1
+			for j < len(group) && group[j].date.Equal(group[i].date) {
+				j++
+			}
+			if i > 0 {
+				k := i - 1
+				for k > 0 && group[k-1].date.Equal(group[i-1].date) {
+					k--
+				}
+				for _, older := range group[k:i] {
+					for _, newer := range group[i:j] {
+						links = append(links, link{older: older.kbID, newer: newer.kbID})
+					}
+				}
+			}
+			i = j
+		}
+	}
+
+	kbs := make(map[string]*microsoftkbTypes.KB, len(us))
+	for _, u := range us {
+		kb, ok := kbs[u.kbID]
+		if !ok {
+			kb = &microsoftkbTypes.KB{
+				KBID: u.kbID,
+				URL:  u.url,
+				DataSource: sourceTypes.Source{
+					ID: sourceTypes.MicrosoftSfB,
+				},
+			}
+			kbs[u.kbID] = kb
+		}
+		if kb.URL == "" {
+			kb.URL = u.url
+		}
+		if !slices.Contains(kb.Products, u.product) {
+			kb.Products = append(kb.Products, u.product)
+		}
+		if !slices.Contains(kb.DataSource.Raws, u.raw) {
+			kb.DataSource.Raws = append(kb.DataSource.Raws, u.raw)
+		}
+	}
+
+	for _, l := range links {
+		// One KB is listed under several products of one month, so two of them
+		// can name each other from opposite sides. It is no edge at all.
+		if l.older == l.newer {
+			continue
+		}
+		if kb, ok := kbs[l.older]; ok {
+			s := microsoftkbSupersededByTypes.SupersededBy{KBID: l.newer}
+			if !slices.Contains(kb.SupersededBy, s) {
+				kb.SupersededBy = append(kb.SupersededBy, s)
+			}
+		}
+		if kb, ok := kbs[l.newer]; ok {
+			s := microsoftkbSupersedesTypes.Supersedes{KBID: l.older}
+			if !slices.Contains(kb.Supersedes, s) {
+				kb.Supersedes = append(kb.Supersedes, s)
+			}
+		}
+	}
+
+	out := make([]microsoftkbTypes.KB, 0, len(kbs))
+	for _, kb := range kbs {
+		out = append(out, *kb)
+	}
+	return out
+}

--- a/pkg/extract/microsoft/sfb/sfb_test.go
+++ b/pkg/extract/microsoft/sfb/sfb_test.go
@@ -1,0 +1,106 @@
+package sfb_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/sfb"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+// The fixture is the page as fetched, chosen for what decides a chain.
+//
+// There is no build number to order these by -- the Subscription Edition's
+// table has one and no other table does -- so the date is the order, and the
+// date is a month. Lync Server 2013 runs the full shape: September 2014 to
+// February 2021 to May 2021 to April 2022 to July 2022, each month superseding
+// the one before it.
+//
+// KB4470124, KB5065372 and KB2493736 are on two rows of different months each,
+// which is Microsoft revising one article in place for every hotfix of a
+// cumulative update line -- fifteen rows of it on the real page. "KB4470124 is
+// installed" does not say which of them a host has, so it is recorded and left
+// unchained rather than given a place it does not have.
+//
+// KB5016714 is on two rows of one month, which is the opposite case: one July
+// 2022 update listed under both products it was released for. It is chained in
+// both.
+//
+// One row names two KBs in one cell, KB5000675 and KB5000688, with only the
+// first linked. They are siblings of one release, so both supersede the
+// February 2021 update before them and both are superseded by the May 2021 one
+// after.
+//
+// A tools table sits among the update histories and names no KB column at all;
+// ten of the page's sixteen tables are like it.
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures/happy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := sfb.Extract(tt.args, sfb.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				return
+			default:
+				ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				gp, err := filepath.Abs(dir)
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}
+
+// The date is the whole order here, so every shape the page writes one in has to
+// read. Almost all of them are a month with no day.
+func TestReleaseDate(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want time.Time
+		ok   bool
+	}{
+		{name: "a month, which is all but four rows", s: "August 2025", want: time.Date(2025, time.August, 1, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "a month with a day", s: "May 11, 2021", want: time.Date(2021, time.May, 11, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "a month Microsoft abbreviated", s: "Sept 2014", want: time.Date(2014, time.September, 1, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "not a date", s: "n/a", ok: false},
+		{name: "a month that is not one", s: "Smarch 2014", ok: false},
+		{name: "nothing", s: "", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := sfb.ReleaseDate(tt.s)
+			if ok != tt.ok {
+				t.Fatalf("releaseDate() ok = %v, want %v", ok, tt.ok)
+			}
+			if !tt.ok {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("releaseDate(). (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/fixtures/happy/raw/sfb-server-updates.json
+++ b/pkg/extract/microsoft/sfb/testdata/fixtures/happy/raw/sfb-server-updates.json
@@ -1,0 +1,225 @@
+{
+	"url": "https://learn.microsoft.com/en-us/skypeforbusiness/sfb-server-updates",
+	"tables": [
+		{
+			"heading": "Skype for Business Server Subscription Edition (SE) update history",
+			"header": [
+				"Package name",
+				"KB number",
+				"Build number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "Skype for Business Server Subscription Edition (SE), Cumulative Update 1"
+					},
+					{
+						"text": "KB 5065372",
+						"href": "https://support.microsoft.com/help/5065372"
+					},
+					{
+						"text": "7.0.2046.849"
+					},
+					{
+						"text": "June 2026"
+					}
+				],
+				[
+					{
+						"text": "Skype for Business Server Subscription Edition (SE) RTM, Hotfix 1"
+					},
+					{
+						"text": "KB 5065372",
+						"href": "https://support.microsoft.com/help/5065372"
+					},
+					{
+						"text": "7.0.2046.826"
+					},
+					{
+						"text": "August 2025"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Skype for Business Server 2019 update history",
+			"header": [
+				"Package name",
+				"KB number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "Skype for Business Server 2019 Cumulative Update 8, Hotfix 2"
+					},
+					{
+						"text": "KB 4470124",
+						"href": "https://support.microsoft.com/help/4470124"
+					},
+					{
+						"text": "August 2025"
+					}
+				],
+				[
+					{
+						"text": "Skype for Business Server 2019 Cumulative Update 8, Hotfix 1"
+					},
+					{
+						"text": "KB 4470124",
+						"href": "https://support.microsoft.com/help/4470124"
+					},
+					{
+						"text": "March 2025"
+					}
+				],
+				[
+					{
+						"text": "Description of the security update for Skype for Business Server and Lync Server: July 12, 2022"
+					},
+					{
+						"text": "KB 5016714",
+						"href": "https://support.microsoft.com/help/5016714"
+					},
+					{
+						"text": "July 2022"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Skype for Business Server 2019 tools",
+			"header": [
+				"Package name",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "Lync Server 2013 Debugging Tools"
+					},
+					{
+						"text": "October 2012"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Lync Server 2013 update history",
+			"header": [
+				"Package name",
+				"KB number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "Description of the security update for Skype for Business Server and Lync Server: July 12, 2022"
+					},
+					{
+						"text": "KB 5016714",
+						"href": "https://support.microsoft.com/help/5016714"
+					},
+					{
+						"text": "July 2022"
+					}
+				],
+				[
+					{
+						"text": "Description of the security update for Skype for Business Lync Server 2013: April 12, 2022"
+					},
+					{
+						"text": "KB 5012681",
+						"href": "https://support.microsoft.com/help/5012681"
+					},
+					{
+						"text": "April 2022"
+					}
+				],
+				[
+					{
+						"text": "Lync Server 2013 Cumulative Update 10, Hotfix 6"
+					},
+					{
+						"text": "KB 5003729",
+						"href": "https://support.microsoft.com/help/5003729"
+					},
+					{
+						"text": "May 11, 2021"
+					}
+				],
+				[
+					{
+						"text": "Lync Server 2013 Cumulative Update 10, Hotfix 5"
+					},
+					{
+						"text": "KB 5000675 , KB 5000688",
+						"href": "https://support.microsoft.com/help/5000675"
+					},
+					{
+						"text": "February 9, 2021"
+					}
+				],
+				[
+					{
+						"text": "Lync Server 2013 Cumulative Update 5, Hotfix 2"
+					},
+					{
+						"text": "KB 2987511",
+						"href": "https://support.microsoft.com/help/2987511"
+					},
+					{
+						"text": "Sept 2014"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Lync Server 2010 update history",
+			"header": [
+				"Package name",
+				"KB number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "Lync Server 2010 Cumulative Update 18 Hotfix 1"
+					},
+					{
+						"text": "KB 2493736",
+						"href": "https://support.microsoft.com/help/2493736"
+					},
+					{
+						"text": "June 2019"
+					}
+				],
+				[
+					{
+						"text": "Lync Server 2010 Cumulative Update 18"
+					},
+					{
+						"text": "KB 2493736",
+						"href": "https://support.microsoft.com/help/2493736"
+					},
+					{
+						"text": "January 2019"
+					}
+				],
+				[
+					{
+						"text": "Lync Server 2010 Cumulative Update 13"
+					},
+					{
+						"text": "KB 2982385 KB 2982388",
+						"href": "https://support.microsoft.com/help/2982385"
+					},
+					{
+						"text": "September 2014"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/datasource.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "microsoft-sfb",
+	"name": "Microsoft Skype for Business Server Updates"
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/2493xxx/2493736.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/2493xxx/2493736.json
@@ -1,0 +1,13 @@
+{
+	"kb_id": "2493736",
+	"url": "https://support.microsoft.com/help/2493736",
+	"products": [
+		"Lync Server 2010 update history"
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/2982xxx/2982385.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/2982xxx/2982385.json
@@ -1,0 +1,13 @@
+{
+	"kb_id": "2982385",
+	"url": "https://support.microsoft.com/help/2982385",
+	"products": [
+		"Lync Server 2010 update history"
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/2982xxx/2982388.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/2982xxx/2982388.json
@@ -1,0 +1,12 @@
+{
+	"kb_id": "2982388",
+	"products": [
+		"Lync Server 2010 update history"
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/2987xxx/2987511.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/2987xxx/2987511.json
@@ -1,0 +1,21 @@
+{
+	"kb_id": "2987511",
+	"url": "https://support.microsoft.com/help/2987511",
+	"products": [
+		"Lync Server 2013 update history"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5000675"
+		},
+		{
+			"kb_id": "5000688"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/4470xxx/4470124.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/4470xxx/4470124.json
@@ -1,0 +1,13 @@
+{
+	"kb_id": "4470124",
+	"url": "https://support.microsoft.com/help/4470124",
+	"products": [
+		"Skype for Business Server 2019 update history"
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5000xxx/5000675.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5000xxx/5000675.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "5000675",
+	"url": "https://support.microsoft.com/help/5000675",
+	"products": [
+		"Lync Server 2013 update history"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5003729"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "2987511"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5000xxx/5000688.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5000xxx/5000688.json
@@ -1,0 +1,22 @@
+{
+	"kb_id": "5000688",
+	"products": [
+		"Lync Server 2013 update history"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5003729"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "2987511"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5003xxx/5003729.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5003xxx/5003729.json
@@ -1,0 +1,26 @@
+{
+	"kb_id": "5003729",
+	"url": "https://support.microsoft.com/help/5003729",
+	"products": [
+		"Lync Server 2013 update history"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5012681"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "5000675"
+		},
+		{
+			"kb_id": "5000688"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5012xxx/5012681.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5012xxx/5012681.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "5012681",
+	"url": "https://support.microsoft.com/help/5012681",
+	"products": [
+		"Lync Server 2013 update history"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5016714"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "5003729"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5016xxx/5016714.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5016xxx/5016714.json
@@ -1,0 +1,19 @@
+{
+	"kb_id": "5016714",
+	"url": "https://support.microsoft.com/help/5016714",
+	"products": [
+		"Lync Server 2013 update history",
+		"Skype for Business Server 2019 update history"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5012681"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5065xxx/5065372.json
+++ b/pkg/extract/microsoft/sfb/testdata/golden/microsoftkb/5065xxx/5065372.json
@@ -1,0 +1,13 @@
+{
+	"kb_id": "5065372",
+	"url": "https://support.microsoft.com/help/5065372",
+	"products": [
+		"Skype for Business Server Subscription Edition (SE) update history"
+	],
+	"data_source": {
+		"id": "microsoft-sfb",
+		"raws": [
+			"sfb-server-updates.json"
+		]
+	}
+}

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -90,6 +90,7 @@ const (
 	MicrosoftMSUC              SourceID = "microsoft-msuc"
 	MicrosoftProduct           SourceID = "microsoft-product"
 	MicrosoftServicing         SourceID = "microsoft-servicing"
+	MicrosoftSfB               SourceID = "microsoft-sfb"
 	MicrosoftVulnerability     SourceID = "microsoft-vulnerability"
 	MicrosoftWSUSSCN2          SourceID = "microsoft-wsusscn2"
 	MinimosSecDB               SourceID = "minimos-secdb"

--- a/pkg/fetch/microsoft/sfb/sfb.go
+++ b/pkg/fetch/microsoft/sfb/sfb.go
@@ -1,0 +1,363 @@
+// Package sfb fetches Microsoft's Skype for Business Server update history --
+// the page listing every cumulative update and hotfix the product line has
+// shipped, back through Lync Server 2010.
+//
+// It is 72 KBs, and the Update Catalog has dropped most of them: eight of
+// eleven sampled answer "We did not find any results", one as recent as 2021.
+// That is the highest rate of the Microsoft pages read here, and the reason
+// this one is worth reading at all -- the product line is small and largely out
+// of support, and the record of it is going.
+//
+// fetch writes <dir>/origin verbatim and then produces <dir>/raw by reading it
+// back, never the HTTP response, so raw/ is reproducible from origin/ alone.
+package sfb
+
+import (
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+	"golang.org/x/net/html"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+const (
+	baseURL = "https://learn.microsoft.com"
+
+	// pagePath is the update history. The name it is stored under is its
+	// last segment, so origin/ stays navigable against the site it came from.
+	pagePath = "/en-us/skypeforbusiness/sfb-server-updates"
+)
+
+type options struct {
+	baseURL string
+	dir     string
+	retry   int
+	wait    time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type baseURLOption string
+
+func (u baseURLOption) apply(opts *options) {
+	opts.baseURL = string(u)
+}
+
+func WithBaseURL(url string) Option {
+	return baseURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+// Fetch stores the page under <dir>/origin and the tables it carries under
+// <dir>/raw.
+func Fetch(opts ...Option) error {
+	options := &options{
+		baseURL: baseURL,
+		dir:     filepath.Join(util.CacheDir(), "fetch", "microsoft", "sfb"),
+		retry:   3,
+		wait:    1 * time.Second,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	if err := options.fetch(); err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+
+	if err := options.convert(); err != nil {
+		return errors.Wrap(err, "convert")
+	}
+
+	return nil
+}
+
+// fetch stores the page as served.
+func (opts options) fetch() error {
+	slog.Info("Fetch Microsoft Skype for Business Server Updates")
+
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
+
+	u, err := url.JoinPath(opts.baseURL, pagePath)
+	if err != nil {
+		return errors.Wrapf(err, "join %s and %s", opts.baseURL, pagePath)
+	}
+
+	if err := client.PipelineGet([]string{u}, 1, opts.wait, false, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, resp.Request.URL)
+		}
+
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", resp.Request.URL)
+		}
+
+		if err := writeOrigin(opts.dir, name(), bs); err != nil {
+			return errors.Wrapf(err, "write %s", name())
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "pipeline get")
+	}
+
+	return nil
+}
+
+// convert reads origin/ back and writes raw/, at the name its origin/
+// counterpart has. Going through the stored bytes rather than the response is
+// what lets the tree be re-derived after this parser changes.
+func (opts options) convert() error {
+	slog.Info("Convert origin to raw")
+
+	root := filepath.Join(opts.dir, "origin")
+
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".html" {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", p)
+		}
+		defer f.Close()
+
+		page, err := parsePage(f)
+		if err != nil {
+			return errors.Wrapf(err, "parse %s", p)
+		}
+
+		// The page is its tables. One that parses to none is not a page whose
+		// history has been retired -- it keeps Lync Server 2010 alongside the
+		// current release -- it is this parser having lost them, and it loses
+		// them all at once. Skipping would leave raw/ empty beside a full
+		// origin/ with the run green.
+		if len(page.Tables) == 0 {
+			return errors.Errorf("no table in %s", p)
+		}
+
+		if err := util.Write(filepath.Join(opts.dir, "raw", strings.TrimSuffix(filepath.ToSlash(rel), ".html")+".json"), page); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, "raw", strings.TrimSuffix(filepath.ToSlash(rel), ".html")+".json"))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", root)
+	}
+
+	return nil
+}
+
+// name is what the page is stored as: the last segment of its path, so origin/
+// stays navigable against the site it came from.
+func name() string {
+	segs := strings.Split(strings.Trim(pagePath, "/"), "/")
+	return segs[len(segs)-1] + ".html"
+}
+
+// writeOrigin stores content under <dir>/origin/<name> as served.
+//
+// Nothing derived from the response is recorded alongside it -- no fetch
+// timestamp, no ETag, no status line. Those change on every run even when the
+// page does not, and would turn every fetch into a diff, drowning the signal
+// this tree exists to carry: that Microsoft revised the page.
+func writeOrigin(dir, name string, content []byte) error {
+	p := filepath.Join(dir, "origin", name)
+
+	if err := os.MkdirAll(filepath.Dir(p), os.ModePerm); err != nil {
+		return errors.Wrapf(err, "mkdir %s", filepath.Dir(p))
+	}
+
+	if err := os.WriteFile(p, content, 0666); err != nil {
+		return errors.Wrapf(err, "write %s", p)
+	}
+
+	return nil
+}
+
+// parsePage reads a stored page for its canonical link and its tables.
+func parsePage(r io.Reader) (Page, error) {
+	doc, err := goquery.NewDocumentFromReader(r)
+	if err != nil {
+		return Page{}, errors.Wrap(err, "new document")
+	}
+
+	var page Page
+	var base *url.URL
+	if u, ok := doc.Find(`link[rel="canonical"]`).First().Attr("href"); ok {
+		page.URL = text(u)
+		base, _ = url.Parse(page.URL)
+	}
+
+	// Only the article body. The page chrome carries tables of its own, the
+	// locale picker among them, and a heading in a banner would otherwise
+	// become the heading of the first history.
+	root := doc.Find("main").First()
+	if root.Length() == 0 {
+		root = doc.Selection
+	}
+
+	// One pass in document order over the headings and the tables together,
+	// since a table's heading is its predecessor in the prose and not its
+	// ancestor. Headings inside a table are skipped: being visited after their
+	// own table's start tag they would otherwise be read as the next one's.
+	var heading string
+	root.Find("h1, h2, h3, h4, h5, h6, table").Each(func(_ int, s *goquery.Selection) {
+		if goquery.NodeName(s) != "table" {
+			if s.Closest("table").Length() == 0 {
+				heading = text(s.Text())
+			}
+			return
+		}
+
+		t, ok := parseTable(s, base)
+		if !ok {
+			return
+		}
+		t.Heading = heading
+
+		page.Tables = append(page.Tables, t)
+	})
+
+	return page, nil
+}
+
+// parseTable reads one table's column names and cells, reporting false for the
+// ones that carry neither.
+func parseTable(s *goquery.Selection, base *url.URL) (Table, bool) {
+	var rows [][]Cell
+	s.Find("tr").Each(func(_ int, tr *goquery.Selection) {
+		var cells []Cell
+		tr.Find("th, td").Each(func(_ int, c *goquery.Selection) {
+			cells = append(cells, parseCell(c, base))
+		})
+		if len(cells) == 0 {
+			return
+		}
+		rows = append(rows, cells)
+	})
+
+	if len(rows) < 2 {
+		return Table{}, false
+	}
+
+	header := make([]string, 0, len(rows[0]))
+	for _, c := range rows[0] {
+		header = append(header, c.Text)
+	}
+
+	return Table{Header: header, Rows: rows[1:]}, true
+}
+
+// parseCell reads a cell's text and the first link it carries.
+//
+// A line break is read as the space it stands for, since a cell broken across
+// lines is one value and reading its text straight through would run the lines
+// together into a word that is in neither.
+func parseCell(s *goquery.Selection, base *url.URL) Cell {
+	var b strings.Builder
+
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			switch {
+			case c.Type == html.TextNode:
+				b.WriteString(c.Data)
+			case c.Type == html.ElementNode && c.Data == "br":
+				b.WriteString(" ")
+			case c.Type == html.ElementNode:
+				walk(c)
+			}
+		}
+	}
+	for _, n := range s.Nodes {
+		walk(n)
+	}
+
+	cell := Cell{Text: text(b.String())}
+	if href, ok := s.Find("a[href]").First().Attr("href"); ok {
+		cell.Href = resolve(base, text(href))
+	}
+
+	return cell
+}
+
+// resolve turns a link into an address that works away from the page it was
+// read on. One that cannot be parsed is kept as served rather than dropped: it
+// is not this parser's to decide that Microsoft meant nothing by it.
+func resolve(base *url.URL, href string) string {
+	if href == "" || base == nil {
+		return href
+	}
+	ref, err := url.Parse(href)
+	if err != nil {
+		return href
+	}
+	return base.ResolveReference(ref).String()
+}
+
+// text normalizes the whitespace HTML is free to write however it likes.
+// goquery has already resolved the entities.
+func text(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/pkg/fetch/microsoft/sfb/sfb_test.go
+++ b/pkg/fetch/microsoft/sfb/sfb_test.go
@@ -1,0 +1,158 @@
+package sfb_test
+
+import (
+	"io/fs"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/sfb"
+)
+
+// The fixture is the page as served, cut down to the rows that decide what is
+// read out of it.
+//
+// Ten of the page's sixteen tables list tools, virtual machines and
+// documentation rather than updates, and name no KB column at all; one of them
+// is here among the ones that do.
+//
+// The Subscription Edition's table has a Build number column and no other table
+// has, so the build cannot be what orders these. Dates are written three ways --
+// "August 2025", "May 11, 2021" and "Sept 2014" -- and all but four rows of the
+// page have no day in them.
+//
+// Two rows name two KBs in one cell, comma-separated on one and merely spaced on
+// the other, with only the first of them linked.
+//
+// KB4470124 is on two rows of different months and KB5065372 on two more, which
+// is Microsoft revising one article in place for every hotfix of a cumulative
+// update line. KB5016714 is on two rows of one month, which is one update
+// listed under both products it was released for -- a different thing entirely.
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		golden   string
+		hasError bool
+	}{
+		{
+			name:    "happy",
+			fixture: "happy",
+			golden:  "happy",
+		},
+		{
+			// A page whose tables this cannot find is not a page that has lost
+			// them: it keeps SfB Server 4.0, released in 1996, alongside
+			// the current release. So the run fails rather than committing an
+			// empty raw/ beside a full origin/.
+			name:     "page without tables",
+			fixture:  "tableless",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(handler(t, tt.fixture))
+			defer ts.Close()
+
+			dir := t.TempDir()
+			err := sfb.Fetch(
+				sfb.WithBaseURL(ts.URL),
+				sfb.WithDir(dir),
+				sfb.WithRetry(0),
+				sfb.WithWait(0),
+			)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Fatalf("unexpected error. err: %v", err)
+			case err == nil && tt.hasError:
+				t.Fatal("expected error has not occurred")
+			case err != nil:
+				return
+			}
+
+			diff(t, filepath.Join("testdata", "golden", tt.golden), dir)
+		})
+	}
+}
+
+// handler serves a fixture tree the way learn.microsoft.com serves the page:
+// one document per path, and nothing anywhere else.
+func handler(t *testing.T, fixture string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		bs, err := os.ReadFile(filepath.Join("testdata", "fixtures", fixture, filepath.Clean(r.URL.Path)+".html"))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(bs)
+	}
+}
+
+// diff compares the produced tree against golden byte for byte. Bytes rather
+// than parsed content: origin/ is only worth keeping if it reproduces exactly,
+// and raw/ is written deterministically, so any difference at all is a
+// regression.
+func diff(t *testing.T, golden, got string) {
+	t.Helper()
+
+	want := walk(t, golden)
+	have := walk(t, got)
+
+	if d := cmp.Diff(slices.Sorted(maps.Keys(want)), slices.Sorted(maps.Keys(have))); d != "" {
+		t.Errorf("files (-expected +got):\n%s", d)
+	}
+
+	for n, w := range want {
+		h, ok := have[n]
+		if !ok {
+			continue
+		}
+		if d := cmp.Diff(string(w), string(h)); d != "" {
+			t.Errorf("%s (-expected +got):\n%s", n, d)
+		}
+	}
+}
+
+func walk(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+
+	out := make(map[string][]byte)
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+
+		bs, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+
+		out[filepath.ToSlash(rel)] = bs
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walk %s. err: %v", root, err)
+	}
+
+	return out
+}

--- a/pkg/fetch/microsoft/sfb/testdata/fixtures/happy/en-us/skypeforbusiness/sfb-server-updates.html
+++ b/pkg/fetch/microsoft/sfb/testdata/fixtures/happy/en-us/skypeforbusiness/sfb-server-updates.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Updates for Skype for Business Server</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/skypeforbusiness/sfb-server-updates" />
+</head>
+<body>
+<nav>
+<h2>Skip to main content</h2>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>Skype for Business Server Subscription Edition (SE) update history</h2>
+<table>
+<tr> <th style="text-align: left;">Package name</th> <th style="text-align: left;">KB number</th> <th style="text-align: left;">Build number</th> <th style="text-align: left;">Release date</th> </tr>
+<tr> <td style="text-align: left;">Skype for Business Server Subscription Edition (SE), Cumulative Update 1</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5065372" data-linktype="external">KB 5065372</a></td> <td style="text-align: left;">7.0.2046.849</td> <td style="text-align: left;">June 2026</td> </tr>
+<tr> <td style="text-align: left;">Skype for Business Server Subscription Edition (SE) RTM, Hotfix 1</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5065372" data-linktype="external">KB 5065372</a></td> <td style="text-align: left;">7.0.2046.826</td> <td style="text-align: left;">August 2025</td> </tr>
+</table>
+<h2>Skype for Business Server 2019 update history</h2>
+<table>
+<tr> <th style="text-align: left;">Package name</th> <th style="text-align: left;">KB number</th> <th style="text-align: left;">Release date</th> </tr>
+<tr> <td style="text-align: left;">Skype for Business Server 2019 Cumulative Update 8, Hotfix 2</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/4470124" data-linktype="external">KB 4470124</a></td> <td style="text-align: left;">August 2025</td> </tr>
+<tr> <td style="text-align: left;">Skype for Business Server 2019 Cumulative Update 8, Hotfix 1</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/4470124" data-linktype="external">KB 4470124</a></td> <td style="text-align: left;">March 2025</td> </tr>
+<tr> <td style="text-align: left;">Description of the security update for Skype for Business Server and Lync Server: July 12, 2022</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5016714" data-linktype="external">KB 5016714</a></td> <td style="text-align: left;">July 2022</td> </tr>
+</table>
+<h2>Skype for Business Server 2019 tools</h2>
+<table>
+<tr> <th style="text-align: left;">Package name</th> <th style="text-align: left;">Release date</th> </tr>
+<tr> <td style="text-align: left;">Lync Server 2013 Debugging Tools</td> <td style="text-align: left;">October 2012</td> </tr>
+</table>
+<h2>Lync Server 2013 update history</h2>
+<table>
+<tr> <th style="text-align: left;">Package name</th> <th style="text-align: left;">KB number</th> <th style="text-align: left;">Release date</th> </tr>
+<tr> <td style="text-align: left;">Description of the security update for Skype for Business Server and Lync Server: July 12, 2022</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5016714" data-linktype="external">KB 5016714</a></td> <td style="text-align: left;">July 2022</td> </tr>
+<tr> <td style="text-align: left;">Description of the security update for Skype for Business Lync Server 2013: April 12, 2022</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5012681" data-linktype="external">KB 5012681</a></td> <td style="text-align: left;">April 2022</td> </tr>
+<tr> <td style="text-align: left;">Lync Server 2013 Cumulative Update 10, Hotfix 6</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5003729" data-linktype="external">KB 5003729</a></td> <td style="text-align: left;">May 11, 2021</td> </tr>
+<tr> <td style="text-align: left;">Lync Server 2013 Cumulative Update 10, Hotfix 5</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5000675" data-linktype="external">KB 5000675</a> , KB 5000688</td> <td style="text-align: left;">February 9, 2021</td> </tr>
+<tr> <td style="text-align: left;">Lync Server 2013 Cumulative Update 5, Hotfix 2</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/2987511" data-linktype="external">KB 2987511</a></td> <td style="text-align: left;">Sept 2014</td> </tr>
+</table>
+<h2>Lync Server 2010 update history</h2>
+<table>
+<tr> <th style="text-align: left;">Package name</th> <th style="text-align: left;">KB number</th> <th style="text-align: left;">Release date</th> </tr>
+<tr> <td style="text-align: left;">Lync Server 2010 Cumulative Update 18 Hotfix 1</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/2493736" data-linktype="external">KB 2493736</a></td> <td style="text-align: left;">June 2019</td> </tr>
+<tr> <td style="text-align: left;">Lync Server 2010 Cumulative Update 18</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/2493736" data-linktype="external">KB 2493736</a></td> <td style="text-align: left;">January 2019</td> </tr>
+<tr> <td style="text-align: left;">Lync Server 2010 Cumulative Update 13</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/2982385" data-linktype="external">KB 2982385</a> KB 2982388</td> <td style="text-align: left;">September 2014</td> </tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/sfb/testdata/fixtures/tableless/en-us/skypeforbusiness/sfb-server-updates.html
+++ b/pkg/fetch/microsoft/sfb/testdata/fixtures/tableless/en-us/skypeforbusiness/sfb-server-updates.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html lang="en-us"><head><meta charset="utf-8" /><title>Updates for Skype for Business Server</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/skypeforbusiness/sfb-server-updates" /></head>
+<body><main><h2>Updates</h2><p>This content has moved.</p></main></body></html>

--- a/pkg/fetch/microsoft/sfb/testdata/golden/happy/origin/sfb-server-updates.html
+++ b/pkg/fetch/microsoft/sfb/testdata/golden/happy/origin/sfb-server-updates.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8" />
+<title>Updates for Skype for Business Server</title>
+<link rel="canonical" href="https://learn.microsoft.com/en-us/skypeforbusiness/sfb-server-updates" />
+</head>
+<body>
+<nav>
+<h2>Skip to main content</h2>
+<table><tr><th>Locale</th><th>Site</th></tr><tr><td>en-us</td><td>learn.microsoft.com</td></tr></table>
+</nav>
+<main>
+<h2>Skype for Business Server Subscription Edition (SE) update history</h2>
+<table>
+<tr> <th style="text-align: left;">Package name</th> <th style="text-align: left;">KB number</th> <th style="text-align: left;">Build number</th> <th style="text-align: left;">Release date</th> </tr>
+<tr> <td style="text-align: left;">Skype for Business Server Subscription Edition (SE), Cumulative Update 1</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5065372" data-linktype="external">KB 5065372</a></td> <td style="text-align: left;">7.0.2046.849</td> <td style="text-align: left;">June 2026</td> </tr>
+<tr> <td style="text-align: left;">Skype for Business Server Subscription Edition (SE) RTM, Hotfix 1</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5065372" data-linktype="external">KB 5065372</a></td> <td style="text-align: left;">7.0.2046.826</td> <td style="text-align: left;">August 2025</td> </tr>
+</table>
+<h2>Skype for Business Server 2019 update history</h2>
+<table>
+<tr> <th style="text-align: left;">Package name</th> <th style="text-align: left;">KB number</th> <th style="text-align: left;">Release date</th> </tr>
+<tr> <td style="text-align: left;">Skype for Business Server 2019 Cumulative Update 8, Hotfix 2</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/4470124" data-linktype="external">KB 4470124</a></td> <td style="text-align: left;">August 2025</td> </tr>
+<tr> <td style="text-align: left;">Skype for Business Server 2019 Cumulative Update 8, Hotfix 1</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/4470124" data-linktype="external">KB 4470124</a></td> <td style="text-align: left;">March 2025</td> </tr>
+<tr> <td style="text-align: left;">Description of the security update for Skype for Business Server and Lync Server: July 12, 2022</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5016714" data-linktype="external">KB 5016714</a></td> <td style="text-align: left;">July 2022</td> </tr>
+</table>
+<h2>Skype for Business Server 2019 tools</h2>
+<table>
+<tr> <th style="text-align: left;">Package name</th> <th style="text-align: left;">Release date</th> </tr>
+<tr> <td style="text-align: left;">Lync Server 2013 Debugging Tools</td> <td style="text-align: left;">October 2012</td> </tr>
+</table>
+<h2>Lync Server 2013 update history</h2>
+<table>
+<tr> <th style="text-align: left;">Package name</th> <th style="text-align: left;">KB number</th> <th style="text-align: left;">Release date</th> </tr>
+<tr> <td style="text-align: left;">Description of the security update for Skype for Business Server and Lync Server: July 12, 2022</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5016714" data-linktype="external">KB 5016714</a></td> <td style="text-align: left;">July 2022</td> </tr>
+<tr> <td style="text-align: left;">Description of the security update for Skype for Business Lync Server 2013: April 12, 2022</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5012681" data-linktype="external">KB 5012681</a></td> <td style="text-align: left;">April 2022</td> </tr>
+<tr> <td style="text-align: left;">Lync Server 2013 Cumulative Update 10, Hotfix 6</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5003729" data-linktype="external">KB 5003729</a></td> <td style="text-align: left;">May 11, 2021</td> </tr>
+<tr> <td style="text-align: left;">Lync Server 2013 Cumulative Update 10, Hotfix 5</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/5000675" data-linktype="external">KB 5000675</a> , KB 5000688</td> <td style="text-align: left;">February 9, 2021</td> </tr>
+<tr> <td style="text-align: left;">Lync Server 2013 Cumulative Update 5, Hotfix 2</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/2987511" data-linktype="external">KB 2987511</a></td> <td style="text-align: left;">Sept 2014</td> </tr>
+</table>
+<h2>Lync Server 2010 update history</h2>
+<table>
+<tr> <th style="text-align: left;">Package name</th> <th style="text-align: left;">KB number</th> <th style="text-align: left;">Release date</th> </tr>
+<tr> <td style="text-align: left;">Lync Server 2010 Cumulative Update 18 Hotfix 1</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/2493736" data-linktype="external">KB 2493736</a></td> <td style="text-align: left;">June 2019</td> </tr>
+<tr> <td style="text-align: left;">Lync Server 2010 Cumulative Update 18</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/2493736" data-linktype="external">KB 2493736</a></td> <td style="text-align: left;">January 2019</td> </tr>
+<tr> <td style="text-align: left;">Lync Server 2010 Cumulative Update 13</td> <td style="text-align: left;"><a href="https://support.microsoft.com/help/2982385" data-linktype="external">KB 2982385</a> KB 2982388</td> <td style="text-align: left;">September 2014</td> </tr>
+</table>
+</main>
+</body>
+</html>

--- a/pkg/fetch/microsoft/sfb/testdata/golden/happy/raw/sfb-server-updates.json
+++ b/pkg/fetch/microsoft/sfb/testdata/golden/happy/raw/sfb-server-updates.json
@@ -1,0 +1,225 @@
+{
+	"url": "https://learn.microsoft.com/en-us/skypeforbusiness/sfb-server-updates",
+	"tables": [
+		{
+			"heading": "Skype for Business Server Subscription Edition (SE) update history",
+			"header": [
+				"Package name",
+				"KB number",
+				"Build number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "Skype for Business Server Subscription Edition (SE), Cumulative Update 1"
+					},
+					{
+						"text": "KB 5065372",
+						"href": "https://support.microsoft.com/help/5065372"
+					},
+					{
+						"text": "7.0.2046.849"
+					},
+					{
+						"text": "June 2026"
+					}
+				],
+				[
+					{
+						"text": "Skype for Business Server Subscription Edition (SE) RTM, Hotfix 1"
+					},
+					{
+						"text": "KB 5065372",
+						"href": "https://support.microsoft.com/help/5065372"
+					},
+					{
+						"text": "7.0.2046.826"
+					},
+					{
+						"text": "August 2025"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Skype for Business Server 2019 update history",
+			"header": [
+				"Package name",
+				"KB number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "Skype for Business Server 2019 Cumulative Update 8, Hotfix 2"
+					},
+					{
+						"text": "KB 4470124",
+						"href": "https://support.microsoft.com/help/4470124"
+					},
+					{
+						"text": "August 2025"
+					}
+				],
+				[
+					{
+						"text": "Skype for Business Server 2019 Cumulative Update 8, Hotfix 1"
+					},
+					{
+						"text": "KB 4470124",
+						"href": "https://support.microsoft.com/help/4470124"
+					},
+					{
+						"text": "March 2025"
+					}
+				],
+				[
+					{
+						"text": "Description of the security update for Skype for Business Server and Lync Server: July 12, 2022"
+					},
+					{
+						"text": "KB 5016714",
+						"href": "https://support.microsoft.com/help/5016714"
+					},
+					{
+						"text": "July 2022"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Skype for Business Server 2019 tools",
+			"header": [
+				"Package name",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "Lync Server 2013 Debugging Tools"
+					},
+					{
+						"text": "October 2012"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Lync Server 2013 update history",
+			"header": [
+				"Package name",
+				"KB number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "Description of the security update for Skype for Business Server and Lync Server: July 12, 2022"
+					},
+					{
+						"text": "KB 5016714",
+						"href": "https://support.microsoft.com/help/5016714"
+					},
+					{
+						"text": "July 2022"
+					}
+				],
+				[
+					{
+						"text": "Description of the security update for Skype for Business Lync Server 2013: April 12, 2022"
+					},
+					{
+						"text": "KB 5012681",
+						"href": "https://support.microsoft.com/help/5012681"
+					},
+					{
+						"text": "April 2022"
+					}
+				],
+				[
+					{
+						"text": "Lync Server 2013 Cumulative Update 10, Hotfix 6"
+					},
+					{
+						"text": "KB 5003729",
+						"href": "https://support.microsoft.com/help/5003729"
+					},
+					{
+						"text": "May 11, 2021"
+					}
+				],
+				[
+					{
+						"text": "Lync Server 2013 Cumulative Update 10, Hotfix 5"
+					},
+					{
+						"text": "KB 5000675 , KB 5000688",
+						"href": "https://support.microsoft.com/help/5000675"
+					},
+					{
+						"text": "February 9, 2021"
+					}
+				],
+				[
+					{
+						"text": "Lync Server 2013 Cumulative Update 5, Hotfix 2"
+					},
+					{
+						"text": "KB 2987511",
+						"href": "https://support.microsoft.com/help/2987511"
+					},
+					{
+						"text": "Sept 2014"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Lync Server 2010 update history",
+			"header": [
+				"Package name",
+				"KB number",
+				"Release date"
+			],
+			"rows": [
+				[
+					{
+						"text": "Lync Server 2010 Cumulative Update 18 Hotfix 1"
+					},
+					{
+						"text": "KB 2493736",
+						"href": "https://support.microsoft.com/help/2493736"
+					},
+					{
+						"text": "June 2019"
+					}
+				],
+				[
+					{
+						"text": "Lync Server 2010 Cumulative Update 18"
+					},
+					{
+						"text": "KB 2493736",
+						"href": "https://support.microsoft.com/help/2493736"
+					},
+					{
+						"text": "January 2019"
+					}
+				],
+				[
+					{
+						"text": "Lync Server 2010 Cumulative Update 13"
+					},
+					{
+						"text": "KB 2982385 KB 2982388",
+						"href": "https://support.microsoft.com/help/2982385"
+					},
+					{
+						"text": "September 2014"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/fetch/microsoft/sfb/types.go
+++ b/pkg/fetch/microsoft/sfb/types.go
@@ -1,0 +1,32 @@
+package sfb
+
+// Page is the Skype for Business Server update history, as served.
+//
+// Nothing is read out of the cells here. Which product an update is for is the
+// table it sits in rather than anything in the row, so reading that apart
+// belongs in extract, under golden tests.
+type Page struct {
+	// URL is the page's own canonical link, taken from the stored HTML rather
+	// than from the request, so raw/ stays derivable from origin/ alone.
+	URL    string  `json:"url,omitempty"`
+	Tables []Table `json:"tables,omitempty"`
+}
+
+// Table is one product's update history, with the heading it sits under.
+//
+// The heading is the only place the product is named. A row says "Cumulative
+// Update 8, Hotfix 2" and leaves which product that is to the table it is in,
+// and the page holds six such tables, from Lync Server 2010 to the Subscription
+// Edition -- beside another ten listing tools and downloads that are not
+// updates at all.
+type Table struct {
+	Heading string   `json:"heading,omitempty"`
+	Header  []string `json:"header,omitempty"`
+	Rows    [][]Cell `json:"rows,omitempty"`
+}
+
+// Cell is one cell, with the link it carries.
+type Cell struct {
+	Text string `json:"text,omitempty"`
+	Href string `json:"href,omitempty"`
+}


### PR DESCRIPTION
## What

Adds `microsoft-sfb`, a fetcher and extractor for the Skype for Business Server update history — Subscription Edition, 2019 and 2015, and Lync Server 2013 and 2010. **74 KBs**.

## Why

**The Update Catalog has dropped most of them: eight of eleven sampled answer "We did not find any results", one as recent as 2021.** That is the highest rate of the Microsoft pages read here, and it is the reason this one is worth reading at all — the product line is small and largely out of support, and the record of it is going.

## How

**There is no build number to order these by.** The Subscription Edition's table has a `Build number` column and no other table does, so the date is the order, within the product a table is filed under.

**The date is a month.** 100 of the page's 104 rows are dated `August 2025` with no day in them, so two updates of one month cannot be told apart and are not ordered against each other: **a month links to the month before it, all of one to all of the other**, which is what `extract/microsoft/servicing` does with the dates it cannot split either. Four rows carry a day and one of those writes its month as `Sept`.

Ten of the page's sixteen tables list tools, virtual machines, developer kits and documentation rather than updates, and are told apart by the `KB number` column the update histories have and they do not.

Two rows name two KBs in one cell — `KB 5000675 , KB 5000688` on one and `KB 2982385 KB 2982388` on the other — a release that shipped an update for the server and another for a component beside it. Both are read; only the first is linked, so the second is recorded without a URL rather than given the first's.

### The limitation worth reviewing

**Four KBs are articles rather than updates.** Microsoft revises one KB in place for every hotfix of a cumulative update line:

- **KB4470124 is fifteen rows** of Skype for Business Server 2019, from Cumulative Update 5 in 2020 to Cumulative Update 8 Hotfix 2 in 2025
- **KB3061064 is twelve rows** of Server 2015

So "KB4470124 is installed" does not say which of the fifteen a host has. Such a KB cannot be placed in a chain at all — an edge into it would claim a patch level it does not name — so **they are recorded for their products and left unchained**, and reported at Warn so a fifth is noticed.

A KB on several rows of **one month** is the opposite case and is chained normally: KB5016714 is one July 2022 update listed under each of the three products it was released for.

This leaves 74 KBs of which 7 carry no edges. If a source that records KBs and products but chains only where the evidence supports it is not wanted, this is the branch to say so on.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` — passes
- `golangci-lint run ./pkg/...` — 0 issues
- Golden tests for both packages
- End to end against the live page: **74 KBs, 7 unchained**, 4 warnings, all of them the revised-in-place articles named above

```
$ vuls-data-update fetch   microsoft-sfb -d <raw>
$ vuls-data-update extract microsoft-sfb <raw> -d <out>
```

## Checklist

- [x] Tests pass
- [x] Golden files updated
- [x] Deterministic output verified (types changed)
- [x] Backward compatibility maintained (types/data changed)

`pkg/extract/types/source` gains one constant, `MicrosoftSfB`. Additive; it is the only file shared with the other Microsoft data-source branches.
