### PR TITLE
feat(microsoft/scom): add operations manager build versions data source

### DIFF
--- a/pkg/cmd/extract/extract.go
+++ b/pkg/cmd/extract/extract.go
@@ -66,6 +66,7 @@ import (
 	microsoftBulletin "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/bulletin"
 	microsoftCVRF "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/cvrf"
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/msuc"
+	microsoftSCOM "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/scom"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/servicing"
 	microsoftWSUSSCN2 "github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/wsusscn2"
 	mitreATTACK "github.com/MaineK00n/vuls-data-update/pkg/extract/mitre/attack"
@@ -180,7 +181,7 @@ func NewCmdExtract() *cobra.Command {
 		newCmdJVNFeedDetail(), newCmdJVNFeedProduct(), newCmdJVNFeedRSS(),
 		newCmdLinuxOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftWSUSSCN2(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftMSUC(), newCmdMicrosoftSCOM(), newCmdMicrosoftServicing(), newCmdMicrosoftWSUSSCN2(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
 		newCmdNetBSD(),
@@ -1656,6 +1657,31 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := microsoftMSUC.Extract(args[0], microsoftMSUC.WithDir(options.dir)); err != nil {
 				return errors.Wrap(err, "failed to extract microsoft msuc")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output extract results to specified directory")
+
+	return cmd
+}
+
+func newCmdMicrosoftSCOM() *cobra.Command {
+	options := &base{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "scom"),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-scom <Raw Microsoft System Center Operations Manager Repository PATH>",
+		Short: "Extract Microsoft System Center Operations Manager Build Versions data source",
+		Example: heredoc.Doc(`
+			$ vuls-data-update extract microsoft-scom vuls-data-raw-microsoft-scom
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := microsoftSCOM.Extract(args[0], microsoftSCOM.WithDir(options.dir)); err != nil {
+				return errors.Wrap(err, "failed to extract microsoft scom")
 			}
 			return nil
 		},

--- a/pkg/cmd/fetch/fetch.go
+++ b/pkg/cmd/fetch/fetch.go
@@ -91,6 +91,7 @@ import (
 	microsoftDeployment "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/deployment"
 	microsoftMSUC "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/msuc"
 	microsoftProduct "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/product"
+	microsoftSCOM "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/scom"
 	microsoftServicing "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/servicing"
 	microsoftVEX "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vex"
 	microsoftVulnerability "github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/vulnerability"
@@ -255,7 +256,7 @@ func NewCmdFetch() *cobra.Command {
 		newCmdLinuxOSV(),
 		newCmdMageiaOSV(),
 		newCmdMavenGHSA(), newCmdMavenGLSA(), newCmdMavenOSV(),
-		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftServicing(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
+		newCmdMicrosoftBulletin(), newCmdMicrosoftCVRF(), newCmdMicrosoftCSAF(), newCmdMicrosoftMSUC(), newCmdMicrosoftSCOM(), newCmdMicrosoftServicing(), newCmdMicrosoftAdvisory(), newCmdMicrosoftVulnerability(), newCmdMicrosoftProduct(), newCmdMicrosoftDeployment(), newCmdMicrosoftVEX(), newCmdMicrosoftWSUSSCN2(), newCmdMicrosoftAzureOVAL(),
 		newCmdMinimOSOSV(), newCmdMinimOSSecDB(),
 		newCmdMitreATTACK(), newCmdMitreCAPEC(), newCmdMitreCVRF(), newCmdMitreCWE(), newCmdMitreEMB3D(), newCmdMitreV4(), newCmdMitreV5(),
 		newCmdMSF(),
@@ -2666,6 +2667,53 @@ func newCmdMicrosoftMSUC() *cobra.Command {
 	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
 	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
 	cmd.Flags().IntVarP(&options.concurrency, "concurrency", "", options.concurrency, "number of concurrent http requests")
+	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
+
+	return cmd
+}
+
+func newCmdMicrosoftSCOM() *cobra.Command {
+	options := &struct {
+		base
+		wait time.Duration
+	}{
+		base: base{
+			dir:   filepath.Join(util.CacheDir(), "fetch", "microsoft", "scom"),
+			retry: 3,
+		},
+		wait: 1 * time.Second,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "microsoft-scom",
+		Short: "Fetch Microsoft System Center Operations Manager Build Versions data source",
+		Long: heredoc.Doc(`
+			Fetch the System Center Operations Manager build versions article as
+			Markdown into <dir>/origin, and the tables it carries into <dir>/raw.
+
+			The article lists every update rollup the product has shipped, from
+			Operations Manager 2016 to 2025. It is fetched from
+			MicrosoftDocs/SystemCenterDocs because the repository is public and keeps
+			the article's history.
+
+			The article holds no tables of its own: it is four INCLUDE directives, one
+			per product version. Those are read out of it and fetched too, one hop and
+			no further, and every file is stored at the path it has in the repository.
+		`),
+		Example: heredoc.Doc(`
+			$ vuls-data-update fetch microsoft-scom
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := microsoftSCOM.Fetch(microsoftSCOM.WithDir(options.dir), microsoftSCOM.WithRetry(options.retry), microsoftSCOM.WithWait(options.wait)); err != nil {
+				return errors.Wrap(err, "failed to fetch microsoft scom")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.dir, "dir", "d", options.dir, "output fetch results to specified directory")
+	cmd.Flags().IntVarP(&options.retry, "retry", "", options.retry, "number of retry http request")
 	cmd.Flags().DurationVarP(&options.wait, "wait", "", options.wait, "wait duration")
 
 	return cmd

--- a/pkg/extract/microsoft/scom/export_test.go
+++ b/pkg/extract/microsoft/scom/export_test.go
@@ -1,0 +1,6 @@
+package scom
+
+var (
+	ReleaseDate = releaseDate
+	Version     = version
+)

--- a/pkg/extract/microsoft/scom/scom.go
+++ b/pkg/extract/microsoft/scom/scom.go
@@ -1,0 +1,424 @@
+// Package scom extracts supersedence from Microsoft's System Center Operations
+// Manager build versions.
+//
+// The article carries no supersedence. What it carries is every update rollup
+// each component has shipped, and the build number is the order within a
+// component: the management server, the agent and gateway and the SCX agent
+// advance on their own numbers under the one rollup, so an update rollup is
+// three builds and one KB.
+//
+// The KB is written as a bare number linked to the support site --
+// "[5068304](https://support.microsoft.com/kb/5068304)" -- so it is read from
+// the link rather than from the text. The same column on the SCX agent's tables
+// holds a version linked to a GitHub release, "[v1.6.9-0](https://github.com/...)",
+// which is not a KB at all and is what makes the link the thing to read.
+//
+// Which product version a table belongs to is in neither the table nor the file
+// it is in. The article is four INCLUDE directives, one per version, and the
+// file each pulls in is named for it, so the path is what says it.
+//
+// The general availability rows carry no KB, being the product rather than an
+// update to it, and are skipped.
+package scom
+
+import (
+	"cmp"
+	"encoding/json/v2"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
+	repositoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource/repository"
+	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
+	microsoftkbSupersededByTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersededby"
+	microsoftkbSupersedesTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb/supersedes"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/util"
+	utilgit "github.com/MaineK00n/vuls-data-update/pkg/extract/util/git"
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/scom"
+)
+
+// The columns a row is read out of, by name.
+const (
+	columnBuild       = "Build Number"
+	columnKB          = "KB"
+	columnDate        = "Release Date"
+	columnDescription = "Description"
+)
+
+var (
+	// kbPattern reads the KB out of the link on the number, that being where
+	// this article puts it. A link anywhere else -- GitHub, on the SCX agent's
+	// tables -- names no KB and does not match.
+	kbPattern = regexp.MustCompile(`support\.microsoft\.com/(?:[a-z-]+/)?(?:kb|help)/(\d{6,})`)
+
+	buildPattern = regexp.MustCompile(`^\d+(?:\.\d+){2,3}$`)
+
+	// versionPattern is the product version, which is in the name of the file a
+	// table was included from and nowhere else.
+	versionPattern = regexp.MustCompile(`release-build-versions-(\d{4})\.json$`)
+
+	// datePattern is the release date, a month with no day in every row.
+	datePattern = regexp.MustCompile(`^([A-Za-z]+) (\d{4})$`)
+)
+
+var months = map[string]time.Month{
+	"january": time.January, "february": time.February, "march": time.March,
+	"april": time.April, "may": time.May, "june": time.June,
+	"july": time.July, "august": time.August, "september": time.September,
+	"october": time.October, "november": time.November, "december": time.December,
+}
+
+type options struct {
+	dir string
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+// update is one build, read for what decides its place in a chain.
+type update struct {
+	kbID string
+	url  string
+
+	// version is the product, taken from the path of the file the table was
+	// included from, e.g. "System Center 2022 - Operations Manager".
+	version string
+
+	// component is the heading the table sits under -- the management server,
+	// the agent and gateway, or the SCX agent -- which advance on their own
+	// build numbers and so are chained apart.
+	component string
+
+	build    []int
+	buildStr string
+
+	// description is the rollup as written, e.g. "Update Rollup 1". Nothing is
+	// parsed out of it: the build number is the order and says the same thing
+	// without being prose.
+	description string
+
+	date time.Time
+
+	raw string
+}
+
+func Extract(args string, opts ...Option) error {
+	options := &options{
+		dir: filepath.Join(util.CacheDir(), "extract", "microsoft", "scom"),
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	slog.Info("Extract Microsoft System Center Operations Manager Build Versions")
+
+	us, err := read(args)
+	if err != nil {
+		return errors.Wrapf(err, "read %s", args)
+	}
+
+	kbs := chain(us)
+
+	for _, kb := range kbs {
+		if err := util.Write(filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)), kb, true); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "microsoftkb", fmt.Sprintf("%sxxx", kb.KBID[:len(kb.KBID)-3]), fmt.Sprintf("%s.json", kb.KBID)))
+		}
+	}
+
+	if err := util.Write(filepath.Join(options.dir, "datasource.json"), datasourceTypes.DataSource{
+		ID:   sourceTypes.MicrosoftSCOM,
+		Name: new("Microsoft System Center Operations Manager Build Versions"),
+		Raw: func() []repositoryTypes.Repository {
+			r, _ := utilgit.GetDataSourceRepository(args)
+			if r == nil {
+				return nil
+			}
+			return []repositoryTypes.Repository{*r}
+		}(),
+		Extracted: func() *repositoryTypes.Repository {
+			if u, err := utilgit.GetOrigin(options.dir); err == nil {
+				return &repositoryTypes.Repository{URL: u}
+			}
+			return nil
+		}(),
+	}, false); err != nil {
+		return errors.Wrapf(err, "write %s", filepath.Join(options.dir, "datasource.json"))
+	}
+
+	return nil
+}
+
+// read walks the raw tree and returns the builds that name a KB.
+func read(args string) ([]update, error) {
+	root := filepath.Join(args, "raw")
+
+	var us []update
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".json" {
+			return nil
+		}
+
+		f, err := os.Open(p)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", p)
+		}
+		defer f.Close()
+
+		var a scom.Article
+		if err := json.UnmarshalRead(f, &a); err != nil {
+			return errors.Wrapf(err, "decode %s", p)
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+
+		us = append(us, parseArticle(a, filepath.ToSlash(rel))...)
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrapf(err, "walk %s", root)
+	}
+
+	return us, nil
+}
+
+// parseArticle reads one file's build tables.
+func parseArticle(a scom.Article, raw string) []update {
+	version, ok := version(raw)
+	if !ok {
+		// The article itself, which holds the INCLUDE directives and no tables,
+		// and the note one of them pulls in beside them.
+		slog.Debug("not a build table file", slog.String("path", raw))
+		return nil
+	}
+
+	var us []update
+	for _, t := range a.Tables {
+		var missing []string
+		for _, c := range []string{columnBuild, columnKB, columnDate} {
+			if !slices.Contains(t.Header, c) {
+				missing = append(missing, c)
+			}
+		}
+		if len(missing) > 0 {
+			slog.Warn("build table is missing columns", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("missing", strings.Join(missing, ", ")), slog.String("header", strings.Join(t.Header, ", ")))
+			continue
+		}
+
+		for _, row := range t.Rows {
+			u, ok := parseRow(t, row, version, raw)
+			if !ok {
+				continue
+			}
+			us = append(us, u)
+		}
+	}
+
+	return us
+}
+
+// version is the product a file's tables are for, which is in the file's name.
+func version(raw string) (string, bool) {
+	m := versionPattern.FindStringSubmatch(raw)
+	if m == nil {
+		return "", false
+	}
+	return fmt.Sprintf("System Center %s - Operations Manager", m[1]), true
+}
+
+// parseRow reads one row, reporting false for the ones that are not updates.
+func parseRow(t scom.Table, row []scom.Cell, version, raw string) (update, bool) {
+	cell := func(column string) scom.Cell {
+		i := slices.Index(t.Header, column)
+		if i < 0 || i >= len(row) {
+			return scom.Cell{}
+		}
+		return row[i]
+	}
+
+	kb := cell(columnKB)
+
+	m := kbPattern.FindStringSubmatch(kb.Href)
+	if m == nil {
+		// A general availability row, which is the product rather than an
+		// update to it and carries no KB -- Microsoft writes the cell empty or
+		// as a dash -- or an SCX agent row, whose KB column holds a version
+		// linked to a GitHub release instead.
+		slog.Debug("build names no KB", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("build", cell(columnBuild).Text), slog.String("kb", kb.Text))
+		return update{}, false
+	}
+
+	bs := cell(columnBuild).Text
+	if !buildPattern.MatchString(bs) {
+		// The build is the whole order within a component. A row without one
+		// cannot be placed.
+		slog.Warn("unexpected build", slog.String("path", raw), slog.String("heading", t.Heading), slog.String("kb", m[1]), slog.String("build", bs))
+		return update{}, false
+	}
+	build := make([]int, 0, 4)
+	for _, p := range strings.Split(bs, ".") {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			slog.Warn("unexpected build", slog.String("path", raw), slog.String("kb", m[1]), slog.String("build", bs))
+			return update{}, false
+		}
+		build = append(build, n)
+	}
+
+	// The date is a tiebreaker between two builds of one component, not the
+	// order, so an unreadable one costs the tie and not the row.
+	var date time.Time
+	if d := cell(columnDate).Text; d != "" {
+		var ok bool
+		date, ok = releaseDate(d)
+		if !ok {
+			slog.Warn("unexpected release date", slog.String("path", raw), slog.String("kb", m[1]), slog.String("date", d))
+		}
+	}
+
+	return update{
+		kbID:        m[1],
+		url:         kb.Href,
+		version:     version,
+		component:   t.Heading,
+		build:       build,
+		buildStr:    bs,
+		description: cell(columnDescription).Text,
+		date:        date,
+		raw:         raw,
+	}, true
+}
+
+// releaseDate reads the month a row was released. Every row of the article is a
+// month with no day, so a month is taken as its first.
+func releaseDate(s string) (time.Time, bool) {
+	m := datePattern.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return time.Time{}, false
+	}
+
+	month, ok := months[strings.ToLower(m[1])]
+	if !ok {
+		return time.Time{}, false
+	}
+
+	year, err := strconv.Atoi(m[2])
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return time.Date(year, month, 1, 0, 0, 0, 0, time.UTC), true
+}
+
+// chain turns the builds into KB records, chained into supersedence.
+func chain(us []update) []microsoftkbTypes.KB {
+	type line struct {
+		version   string
+		component string
+	}
+
+	lines := make(map[line][]update)
+	for _, u := range us {
+		lines[line{version: u.version, component: u.component}] = append(lines[line{version: u.version, component: u.component}], u)
+	}
+
+	type link struct{ older, newer string }
+	var links []link
+	for l, group := range lines {
+		slices.SortFunc(group, func(x, y update) int {
+			return cmp.Or(slices.Compare(x.build, y.build), x.date.Compare(y.date), cmp.Compare(x.kbID, y.kbID))
+		})
+
+		for i := 1; i < len(group); i++ {
+			older, newer := group[i-1], group[i]
+
+			if !older.date.IsZero() && !newer.date.IsZero() && newer.date.Before(older.date) {
+				slog.Warn("a component's builds and release dates disagree",
+					slog.String("version", l.version), slog.String("component", l.component),
+					slog.String("older", fmt.Sprintf("KB%s %s %s", older.kbID, older.buildStr, older.date.Format("January 2006"))),
+					slog.String("newer", fmt.Sprintf("KB%s %s %s", newer.kbID, newer.buildStr, newer.date.Format("January 2006"))))
+			}
+
+			links = append(links, link{older: older.kbID, newer: newer.kbID})
+		}
+	}
+
+	kbs := make(map[string]*microsoftkbTypes.KB, len(us))
+	for _, u := range us {
+		kb, ok := kbs[u.kbID]
+		if !ok {
+			kb = &microsoftkbTypes.KB{
+				KBID: u.kbID,
+				URL:  u.url,
+				DataSource: sourceTypes.Source{
+					ID: sourceTypes.MicrosoftSCOM,
+				},
+			}
+			kbs[u.kbID] = kb
+		}
+		if !slices.Contains(kb.Products, u.version) {
+			kb.Products = append(kb.Products, u.version)
+		}
+		if !slices.Contains(kb.DataSource.Raws, u.raw) {
+			kb.DataSource.Raws = append(kb.DataSource.Raws, u.raw)
+		}
+	}
+
+	for _, l := range links {
+		// One update rollup is one KB across three components, so a component
+		// can name an edge another has already named. It is one edge either way.
+		if l.older == l.newer {
+			continue
+		}
+		if kb, ok := kbs[l.older]; ok {
+			s := microsoftkbSupersededByTypes.SupersededBy{KBID: l.newer}
+			if !slices.Contains(kb.SupersededBy, s) {
+				kb.SupersededBy = append(kb.SupersededBy, s)
+			}
+		}
+		if kb, ok := kbs[l.newer]; ok {
+			s := microsoftkbSupersedesTypes.Supersedes{KBID: l.older}
+			if !slices.Contains(kb.Supersedes, s) {
+				kb.Supersedes = append(kb.Supersedes, s)
+			}
+		}
+	}
+
+	out := make([]microsoftkbTypes.KB, 0, len(kbs))
+	for _, kb := range kbs {
+		out = append(out, *kb)
+	}
+	return out
+}

--- a/pkg/extract/microsoft/scom/scom_test.go
+++ b/pkg/extract/microsoft/scom/scom_test.go
@@ -1,0 +1,126 @@
+package scom_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/extract/microsoft/scom"
+	utiltest "github.com/MaineK00n/vuls-data-update/pkg/extract/util/test"
+)
+
+// The fixture is the article and its includes as fetched.
+//
+// An update rollup is one KB and three builds -- the management server, the
+// agent and gateway and the SCX agent each advance on their own numbers -- so
+// the component is the chain and a KB takes its place in each of them. The
+// components do not advance in step: Operations Manager 2025's agent skipped a
+// rollup its management server took, which is why KB5068304 is superseded by
+// two KBs rather than one.
+//
+// Which product version a table is for is in neither the table nor the file it
+// sits in. The article is INCLUDE directives, and the file each pulls in is
+// named for the version, so the path is what says it -- and the article itself,
+// along with the note one of its includes brings in, holds no tables at all.
+//
+// The KB is a bare number linked to the support site, so it is read from the
+// link. The SCX agent's tables put a version linked to a GitHub release in the
+// same column, and the general availability rows leave it empty or write a
+// dash; none of the three is a KB.
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		hasError bool
+	}{
+		{
+			name: "happy",
+			args: "./testdata/fixtures/happy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := scom.Extract(tt.args, scom.WithDir(dir))
+			switch {
+			case err != nil && !tt.hasError:
+				t.Error("unexpected error:", err)
+			case err == nil && tt.hasError:
+				t.Error("expected error has not occurred")
+			case err != nil && tt.hasError:
+				return
+			default:
+				ep, err := filepath.Abs(filepath.Join("testdata", "golden"))
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				gp, err := filepath.Abs(dir)
+				if err != nil {
+					t.Error("unexpected error:", err)
+				}
+				utiltest.Diff(t, ep, gp)
+			}
+		})
+	}
+}
+
+// The product a table is for is in the path of the file it was included from,
+// and in nothing else.
+func TestVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+		ok   bool
+	}{
+		{name: "an included table file", raw: "SystemCenterDocs/includes/release-build-versions-2025.json", want: "System Center 2025 - Operations Manager", ok: true},
+		{name: "another", raw: "SystemCenterDocs/includes/release-build-versions-2016.json", want: "System Center 2016 - Operations Manager", ok: true},
+		{name: "the article that includes them", raw: "SystemCenterDocs/scom/release-build-versions.json", ok: false},
+		{name: "a note one of them brings in", raw: "SystemCenterDocs/includes/discontinue-spf-2025.json", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := scom.Version(tt.raw)
+			if ok != tt.ok {
+				t.Fatalf("version() ok = %v, want %v", ok, tt.ok)
+			}
+			if !tt.ok {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("version(). (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// Every row of the article is a month with no day.
+func TestReleaseDate(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want time.Time
+		ok   bool
+	}{
+		{name: "a month", s: "November 2025", want: time.Date(2025, time.November, 1, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "another", s: "September 2016", want: time.Date(2016, time.September, 1, 0, 0, 0, 0, time.UTC), ok: true},
+		{name: "a month that is not one", s: "Smarch 2016", ok: false},
+		{name: "nothing", s: "", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := scom.ReleaseDate(tt.s)
+			if ok != tt.ok {
+				t.Fatalf("releaseDate() ok = %v, want %v", ok, tt.ok)
+			}
+			if !tt.ok {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("releaseDate(). (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/extract/microsoft/scom/testdata/fixtures/happy/raw/SystemCenterDocs/includes/discontinue-spf-2025.json
+++ b/pkg/extract/microsoft/scom/testdata/fixtures/happy/raw/SystemCenterDocs/includes/discontinue-spf-2025.json
@@ -1,0 +1,3 @@
+{
+	"path": "SystemCenterDocs/includes/discontinue-spf-2025.md"
+}

--- a/pkg/extract/microsoft/scom/testdata/fixtures/happy/raw/SystemCenterDocs/includes/release-build-versions-2016.json
+++ b/pkg/extract/microsoft/scom/testdata/fixtures/happy/raw/SystemCenterDocs/includes/release-build-versions-2016.json
@@ -1,0 +1,168 @@
+{
+	"path": "SystemCenterDocs/includes/release-build-versions-2016.md",
+	"tables": [
+		{
+			"heading": "Management Server (and other components*)",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "7.2.11719.0"
+					},
+					{},
+					{
+						"text": "September 2016"
+					},
+					{
+						"text": "General Availability release"
+					}
+				],
+				[
+					{
+						"text": "7.2.11759.0"
+					},
+					{
+						"text": "3190029",
+						"href": "https://support.microsoft.com/kb/3190029"
+					},
+					{
+						"text": "October 2016"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				],
+				[
+					{
+						"text": "7.2.11822.0"
+					},
+					{
+						"text": "3209591",
+						"href": "https://support.microsoft.com/kb/3209591"
+					},
+					{
+						"text": "February 2017"
+					},
+					{
+						"text": "Update Rollup 2"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Agent and Gateway",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "8.0.10918.0"
+					},
+					{},
+					{
+						"text": "September 2016"
+					},
+					{
+						"text": "General Availability release"
+					}
+				],
+				[
+					{
+						"text": "8.0.10931.0"
+					},
+					{
+						"text": "3190029",
+						"href": "https://support.microsoft.com/kb/3190029"
+					},
+					{
+						"text": "October 2016"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				],
+				[
+					{
+						"text": "8.0.10949.0"
+					},
+					{
+						"text": "3209591",
+						"href": "https://support.microsoft.com/kb/3209591"
+					},
+					{
+						"text": "February 2017"
+					},
+					{
+						"text": "Update Rollup 2"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SCX Agent",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Agent Version",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "7.6.1064.0"
+					},
+					{},
+					{
+						"text": "September 2016"
+					},
+					{
+						"text": "1.6.2-336"
+					},
+					{
+						"text": "General Availability release"
+					}
+				],
+				[
+					{
+						"text": "7.6.1067.0"
+					},
+					{},
+					{
+						"text": "October 2016"
+					},
+					{
+						"text": "1.6.2-337"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				],
+				[
+					{
+						"text": "7.6.1072.0"
+					},
+					{},
+					{
+						"text": "February 2017"
+					},
+					{
+						"text": "1.6.2-338"
+					},
+					{
+						"text": "Update Rollup 2"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/extract/microsoft/scom/testdata/fixtures/happy/raw/SystemCenterDocs/includes/release-build-versions-2025.json
+++ b/pkg/extract/microsoft/scom/testdata/fixtures/happy/raw/SystemCenterDocs/includes/release-build-versions-2025.json
@@ -1,0 +1,177 @@
+{
+	"path": "SystemCenterDocs/includes/release-build-versions-2025.md",
+	"tables": [
+		{
+			"heading": "Management Server (and other components*)",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "10.25.10132.0"
+					},
+					{
+						"text": "-"
+					},
+					{
+						"text": "November 2024"
+					},
+					{
+						"text": "General Availability"
+					}
+				],
+				[
+					{
+						"text": "10.25.10324.0"
+					},
+					{
+						"text": "5068304",
+						"href": "https://support.microsoft.com/kb/5068304"
+					},
+					{
+						"text": "November 2025"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				],
+				[
+					{
+						"text": "10.25.10377.0"
+					},
+					{
+						"text": "5073079",
+						"href": "https://support.microsoft.com/kb/5073079"
+					},
+					{
+						"text": "March 2026"
+					},
+					{
+						"text": "Update Rollup 1 MSRC Hotfix"
+					}
+				],
+				[
+					{
+						"text": "10.25.10644.0"
+					},
+					{
+						"text": "5080648",
+						"href": "https://support.microsoft.com/kb/5080648"
+					},
+					{
+						"text": "March 2026"
+					},
+					{
+						"text": "Update Rollup 1 Hotfix"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Agent and Gateway",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "10.25.10079.0"
+					},
+					{
+						"text": "-"
+					},
+					{
+						"text": "November 2024"
+					},
+					{
+						"text": "General Availability"
+					}
+				],
+				[
+					{
+						"text": "10.25.10994.0"
+					},
+					{
+						"text": "5068304",
+						"href": "https://support.microsoft.com/kb/5068304"
+					},
+					{
+						"text": "November 2025"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				],
+				[
+					{
+						"text": "10.25.11182.0"
+					},
+					{
+						"text": "5080648",
+						"href": "https://support.microsoft.com/kb/5080648"
+					},
+					{
+						"text": "March 2026"
+					},
+					{
+						"text": "Update Rollup 1 Hotfix"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SCX Agent",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Agent Version",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "10.25.1005.0"
+					},
+					{
+						"text": "-"
+					},
+					{
+						"text": "November 2024"
+					},
+					{
+						"text": "1.9.1-0"
+					},
+					{
+						"text": "General Availability"
+					}
+				],
+				[
+					{
+						"text": "10.25.1016.0"
+					},
+					{
+						"text": "5068304",
+						"href": "https://support.microsoft.com/kb/5068304"
+					},
+					{
+						"text": "November 2025"
+					},
+					{
+						"text": "1.9.3-0"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/extract/microsoft/scom/testdata/fixtures/happy/raw/SystemCenterDocs/scom/release-build-versions.json
+++ b/pkg/extract/microsoft/scom/testdata/fixtures/happy/raw/SystemCenterDocs/scom/release-build-versions.json
@@ -1,0 +1,3 @@
+{
+	"path": "SystemCenterDocs/scom/release-build-versions.md"
+}

--- a/pkg/extract/microsoft/scom/testdata/golden/datasource.json
+++ b/pkg/extract/microsoft/scom/testdata/golden/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "microsoft-scom",
+	"name": "Microsoft System Center Operations Manager Build Versions"
+}

--- a/pkg/extract/microsoft/scom/testdata/golden/microsoftkb/3190xxx/3190029.json
+++ b/pkg/extract/microsoft/scom/testdata/golden/microsoftkb/3190xxx/3190029.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "3190029",
+	"url": "https://support.microsoft.com/kb/3190029",
+	"products": [
+		"System Center 2016 - Operations Manager"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "3209591"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-scom",
+		"raws": [
+			"SystemCenterDocs/includes/release-build-versions-2016.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/scom/testdata/golden/microsoftkb/3209xxx/3209591.json
+++ b/pkg/extract/microsoft/scom/testdata/golden/microsoftkb/3209xxx/3209591.json
@@ -1,0 +1,18 @@
+{
+	"kb_id": "3209591",
+	"url": "https://support.microsoft.com/kb/3209591",
+	"products": [
+		"System Center 2016 - Operations Manager"
+	],
+	"supersedes": [
+		{
+			"kb_id": "3190029"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-scom",
+		"raws": [
+			"SystemCenterDocs/includes/release-build-versions-2016.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/scom/testdata/golden/microsoftkb/5068xxx/5068304.json
+++ b/pkg/extract/microsoft/scom/testdata/golden/microsoftkb/5068xxx/5068304.json
@@ -1,0 +1,21 @@
+{
+	"kb_id": "5068304",
+	"url": "https://support.microsoft.com/kb/5068304",
+	"products": [
+		"System Center 2025 - Operations Manager"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5073079"
+		},
+		{
+			"kb_id": "5080648"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-scom",
+		"raws": [
+			"SystemCenterDocs/includes/release-build-versions-2025.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/scom/testdata/golden/microsoftkb/5073xxx/5073079.json
+++ b/pkg/extract/microsoft/scom/testdata/golden/microsoftkb/5073xxx/5073079.json
@@ -1,0 +1,23 @@
+{
+	"kb_id": "5073079",
+	"url": "https://support.microsoft.com/kb/5073079",
+	"products": [
+		"System Center 2025 - Operations Manager"
+	],
+	"superseded_by": [
+		{
+			"kb_id": "5080648"
+		}
+	],
+	"supersedes": [
+		{
+			"kb_id": "5068304"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-scom",
+		"raws": [
+			"SystemCenterDocs/includes/release-build-versions-2025.json"
+		]
+	}
+}

--- a/pkg/extract/microsoft/scom/testdata/golden/microsoftkb/5080xxx/5080648.json
+++ b/pkg/extract/microsoft/scom/testdata/golden/microsoftkb/5080xxx/5080648.json
@@ -1,0 +1,21 @@
+{
+	"kb_id": "5080648",
+	"url": "https://support.microsoft.com/kb/5080648",
+	"products": [
+		"System Center 2025 - Operations Manager"
+	],
+	"supersedes": [
+		{
+			"kb_id": "5068304"
+		},
+		{
+			"kb_id": "5073079"
+		}
+	],
+	"data_source": {
+		"id": "microsoft-scom",
+		"raws": [
+			"SystemCenterDocs/includes/release-build-versions-2025.json"
+		]
+	}
+}

--- a/pkg/extract/types/source/source.go
+++ b/pkg/extract/types/source/source.go
@@ -89,6 +89,7 @@ const (
 	MicrosoftDeployment        SourceID = "microsoft-deployment"
 	MicrosoftMSUC              SourceID = "microsoft-msuc"
 	MicrosoftProduct           SourceID = "microsoft-product"
+	MicrosoftSCOM              SourceID = "microsoft-scom"
 	MicrosoftServicing         SourceID = "microsoft-servicing"
 	MicrosoftVulnerability     SourceID = "microsoft-vulnerability"
 	MicrosoftWSUSSCN2          SourceID = "microsoft-wsusscn2"

--- a/pkg/fetch/microsoft/scom/scom.go
+++ b/pkg/fetch/microsoft/scom/scom.go
@@ -1,0 +1,431 @@
+// Package scom fetches Microsoft's System Center Operations Manager build
+// versions -- the article listing every update rollup the product has shipped,
+// from Operations Manager 2016 to 2025.
+//
+// It is a small source, 36 KBs, and it is fetched as Markdown from
+// MicrosoftDocs/SystemCenterDocs because the repository is public and keeps the
+// article's history.
+//
+// The article holds no tables of its own. It is four INCLUDE directives, one
+// per product version, each pulling in a file of three tables -- the management
+// server, the agent and gateway, and the SCX agent, which advance on their own
+// build numbers under the one update rollup. So the includes are read out of the
+// article and fetched too, and every file is stored at the path it has in the
+// repository, which is what says which product version an include is for.
+//
+// Only one hop is followed. The included files are tables and prose and include
+// nothing further, and a crawl that kept going would leave this article for the
+// rest of the docset.
+//
+// fetch writes <dir>/origin verbatim and then produces <dir>/raw by reading it
+// back, never the HTTP response, so raw/ is reproducible from origin/ alone.
+package scom
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/util"
+	utilhttp "github.com/MaineK00n/vuls-data-update/pkg/fetch/util/http"
+)
+
+const (
+	baseURL = "https://raw.githubusercontent.com/MicrosoftDocs/SystemCenterDocs/main"
+
+	// articlePath is the article's path in the docs repository, which is both
+	// where it is fetched from and where its history is read.
+	articlePath = "SystemCenterDocs/scom/release-build-versions.md"
+)
+
+var (
+	// separatorPattern is the row of dashes under a Markdown table's header. It
+	// is the only row that is not content.
+	separatorPattern = regexp.MustCompile(`^:?-{2,}:?$`)
+
+	headingPattern = regexp.MustCompile(`^#{1,6}\s+(.*)$`)
+
+	// boldPattern is a line of nothing but bold text, which is how the included
+	// files head their tables. They name the component a table is for --
+	// "**Management Server (and other components*)**" -- and Microsoft writes
+	// them this way rather than as headings, so a reader that looked only for
+	// headings would find every table filed under the article's title.
+	boldPattern = regexp.MustCompile(`^\*\*(.+?)\*\*$`)
+
+	// includePattern is the directive that stands in for the tables. The
+	// article is four of these and nothing else.
+	includePattern = regexp.MustCompile(`^\[!INCLUDE\s*\[[^\]]*\]\(([^)]+)\)\s*\]`)
+
+	// linkPattern is a Markdown link. Only the first of a cell is taken: a cell
+	// naming two links names two things, and which of them is the cell's own
+	// address is not this parser's to decide.
+	linkPattern = regexp.MustCompile(`\[([^\]]*)\]\(([^)]*)\)`)
+
+	// markupPattern is the emphasis and the line breaks Microsoft writes inside
+	// cells, which are presentation and not content.
+	markupPattern = regexp.MustCompile(`\*\*|<br\s*/?>|__`)
+)
+
+type options struct {
+	baseURL string
+	dir     string
+	retry   int
+	wait    time.Duration
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type baseURLOption string
+
+func (u baseURLOption) apply(opts *options) {
+	opts.baseURL = string(u)
+}
+
+func WithBaseURL(url string) Option {
+	return baseURLOption(url)
+}
+
+type dirOption string
+
+func (d dirOption) apply(opts *options) {
+	opts.dir = string(d)
+}
+
+func WithDir(dir string) Option {
+	return dirOption(dir)
+}
+
+type retryOption int
+
+func (r retryOption) apply(opts *options) {
+	opts.retry = int(r)
+}
+
+func WithRetry(retry int) Option {
+	return retryOption(retry)
+}
+
+type waitOption time.Duration
+
+func (w waitOption) apply(opts *options) {
+	opts.wait = time.Duration(w)
+}
+
+func WithWait(wait time.Duration) Option {
+	return waitOption(wait)
+}
+
+// Fetch stores the article under <dir>/origin and the tables it carries under
+// <dir>/raw.
+func Fetch(opts ...Option) error {
+	options := &options{
+		baseURL: baseURL,
+		dir:     filepath.Join(util.CacheDir(), "fetch", "microsoft", "scom"),
+		retry:   3,
+		wait:    1 * time.Second,
+	}
+
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	if err := util.RemoveAll(options.dir); err != nil {
+		return errors.Wrapf(err, "remove %s", options.dir)
+	}
+
+	if err := options.fetch(); err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+
+	if err := options.convert(); err != nil {
+		return errors.Wrap(err, "convert")
+	}
+
+	return nil
+}
+
+// fetch stores the article and the files it includes, as served.
+func (opts options) fetch() error {
+	slog.Info("Fetch Microsoft System Center Operations Manager Build Versions")
+
+	client := utilhttp.NewClient(utilhttp.WithClientRetryMax(opts.retry))
+
+	bs, err := opts.get(client, articlePath)
+	if err != nil {
+		return errors.Wrapf(err, "get %s", articlePath)
+	}
+	if err := writeOrigin(opts.dir, articlePath, bs); err != nil {
+		return errors.Wrapf(err, "write %s", articlePath)
+	}
+
+	includes := parseIncludes(string(bs), articlePath)
+
+	// An article of four includes that names none is an article whose shape has
+	// changed, and it would extract to nothing at all with the run green.
+	if len(includes) == 0 {
+		return errors.Errorf("no include in %s", articlePath)
+	}
+
+	slog.Info("Fetch included files", slog.Int("count", len(includes)))
+
+	for _, p := range includes {
+		bs, err := opts.get(client, p)
+		if err != nil {
+			return errors.Wrapf(err, "get %s", p)
+		}
+		if err := writeOrigin(opts.dir, p, bs); err != nil {
+			return errors.Wrapf(err, "write %s", p)
+		}
+	}
+
+	return nil
+}
+
+// get retrieves one file of the repository.
+func (opts options) get(client *utilhttp.Client, p string) ([]byte, error) {
+	u, err := url.JoinPath(opts.baseURL, p)
+	if err != nil {
+		return nil, errors.Wrapf(err, "join %s and %s", opts.baseURL, p)
+	}
+
+	var content []byte
+	if err := client.PipelineGet([]string{u}, 1, opts.wait, true, func(resp *http.Response) error {
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			return errors.Errorf("error response with status code %d, url: %s", resp.StatusCode, resp.Request.URL)
+		}
+
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", resp.Request.URL)
+		}
+		content = bs
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "pipeline get")
+	}
+
+	return content, nil
+}
+
+// parseIncludes reads the files an article pulls its tables in from, as paths
+// in the repository.
+//
+// A target is resolved against the article's own directory and refused if it
+// climbs out of the repository, an INCLUDE being a path off the network like
+// any other.
+func parseIncludes(doc, from string) []string {
+	var out []string
+	for line := range strings.SplitSeq(doc, "\n") {
+		m := includePattern.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+
+		p := path.Join(path.Dir(from), m[1])
+		if p == ".." || strings.HasPrefix(p, "../") {
+			slog.Warn("include points out of the repository", slog.String("from", from), slog.String("target", m[1]))
+			continue
+		}
+		if slices.Contains(out, p) {
+			continue
+		}
+
+		out = append(out, p)
+	}
+
+	return out
+}
+
+// convert reads origin/ back and writes raw/, at the path its origin/
+// counterpart has. Going through the stored bytes rather than the response is
+// what lets the tree be re-derived after this parser changes.
+func (opts options) convert() error {
+	slog.Info("Convert origin to raw")
+
+	root := filepath.Join(opts.dir, "origin")
+
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(p) != ".md" {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return errors.Wrapf(err, "rel %s", p)
+		}
+		rel = filepath.ToSlash(rel)
+
+		bs, err := os.ReadFile(p)
+		if err != nil {
+			return errors.Wrapf(err, "read %s", p)
+		}
+
+		a := parseArticle(string(bs), rel)
+
+		if err := util.Write(filepath.Join(opts.dir, "raw", fmt.Sprintf("%s.json", strings.TrimSuffix(rel, ".md"))), a); err != nil {
+			return errors.Wrapf(err, "write %s", filepath.Join(opts.dir, "raw", fmt.Sprintf("%s.json", strings.TrimSuffix(rel, ".md"))))
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrapf(err, "walk %s", root)
+	}
+
+	return nil
+}
+
+// writeOrigin stores content under <dir>/origin/<name> as served.
+//
+// Nothing derived from the response is recorded alongside it -- no fetch
+// timestamp, no ETag, no commit. Those change on every run even when the article
+// does not, and would turn every fetch into a diff, drowning the signal this
+// tree exists to carry: that Microsoft revised the article.
+func writeOrigin(dir, name string, content []byte) error {
+	path := filepath.Join(dir, "origin", filepath.FromSlash(name))
+
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return errors.Wrapf(err, "mkdir %s", filepath.Dir(path))
+	}
+
+	if err := os.WriteFile(path, content, 0666); err != nil {
+		return errors.Wrapf(err, "write %s", path)
+	}
+
+	return nil
+}
+
+// parseArticle reads an article's tables, each under the heading it follows.
+func parseArticle(doc, path string) Article {
+	a := Article{Path: path}
+
+	var heading string
+	// The table being read, as an index rather than a pointer: appending the
+	// next one may move the slice out from under a pointer into it.
+	table := -1
+	for _, line := range strings.Split(doc, "\n") {
+		line = strings.TrimRight(line, "\r")
+
+		if m := headingPattern.FindStringSubmatch(line); m != nil {
+			heading = strings.TrimSpace(m[1])
+			table = -1
+			continue
+		}
+
+		if m := boldPattern.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			heading = strings.TrimSpace(m[1])
+			table = -1
+			continue
+		}
+
+		cells, ok := parseRow(line, table >= 0)
+		if !ok {
+			table = -1
+			continue
+		}
+		if cells == nil {
+			// The dashes under a header. They say how the columns align and
+			// nothing about what is in them.
+			continue
+		}
+
+		if table < 0 {
+			a.Tables = append(a.Tables, Table{Heading: heading, Header: texts(cells)})
+			table = len(a.Tables) - 1
+			continue
+		}
+		a.Tables[table].Rows = append(a.Tables[table].Rows, cells)
+	}
+
+	// A table of nothing but a header is not a table. The article carries one:
+	// its opening summary is a header row Microsoft never filled in.
+	a.Tables = slices.DeleteFunc(a.Tables, func(t Table) bool { return len(t.Rows) == 0 })
+
+	return a
+}
+
+// parseRow reads one line as a table row, reporting false for the lines that
+// are not one and a nil row for the separator under a header.
+//
+// A row is recognised by its leading pipe, except inside a table, where a line
+// carrying pipes is taken as a row without one. Microsoft has served such a row
+// -- the SQL Server 2016 article has one that lost its leading pipe -- and the
+// docs pipeline renders it as part of the table, so a reader that stopped there
+// would end the table early and read the rest of it as a new one, header and
+// all. Being inside a table is what makes it safe: the prose between tables is
+// never taken this way.
+func parseRow(line string, inTable bool) ([]Cell, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return nil, false
+	}
+
+	if !strings.HasPrefix(trimmed, "|") {
+		if !inTable || !strings.Contains(trimmed, "|") {
+			return nil, false
+		}
+		slog.Warn("table row without a leading pipe", slog.String("row", trimmed))
+	}
+
+	fields := strings.Split(strings.Trim(trimmed, "|"), "|")
+
+	separator := true
+	for _, f := range fields {
+		if !separatorPattern.MatchString(strings.TrimSpace(f)) {
+			separator = false
+			break
+		}
+	}
+	if separator {
+		return nil, true
+	}
+
+	cells := make([]Cell, 0, len(fields))
+	for _, f := range fields {
+		cells = append(cells, parseCell(f))
+	}
+
+	return cells, true
+}
+
+// parseCell reads a cell's text and the first link it carries.
+func parseCell(s string) Cell {
+	var href string
+	if m := linkPattern.FindStringSubmatch(s); m != nil {
+		href = strings.TrimSpace(m[2])
+	}
+
+	// The link's text stands in for the link, which is what the cell reads as.
+	text := linkPattern.ReplaceAllString(s, "$1")
+	text = markupPattern.ReplaceAllString(text, " ")
+
+	return Cell{Text: strings.Join(strings.Fields(text), " "), Href: href}
+}
+
+func texts(cells []Cell) []string {
+	out := make([]string, 0, len(cells))
+	for _, c := range cells {
+		out = append(out, c.Text)
+	}
+	return out
+}

--- a/pkg/fetch/microsoft/scom/scom_test.go
+++ b/pkg/fetch/microsoft/scom/scom_test.go
@@ -1,0 +1,149 @@
+package scom_test
+
+import (
+	"io/fs"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls-data-update/pkg/fetch/microsoft/scom"
+)
+
+// The fixture is the article and the files it includes, as authored.
+//
+// The article holds no tables of its own -- it is INCLUDE directives and prose
+// -- so the tables have to be followed to. One of the includes it names is a
+// note rather than a table, and is fetched and stored like the rest: which of
+// them carry tables is not the crawl's to decide.
+//
+// The included files head their tables with bold text rather than headings, so
+// a reader looking only for headings would file every table under the file's
+// title. The SCX agent's tables carry a column the others do not, and its KB
+// column holds a version linked to a GitHub release rather than a KB.
+func TestFetch(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		golden   string
+		hasError bool
+	}{
+		{
+			name:    "happy",
+			fixture: "happy",
+			golden:  "happy",
+		},
+		{
+			// An article of four includes that names none is an article whose
+			// shape has changed, and it would extract to nothing at all with
+			// the run green.
+			name:     "article without includes",
+			fixture:  "includeless",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(handler(t, tt.fixture))
+			defer ts.Close()
+
+			dir := t.TempDir()
+			err := scom.Fetch(
+				scom.WithBaseURL(ts.URL),
+				scom.WithDir(dir),
+				scom.WithRetry(0),
+				scom.WithWait(0),
+			)
+			switch {
+			case err != nil && !tt.hasError:
+				t.Fatalf("unexpected error. err: %v", err)
+			case err == nil && tt.hasError:
+				t.Fatal("expected error has not occurred")
+			case err != nil:
+				return
+			}
+
+			diff(t, filepath.Join("testdata", "golden", tt.golden), dir)
+		})
+	}
+}
+
+// handler serves a fixture tree the way raw.githubusercontent.com serves the
+// repository: one document per path, and nothing anywhere else.
+func handler(t *testing.T, fixture string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		bs, err := os.ReadFile(filepath.Join("testdata", "fixtures", fixture, filepath.Clean(r.URL.Path)))
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(bs)
+	}
+}
+
+// diff compares the produced tree against golden byte for byte. Bytes rather
+// than parsed content: origin/ is only worth keeping if it reproduces exactly,
+// and raw/ is written deterministically, so any difference at all is a
+// regression.
+func diff(t *testing.T, golden, got string) {
+	t.Helper()
+
+	want := walk(t, golden)
+	have := walk(t, got)
+
+	if d := cmp.Diff(slices.Sorted(maps.Keys(want)), slices.Sorted(maps.Keys(have))); d != "" {
+		t.Errorf("files (-expected +got):\n%s", d)
+	}
+
+	for n, w := range want {
+		h, ok := have[n]
+		if !ok {
+			continue
+		}
+		if d := cmp.Diff(string(w), string(h)); d != "" {
+			t.Errorf("%s (-expected +got):\n%s", n, d)
+		}
+	}
+}
+
+func walk(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+
+	out := make(map[string][]byte)
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+
+		bs, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+
+		out[filepath.ToSlash(rel)] = bs
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walk %s. err: %v", root, err)
+	}
+
+	return out
+}

--- a/pkg/fetch/microsoft/scom/testdata/fixtures/happy/SystemCenterDocs/includes/discontinue-spf-2025.md
+++ b/pkg/fetch/microsoft/scom/testdata/fixtures/happy/SystemCenterDocs/includes/discontinue-spf-2025.md
@@ -1,0 +1,15 @@
+---
+ms.assetid: 6361dd76-0c8a-4575-9b6a-43916408f448
+title: include file
+description: include file with notes on end of support information for 1801 and 1807, notes for use in all articles under 1801 and 1807 monikers
+author: Jeronika-MS
+ms.author: v-gajeronika
+ms.date:  10/27/2025
+ms.topic:  include
+ms.service: system-center
+ms.subservice: data-protection-manager
+ms.update-cycle: 1095-days
+---
+> [!IMPORTANT]
+>
+>Service Provider Foundation (SPF) is discontinued from System Center 2025. However, SPF 2022 will continue to work with System Center 2025 components.

--- a/pkg/fetch/microsoft/scom/testdata/fixtures/happy/SystemCenterDocs/includes/release-build-versions-2016.md
+++ b/pkg/fetch/microsoft/scom/testdata/fixtures/happy/SystemCenterDocs/includes/release-build-versions-2016.md
@@ -1,0 +1,44 @@
+---
+title: System Center 2016 - Operations Manager Release Build Versions
+description: Include file that shows the list of release builds for System Center 2016 - Operations Manager.
+author: Jeronika-MS
+ms.author: v-gajeronika
+ms.date: 10/02/2024
+ms.update-cycle: 1095-days
+ms.service: system-center
+ms.assetid:
+ms.subservice: operations-manager
+ms.topic: include
+---
+
+## Operations Manager 2016 build versions
+
+>[!NOTE]
+>All System Center Operations Manager update rollups are cumulative. This means you don't need to apply them in order; you can always apply the latest update. If you've deployed System Center 2016 - Operations Manager and never applied an update rollup, you can proceed to install the latest one available.
+
+The following tables list the release history for Operations Manager 2016.
+
+### Management Server (and other components*)
+|Build Number |KB |Release Date |Description |
+|-------------|---|-------------|------------|
+|7.2.11719.0 ||September 2016 |General Availability release|  
+|7.2.11759.0 |[3190029](https://support.microsoft.com/kb/3190029) |October 2016 |Update Rollup 1 |  
+|7.2.11822.0 |[3209591](https://support.microsoft.com/kb/3209591) |February 2017 |Update Rollup 2 |  
+
+### Agent and Gateway
+|Build Number |KB |Release Date |Description |
+|-------------|---|-------------|------------|
+|8.0.10918.0 ||September 2016 |General Availability release|  
+|8.0.10931.0 |[3190029](https://support.microsoft.com/kb/3190029) |October 2016 |Update Rollup 1 |  
+|8.0.10949.0 |[3209591](https://support.microsoft.com/kb/3209591) |February 2017 |Update Rollup 2 |  
+
+### SCX Agent
+|Build Number |KB |Release Date |Agent Version |Description |
+|-------------|---|-------------|--------------|------------|
+|7.6.1064.0 ||September 2016 |1.6.2-336 |General Availability release|  
+|7.6.1067.0 ||October 2016 |1.6.2-337 |Update Rollup 1 |  
+|7.6.1072.0 ||February 2017 |1.6.2-338 |Update Rollup 2 |  
+
+ \* *The other components include: Databases, Operations Consoles, Reporting, and Web Consoles.*
+
+ <sup>1</sup> *All System Center Operations Manager update rollups are cumulative. This means you don't need to apply them in order; you can always apply the latest update. However, there's one exception to this upgrade behavior. If you want the ability to uninstall UR4, you should ensure you've previously applied UR2 or UR3, which fixed an uninstall issue. Update rollups subsequent to UR4 can be uninstalled without previous rollups being applied.*

--- a/pkg/fetch/microsoft/scom/testdata/fixtures/happy/SystemCenterDocs/includes/release-build-versions-2025.md
+++ b/pkg/fetch/microsoft/scom/testdata/fixtures/happy/SystemCenterDocs/includes/release-build-versions-2025.md
@@ -1,0 +1,40 @@
+---
+title: System Center 2025 - Operations Manager Release Build Versions
+description: Include file that shows the list of release builds for System Center 2025 - Operations Manager.
+author: Jeronika-MS
+ms.author: v-gajeronika
+ms.date: 03/03/2026
+ms.service: system-center
+ms.assetid: 
+ms.subservice: operations-manager
+ms.topic: include
+ms.update-cycle: 1095-days
+---
+
+## Operations Manager 2025 build versions
+
+The following tables list the release history for Operations Manager 2025.
+
+### Management Server (and other components*)
+
+|Build Number |KB |Release Date |Description |
+|-------------|---|-------------|------------|
+|10.25.10132.0|-|November 2024 |General Availability |
+|10.25.10324.0| [5068304](https://support.microsoft.com/kb/5068304) | November 2025 | Update Rollup 1 |
+|10.25.10377.0|	[5073079](https://support.microsoft.com/kb/5073079) | March 2026 | Update Rollup 1 MSRC Hotfix |
+|10.25.10644.0|	[5080648](https://support.microsoft.com/kb/5080648) | March 2026 | Update Rollup 1 Hotfix |
+
+### Agent and Gateway
+
+|Build Number |KB |Release Date |Description |
+|-------------|---|-------------|------------|
+|10.25.10079.0|-|November 2024 |General Availability |
+|10.25.10994.0| [5068304](https://support.microsoft.com/kb/5068304) | November 2025 | Update Rollup 1 |
+|10.25.11182.0|	[5080648](https://support.microsoft.com/kb/5080648) | March 2026 | Update Rollup 1 Hotfix |
+
+### SCX Agent
+
+|Build Number |KB |Release Date |Agent Version |Description |
+|-------------|---|-------------|--------------|------------|
+|10.25.1005.0|-|November 2024 |1.9.1-0|General Availability |
+|10.25.1016.0| [5068304](https://support.microsoft.com/kb/5068304) | November 2025 |1.9.3-0| Update Rollup 1 |

--- a/pkg/fetch/microsoft/scom/testdata/fixtures/happy/SystemCenterDocs/scom/release-build-versions.md
+++ b/pkg/fetch/microsoft/scom/testdata/fixtures/happy/SystemCenterDocs/scom/release-build-versions.md
@@ -1,0 +1,28 @@
+---
+title: Release build versions for System Center Operations Manager
+ms.date: 08/03/2026
+---
+
+# System Center - Operations Manager build versions
+
+::: moniker range="sc-om-2025"
+
+[!INCLUDE [discontinue-spf-2025.md](../includes/discontinue-spf-2025.md)]
+
+This article lists Microsoft System Center 2025 - Operations Manager build versions.
+
+[!INCLUDE [release-build-versions-2025.md](../includes/release-build-versions-2025.md)]
+
+::: moniker-end
+
+::: moniker range="sc-om-2016"
+
+This article lists Microsoft System Center 2016 - Operations Manager build versions.
+
+[!INCLUDE [release-build-versions-2016.md](../includes/release-build-versions-2016.md)]
+
+::: moniker-end
+
+## Next steps
+
+- See [What's New in Operations Manager](./whats-new-in-om.md).

--- a/pkg/fetch/microsoft/scom/testdata/fixtures/includeless/SystemCenterDocs/scom/release-build-versions.md
+++ b/pkg/fetch/microsoft/scom/testdata/fixtures/includeless/SystemCenterDocs/scom/release-build-versions.md
@@ -1,0 +1,7 @@
+---
+title: Release build versions for System Center Operations Manager
+---
+
+# System Center - Operations Manager build versions
+
+This content has moved.

--- a/pkg/fetch/microsoft/scom/testdata/golden/happy/origin/SystemCenterDocs/includes/discontinue-spf-2025.md
+++ b/pkg/fetch/microsoft/scom/testdata/golden/happy/origin/SystemCenterDocs/includes/discontinue-spf-2025.md
@@ -1,0 +1,15 @@
+---
+ms.assetid: 6361dd76-0c8a-4575-9b6a-43916408f448
+title: include file
+description: include file with notes on end of support information for 1801 and 1807, notes for use in all articles under 1801 and 1807 monikers
+author: Jeronika-MS
+ms.author: v-gajeronika
+ms.date:  10/27/2025
+ms.topic:  include
+ms.service: system-center
+ms.subservice: data-protection-manager
+ms.update-cycle: 1095-days
+---
+> [!IMPORTANT]
+>
+>Service Provider Foundation (SPF) is discontinued from System Center 2025. However, SPF 2022 will continue to work with System Center 2025 components.

--- a/pkg/fetch/microsoft/scom/testdata/golden/happy/origin/SystemCenterDocs/includes/release-build-versions-2016.md
+++ b/pkg/fetch/microsoft/scom/testdata/golden/happy/origin/SystemCenterDocs/includes/release-build-versions-2016.md
@@ -1,0 +1,44 @@
+---
+title: System Center 2016 - Operations Manager Release Build Versions
+description: Include file that shows the list of release builds for System Center 2016 - Operations Manager.
+author: Jeronika-MS
+ms.author: v-gajeronika
+ms.date: 10/02/2024
+ms.update-cycle: 1095-days
+ms.service: system-center
+ms.assetid:
+ms.subservice: operations-manager
+ms.topic: include
+---
+
+## Operations Manager 2016 build versions
+
+>[!NOTE]
+>All System Center Operations Manager update rollups are cumulative. This means you don't need to apply them in order; you can always apply the latest update. If you've deployed System Center 2016 - Operations Manager and never applied an update rollup, you can proceed to install the latest one available.
+
+The following tables list the release history for Operations Manager 2016.
+
+### Management Server (and other components*)
+|Build Number |KB |Release Date |Description |
+|-------------|---|-------------|------------|
+|7.2.11719.0 ||September 2016 |General Availability release|  
+|7.2.11759.0 |[3190029](https://support.microsoft.com/kb/3190029) |October 2016 |Update Rollup 1 |  
+|7.2.11822.0 |[3209591](https://support.microsoft.com/kb/3209591) |February 2017 |Update Rollup 2 |  
+
+### Agent and Gateway
+|Build Number |KB |Release Date |Description |
+|-------------|---|-------------|------------|
+|8.0.10918.0 ||September 2016 |General Availability release|  
+|8.0.10931.0 |[3190029](https://support.microsoft.com/kb/3190029) |October 2016 |Update Rollup 1 |  
+|8.0.10949.0 |[3209591](https://support.microsoft.com/kb/3209591) |February 2017 |Update Rollup 2 |  
+
+### SCX Agent
+|Build Number |KB |Release Date |Agent Version |Description |
+|-------------|---|-------------|--------------|------------|
+|7.6.1064.0 ||September 2016 |1.6.2-336 |General Availability release|  
+|7.6.1067.0 ||October 2016 |1.6.2-337 |Update Rollup 1 |  
+|7.6.1072.0 ||February 2017 |1.6.2-338 |Update Rollup 2 |  
+
+ \* *The other components include: Databases, Operations Consoles, Reporting, and Web Consoles.*
+
+ <sup>1</sup> *All System Center Operations Manager update rollups are cumulative. This means you don't need to apply them in order; you can always apply the latest update. However, there's one exception to this upgrade behavior. If you want the ability to uninstall UR4, you should ensure you've previously applied UR2 or UR3, which fixed an uninstall issue. Update rollups subsequent to UR4 can be uninstalled without previous rollups being applied.*

--- a/pkg/fetch/microsoft/scom/testdata/golden/happy/origin/SystemCenterDocs/includes/release-build-versions-2025.md
+++ b/pkg/fetch/microsoft/scom/testdata/golden/happy/origin/SystemCenterDocs/includes/release-build-versions-2025.md
@@ -1,0 +1,40 @@
+---
+title: System Center 2025 - Operations Manager Release Build Versions
+description: Include file that shows the list of release builds for System Center 2025 - Operations Manager.
+author: Jeronika-MS
+ms.author: v-gajeronika
+ms.date: 03/03/2026
+ms.service: system-center
+ms.assetid: 
+ms.subservice: operations-manager
+ms.topic: include
+ms.update-cycle: 1095-days
+---
+
+## Operations Manager 2025 build versions
+
+The following tables list the release history for Operations Manager 2025.
+
+### Management Server (and other components*)
+
+|Build Number |KB |Release Date |Description |
+|-------------|---|-------------|------------|
+|10.25.10132.0|-|November 2024 |General Availability |
+|10.25.10324.0| [5068304](https://support.microsoft.com/kb/5068304) | November 2025 | Update Rollup 1 |
+|10.25.10377.0|	[5073079](https://support.microsoft.com/kb/5073079) | March 2026 | Update Rollup 1 MSRC Hotfix |
+|10.25.10644.0|	[5080648](https://support.microsoft.com/kb/5080648) | March 2026 | Update Rollup 1 Hotfix |
+
+### Agent and Gateway
+
+|Build Number |KB |Release Date |Description |
+|-------------|---|-------------|------------|
+|10.25.10079.0|-|November 2024 |General Availability |
+|10.25.10994.0| [5068304](https://support.microsoft.com/kb/5068304) | November 2025 | Update Rollup 1 |
+|10.25.11182.0|	[5080648](https://support.microsoft.com/kb/5080648) | March 2026 | Update Rollup 1 Hotfix |
+
+### SCX Agent
+
+|Build Number |KB |Release Date |Agent Version |Description |
+|-------------|---|-------------|--------------|------------|
+|10.25.1005.0|-|November 2024 |1.9.1-0|General Availability |
+|10.25.1016.0| [5068304](https://support.microsoft.com/kb/5068304) | November 2025 |1.9.3-0| Update Rollup 1 |

--- a/pkg/fetch/microsoft/scom/testdata/golden/happy/origin/SystemCenterDocs/scom/release-build-versions.md
+++ b/pkg/fetch/microsoft/scom/testdata/golden/happy/origin/SystemCenterDocs/scom/release-build-versions.md
@@ -1,0 +1,28 @@
+---
+title: Release build versions for System Center Operations Manager
+ms.date: 08/03/2026
+---
+
+# System Center - Operations Manager build versions
+
+::: moniker range="sc-om-2025"
+
+[!INCLUDE [discontinue-spf-2025.md](../includes/discontinue-spf-2025.md)]
+
+This article lists Microsoft System Center 2025 - Operations Manager build versions.
+
+[!INCLUDE [release-build-versions-2025.md](../includes/release-build-versions-2025.md)]
+
+::: moniker-end
+
+::: moniker range="sc-om-2016"
+
+This article lists Microsoft System Center 2016 - Operations Manager build versions.
+
+[!INCLUDE [release-build-versions-2016.md](../includes/release-build-versions-2016.md)]
+
+::: moniker-end
+
+## Next steps
+
+- See [What's New in Operations Manager](./whats-new-in-om.md).

--- a/pkg/fetch/microsoft/scom/testdata/golden/happy/raw/SystemCenterDocs/includes/discontinue-spf-2025.json
+++ b/pkg/fetch/microsoft/scom/testdata/golden/happy/raw/SystemCenterDocs/includes/discontinue-spf-2025.json
@@ -1,0 +1,3 @@
+{
+	"path": "SystemCenterDocs/includes/discontinue-spf-2025.md"
+}

--- a/pkg/fetch/microsoft/scom/testdata/golden/happy/raw/SystemCenterDocs/includes/release-build-versions-2016.json
+++ b/pkg/fetch/microsoft/scom/testdata/golden/happy/raw/SystemCenterDocs/includes/release-build-versions-2016.json
@@ -1,0 +1,168 @@
+{
+	"path": "SystemCenterDocs/includes/release-build-versions-2016.md",
+	"tables": [
+		{
+			"heading": "Management Server (and other components*)",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "7.2.11719.0"
+					},
+					{},
+					{
+						"text": "September 2016"
+					},
+					{
+						"text": "General Availability release"
+					}
+				],
+				[
+					{
+						"text": "7.2.11759.0"
+					},
+					{
+						"text": "3190029",
+						"href": "https://support.microsoft.com/kb/3190029"
+					},
+					{
+						"text": "October 2016"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				],
+				[
+					{
+						"text": "7.2.11822.0"
+					},
+					{
+						"text": "3209591",
+						"href": "https://support.microsoft.com/kb/3209591"
+					},
+					{
+						"text": "February 2017"
+					},
+					{
+						"text": "Update Rollup 2"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Agent and Gateway",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "8.0.10918.0"
+					},
+					{},
+					{
+						"text": "September 2016"
+					},
+					{
+						"text": "General Availability release"
+					}
+				],
+				[
+					{
+						"text": "8.0.10931.0"
+					},
+					{
+						"text": "3190029",
+						"href": "https://support.microsoft.com/kb/3190029"
+					},
+					{
+						"text": "October 2016"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				],
+				[
+					{
+						"text": "8.0.10949.0"
+					},
+					{
+						"text": "3209591",
+						"href": "https://support.microsoft.com/kb/3209591"
+					},
+					{
+						"text": "February 2017"
+					},
+					{
+						"text": "Update Rollup 2"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SCX Agent",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Agent Version",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "7.6.1064.0"
+					},
+					{},
+					{
+						"text": "September 2016"
+					},
+					{
+						"text": "1.6.2-336"
+					},
+					{
+						"text": "General Availability release"
+					}
+				],
+				[
+					{
+						"text": "7.6.1067.0"
+					},
+					{},
+					{
+						"text": "October 2016"
+					},
+					{
+						"text": "1.6.2-337"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				],
+				[
+					{
+						"text": "7.6.1072.0"
+					},
+					{},
+					{
+						"text": "February 2017"
+					},
+					{
+						"text": "1.6.2-338"
+					},
+					{
+						"text": "Update Rollup 2"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/fetch/microsoft/scom/testdata/golden/happy/raw/SystemCenterDocs/includes/release-build-versions-2025.json
+++ b/pkg/fetch/microsoft/scom/testdata/golden/happy/raw/SystemCenterDocs/includes/release-build-versions-2025.json
@@ -1,0 +1,177 @@
+{
+	"path": "SystemCenterDocs/includes/release-build-versions-2025.md",
+	"tables": [
+		{
+			"heading": "Management Server (and other components*)",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "10.25.10132.0"
+					},
+					{
+						"text": "-"
+					},
+					{
+						"text": "November 2024"
+					},
+					{
+						"text": "General Availability"
+					}
+				],
+				[
+					{
+						"text": "10.25.10324.0"
+					},
+					{
+						"text": "5068304",
+						"href": "https://support.microsoft.com/kb/5068304"
+					},
+					{
+						"text": "November 2025"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				],
+				[
+					{
+						"text": "10.25.10377.0"
+					},
+					{
+						"text": "5073079",
+						"href": "https://support.microsoft.com/kb/5073079"
+					},
+					{
+						"text": "March 2026"
+					},
+					{
+						"text": "Update Rollup 1 MSRC Hotfix"
+					}
+				],
+				[
+					{
+						"text": "10.25.10644.0"
+					},
+					{
+						"text": "5080648",
+						"href": "https://support.microsoft.com/kb/5080648"
+					},
+					{
+						"text": "March 2026"
+					},
+					{
+						"text": "Update Rollup 1 Hotfix"
+					}
+				]
+			]
+		},
+		{
+			"heading": "Agent and Gateway",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "10.25.10079.0"
+					},
+					{
+						"text": "-"
+					},
+					{
+						"text": "November 2024"
+					},
+					{
+						"text": "General Availability"
+					}
+				],
+				[
+					{
+						"text": "10.25.10994.0"
+					},
+					{
+						"text": "5068304",
+						"href": "https://support.microsoft.com/kb/5068304"
+					},
+					{
+						"text": "November 2025"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				],
+				[
+					{
+						"text": "10.25.11182.0"
+					},
+					{
+						"text": "5080648",
+						"href": "https://support.microsoft.com/kb/5080648"
+					},
+					{
+						"text": "March 2026"
+					},
+					{
+						"text": "Update Rollup 1 Hotfix"
+					}
+				]
+			]
+		},
+		{
+			"heading": "SCX Agent",
+			"header": [
+				"Build Number",
+				"KB",
+				"Release Date",
+				"Agent Version",
+				"Description"
+			],
+			"rows": [
+				[
+					{
+						"text": "10.25.1005.0"
+					},
+					{
+						"text": "-"
+					},
+					{
+						"text": "November 2024"
+					},
+					{
+						"text": "1.9.1-0"
+					},
+					{
+						"text": "General Availability"
+					}
+				],
+				[
+					{
+						"text": "10.25.1016.0"
+					},
+					{
+						"text": "5068304",
+						"href": "https://support.microsoft.com/kb/5068304"
+					},
+					{
+						"text": "November 2025"
+					},
+					{
+						"text": "1.9.3-0"
+					},
+					{
+						"text": "Update Rollup 1"
+					}
+				]
+			]
+		}
+	]
+}

--- a/pkg/fetch/microsoft/scom/testdata/golden/happy/raw/SystemCenterDocs/scom/release-build-versions.json
+++ b/pkg/fetch/microsoft/scom/testdata/golden/happy/raw/SystemCenterDocs/scom/release-build-versions.json
@@ -1,0 +1,3 @@
+{
+	"path": "SystemCenterDocs/scom/release-build-versions.md"
+}

--- a/pkg/fetch/microsoft/scom/types.go
+++ b/pkg/fetch/microsoft/scom/types.go
@@ -1,0 +1,38 @@
+package scom
+
+// Article is one file of the docset, as served, with the tables read out of it.
+//
+// Nothing is read out of the cells here. The KB an update rollup ships as is
+// written as a bare number linked to the support site, and the same column
+// holds a GitHub release on the SCX agent's tables, so what a cell means is
+// extract's to decide, under golden tests.
+type Article struct {
+	// Path is where the article lives in the docs repository, which is also
+	// where its history is. It is taken from the request rather than from the
+	// document, the document naming only its rendered address.
+	Path   string  `json:"path,omitempty"`
+	Tables []Table `json:"tables,omitempty"`
+}
+
+// Table is one table of a file, with the heading it sits under.
+//
+// The heading is the component -- "Management Server (and other components*)",
+// "Agent and Gateway", "SCX Agent" -- which each advance on their own build
+// numbers under the one update rollup. Which product version they belong to is
+// not in the file at all; it is the file's own path.
+type Table struct {
+	Heading string   `json:"heading,omitempty"`
+	Header  []string `json:"header,omitempty"`
+	Rows    [][]Cell `json:"rows,omitempty"`
+}
+
+// Cell is one cell, with the link it carries.
+//
+// The link is what identifies a KB here. The cell reads "5068304" with no KB in
+// front of it, and the same column on the SCX agent's tables reads "v1.6.9-0"
+// and links to a GitHub release, so it is the link that says whether a row
+// names a KB at all.
+type Cell struct {
+	Text string `json:"text,omitempty"`
+	Href string `json:"href,omitempty"`
+}


### PR DESCRIPTION
## What

Adds `microsoft-scom`, a fetcher and extractor for the System Center Operations Manager build versions article. **36 KBs**, Operations Manager 2016 to 2025.

## Why

A small source, and the cheapest of this set to keep: it is fetched as **Markdown from `MicrosoftDocs/SystemCenterDocs`**, which is public and keeps the article's history.

## How

**The article holds no tables of its own.** It is four `INCLUDE` directives, one per product version, each pulling in a file of three tables:

```markdown
[!INCLUDE [release-build-versions-2025.md](../includes/release-build-versions-2025.md)]
```

So the includes are read out of the article and fetched too, **one hop and no further** — the included files are tables and prose and include nothing themselves, and a crawl that kept going would leave this article for the rest of the docset. An include target is resolved against the article's own directory and refused if it climbs out of the repository. An article that names no include fails the run rather than extracting to nothing with the run green.

Every file is stored at the path it has in the repository, because **which product version a table belongs to is in neither the table nor the file it sits in** — it is the name of the file the article included it from.

**The included files head their tables with bold text rather than headings** (`**Management Server (and other components*)**`), so a reader looking only for headings would file every table under the article's title.

**An update rollup is one KB and three builds.** The management server, the agent and gateway and the SCX agent each advance on their own numbers under the one rollup, so the component is the chain and a KB takes its place in each. They do not advance in step — Operations Manager 2025's agent skipped a rollup its management server took — which is why a KB can be superseded by more than one.

**The KB is read from the link, not the text.** A cell reads `5068304` with no `KB` in front of it, and the same column on the SCX agent's tables reads `v1.6.9-0` and links to a **GitHub release**, which is not a KB at all. General availability rows leave the cell empty or write a dash.

## Testing

- `GOEXPERIMENT=jsonv2 go test ./...` — passes
- `golangci-lint run ./pkg/...` — 0 issues
- Golden tests for both packages, the fetch fixture being the article and the files it includes
- End to end against the live repository: **36 KBs, 0 unchained**, 1 warning — Operations Manager 2022's UR4 and UR5 are dated August and July 2023 in that order, which the build number contradicts and the warning names

```
$ vuls-data-update fetch   microsoft-scom -d <raw>
$ vuls-data-update extract microsoft-scom <raw> -d <out>
```

## Checklist

- [x] Tests pass
- [x] Golden files updated
- [x] Deterministic output verified (types changed)
- [x] Backward compatibility maintained (types/data changed)

`pkg/extract/types/source` gains one constant, `MicrosoftSCOM`. Additive; it is the only file shared with the other Microsoft data-source branches.
