### PR TITLE
fix(extract/apple): bound 10.x in-line updates below by their own line

### DIFF
--- a/pkg/extract/apple/security-releases/security-releases.go
+++ b/pkg/extract/apple/security-releases/security-releases.go
@@ -496,9 +496,12 @@ func releaseCriterions(name string) ([]criterionTypes.Criterion, error) {
 // the same day, and with an upper bound alone a host on an older major would
 // match every newer major's advisory. NVD models the same per-major
 // intervals (versionStartIncluding 13.0 / 14.0 / 15.0 / ...), and every
-// lower bound it uses for apple:macos is such a major boundary. The
-// initial release of a major and the 10.x generations stay upper-only
-// like the other families, matching NVD's modeling.
+// lower bound it uses for apple:macos is such a major boundary. The 10.x
+// generations get the same treatment with the line as the boundary — ge
+// 10.<minor> — because they behave the same way: Apple ships Catalina
+// 10.15.7 and Mojave 10.14.6 together, and an upper bound alone would let
+// the Catalina advisory match a Mojave or High Sierra host. Only the
+// initial release of a line stays upper-only.
 //
 // "macOS Server <version>" shares the release-name shape and is skipped —
 // by the same major check rather than by name: its majors are 2 through 5
@@ -513,27 +516,41 @@ func macOSCriterion(part, version, rsr string) (*criterionTypes.Criterion, error
 	case err != nil:
 		return nil, errors.Wrapf(err, "parse major of %q", version)
 	case n >= 11:
-		r := &ccRangeTypes.Range{
-			Type:     ccRangeTypes.RangeTypeApple,
+		c := releaseCriterion("cpe:2.3:o:apple:macos:*:*:*:*:*:*:*:*", &ccRangeTypes.Range{
+			Type: ccRangeTypes.RangeTypeApple,
+			GreaterEqual: func() string {
+				// an initial release — "macOS Ventura 13", also spellable
+				// "13.0" — fixes bugs whose vulnerable population is the
+				// previous major line, so there is nothing below it inside
+				// its own major to bound: ge would make the range empty
+				// ([15.0, 15) with 15 == 15.0 under the comparator), and NVD
+				// leaves exactly these advisories unbounded below. The lower
+				// bound goes on only when the fixed version sorts strictly
+				// above <major>.0
+				if rsr == "" && !slices.ContainsFunc(strings.Split(rest, "."), func(s string) bool { return s != "" && s != "0" }) {
+					return ""
+				}
+				return fmt.Sprintf("%d.0", n)
+			}(),
 			LessThan: fixed,
-		}
-		// an initial release — "macOS Ventura 13", also spellable "13.0" —
-		// fixes bugs whose vulnerable population is the previous major
-		// line, so there is nothing below it inside its own major to
-		// bound: ge would make the range empty ([15.0, 15) with 15 ==
-		// 15.0 under the comparator), and NVD leaves exactly these
-		// advisories unbounded below. The lower bound goes on only when
-		// the fixed version sorts strictly above <major>.0
-		if rsr != "" || slices.ContainsFunc(strings.Split(rest, "."), func(s string) bool { return s != "" && s != "0" }) {
-			r.GreaterEqual = fmt.Sprintf("%d.0", n)
-		}
-		c := releaseCriterion("cpe:2.3:o:apple:macos:*:*:*:*:*:*:*:*", r, fixed)
+		}, fixed)
 		return &c, nil
 	case n == 10:
-		minor, _, _ := strings.Cut(rest, ".")
+		minor, patch, _ := strings.Cut(rest, ".")
 		if mn, err := strconv.Atoi(minor); err == nil && mn >= 12 && mn <= 15 {
 			c := releaseCriterion("cpe:2.3:o:apple:mac_os_x:*:*:*:*:*:*:*:*", &ccRangeTypes.Range{
-				Type:     ccRangeTypes.RangeTypeApple,
+				Type: ccRangeTypes.RangeTypeApple,
+				GreaterEqual: func() string {
+					// the 10.x line plays the part a major plays from 11 on,
+					// so the bound is the line: "macOS Catalina 10.15.7" is
+					// ge 10.15, which keeps it off a Mojave or High Sierra
+					// host. As above, the initial release of the line has
+					// nothing below it inside the line to bound
+					if !slices.ContainsFunc(strings.Split(patch, "."), func(s string) bool { return s != "" && s != "0" }) {
+						return ""
+					}
+					return fmt.Sprintf("10.%d", mn)
+				}(),
 				LessThan: fixed,
 			}, fixed)
 			return &c, nil

--- a/pkg/extract/apple/security-releases/testdata/fixtures/happy/advisories/HT210634.json
+++ b/pkg/extract/apple/security-releases/testdata/fixtures/happy/advisories/HT210634.json
@@ -1,0 +1,41 @@
+{
+	"id": "HT210634",
+	"url": "https://support.apple.com/en-us/106323",
+	"title": "About the security content of macOS Catalina 10.15",
+	"sections": [
+		{
+			"entries": [
+				{
+					"others": [
+						"This document describes the security content of macOS Catalina 10.15."
+					]
+				}
+			]
+		},
+		{
+			"name": "macOS Catalina 10.15",
+			"entries": [
+				{
+					"notes": [
+						"Released October 7, 2019"
+					]
+				},
+				{
+					"component": "AppleFirmwareUpdateKext",
+					"available_for": [
+						"macOS Mojave 10.14.6"
+					],
+					"impact": [
+						"An application may be able to execute arbitrary code with system privileges"
+					],
+					"description": [
+						"A memory corruption issue was addressed with improved memory handling."
+					],
+					"ids": [
+						"CVE-2019-8747"
+					]
+				}
+			]
+		}
+	]
+}

--- a/pkg/extract/apple/security-releases/testdata/golden/happy/data/HT207483.json
+++ b/pkg/extract/apple/security-releases/testdata/golden/happy/data/HT207483.json
@@ -232,6 +232,7 @@
 									"cpe": "cpe:2.3:o:apple:mac_os_x:*:*:*:*:*:*:*:*",
 									"range": {
 										"type": "apple",
+										"ge": "10.12",
 										"lt": "10.12.3"
 									},
 									"fixed": [

--- a/pkg/extract/apple/security-releases/testdata/golden/happy/data/HT210634.json
+++ b/pkg/extract/apple/security-releases/testdata/golden/happy/data/HT210634.json
@@ -1,0 +1,78 @@
+{
+	"id": "HT210634",
+	"advisories": [
+		{
+			"content": {
+				"id": "HT210634",
+				"title": "About the security content of macOS Catalina 10.15",
+				"references": [
+					{
+						"source": "support.apple.com",
+						"url": "https://support.apple.com/en-us/106323"
+					}
+				],
+				"published": "2019-10-07T00:00:00Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2019-8747",
+				"references": [
+					{
+						"source": "support.apple.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2019-8747"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "cpe",
+								"cpe": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"cpe": "cpe:2.3:o:apple:mac_os_x:*:*:*:*:*:*:*:*",
+									"range": {
+										"type": "apple",
+										"lt": "10.15"
+									},
+									"fixed": [
+										"10.15"
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "apple-security-releases",
+		"raws": [
+			"happy/advisories/HT210634.json"
+		]
+	}
+}


### PR DESCRIPTION
## What

`macOSCriterion` gives majors of 11 and later the lower bound `ge <major>.0`, but leaves the 10.12–10.15 generations upper-only. `About the security content of macOS Catalina 10.15.7` therefore extracts as `lt 10.15.7` with nothing below it.

This adds the same bound to the 10.x arm, with the line as the boundary: `ge 10.<minor>`.

```go
 case n == 10:
-	minor, _, _ := strings.Cut(rest, ".")
+	minor, patch, _ := strings.Cut(rest, ".")
 	if mn, err := strconv.Atoi(minor); err == nil && mn >= 12 && mn <= 15 {
+		if slices.ContainsFunc(strings.Split(patch, "."), func(s string) bool { return s != "" && s != "0" }) {
+			r.GreaterEqual = fmt.Sprintf("10.%d", mn)
+		}
```

## Why

Apple ships one advisory per supported line on the same day — Catalina 10.15.7, Mojave 10.14.6 and the matching Security Updates all went out on 2020-09-24. With no lower bound, every newer line's advisory matches every older host.

Scanning a macOS 10.13.6 host against a DB built from this source, it matched all 7 Mojave and all 8 Catalina advisories, none of which are about it:

```
About the security content of macOS Mojave 10.14      lt 10.14
About the security content of macOS Mojave 10.14.1    lt 10.14.1
...
About the security content of macOS Catalina 10.15.7  lt 10.15.7
```

Its own line contributed nothing, so every CVE reported for that host came from a line it does not run.

## Effect

| | before | after |
|---|---|---|
| `mac_os_x` criteria with a lower bound | 32 / 57 | **57 / 57 minus the 25 initial releases** |
| CVEs detected on a macOS 10.13.6 host | 1092 | **577** |

Measured over the full feed: 25 of the 57 `mac_os_x` criteria move from unbounded to bounded.

## Not in scope

The remaining 32 unbounded `mac_os_x` criteria are the initial release of each line (`OS X Yosemite v10.10.1`, `macOS Mojave 10.14`, `macOS Catalina 10.15`, …), which stay upper-only for the same reason the 11+ arm does: an initial release has nothing below it inside its own line to bound.

Those need a different source of truth. Apple states the affected systems per entry in **`Available for`**, which the extractor does not read today:

```
macOS Catalina 10.15.7   available_for: "macOS Mojave 10.14.6, macOS High Sierra 10.13.6, macOS Catalina 10.15"
macOS Sonoma 14.7.5      available_for: "macOS Sonoma"
macOS Sequoia 15         available_for: "Mac Studio (2022 and later), iMac (2019 and later), …"
```

Note the last one: for an initial release Apple lists hardware, not OS versions — it does not say which systems are affected. NVD leaves exactly these advisories unbounded below too. Reading `Available for` is worth doing as a follow-up, but it will not settle the initial releases on its own.

## Test

`testdata/golden/happy/data/HT207483.json` (macOS Sierra 10.12.3) gains `"ge": "10.12"`.