### PR TITLE
fix(extract/fortinet/cvrf): rebuild supplement rows from the advisories

### DIFF
--- a/pkg/extract/fortinet/cvrf/cvrf_test.go
+++ b/pkg/extract/fortinet/cvrf/cvrf_test.go
@@ -293,14 +293,16 @@ func TestSupplementCriterions(t *testing.T) {
 			},
 		},
 		{
-			// "FortiIsolator version 2.3.2 and below" — enumerated releases.
-			name: "production row: enumerated versions (FG-IR-21-040)",
-			args: args{table: cvrf.SupplementTable, id: "FG-IR-21-040"},
+			// "FortiClientMAC 6.0.1, 6.0.2, 6.0.3 and 6.0.4" — the advisory
+			// enumerates the releases, so the row does too.
+			name: "production row: enumerated versions (FG-IR-19-003)",
+			args: args{table: cvrf.SupplementTable, id: "FG-IR-19-003"},
 			want: []criterionTypes.Criterion{
-				supplementCPECriterion("cpe:2.3:o:fortinet:fortiisolator:*:*:*:*:*:*:*:*", []ccTypes.CPE{
-					"cpe:2.3:o:fortinet:fortiisolator:2.3.0:*:*:*:*:*:*:*",
-					"cpe:2.3:o:fortinet:fortiisolator:2.3.1:*:*:*:*:*:*:*",
-					"cpe:2.3:o:fortinet:fortiisolator:2.3.2:*:*:*:*:*:*:*",
+				supplementCPECriterion("cpe:2.3:a:fortinet:forticlient:*:*:*:*:*:*:*:*", []ccTypes.CPE{
+					"cpe:2.3:a:fortinet:forticlient:6.0.1:*:*:*:*:*:*:*",
+					"cpe:2.3:a:fortinet:forticlient:6.0.2:*:*:*:*:*:*:*",
+					"cpe:2.3:a:fortinet:forticlient:6.0.3:*:*:*:*:*:*:*",
+					"cpe:2.3:a:fortinet:forticlient:6.0.4:*:*:*:*:*:*:*",
 				}, nil),
 			},
 		},

--- a/pkg/extract/fortinet/cvrf/supplement.go
+++ b/pkg/extract/fortinet/cvrf/supplement.go
@@ -14,12 +14,16 @@ import (
 )
 
 // supplementTable (supplement_data.go) carries the affected-product data for
-// the historical CVRF advisories (2012 through 2022) whose
-// product_statuses/product_tree are empty upstream, so the CVRF document
-// itself yields no detection. The gap is historical — from 2022 on Fortinet
-// populates product_statuses (and publishes CSAF) — but the rows are not
-// frozen: they state what the advisory says, and an advisory whose note is
-// read differently later is re-read.
+// the CVRF advisories whose product_statuses/product_tree are empty upstream,
+// so the CVRF document itself yields no detection. Fortinet did not switch
+// over on a date, so the two shapes overlap: filled documents go as far back
+// as FG-IR-16-035, but through 2021 they are the exception (21 filled against
+// 123 empty), 2022 is where it flips (155 filled against 13 empty), and from
+// FG-IR-23-* on every document carries product_statuses. That leaves the 427
+// advisories numbered FG-IR-012-* through FG-IR-22-* in this table, a set
+// that only shrinks if Fortinet backfills an old document. The rows are not
+// frozen either: they state what the advisory says, and an advisory whose
+// note is read differently later is re-read.
 //
 // A row's authority is the advisory's own Affected Products note, with the
 // affected-version data Fortinet publishes as a CNA in its cvelistV5 records

--- a/pkg/extract/fortinet/cvrf/supplement.go
+++ b/pkg/extract/fortinet/cvrf/supplement.go
@@ -28,14 +28,14 @@ import (
 // A row's authority is the advisory's own Affected Products note, with the
 // affected-version data Fortinet publishes as a CNA in its cvelistV5 records
 // as the second source: a row covers what the note claims, plus what the CNA
-// record adds for that product. Of the 721 rows, 549 have a version in their
-// note, 34 rest on the CNA record alone, and 138 have neither — the note
+// record adds for that product. Of the 721 rows, 555 have a version in their
+// note, 34 rest on the CNA record alone, and 132 have neither — the note
 // names the product without a version, or gives no version at all — and keep
 // the ranges the table was seeded with. That seed was the curated ranges of
 // the legacy vuls-data-raw-fortinet (handmade) dataset, which is no longer a
 // source: it expressed "<v> and below" as an open-ended bound and stopped
 // "<train> all versions" at whatever release existed when it was curated,
-// neither of which is what the advisories say. Those 138 are a deliberate
+// neither of which is what the advisories say. Those 132 are a deliberate
 // hold rather than an oversight: making them whole-product rows would flag
 // every release of the product, and dropping them would take away the only
 // detection their advisories have.

--- a/pkg/extract/fortinet/cvrf/supplement.go
+++ b/pkg/extract/fortinet/cvrf/supplement.go
@@ -35,7 +35,10 @@ import (
 // the legacy vuls-data-raw-fortinet (handmade) dataset, which is no longer a
 // source: it expressed "<v> and below" as an open-ended bound and stopped
 // "<train> all versions" at whatever release existed when it was curated,
-// neither of which is what the advisories say.
+// neither of which is what the advisories say. Those 138 are a deliberate
+// hold rather than an oversight: making them whole-product rows would flag
+// every release of the product, and dropping them would take away the only
+// detection their advisories have.
 //
 // How the notes' wording maps onto rows:
 //
@@ -48,6 +51,15 @@ import (
 //     a later release of an EOL train cannot fall out of range.
 //   - "all versions below <v>" is open-ended below, and "<a> through <b>"
 //     is exactly that.
+//   - The CNA record may add versions the note is silent about — typically an
+//     EOL train Fortinet stopped enumerating — but never a release the same
+//     advisory calls a fix. An advisory that caps a product at the very
+//     release its own Solutions note tells you to install contradicts itself,
+//     and the fix wins: the cap is the release before it. FG-IR-20-171 says
+//     "3.2.2 and earlier" against "Upgrade to 3.2.2 or later", and its other
+//     pair in the same note — "3.1.4 and earlier" against "upgrade to 3.1.5"
+//     — shows which half is the slip (FG-IR-17-073, FG-IR-20-222 and
+//     FG-IR-21-023 are the same shape).
 //
 // A handful of notes cannot be expressed in versions at all — an impact
 // scoped to hardware models (FG-IR-19-224 to the FortiSwitch 424E/426E/448E,

--- a/pkg/extract/fortinet/cvrf/supplement.go
+++ b/pkg/extract/fortinet/cvrf/supplement.go
@@ -42,13 +42,15 @@ import (
 //
 // How the notes' wording maps onto rows:
 //
-//   - "<v> and below/earlier" bounds the train it names — ge <train>.0,
-//     le <v>. Fortinet's own CNA records read it that way: across the
-//     records for these advisories, 58 entries bound their lowest affected
-//     train explicitly against 4 that leave it open.
+//   - "<v> and below/earlier" bounds the train it names: ge "<train>.0",
+//     le "<v>" — the floor is what keeps the cap from reaching into the
+//     trains below it. Fortinet's own CNA records read it that way: across
+//     the records for these advisories, 58 entries bound their lowest
+//     affected train explicitly against 4 that leave it open.
 //   - "<train> all versions" / "<train>.x" is the whole train, in the shape
-//     product.TrainRange emits for the CSAF source (ge "6.0", lt "6.1"), so
-//     a later release of an EOL train cannot fall out of range.
+//     product.TrainRange emits for the CSAF source — ge "6.0", lt "6.1",
+//     bare train bounds rather than the "6.0.0" floor a cap carries — so a
+//     later release of an EOL train cannot fall out of range.
 //   - "all versions below <v>" is open-ended below, and "<a> through <b>"
 //     is exactly that.
 //   - The CNA record may add versions the note is silent about — typically an

--- a/pkg/extract/fortinet/cvrf/supplement.go
+++ b/pkg/extract/fortinet/cvrf/supplement.go
@@ -58,8 +58,16 @@ import (
 //     and the fix wins: the cap is the release before it. FG-IR-20-171 says
 //     "3.2.2 and earlier" against "Upgrade to 3.2.2 or later", and its other
 //     pair in the same note — "3.1.4 and earlier" against "upgrade to 3.1.5"
-//     — shows which half is the slip (FG-IR-17-073, FG-IR-20-222 and
-//     FG-IR-21-023 are the same shape).
+//     — shows which half is the slip (FG-IR-17-073, FG-IR-20-222, FG-IR-21-023,
+//     FG-IR-21-132, FG-IR-22-046 and FG-IR-22-061 are the same shape).
+//     Three kinds of overlap are not that slip and stay as they are: an
+//     advisory that scopes per CVE, where a release fixed for one CVE is
+//     affected by another (FG-IR-17-214, FG-IR-19-107, FG-IR-19-238); a
+//     remediation that is a setting rather than a release, so the named
+//     version is both affected and the one to run it on (FG-IR-14-031's
+//     "Upgrade to 5.0.9 or 5.2.1 and apply the settings"); and a target
+//     given for particular hardware (FG-IR-20-131 and FG-IR-21-049 send the
+//     high-end F-series models to 6.2.9 while 6.2.9 is affected elsewhere).
 //
 // A handful of notes cannot be expressed in versions at all — an impact
 // scoped to hardware models (FG-IR-19-224 to the FortiSwitch 424E/426E/448E,

--- a/pkg/extract/fortinet/cvrf/supplement.go
+++ b/pkg/extract/fortinet/cvrf/supplement.go
@@ -89,6 +89,7 @@ var wholeProductAudited = map[advisoryProduct]struct{}{
 	{"FG-IR-15-007", "FortiMail"}:          {},
 	{"FG-IR-16-041", "FortiClientSSLVPN"}:  {},
 	{"FG-IR-16-069", "FortiClientSSLVPN"}:  {},
+	{"FG-IR-16-090", "FortiOS"}:            {},
 }
 
 // supplementCriterions builds the detection criterions for an advisory from

--- a/pkg/extract/fortinet/cvrf/supplement.go
+++ b/pkg/extract/fortinet/cvrf/supplement.go
@@ -16,16 +16,40 @@ import (
 // supplementTable (supplement_data.go) carries the affected-product data for
 // the historical CVRF advisories (2012 through 2022) whose
 // product_statuses/product_tree are empty upstream, so the CVRF document
-// itself yields no detection. The rows were generated once from two
-// Fortinet-authored sources and then frozen: the curated version ranges of
-// the legacy vuls-data-raw-fortinet (handmade) dataset, and the
-// affected-version data Fortinet publishes as a CNA in its cvelistV5 records.
-// Where both sources cover an advisory, handmade rows win per product
-// (curated ranges) and CNA rows fill the products handmade misses;
-// disagreements were reviewed by hand. The gap is historical — from 2022 on
-// Fortinet populates product_statuses (and publishes CSAF) — so the table is
-// a frozen asset, not a maintained feed (mirroring how microsoft/bulletin
-// compiles its frozen archive amendments in).
+// itself yields no detection. The gap is historical — from 2022 on Fortinet
+// populates product_statuses (and publishes CSAF) — but the rows are not
+// frozen: they state what the advisory says, and an advisory whose note is
+// read differently later is re-read.
+//
+// A row's authority is the advisory's own Affected Products note, with the
+// affected-version data Fortinet publishes as a CNA in its cvelistV5 records
+// as the second source: a row covers what the note claims, plus what the CNA
+// record adds for that product. Of the 721 rows, 549 have a version in their
+// note, 34 rest on the CNA record alone, and 138 have neither — the note
+// names the product without a version, or gives no version at all — and keep
+// the ranges the table was seeded with. That seed was the curated ranges of
+// the legacy vuls-data-raw-fortinet (handmade) dataset, which is no longer a
+// source: it expressed "<v> and below" as an open-ended bound and stopped
+// "<train> all versions" at whatever release existed when it was curated,
+// neither of which is what the advisories say.
+//
+// How the notes' wording maps onto rows:
+//
+//   - "<v> and below/earlier" bounds the train it names — ge <train>.0,
+//     le <v>. Fortinet's own CNA records read it that way: across the
+//     records for these advisories, 58 entries bound their lowest affected
+//     train explicitly against 4 that leave it open.
+//   - "<train> all versions" / "<train>.x" is the whole train, in the shape
+//     product.TrainRange emits for the CSAF source (ge "6.0", lt "6.1"), so
+//     a later release of an EOL train cannot fall out of range.
+//   - "all versions below <v>" is open-ended below, and "<a> through <b>"
+//     is exactly that.
+//
+// A handful of notes cannot be expressed in versions at all — an impact
+// scoped to hardware models (FG-IR-19-224 to the FortiSwitch 424E/426E/448E,
+// FG-IR-20-036 to the FortiAnalyzer models that manage a FortiRecorder) or
+// to a configuration (FG-IR-16-090 to the default TCP timestamp setting).
+// Those rows carry the version bound the note gives and say so in a comment.
 //
 // Scope: rows are advisory-granular; per-CVE attribution is deliberately
 // not modeled. A few multi-CVE advisories scope products per CVE in their

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -86,7 +86,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-14-031": {
 		{Product: "FortiADC"}, // whole product, audited: POODLE: default-config, no version bound in the note
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.9"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.1"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"5.0.9", "5.2.1"}},
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.3"}}},
 		{Product: "FortiCache", Ranges: []supplementRange{{GreaterEqual: "2.2.0", LessEqual: "3.0.8"}}},
 		{Product: "FortiClientWindows"}, // whole product, audited: POODLE: default-config, no version bound in the note
@@ -1137,7 +1137,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-21-023": {
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.7"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.10"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.10"}, {GreaterEqual: "5.3.12", LessEqual: "5.3.13"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessThan: "6.4.5"}}},
-		{Product: "FortiNDR", Ranges: []supplementRange{{GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2", LessThan: "1.3"}, {GreaterEqual: "1.3", LessThan: "1.4"}, {GreaterEqual: "1.4", LessThan: "1.5"}, {GreaterEqual: "1.5", LessThan: "1.6"}, {GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "7.1", LessThan: "7.2"}, {GreaterEqual: "7.2.0", LessEqual: "7.2.1"}}},
+		{Product: "FortiNDR", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2", LessThan: "1.3"}, {GreaterEqual: "1.3", LessThan: "1.4"}, {GreaterEqual: "1.4", LessThan: "1.5"}, {GreaterEqual: "1.5", LessThan: "1.6"}, {GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "7.1", LessThan: "7.2"}}},
 	},
 	"FG-IR-21-026": {
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.6", LessThan: "3.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
@@ -1332,8 +1332,8 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-21-132": {
 		{Product: "FortiADC", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
-		{Product: "FortiDDoS", Versions: []string{"5.7.0"}, Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "4.5"}, {GreaterEqual: "4.5", LessThan: "4.6"}, {GreaterEqual: "4.6", LessThan: "4.7"}, {GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.2"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.3"}, {GreaterEqual: "5.5.0", LessEqual: "5.5.1"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.1"}}},
-		{Product: "FortiDDoS-CM", Ranges: []supplementRange{{GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.1"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.3"}, {GreaterEqual: "5.5.0", LessEqual: "5.5.1"}}},
+		{Product: "FortiDDoS", Versions: []string{"5.7.0"}, Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "4.5"}, {GreaterEqual: "4.5", LessThan: "4.6"}, {GreaterEqual: "4.6", LessThan: "4.7"}, {GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.1"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.2"}, {GreaterEqual: "5.5.0", LessEqual: "5.5.1"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.1"}}},
+		{Product: "FortiDDoS-CM", Ranges: []supplementRange{{GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.1"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.2"}, {GreaterEqual: "5.5.0", LessEqual: "5.5.1"}}},
 		{Product: "FortiDDoS-F", Versions: []string{"6.3.0"}, Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.4"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 		{Product: "FortiFone", Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.11"}}},
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
@@ -1528,7 +1528,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-22-046": {
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-22-050": {
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
@@ -1580,6 +1580,6 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSandbox", Versions: []string{"4.2.0"}, Ranges: []supplementRange{{GreaterEqual: "3.0.1", LessEqual: "3.0.7"}, {GreaterEqual: "3.1", LessThan: "3.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}}},
 	},
 	"FG-IR-22-061": {
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 }

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -53,7 +53,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.5"}}},
 	},
 	"FG-IR-14-004": {
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "3.2.0", LessEqual: "3.2.0"}}},
+		{Product: "FortiADC", Versions: []string{"3.2.0"}},
 	},
 	"FG-IR-14-006": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.3.0", LessEqual: "4.3.15"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.7"}}},
@@ -82,7 +82,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "1", LessThan: "2"}, {GreaterEqual: "2", LessThan: "3"}, {GreaterEqual: "3.0", LessThan: "3.1"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.1"}}},
 		{Product: "FortiDB", Ranges: []supplementRange{{GreaterEqual: "4", LessThan: "5"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.1"}}},
 		{Product: "FortiManager", Versions: []string{"5.2.0"}, Ranges: []supplementRange{{GreaterEqual: "4", LessThan: "5"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.7"}}},
-		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.0.0", LessEqual: "8.5.3"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.0"}}}, // 32-bit controllers only; fixed in 8.5.4 / 8.6.1
+		{Product: "FortiWLC", Versions: []string{"8.6.0"}, Ranges: []supplementRange{{GreaterEqual: "8.0.0", LessEqual: "8.5.3"}}}, // 32-bit controllers only; fixed in 8.5.4 / 8.6.1
 	},
 	"FG-IR-14-031": {
 		{Product: "FortiADC"}, // whole product, audited: POODLE: default-config, no version bound in the note
@@ -101,10 +101,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.4"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.2"}}},
 	},
 	"FG-IR-14-032": {
-		{Product: "FortiADC", Versions: []string{"10.2.0"}, Ranges: []supplementRange{{GreaterEqual: "3.1.1", LessEqual: "4.0.4"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "3.1.1", LessEqual: "4.0.4"}}},
 	},
 	"FG-IR-14-033": {
-		{Product: "FortiAnalyzer", Versions: []string{"5.0.7"}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessThan: "5.0.7"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{LessThan: "5.0.7"}}},
 	},
 	"FG-IR-14-034": {
@@ -133,7 +133,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-15-007": {
 		{Product: "FortiMail"}, // whole product, audited: FREAK: note says all versions in default configuration
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.0.11"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.2"}}},
 	},
 	"FG-IR-15-008": {
 		{Product: "FortiADC", Ranges: []supplementRange{{LessThan: "4.2.2"}}},
@@ -319,7 +319,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Versions: []string{"5.4.0", "5.4.1"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.9"}}},
 		{Product: "FortiRecorder", Versions: []string{"1.0.0", "1.1.0", "1.2.0", "2.0.0", "2.3.0"}, Ranges: []supplementRange{{GreaterEqual: "1.3.0", LessEqual: "1.3.1"}, {GreaterEqual: "1.4.0", LessEqual: "1.4.1"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.1"}, {GreaterEqual: "2.2.0", LessEqual: "2.2.2"}, {GreaterEqual: "2.4.0", LessEqual: "2.4.1"}}},
 		{Product: "FortiSandbox", Versions: []string{"1.1.0", "1.3.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.3"}, {GreaterEqual: "1.4.0", LessEqual: "1.4.3"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.3"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.3"}, {GreaterEqual: "2.2.0", LessEqual: "2.2.2"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.2"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.5.0", LessEqual: "3.5.0"}}},
+		{Product: "FortiSwitch", Versions: []string{"3.5.0"}},
 		{Product: "FortiTester", Versions: []string{"2.3.0", "2.5.0", "2.6.0", "2.7.0"}, Ranges: []supplementRange{{GreaterEqual: "2.4.0", LessEqual: "2.4.1"}}},
 		{Product: "FortiTokenIOS", Versions: []string{"3.0.5"}},
 		{Product: "FortiVoice", Versions: []string{"5.0.5", "5.3.3"}},
@@ -390,7 +390,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientWindows", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.3"}}},
 	},
 	"FG-IR-17-073": {
-		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.11"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.4"}}},
+		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.10"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.4"}}},
 	},
 	"FG-IR-17-076": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.7.0", LessEqual: "5.7.1"}}},
@@ -416,21 +416,21 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}}},
 	},
 	"FG-IR-17-114": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.0"}}},
+		{Product: "FortiPortal", Versions: []string{"4.0.0"}},
 	},
 	"FG-IR-17-115": {
-		{Product: "FortiWLM", Ranges: []supplementRange{{GreaterEqual: "8.3.0", LessEqual: "8.3.0"}}},
+		{Product: "FortiWLM", Versions: []string{"8.3.0"}},
 	},
 	"FG-IR-17-118": {
 		{Product: "FortiAP", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.3"}}},
-		{Product: "FortiAP-S", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
-		{Product: "FortiAP-W2", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
+		{Product: "FortiAP-S", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.3"}}},
+		{Product: "FortiAP-W2", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.3"}}},
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.2"}}},
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
+		{Product: "FortiOS", Versions: []string{"5.6.0"}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.6.0", LessEqual: "3.6.2"}}},
 	},
 	"FG-IR-17-119": {
-		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.0.0", LessEqual: "8.2"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.2"}}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "6.1.2", LessEqual: "6.1.5"}, {GreaterEqual: "7.0.7", LessEqual: "7.0.10"}, {GreaterEqual: "8.0.0", LessThan: "8.3"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.2"}}},
 	},
 	"FG-IR-17-127": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.4.4"}}},
@@ -452,17 +452,17 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-17-196": {
 		{Product: "FortiAP", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.3"}, {LessEqual: "5.2.6"}}},
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.2.11"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}}, // previous branches: all versions
-		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.2", LessThan: "8.3"}, {GreaterEqual: "8.3", LessThan: "8.4"}, {GreaterEqual: "801.11", LessThan: "801.12"}}},
-		{Product: "Meru AP", Ranges: []supplementRange{{GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.2", LessThan: "8.3"}, {GreaterEqual: "8.3", LessThan: "8.4"}, {GreaterEqual: "801.11", LessThan: "801.12"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.2.11"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},                                          // previous branches: all versions
+		{Product: "FortiWLC", Ranges: []supplementRange{{LessEqual: "7.0.11"}, {GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.2.0", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.3"}}}, // mesh/SAM/802.11r only; previous branches: all versions
+		{Product: "Meru AP", Ranges: []supplementRange{{LessEqual: "7.0.11"}, {GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.2.0", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.3"}}},  // mesh/SAM/802.11r only; previous branches: all versions
 	},
 	"FG-IR-17-206": {
 		{Product: "FortiOS", Versions: []string{"5.4.0", "5.4.1", "5.4.2", "5.4.3", "5.4.4", "5.4.5"}},
 	},
 	"FG-IR-17-214": {
-		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
+		{Product: "FortiClientMac", Versions: []string{"5.6.0"}},
 		{Product: "FortiClientSSLVPN", Ranges: []supplementRange{{LessEqual: "4.4.2335"}}},
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
+		{Product: "FortiClientWindows", Versions: []string{"5.6.0"}},
 	},
 	"FG-IR-17-231": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.8"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},
@@ -493,14 +493,14 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.4"}}},
 	},
 	"FG-IR-18-006": {
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
+		{Product: "FortiManager", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.6"}}},
 	},
 	"FG-IR-18-013": {
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.6.0", LessEqual: "3.6.8"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 	},
 	"FG-IR-18-014": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}}},
+		{Product: "FortiManager", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}}},
 	},
 	"FG-IR-18-016": {
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
@@ -509,8 +509,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Versions: []string{"5.6.0"}},
 	},
 	"FG-IR-18-022": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}}},
+		{Product: "FortiManager", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}}},
 	},
 	"FG-IR-18-024": {
 		{Product: "FortiSandbox", Versions: []string{"2.4.0", "2.4.1", "2.5.0", "2.5.1", "2.5.2"}},
@@ -519,7 +519,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiCloud", Ranges: []supplementRange{{LessEqual: "3.2.1"}}},
 	},
 	"FG-IR-18-027": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
+		{Product: "FortiOS", Versions: []string{"6.0.0"}},
 	},
 	"FG-IR-18-051": {
 		{Product: "FortiManager", Versions: []string{"5.4.0", "5.4.1"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.7"}}},
@@ -545,18 +545,18 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 	},
 	"FG-IR-18-108": {
-		{Product: "FortiClientWindows", Versions: []string{"5.6.6"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}}},
+		{Product: "FortiClientWindows", Versions: []string{"5.6.6"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-18-121": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"5.6.0"}},
+		{Product: "FortiManager", Versions: []string{"5.6.0"}},
 	},
 	"FG-IR-18-157": {
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.4"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.1"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.0"}}},
+		{Product: "FortiADC", Versions: []string{"6.1.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.4"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.2"}}},
 	},
 	"FG-IR-18-173": {
-		{Product: "FortiOS", Versions: []string{"6.2.3"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
+		{Product: "FortiOS", Versions: []string{"6.2.0", "6.2.3"}},
 	},
 	"FG-IR-18-232": {
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
@@ -572,7 +572,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessThan: "6.0.4"}, {LessThan: "5.6.4"}}},
 	},
 	"FG-IR-18-382": {
-		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.0"}}},
+		{Product: "FortiSIEM", Versions: []string{"5.2.0"}},
 	},
 	"FG-IR-18-383": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
@@ -620,7 +620,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-19-037": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
+		{Product: "FortiOS", Versions: []string{"6.2.0"}},
 	},
 	"FG-IR-19-043": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "6.2.3"}}},
@@ -633,10 +633,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.2"}}},
 	},
 	"FG-IR-19-072": {
-		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
+		{Product: "FortiClientEMS", Versions: []string{"6.2.0"}},
 	},
 	"FG-IR-19-099": {
-		{Product: "FortiOS", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}}},
+		{Product: "FortiOS", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}}},
 	},
 	"FG-IR-19-100": {
 		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.2"}}},
@@ -648,8 +648,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-19-110": {
-		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
+		{Product: "FortiClientMac", Versions: []string{"6.2.0"}},
+		{Product: "FortiClientWindows", Versions: []string{"6.2.0"}},
 	},
 	"FG-IR-19-111": {
 		{Product: "FortiOS", Versions: []string{"6.2.0"}},
@@ -668,7 +668,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 	},
 	"FG-IR-19-179": {
-		{Product: "FortiOS", Versions: []string{"6.2.0", "6.2.1"}},
+		{Product: "FortiOS", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "6.0.8"}}},
 	},
 	"FG-IR-19-184": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
@@ -695,7 +695,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAP", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}}},
 		{Product: "FortiAP-S", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}}},
 		{Product: "FortiAP-U", Ranges: []supplementRange{{LessThan: "6.0.0"}}},
-		{Product: "FortiAP-W2", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{LessEqual: "6.0.5"}}},
+		{Product: "FortiAP-W2", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}}},
 	},
 	"FG-IR-19-210": {
 		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
@@ -715,7 +715,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}}}, // 424E/426E/448E with bluetooth enabled only, which version data cannot express
 	},
 	"FG-IR-19-227": {
-		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
+		{Product: "FortiClientMac", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}}},
 	},
 	"FG-IR-19-236": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
@@ -731,20 +731,20 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-19-244": {
 		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.3.0", LessEqual: "5.3.7"}}},
-		{Product: "FortiADCManager", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.1"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.0"}}},
+		{Product: "FortiADCManager", Versions: []string{"5.3.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.1"}}},
 	},
 	"FG-IR-19-248": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
-		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.0"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}}},
 	},
 	"FG-IR-19-258": {
-		{Product: "FortiPresence", Ranges: []supplementRange{{GreaterEqual: "2.1.0", LessEqual: "2.1.0"}}},
+		{Product: "FortiPresence", Versions: []string{"2.1.0"}},
 	},
 	"FG-IR-19-265": {
 		{Product: "FortiWeb", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.1"}}},
 	},
 	"FG-IR-19-269": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
+		{Product: "FortiWeb", Versions: []string{"6.2.0"}},
 	},
 	"FG-IR-19-270": {
 		{Product: "FortiIsolator", Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.2"}}},
@@ -763,10 +763,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAP-C", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.2"}}},
 		{Product: "FortiAP-S", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
 		{Product: "FortiAP-U", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
-		{Product: "FortiAP-W2", Ranges: []supplementRange{{LessEqual: "6.2.3"}}},
+		{Product: "FortiAP-W2", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
-		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.0"}}},
-		{Product: "FortiExtender", Ranges: []supplementRange{{GreaterEqual: "4.2.0", LessEqual: "4.2.0"}}},
+		{Product: "FortiDDoS", Versions: []string{"5.2.0"}},
+		{Product: "FortiExtender", Versions: []string{"4.2.0"}},
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
 		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.4"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.2"}}},
 		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}}},
@@ -783,7 +783,7 @@ var supplementTable = map[string][]supplementProduct{
 	"FG-IR-19-298": {
 		{Product: "FortiAP-S", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 		{Product: "FortiAP-U", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
-		{Product: "FortiAP-W2", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}, {LessEqual: "6.0.5"}}},
+		{Product: "FortiAP-W2", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-19-301": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
@@ -805,7 +805,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6"}},
 	},
 	"FG-IR-20-006": {
-		{Product: "FortiDeceptor", Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.0"}}},
+		{Product: "FortiDeceptor", Versions: []string{"3.0.0"}},
 	},
 	"FG-IR-20-009": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.4"}}},
@@ -957,7 +957,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWLC", Versions: []string{"8.3.3", "8.6.0"}, Ranges: []supplementRange{{GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.4.4", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.3"}}},
 	},
 	"FG-IR-20-138": {
-		{Product: "FortiWLC", Versions: []string{"8.1.3"}, Ranges: []supplementRange{{GreaterEqual: "8.2.4", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.4.4", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.3"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.0"}}},
+		{Product: "FortiWLC", Versions: []string{"8.1.3", "8.6.0"}, Ranges: []supplementRange{{GreaterEqual: "8.2.4", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.4.4", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.3"}}},
 	},
 	"FG-IR-20-147": {
 		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.2.6", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.2", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.4.4", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}}},
@@ -968,10 +968,10 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-20-170": {
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
-		{Product: "FortiSandbox", Versions: []string{"3.2.2"}, Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.6"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.1"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.6"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.1"}}},
 	},
 	"FG-IR-20-171": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.1"}}},
 	},
 	"FG-IR-20-172": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.5"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
@@ -1036,7 +1036,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "4.0.0"}}},
 	},
 	"FG-IR-20-222": {
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.3"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
+		{Product: "FortiADC", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.3"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.3"}}},
 		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "4.5"}, {GreaterEqual: "4.5", LessThan: "4.6"}, {GreaterEqual: "4.6", LessThan: "4.7"}, {GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "5.5", LessThan: "5.6"}}},
 		{Product: "FortiDDoS-F", Versions: []string{"6.3.0"}, Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.4"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
@@ -1091,7 +1091,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "7.0.0"}}},
 	},
 	"FG-IR-21-001": {
-		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.5.0", LessEqual: "8.5.3"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.0"}}},
+		{Product: "FortiWLC", Versions: []string{"8.6.0"}, Ranges: []supplementRange{{GreaterEqual: "8.5.0", LessEqual: "8.5.3"}}},
 	},
 	"FG-IR-21-002": {
 		{Product: "FortiWLC", Versions: []string{"8.0.6"}, Ranges: []supplementRange{{GreaterEqual: "8.1.2", LessEqual: "8.1.3"}, {GreaterEqual: "8.2.4", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.5"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
@@ -1231,7 +1231,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.5.0", LessThan: "4.5.9"}}},
 	},
 	"FG-IR-21-079": {
-		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.0"}}},
+		{Product: "FortiClientMac", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-21-084": {
 		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
@@ -1411,7 +1411,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSIEMWindowsAgent", Versions: []string{"3.3.0", "4.0.0"}, Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.4"}}},
 	},
 	"FG-IR-21-178": {
-		{Product: "FortiNAC", Ranges: []supplementRange{{GreaterEqual: "8.8.0", LessEqual: "8.8.9"}, {GreaterEqual: "9.1.0", LessEqual: "9.1.3"}, {GreaterEqual: "9.2.0", LessEqual: "9.2.0"}}},
+		{Product: "FortiNAC", Versions: []string{"9.2.0"}, Ranges: []supplementRange{{GreaterEqual: "8.8.0", LessEqual: "8.8.9"}, {GreaterEqual: "9.1.0", LessEqual: "9.1.3"}}},
 	},
 	"FG-IR-21-179": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessThan: "7.0.4"}}},
@@ -1571,7 +1571,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiRecorder", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 		{Product: "FortiSIEM", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3", LessThan: "6.4"}}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.10"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
-		{Product: "FortiTester", Ranges: []supplementRange{{GreaterEqual: "7.1.0", LessEqual: "7.1.0"}}},
+		{Product: "FortiTester", Versions: []string{"7.1.0"}},
 		{Product: "FortiVoice", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
 		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.3", LessThan: "4.4"}, {GreaterEqual: "4.4", LessThan: "4.5"}, {GreaterEqual: "4.5.0", LessEqual: "4.5.9"}}},
 		{Product: "FortiWeb", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.18"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -13,7 +13,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "4.3", LessThan: "4.4"}}},
 	},
 	"FG-IR-012-003": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.2.0", LessEqual: "4.2.16"}, {GreaterEqual: "4.3.0", LessThan: "4.3.8"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.2", LessThan: "4.3"}, {GreaterEqual: "4.3.0", LessThan: "4.3.8"}}}, // 4.2 affects the FortiGate 60C only
 	},
 	"FG-IR-012-007": {
 		{Product: "FortiDB", Ranges: []supplementRange{{LessThan: "4.4.2"}}},
@@ -80,8 +80,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAnalyzer", Versions: []string{"5.2.0"}, Ranges: []supplementRange{{GreaterEqual: "4", LessThan: "5"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.7"}}},
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "1", LessThan: "2"}, {GreaterEqual: "2", LessThan: "3"}, {GreaterEqual: "3.0", LessThan: "3.1"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.1"}}},
 		{Product: "FortiDB", Ranges: []supplementRange{{GreaterEqual: "4", LessThan: "5"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.1"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "5.0.7"}, {GreaterEqual: "4.0.0", LessEqual: "5.2.0"}}},
-		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.0.0", LessEqual: "8.5.3"}, {GreaterEqual: "8.0.0", LessEqual: "8.6.0"}}},
+		{Product: "FortiManager", Versions: []string{"5.2.0"}, Ranges: []supplementRange{{GreaterEqual: "4", LessThan: "5"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.7"}}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.0.0", LessEqual: "8.5.3"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.0"}}}, // 32-bit controllers only; fixed in 8.5.4 / 8.6.1
 	},
 	"FG-IR-14-031": {
 		{Product: "FortiADC"}, // whole product, audited: POODLE: default-config, no version bound in the note
@@ -92,7 +92,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiDB"},            // whole product, audited: POODLE: default-config, no version bound in the note
 		{Product: "FortiDDoS", Ranges: []supplementRange{{LessThan: "4.1.3"}}},
 		{Product: "FortiMail"}, // whole product, audited: POODLE: default-config, no version bound in the note
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.9"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.1"}}},
+		{Product: "FortiManager", Versions: []string{"5.0.9", "5.2.1"}},
 		{Product: "FortiOS"},       // whole product, audited: POODLE: default-config, no version bound in the note
 		{Product: "FortiRecorder"}, // whole product, audited: POODLE: default-config, no version bound in the note
 		{Product: "FortiSwitch"},   // whole product, audited: POODLE: default-config, no version bound in the note
@@ -140,7 +140,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientMac", Ranges: []supplementRange{{LessThan: "5.2.4"}}},
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessThan: "5.2.4"}}},
 		{Product: "FortiClientiOS", Ranges: []supplementRange{{LessThan: "5.2.1"}}},
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.3"}, {LessEqual: "5.0.11"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.3"}}},
 	},
 	"FG-IR-15-009": {
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.3", LessEqual: "5.2.3"}}},
@@ -265,8 +265,8 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-16-026": {
 		{Product: "FortiAP", Versions: []string{"5.4.0"}},
-		{Product: "FortiAnalyzer", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{LessEqual: "5.2.7"}}},
-		{Product: "FortiOS", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.7"}, {LessEqual: "5.0.13"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.7"}}},
+		{Product: "FortiOS", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.13"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.7"}}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.3.0", LessEqual: "3.3.3"}, {GreaterEqual: "3.4.0", LessEqual: "3.4.1"}}},
 	},
 	"FG-IR-16-029": {
@@ -294,7 +294,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-16-047": {
 		{Product: "FortiAnalyzer", Versions: []string{"5.4.0", "5.4.1"}},
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.1"}, {LessEqual: "5.2.8"}}},
+		{Product: "FortiOS", Versions: []string{"5.4.0", "5.4.1"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.8"}}},
 	},
 	"FG-IR-16-048": {
 		{Product: "AscenLink", Ranges: []supplementRange{{GreaterEqual: "7.2.0", LessEqual: "7.2.16"}}},
@@ -315,7 +315,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiExplorer", Versions: []string{"1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0", "2.5.0", "2.6.0"}},
 		{Product: "FortiMail", Versions: []string{"2.0.1"}, Ranges: []supplementRange{{GreaterEqual: "4.0.1", LessEqual: "4.0.5"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.3"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "4.3.0", LessEqual: "4.3.9"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.6"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.8"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.3"}, {GreaterEqual: "4.1.1", LessEqual: "4.1.4"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.9"}, {GreaterEqual: "4.3.0", LessEqual: "4.3.8"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.12"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.9"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.1"}}},
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.1"}, {LessEqual: "5.2.9"}}},
+		{Product: "FortiOS", Versions: []string{"5.4.0", "5.4.1"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.9"}}},
 		{Product: "FortiRecorder", Versions: []string{"1.0.0", "1.1.0", "1.2.0", "2.0.0", "2.3.0"}, Ranges: []supplementRange{{GreaterEqual: "1.3.0", LessEqual: "1.3.1"}, {GreaterEqual: "1.4.0", LessEqual: "1.4.1"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.1"}, {GreaterEqual: "2.2.0", LessEqual: "2.2.2"}, {GreaterEqual: "2.4.0", LessEqual: "2.4.1"}}},
 		{Product: "FortiSandbox", Versions: []string{"1.1.0", "1.3.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.3"}, {GreaterEqual: "1.4.0", LessEqual: "1.4.3"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.3"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.3"}, {GreaterEqual: "2.2.0", LessEqual: "2.2.2"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.2"}}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.5.0", LessEqual: "3.5.0"}}},
@@ -370,7 +370,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.10"}}},
 	},
 	"FG-IR-17-019": {
-		{Product: "FortiAP", Ranges: []supplementRange{{LessEqual: "5.4.2"}}},
+		{Product: "FortiAP", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.2"}}},
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.2"}}},
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.5.0", LessEqual: "3.5.2"}}},
@@ -389,13 +389,13 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientWindows", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.3"}}},
 	},
 	"FG-IR-17-073": {
-		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.4.4"}}},
+		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.11"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.4"}}},
 	},
 	"FG-IR-17-076": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.7.0", LessEqual: "5.7.1"}}},
 	},
 	"FG-IR-17-097": {
-		{Product: "FortiWLC-SD", Ranges: []supplementRange{{LessEqual: "8.2.4"}}},
+		{Product: "FortiWLC-SD", Ranges: []supplementRange{{GreaterEqual: "8.2.0", LessEqual: "8.2.4"}}},
 	},
 	"FG-IR-17-099": {
 		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "5.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.9"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.9"}}},
@@ -421,7 +421,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWLM", Ranges: []supplementRange{{GreaterEqual: "8.3.0", LessEqual: "8.3.0"}}},
 	},
 	"FG-IR-17-118": {
-		{Product: "FortiAP", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
+		{Product: "FortiAP", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.3"}}},
 		{Product: "FortiAP-S", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
 		{Product: "FortiAP-W2", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.2"}}},
@@ -438,7 +438,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Versions: []string{"5.8.0"}, Ranges: []supplementRange{{GreaterEqual: "5.7.0", LessEqual: "5.7.1"}}},
 	},
 	"FG-IR-17-137": {
-		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.12"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {LessEqual: "5.0.14"}}},
+		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.5"}}},
 	},
 	"FG-IR-17-162": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.4.1", LessEqual: "5.8.2"}}},
@@ -447,11 +447,11 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.11"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.5"}}},
 	},
 	"FG-IR-17-172": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}, {LessEqual: "5.2.15"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},
 	},
 	"FG-IR-17-196": {
 		{Product: "FortiAP", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.3"}, {LessEqual: "5.2.6"}}},
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.8"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}, {LessEqual: "5.2.11"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.2.11"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}}, // previous branches: all versions
 		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.2", LessThan: "8.3"}, {GreaterEqual: "8.3", LessThan: "8.4"}, {GreaterEqual: "801.11", LessThan: "801.12"}}},
 		{Product: "Meru AP", Ranges: []supplementRange{{GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.2", LessThan: "8.3"}, {GreaterEqual: "8.3", LessThan: "8.4"}, {GreaterEqual: "801.11", LessThan: "801.12"}}},
 	},
@@ -467,7 +467,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.8"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},
 	},
 	"FG-IR-17-242": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {LessEqual: "5.4.9"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.5"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-17-245": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.8"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},
@@ -530,7 +530,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiCloud", Ranges: []supplementRange{{LessEqual: "3.2.1"}}},
 	},
 	"FG-IR-18-085": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}, {LessEqual: "5.6.5"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 	},
 	"FG-IR-18-092": {
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.2"}}},
@@ -544,15 +544,15 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 	},
 	"FG-IR-18-108": {
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.0.4"}}},
+		{Product: "FortiClientWindows", Versions: []string{"5.6.6"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}}},
 	},
 	"FG-IR-18-121": {
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
 	},
 	"FG-IR-18-157": {
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.0"}, {LessEqual: "5.4.4"}}},
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.2"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.4"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.1"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.0"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.2"}}},
 	},
 	"FG-IR-18-173": {
 		{Product: "FortiOS", Versions: []string{"6.2.3"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
@@ -564,7 +564,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.10"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
 	},
 	"FG-IR-18-325": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.12", LessEqual: "5.2.15"}, {GreaterEqual: "5.4.6", LessEqual: "5.4.7"}, {GreaterEqual: "5.6.1", LessEqual: "5.6.3"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.4.6", LessEqual: "5.4.7"}, {GreaterEqual: "5.6.1", LessEqual: "5.6.3"}}},
 	},
 	"FG-IR-18-356": {
 		{Product: "FortiAP-S", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessThan: "6.0.4"}, {LessThan: "5.6.4"}}},
@@ -597,7 +597,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiCASB", Ranges: []supplementRange{{LessThan: "4.1.0"}}},
 	},
 	"FG-IR-19-002": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.2.14"}, {GreaterEqual: "5.4.0", LessEqual: "6.0.4"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "6.0.5"}}},
 	},
 	"FG-IR-19-003": {
 		{Product: "FortiClientMac", Versions: []string{"6.0.1", "6.0.2", "6.0.3", "6.0.4"}},
@@ -613,7 +613,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{LessThan: "6.2.2"}}},
 		{Product: "FortiAnalyzer", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{LessThan: "7.0.4"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{LessThan: "6.2.3"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{LessThan: "3.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{LessThan: "3.6.11"}, {GreaterEqual: "6.0.0", LessThan: "6.0.6"}, {GreaterEqual: "6.2.0", LessThan: "6.2.2"}}},
 	},
 	"FG-IR-19-034": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
@@ -622,11 +622,11 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
 	},
 	"FG-IR-19-043": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "6.0.4"}, {GreaterEqual: "6.2.0", LessThan: "6.2.3"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "6.2.3"}}},
 	},
 	"FG-IR-19-060": {
 		{Product: "FortiClientEMS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
-		{Product: "FortiClientWindows", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "6.4.6"}}},
+		{Product: "FortiClientWindows", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0.0", LessThan: "6.0.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-19-070": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.2"}}},
@@ -693,7 +693,7 @@ var supplementTable = map[string][]supplementProduct{
 	"FG-IR-19-209": {
 		{Product: "FortiAP", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}}},
 		{Product: "FortiAP-S", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}}},
-		{Product: "FortiAP-U", Ranges: []supplementRange{{LessEqual: "6.0.5"}}},
+		{Product: "FortiAP-U", Ranges: []supplementRange{{LessThan: "6.0.0"}}},
 		{Product: "FortiAP-W2", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{LessEqual: "6.0.5"}}},
 	},
 	"FG-IR-19-210": {
@@ -714,7 +714,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}}}, // 424E/426E/448E with bluetooth enabled only, which version data cannot express
 	},
 	"FG-IR-19-227": {
-		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.2.0"}}},
+		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
 	},
 	"FG-IR-19-236": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
@@ -723,7 +723,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}}},
 	},
 	"FG-IR-19-238": {
-		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.2.2"}}},
+		{Product: "FortiClientLinux", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-19-240": {
 		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.5"}}},
@@ -737,7 +737,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.0"}}},
 	},
 	"FG-IR-19-258": {
-		{Product: "FortiPresence", Ranges: []supplementRange{{LessEqual: "2.1.0"}}},
+		{Product: "FortiPresence", Ranges: []supplementRange{{GreaterEqual: "2.1.0", LessEqual: "2.1.0"}}},
 	},
 	"FG-IR-19-265": {
 		{Product: "FortiWeb", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.1"}}},
@@ -755,7 +755,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-19-283": {
-		{Product: "FortiOS", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
+		{Product: "FortiOS", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
 	},
 	"FG-IR-19-292": {
 		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.4"}}},
@@ -794,7 +794,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Versions: []string{"6.3.0"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-20-002": {
-		{Product: "FortiNAC", Ranges: []supplementRange{{LessEqual: "8.7.2"}}},
+		{Product: "FortiNAC", Ranges: []supplementRange{{GreaterEqual: "8.7.0", LessEqual: "8.7.2"}}},
 	},
 	"FG-IR-20-003": {
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
@@ -814,7 +814,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiIsolator", Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-20-012": {
-		{Product: "FortiADC", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.3", LessThan: "5.4"}, {LessThan: "5.3.5"}}},
+		{Product: "FortiADC", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.3.0", LessEqual: "5.3.4"}}},
 	},
 	"FG-IR-20-013": {
 		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.3.0", LessEqual: "5.3.4"}}},
@@ -833,7 +833,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWebManager", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
 	},
 	"FG-IR-20-033": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.5"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.5"}, {GreaterEqual: "6.4.0", LessThan: "6.4.1"}}},
 	},
 	"FG-IR-20-035": {
 		{Product: "FortiAP-U", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.2"}}},
@@ -855,7 +855,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.8"}}},
 	},
 	"FG-IR-20-044": {
-		{Product: "FortiADC", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
+		{Product: "FortiADC", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5", LessEqual: "5.4.3"}}},
 		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}}},
 		{Product: "FortiDDoS-F", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}}},
 		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "6", LessThan: "6.3"}}},
@@ -884,10 +884,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.2", LessEqual: "6.2.5"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-20-070": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessEqual: "3.2.1"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.2.0", LessEqual: "3.2.1"}}},
 	},
 	"FG-IR-20-071": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessEqual: "3.2.1"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.1"}}},
 	},
 	"FG-IR-20-072": {
 		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
@@ -907,7 +907,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.2"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-20-082": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.6.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.4"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.4"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-20-083": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}}},
@@ -950,7 +950,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-20-131": {
 		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
-		{Product: "FortiProxy", Ranges: []supplementRange{{LessEqual: "2.0.1"}}},
+		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-20-137": {
 		{Product: "FortiWLC", Versions: []string{"8.3.3", "8.6.0"}, Ranges: []supplementRange{{GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.4.4", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.3"}}},
@@ -963,38 +963,38 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-20-158": {
 		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
-		{Product: "FortiProxy", Ranges: []supplementRange{{LessEqual: "2.0.3"}}},
+		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.11"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.3"}}},
 	},
 	"FG-IR-20-170": {
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
-		{Product: "FortiSandbox", Versions: []string{"3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.1.0", "3.1.1", "3.1.2", "3.1.3", "3.1.4", "3.2.0", "3.2.1"}},
+		{Product: "FortiSandbox", Versions: []string{"3.2.2"}, Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.6"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.1"}}},
 	},
 	"FG-IR-20-171": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}}},
 	},
 	"FG-IR-20-172": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.2.5"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.5"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 	},
 	"FG-IR-20-177": {
-		{Product: "FortiDeceptor", Versions: []string{"4.0.0"}, Ranges: []supplementRange{{LessEqual: "3.3.1"}}},
+		{Product: "FortiDeceptor", Versions: []string{"4.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1", LessThan: "2"}, {GreaterEqual: "3.0", LessThan: "3.1"}, {GreaterEqual: "3.1", LessThan: "3.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.1"}, {GreaterEqual: "3.3.0", LessEqual: "3.3.1"}}},
 	},
 	"FG-IR-20-178": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "3.2.2"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessThan: "3.2.2"}}},
 	},
 	"FG-IR-20-183": {
-		{Product: "FortiSDNConnector", Ranges: []supplementRange{{LessEqual: "1.1.7"}}},
+		{Product: "FortiSDNConnector", Versions: []string{"1.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.1.0", LessEqual: "1.1.7"}}},
 	},
 	"FG-IR-20-185": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "3.2.2"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessThan: "3.2.2"}}},
 	},
 	"FG-IR-20-188": {
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "4.0.0"}}},
 	},
 	"FG-IR-20-189": {
-		{Product: "FortiManager", Ranges: []supplementRange{{LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-20-190": {
-		{Product: "FortiManager", Ranges: []supplementRange{{LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-20-191": {
 		{Product: "FSSO", Ranges: []supplementRange{{LessEqual: "5.0.295"}}},
@@ -1008,10 +1008,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-20-198": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessEqual: "3.0.6"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.6"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}}},
 	},
 	"FG-IR-20-199": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.13"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.10", LessEqual: "5.2.15"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.13"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-20-202": {
@@ -1029,18 +1029,18 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{GreaterEqual: "6.2.4", LessEqual: "6.2.5"}}},
 	},
 	"FG-IR-20-217": {
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessEqual: "6.3.2"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.2"}}},
 	},
 	"FG-IR-20-218": {
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "4.0.0"}}},
 	},
 	"FG-IR-20-222": {
-		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.3"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "4.5"}, {GreaterEqual: "4.5", LessThan: "4.6"}, {GreaterEqual: "4.6", LessThan: "4.7"}, {GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "5.5", LessThan: "5.6"}}},
 		{Product: "FortiDDoS-F", Versions: []string{"6.3.0"}, Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.4"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
-		{Product: "FortiMail", Ranges: []supplementRange{{LessEqual: "7.0.1"}}},
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "4.0.1"}}},
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessThan: "6.3.12"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.2.0", LessEqual: "3.2.2"}, {GreaterEqual: "4.0.0", LessThan: "4.0.1"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.7.0", LessEqual: "5.7.3"}, {GreaterEqual: "5.8.0", LessEqual: "5.8.7"}, {GreaterEqual: "5.9.0", LessEqual: "5.9.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.4"}, {GreaterEqual: "6.3.0", LessThan: "6.3.12"}}},
 	},
 	"FG-IR-20-224": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
@@ -1055,7 +1055,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-20-230": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {LessEqual: "5.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-20-231": {
@@ -1063,7 +1063,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-20-232": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {LessEqual: "5.4"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.5"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-20-233": {
@@ -1071,7 +1071,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-20-234": {
-		{Product: "FortiSandbox", Versions: []string{"4.0.0"}, Ranges: []supplementRange{{LessEqual: "3.2.2"}}},
+		{Product: "FortiSandbox", Versions: []string{"4.0.0"}, Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}}},
 	},
 	"FG-IR-20-235": {
 		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}}},
@@ -1090,7 +1090,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "7.0.0"}}},
 	},
 	"FG-IR-21-001": {
-		{Product: "FortiWLC", Ranges: []supplementRange{{LessEqual: "8.6.0"}}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.5.0", LessEqual: "8.5.3"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.0"}}},
 	},
 	"FG-IR-21-002": {
 		{Product: "FortiWLC", Versions: []string{"8.0.6"}, Ranges: []supplementRange{{GreaterEqual: "8.1.2", LessEqual: "8.1.3"}, {GreaterEqual: "8.2.4", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.5"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
@@ -1102,7 +1102,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "Meru AP", Ranges: []supplementRange{{GreaterEqual: "8.5.0", LessEqual: "8.5.5"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.1"}}},
 	},
 	"FG-IR-21-005": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "3.2.2"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.0", LessThan: "3.1"}, {GreaterEqual: "3.1", LessThan: "3.2"}, {GreaterEqual: "3.2.0", LessThan: "3.2.2"}}},
 	},
 	"FG-IR-21-006": {
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
@@ -1112,13 +1112,13 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-21-008": {
-		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "7.0.1"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}, {GreaterEqual: "7.0.0", LessThan: "7.0.1"}}},
 	},
 	"FG-IR-21-012": {
-		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "6.4.4"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-21-014": {
-		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "6.4.4"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessThan: "6.4.4"}}},
 		{Product: "FortiNDR", Versions: []string{"1.1.0", "1.2.0", "1.4.0"}, Ranges: []supplementRange{{GreaterEqual: "1.3.0", LessEqual: "1.3.1"}, {GreaterEqual: "1.5.0", LessEqual: "1.5.3"}}},
 		{Product: "FortiWeb", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.9.0", LessEqual: "5.9.2"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.17"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 	},
@@ -1129,7 +1129,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
 	},
 	"FG-IR-21-021": {
-		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "6.4.4"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-21-022": {
 		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
@@ -1145,7 +1145,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
 	},
 	"FG-IR-21-028": {
-		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "7.0.1"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}, {GreaterEqual: "7.0.0", LessThan: "7.0.1"}}},
 	},
 	"FG-IR-21-031": {
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
@@ -1187,7 +1187,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-21-059": {
 		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
-		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-21-060": {
 		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.5.0", LessThan: "4.5.9"}}},
@@ -1206,7 +1206,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.5.0", LessThan: "4.5.9"}}},
 	},
 	"FG-IR-21-068": {
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessThan: "6.3.1"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.1"}, {GreaterEqual: "6.3.0", LessThan: "6.3.1"}}},
 	},
 	"FG-IR-21-069": {
 		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.6"}, {GreaterEqual: "4.1.1", LessEqual: "4.1.3"}, {GreaterEqual: "4.2.1", LessEqual: "4.2.2"}, {GreaterEqual: "4.2.5", LessEqual: "4.2.7"}, {GreaterEqual: "4.3.0", LessEqual: "4.3.1"}, {GreaterEqual: "4.4.0", LessEqual: "4.4.1"}, {GreaterEqual: "4.5.0", LessEqual: "4.5.7"}}},
@@ -1252,22 +1252,22 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-21-096": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.6"}, {GreaterEqual: "6.0.0", LessThan: "6.0.6"}}},
 	},
 	"FG-IR-21-099": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.6"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.6"}, {GreaterEqual: "6.0.0", LessThan: "6.0.6"}}},
 	},
 	"FG-IR-21-100": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.6"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.6"}, {GreaterEqual: "6.0.0", LessThan: "6.0.6"}}},
 	},
 	"FG-IR-21-102": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.2"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.2"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.6"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.6"}, {GreaterEqual: "6.0.0", LessThan: "6.0.6"}}},
 	},
 	"FG-IR-21-103": {
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-104": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.6"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.6"}, {GreaterEqual: "6.0.0", LessThan: "6.0.6"}}},
 	},
 	"FG-IR-21-106": {
 		{Product: "FortiWLM", Versions: []string{"8.2.2"}, Ranges: []supplementRange{{GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
@@ -1276,7 +1276,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWLM", Versions: []string{"8.2.2", "8.3.0", "8.3.1", "8.3.2", "8.4.0", "8.4.1", "8.4.2", "8.5.0", "8.5.1", "8.5.2"}, Ranges: []supplementRange{{GreaterEqual: "8.6.0", LessEqual: "8.6.1"}}},
 	},
 	"FG-IR-21-109": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.2"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.6"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.6"}, {GreaterEqual: "6.0.0", LessThan: "6.0.6"}}},
 	},
 	"FG-IR-21-110": {
 		{Product: "FortiWLM", Versions: []string{"8.2.2", "8.3.0", "8.3.1", "8.3.2", "8.4.0", "8.4.1", "8.4.2", "8.5.0", "8.5.1", "8.5.2"}, Ranges: []supplementRange{{GreaterEqual: "8.6.0", LessEqual: "8.6.1"}}},
@@ -1320,7 +1320,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWLM", Versions: []string{"8.2.2", "8.3.0", "8.3.1", "8.3.2"}, Ranges: []supplementRange{{GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
 	},
 	"FG-IR-21-129": {
-		{Product: "FortiWLM", Ranges: []supplementRange{{LessEqual: "8.6.1"}}},
+		{Product: "FortiWLM", Versions: []string{"8.6.0", "8.6.1"}, Ranges: []supplementRange{{GreaterEqual: "8.2", LessThan: "8.3"}, {GreaterEqual: "8.3", LessThan: "8.4"}, {GreaterEqual: "8.4", LessThan: "8.5"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.3"}}},
 	},
 	"FG-IR-21-130": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
@@ -1360,7 +1360,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-21-148": {
-		{Product: "FortiExtender", Ranges: []supplementRange{{LessEqual: "7.0.1"}}},
+		{Product: "FortiExtender", Ranges: []supplementRange{{GreaterEqual: "4.1.0", LessEqual: "4.1.7"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-152": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
@@ -1379,7 +1379,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-158": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.4.1"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.8", LessThan: "5.9"}, {GreaterEqual: "5.9", LessThan: "5.10"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-160": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
@@ -1391,7 +1391,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAP-W2", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-21-166": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.4.1"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-167": {
 		{Product: "FortiClientWindows", Versions: []string{"4.0.1", "4.0.2", "4.0.3", "4.0.4", "4.1.0", "4.1.1", "4.1.2", "4.1.3", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6", "4.2.7", "4.3.0", "4.3.1", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "5.0.0", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6", "5.0.7", "5.0.8", "5.0.9", "5.0.10", "5.0.11", "5.2.0", "5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.2.5", "5.2.6", "5.4.0", "5.4.1", "5.4.2", "5.4.3", "5.4.4", "5.4.5", "5.6.0", "5.6.1", "5.6.2", "5.6.3", "5.6.4", "5.6.5", "5.6.6", "6.4.0", "6.4.1"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}}},
@@ -1448,8 +1448,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.13"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessThan: "7.0.3"}}},
 	},
 	"FG-IR-21-206": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.12"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.12"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.5"}}},
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.13"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
@@ -1493,7 +1493,7 @@ var supplementTable = map[string][]supplementProduct{
 	"FG-IR-21-235": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.14"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.15"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.13"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 		{Product: "FortiOS-6K7K", Versions: []string{"6.0.10", "6.2.4", "6.4.2", "6.4.6"}, Ranges: []supplementRange{{GreaterEqual: "6.0.12", LessEqual: "6.0.16"}, {GreaterEqual: "6.2.6", LessEqual: "6.2.7"}, {GreaterEqual: "6.2.9", LessEqual: "6.2.13"}}},
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.5"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
+		{Product: "FortiADC", Versions: []string{"6.1.6"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.5"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.13"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
@@ -1527,7 +1527,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-22-046": {
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.4"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.7"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.8"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.7"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-22-050": {
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
@@ -1535,14 +1535,14 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSIEM", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.3"}}},
 	},
 	"FG-IR-22-052": {
-		{Product: "FortiEDR", Versions: []string{"4.0.0", "4.2.2"}, Ranges: []supplementRange{{GreaterEqual: "4.1.0", LessEqual: "4.1.1"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.2"}}},
+		{Product: "FortiEDR", Versions: []string{"4.0.0", "5.0.0", "5.0.1", "5.0.2", "5.0.3"}},
 	},
 	"FG-IR-22-056": {
 		{Product: "FortiDeceptor", Versions: []string{"4.1.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "2.0", LessThan: "2.1"}, {GreaterEqual: "2.1", LessThan: "2.2"}, {GreaterEqual: "3.0", LessThan: "3.1"}, {GreaterEqual: "3.1", LessThan: "3.2"}, {GreaterEqual: "3.2", LessThan: "3.3"}, {GreaterEqual: "3.3.0", LessEqual: "3.3.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}}},
 		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "2.5", LessThan: "2.6"}, {GreaterEqual: "3.0", LessThan: "3.1"}, {GreaterEqual: "3.1", LessThan: "3.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.2"}}},
 	},
 	"FG-IR-22-058": {
-		{Product: "FortiNAC", Versions: []string{"8.5.4", "8.6.0"}, Ranges: []supplementRange{{GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.2", LessEqual: "8.6.5"}, {GreaterEqual: "8.7.0", LessEqual: "8.7.6"}, {GreaterEqual: "8.8.0", LessEqual: "8.8.11"}, {GreaterEqual: "9.1.0", LessEqual: "9.1.5"}, {GreaterEqual: "9.2.0", LessEqual: "9.2.3"}, {LessEqual: "8.3.7"}}},
+		{Product: "FortiNAC", Versions: []string{"8.5.4"}, Ranges: []supplementRange{{GreaterEqual: "8.3.0", LessEqual: "8.3.7"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.5"}, {GreaterEqual: "8.7.0", LessEqual: "8.7.6"}, {GreaterEqual: "8.8.0", LessEqual: "8.8.11"}, {GreaterEqual: "9.1.0", LessEqual: "9.1.5"}, {GreaterEqual: "9.2.0", LessEqual: "9.2.3"}}},
 	},
 	"FG-IR-22-059": {
 		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
@@ -1552,12 +1552,12 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAP-W2", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.4", LessThan: "6.5"}, {GreaterEqual: "7.0", LessThan: "7.1"}}},
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3", LessThan: "6.4"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
-		{Product: "FortiClientAndroid", Ranges: []supplementRange{{LessThan: "7.0.3"}}},
+		{Product: "FortiClientAndroid", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "6.0", LessThan: "6.1"}}},
 		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiClientLinux", Ranges: []supplementRange{{GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4", LessThan: "6.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.5"}}},
 		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.5"}}},
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
-		{Product: "FortiClientiOS", Ranges: []supplementRange{{LessThan: "7.0.3"}}},
+		{Product: "FortiClientiOS", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "6.0", LessThan: "6.1"}}},
 		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "4.5", LessThan: "4.6"}, {GreaterEqual: "4.6", LessThan: "4.7"}, {GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "5.5", LessThan: "5.6"}, {GreaterEqual: "5.6", LessThan: "5.7"}}},
 		{Product: "FortiDDoS-F", Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.4"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.3"}}},
 		{Product: "FortiDeceptor", Versions: []string{"4.1.0"}, Ranges: []supplementRange{{GreaterEqual: "3", LessThan: "4"}, {GreaterEqual: "4.0", LessThan: "4.1"}}},
@@ -1568,9 +1568,9 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.5"}}},
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiRecorder", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
-		{Product: "FortiSIEM", Ranges: []supplementRange{{LessThan: "6.4.0"}}},
+		{Product: "FortiSIEM", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3", LessThan: "6.4"}}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.10"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
-		{Product: "FortiTester", Ranges: []supplementRange{{LessEqual: "7.1.1"}}},
+		{Product: "FortiTester", Ranges: []supplementRange{{GreaterEqual: "7.1.0", LessEqual: "7.1.0"}}},
 		{Product: "FortiVoice", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
 		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.3", LessThan: "4.4"}, {GreaterEqual: "4.4", LessThan: "4.5"}, {GreaterEqual: "4.5.0", LessEqual: "4.5.9"}}},
 		{Product: "FortiWeb", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.18"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
@@ -1579,6 +1579,6 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSandbox", Versions: []string{"4.2.0"}, Ranges: []supplementRange{{GreaterEqual: "3.0.1", LessEqual: "3.0.7"}, {GreaterEqual: "3.1", LessThan: "3.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}}},
 	},
 	"FG-IR-22-061": {
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 }

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -10,7 +10,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.3.0", LessEqual: "4.3.5"}}},
 	},
 	"FG-IR-012-002": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "4.3.6"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "4.3", LessThan: "4.4"}}},
 	},
 	"FG-IR-012-003": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.2.0", LessEqual: "4.2.16"}, {GreaterEqual: "4.3.0", LessThan: "4.3.8"}}},
@@ -31,10 +31,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientWindows", Versions: []string{"4.3.3.445"}},
 	},
 	"FG-IR-13-009": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.2"}, {LessEqual: "4.4.7"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "4.4.0", LessEqual: "4.4.7"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.2"}}},
 	},
 	"FG-IR-13-014": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "4.3.12"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.3.0", LessEqual: "4.3.12"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.2"}}},
 	},
 	"FG-IR-13-016": {
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.3.1"}, {GreaterEqual: "2.0.0", LessEqual: "2.2.0"}}},
@@ -43,43 +43,43 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessThan: "4.3.7"}, {GreaterEqual: "5.0.0", LessThan: "5.0.5"}}},
 	},
 	"FG-IR-14-001": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "5.0.3"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.3"}}},
 	},
 	"FG-IR-14-002": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "5.0.3"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.3"}}},
 	},
 	"FG-IR-14-003": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.0.5"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.5"}}},
 	},
 	"FG-IR-14-004": {
-		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "3.2.0"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "3.2.0", LessEqual: "3.2.0"}}},
 	},
 	"FG-IR-14-006": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.7"}, {LessEqual: "4.3.15"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.3.0", LessEqual: "4.3.15"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.7"}}},
 	},
 	"FG-IR-14-010": {
 		{Product: "FortiBalancer"}, // whole product, audited: advisory: all software versions affected
 	},
 	"FG-IR-14-011": {
-		{Product: "AscenLink", Ranges: []supplementRange{{GreaterEqual: "7.1", LessThan: "7.2"}}},
+		{Product: "AscenLink", Ranges: []supplementRange{{GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "7.1", LessThan: "7.2"}}},
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.6"}}},
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "2.2", LessThan: "2.3"}, {GreaterEqual: "3.0", LessThan: "4.0"}}},
-		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "4.3", LessThan: "4.4"}, {GreaterEqual: "5.0", LessThan: "6.0"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "2.2", LessThan: "2.3"}, {GreaterEqual: "3", LessThan: "4"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "4.3", LessThan: "4.4"}, {GreaterEqual: "5", LessThan: "6"}}},
 		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "3.0", LessThan: "4.0"}}},
 	},
 	"FG-IR-14-012": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.2.0"}}},
+		{Product: "FortiWeb", Versions: []string{"5.2.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}}},
 	},
 	"FG-IR-14-013": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "5.1.4"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.1", LessThan: "5.2"}}},
 	},
 	"FG-IR-14-018": {
 		{Product: "AscenLink", Ranges: []supplementRange{{GreaterEqual: "7.1", LessThan: "7.2"}}},
 	},
 	"FG-IR-14-030": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "5.0.7"}, {GreaterEqual: "4.0.0", LessEqual: "5.2.0"}}},
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessEqual: "3.1.1"}}},
-		{Product: "FortiDB", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "5.1.1"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"5.2.0"}, Ranges: []supplementRange{{GreaterEqual: "4", LessThan: "5"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.7"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "1", LessThan: "2"}, {GreaterEqual: "2", LessThan: "3"}, {GreaterEqual: "3.0", LessThan: "3.1"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.1"}}},
+		{Product: "FortiDB", Ranges: []supplementRange{{GreaterEqual: "4", LessThan: "5"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.1"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "5.0.7"}, {GreaterEqual: "4.0.0", LessEqual: "5.2.0"}}},
 		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.0.0", LessEqual: "8.5.3"}, {GreaterEqual: "8.0.0", LessEqual: "8.6.0"}}},
 	},
@@ -100,20 +100,20 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.4"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.2"}}},
 	},
 	"FG-IR-14-032": {
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "3.1.1", LessEqual: "4.0.4"}}},
+		{Product: "FortiADC", Versions: []string{"10.2.0"}, Ranges: []supplementRange{{GreaterEqual: "3.1.1", LessEqual: "4.0.4"}}},
 	},
 	"FG-IR-14-033": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessThan: "5.0.7"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"5.0.7"}},
 		{Product: "FortiManager", Ranges: []supplementRange{{LessThan: "5.0.7"}}},
 	},
 	"FG-IR-14-034": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.10"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.2"}}},
 	},
 	"FG-IR-15-002": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.2"}, {LessEqual: "5.0.11"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.2"}}},
 	},
 	"FG-IR-15-003": {
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessThan: "3.2.1"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessThan: "3.2.0"}, {GreaterEqual: "3.2.0", LessThan: "3.2.1"}}},
 	},
 	"FG-IR-15-004": {
 		{Product: "FortiClientAndroid", Ranges: []supplementRange{{LessThan: "5.2.6"}}},
@@ -132,7 +132,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-15-007": {
 		{Product: "FortiMail"}, // whole product, audited: FREAK: note says all versions in default configuration
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessThan: "5.2.3"}, {LessThan: "5.0.11"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.2"}}},
 	},
 	"FG-IR-15-008": {
 		{Product: "FortiADC", Ranges: []supplementRange{{LessThan: "4.2.2"}}},
@@ -152,7 +152,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.10"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.1"}}},
 	},
 	"FG-IR-15-012": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessEqual: "2.0.2"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.2"}}},
 	},
 	"FG-IR-15-014": {
 		{Product: "AscenLink", Ranges: []supplementRange{{LessEqual: "7.2.4"}}},
@@ -168,13 +168,13 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWAN", Ranges: []supplementRange{{LessEqual: "4.0.2"}}},
 	},
 	"FG-IR-15-016": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "4.3.12"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.3.0", LessEqual: "4.3.12"}}},
 	},
 	"FG-IR-15-017": {
 		{Product: "FortiClientSSLVPN", Ranges: []supplementRange{{LessEqual: "4.0.2312"}}},
 	},
 	"FG-IR-15-019": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessEqual: "2.0.4"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.4"}}},
 	},
 	"FG-IR-15-020": {
 		{Product: "FortiOS", Versions: []string{"5.2.3"}},
@@ -183,7 +183,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.3"}}},
 	},
 	"FG-IR-15-022": {
-		{Product: "FortiManager", Ranges: []supplementRange{{LessEqual: "5.2.3"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.3"}}},
 	},
 	"FG-IR-15-023": {
 		{Product: "FortiADC", Ranges: []supplementRange{{LessThan: "4.4.0"}}},
@@ -254,29 +254,29 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.5"}}},
 	},
 	"FG-IR-16-020": {
-		{Product: "FortiVoice", Ranges: []supplementRange{{LessEqual: "5.0.4"}}},
+		{Product: "FortiVoice", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.4"}}},
 	},
 	"FG-IR-16-021": {
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "5.4.0"}}},
 	},
 	"FG-IR-16-023": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.1.10"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.12"}, {GreaterEqual: "4.3.0", LessEqual: "4.3.8"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{LessEqual: "3.4.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.1.0", LessEqual: "4.1.10"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.12"}, {GreaterEqual: "4.3.0", LessEqual: "4.3.8"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.4.0", LessEqual: "3.4.2"}}},
 	},
 	"FG-IR-16-026": {
 		{Product: "FortiAP", Versions: []string{"5.4.0"}},
 		{Product: "FortiAnalyzer", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{LessEqual: "5.2.7"}}},
 		{Product: "FortiOS", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.7"}, {LessEqual: "5.0.13"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{LessEqual: "3.3.3"}, {GreaterEqual: "3.4.0", LessEqual: "3.4.1"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.3.0", LessEqual: "3.3.3"}, {GreaterEqual: "3.4.0", LessEqual: "3.4.1"}}},
 	},
 	"FG-IR-16-029": {
-		{Product: "FortiWLC", Versions: []string{"7.0.9.1", "7.0.10.0", "8.0.5.0", "8.1.2.0", "8.2.4.0"}, Ranges: []supplementRange{{LessEqual: "6.1.2.29"}}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.1", LessThan: "8.2"}, {GreaterEqual: "8.2", LessThan: "8.3"}}},
 	},
 	"FG-IR-16-030": {
-		{Product: "FortiWLC", Versions: []string{"7.0.9.1", "7.0.10.0", "8.0.5.0", "8.1.2.0", "8.2.4.0"}, Ranges: []supplementRange{{LessEqual: "6.1.2.29"}}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.1", LessThan: "8.2"}, {GreaterEqual: "8.2", LessThan: "8.3"}}},
 	},
 	"FG-IR-16-037": {
-		{Product: "FortiDDoS", Ranges: []supplementRange{{LessEqual: "4.2.2"}}},
+		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "4.2.0", LessEqual: "4.2.2"}}},
 	},
 	"FG-IR-16-039": {
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.9"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
@@ -293,16 +293,16 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWAN", Ranges: []supplementRange{{LessEqual: "4.2.4"}}},
 	},
 	"FG-IR-16-047": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.1"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"5.4.0", "5.4.1"}},
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.1"}, {LessEqual: "5.2.8"}}},
 	},
 	"FG-IR-16-048": {
 		{Product: "AscenLink", Ranges: []supplementRange{{GreaterEqual: "7.2.0", LessEqual: "7.2.16"}}},
 		{Product: "FSSO CA", Versions: []string{"0.4.20", "3.0.0", "4.1.2"}, Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.2"}, {GreaterEqual: "4.2.2", LessEqual: "4.2.9"}, {GreaterEqual: "4.3.0", LessEqual: "4.3.10"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.9"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.3"}, {GreaterEqual: "5.2.6", LessEqual: "5.2.9"}}},
 		{Product: "FortiADC", Versions: []string{"3.0.0", "3.1.0", "4.6.0"}, Ranges: []supplementRange{{GreaterEqual: "3.2.0", LessEqual: "3.2.2"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.1"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.3"}, {GreaterEqual: "4.3.0", LessEqual: "4.3.2"}, {GreaterEqual: "4.4.0", LessEqual: "4.4.1"}, {GreaterEqual: "4.5.0", LessEqual: "4.5.4"}}},
-		{Product: "FortiAP", Ranges: []supplementRange{{LessEqual: "5.4.1"}}},
+		{Product: "FortiAP", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.1"}}},
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.1"}}},
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.5"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.6"}, {GreaterEqual: "4.3.0", LessEqual: "4.3.8"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.13"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.9"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.1"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"5.4.0", "5.4.1"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.9"}}},
 		{Product: "FortiAuthenticator", Versions: []string{"1.0.0", "1.1.0", "2.1.0", "2.2.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.1"}, {GreaterEqual: "1.3.0", LessEqual: "1.3.1"}, {GreaterEqual: "3.0.0", LessEqual: "3.0.3"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.1"}, {GreaterEqual: "3.3.0", LessEqual: "3.3.2"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.1"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}}},
 		{Product: "FortiCache", Versions: []string{"0.4.10", "1.0.0", "4.1.1"}, Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.1"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.3"}, {GreaterEqual: "2.2.0", LessEqual: "2.2.4"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.7"}, {GreaterEqual: "3.0.0", LessEqual: "3.0.8"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.1"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.4"}}},
 		{Product: "FortiClientAndroid", Versions: []string{"5.4.0"}},
@@ -318,7 +318,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.1"}, {LessEqual: "5.2.9"}}},
 		{Product: "FortiRecorder", Versions: []string{"1.0.0", "1.1.0", "1.2.0", "2.0.0", "2.3.0"}, Ranges: []supplementRange{{GreaterEqual: "1.3.0", LessEqual: "1.3.1"}, {GreaterEqual: "1.4.0", LessEqual: "1.4.1"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.1"}, {GreaterEqual: "2.2.0", LessEqual: "2.2.2"}, {GreaterEqual: "2.4.0", LessEqual: "2.4.1"}}},
 		{Product: "FortiSandbox", Versions: []string{"1.1.0", "1.3.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.3"}, {GreaterEqual: "1.4.0", LessEqual: "1.4.3"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.3"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.3"}, {GreaterEqual: "2.2.0", LessEqual: "2.2.2"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.2"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{LessEqual: "3.5.0"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.5.0", LessEqual: "3.5.0"}}},
 		{Product: "FortiTester", Versions: []string{"2.3.0", "2.5.0", "2.6.0", "2.7.0"}, Ranges: []supplementRange{{GreaterEqual: "2.4.0", LessEqual: "2.4.1"}}},
 		{Product: "FortiTokenIOS", Versions: []string{"3.0.5"}},
 		{Product: "FortiVoice", Versions: []string{"5.0.5", "5.3.3"}},
@@ -339,7 +339,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.0.6", LessEqual: "5.2.7"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.1"}}},
 	},
 	"FG-IR-16-065": {
-		{Product: "FortiWLC", Versions: []string{"7.0.9.1", "7.0.10.0", "8.1.2.0", "8.1.3.2", "8.2.4.0"}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.1", LessThan: "8.2"}, {GreaterEqual: "8.2", LessThan: "8.3"}}},
 	},
 	"FG-IR-16-067": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "4.3.0", LessEqual: "4.3.18"}}},
@@ -351,13 +351,13 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "Connect", Ranges: []supplementRange{{GreaterEqual: "14.10.0.0", LessThan: "14.10.0.5"}, {GreaterEqual: "14.2.0.0", LessThan: "14.2.0.12"}, {GreaterEqual: "15.10.0.0", LessThan: "15.10.0.3"}, {GreaterEqual: "16.7.0.0", LessThan: "16.7.0.1"}}},
 	},
 	"FG-IR-16-088": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.14"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.15"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.2", LessThan: "5.3"}}},
 	},
 	"FG-IR-16-090": {
 		{Product: "FortiOS"}, // whole product, audited: advisory: FortiOS all versions, when TCP timestamp is enabled (the default)
 	},
 	"FG-IR-16-095": {
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "5.4.1", LessEqual: "5.4.2"}}},
+		{Product: "FortiClientWindows", Versions: []string{"5.4.1", "5.4.2"}},
 	},
 	"FG-IR-17-011": {
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.2.9"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.8"}}},
@@ -371,39 +371,39 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-17-019": {
 		{Product: "FortiAP", Ranges: []supplementRange{{LessEqual: "5.4.2"}}},
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessEqual: "5.4.2"}}},
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.4.5"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{LessEqual: "3.5.2"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.5.0", LessEqual: "3.5.2"}}},
 	},
 	"FG-IR-17-051": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessEqual: "5.4.2"}}},
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.4.4"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.4"}}},
 	},
 	"FG-IR-17-053": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {LessEqual: "5.4.13"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}}},
 	},
 	"FG-IR-17-057": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.14"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.10"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.10"}}},
 	},
 	"FG-IR-17-070": {
-		{Product: "FortiClientWindows", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
+		{Product: "FortiClientWindows", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.3"}}},
 	},
 	"FG-IR-17-073": {
 		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.4.4"}}},
 	},
 	"FG-IR-17-076": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "5.7.1"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.7.0", LessEqual: "5.7.1"}}},
 	},
 	"FG-IR-17-097": {
 		{Product: "FortiWLC-SD", Ranges: []supplementRange{{LessEqual: "8.2.4"}}},
 	},
 	"FG-IR-17-099": {
-		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.9"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.9"}, {LessEqual: "5.1.7"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "5.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.9"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.9"}}},
 	},
 	"FG-IR-17-103": {
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.0"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}}},
 		{Product: "FortiMail", Versions: []string{"5.3.13"}},
-		{Product: "FortiOS", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.5"}}},
+		{Product: "FortiOS", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}}},
 	},
 	"FG-IR-17-104": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.6.0"}}},
@@ -415,27 +415,27 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}}},
 	},
 	"FG-IR-17-114": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "4.0.0"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.0"}}},
 	},
 	"FG-IR-17-115": {
-		{Product: "FortiWLM", Ranges: []supplementRange{{LessEqual: "8.3.0"}}},
+		{Product: "FortiWLM", Ranges: []supplementRange{{GreaterEqual: "8.3.0", LessEqual: "8.3.0"}}},
 	},
 	"FG-IR-17-118": {
 		{Product: "FortiAP", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
 		{Product: "FortiAP-S", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
 		{Product: "FortiAP-W2", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessEqual: "5.4.2"}}},
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.6.0"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{LessEqual: "3.6.2"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.6.0", LessEqual: "3.6.2"}}},
 	},
 	"FG-IR-17-119": {
-		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "6.1.2", LessEqual: "6.1.5"}, {GreaterEqual: "7.0.7", LessEqual: "7.0.10"}, {GreaterEqual: "8.0.0", LessEqual: "8.3.2"}}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.0.0", LessEqual: "8.2"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.2"}}},
 	},
 	"FG-IR-17-127": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.4.4"}}},
 	},
 	"FG-IR-17-131": {
-		{Product: "FortiWeb", Versions: []string{"5.8.0"}, Ranges: []supplementRange{{LessEqual: "5.7.1"}}},
+		{Product: "FortiWeb", Versions: []string{"5.8.0"}, Ranges: []supplementRange{{GreaterEqual: "5.7.0", LessEqual: "5.7.1"}}},
 	},
 	"FG-IR-17-137": {
 		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.12"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {LessEqual: "5.0.14"}}},
@@ -452,31 +452,31 @@ var supplementTable = map[string][]supplementProduct{
 	"FG-IR-17-196": {
 		{Product: "FortiAP", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.3"}, {LessEqual: "5.2.6"}}},
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.8"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}, {LessEqual: "5.2.11"}}},
-		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.0.0", LessEqual: "8.0.6"}, {GreaterEqual: "8.2.0", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {LessEqual: "7.0.11"}}},
-		{Product: "Meru AP", Ranges: []supplementRange{{GreaterEqual: "8.0.0", LessEqual: "8.0.0"}, {GreaterEqual: "8.2.0", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {LessEqual: "7.0.11"}}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.2", LessThan: "8.3"}, {GreaterEqual: "8.3", LessThan: "8.4"}, {GreaterEqual: "801.11", LessThan: "801.12"}}},
+		{Product: "Meru AP", Ranges: []supplementRange{{GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.2", LessThan: "8.3"}, {GreaterEqual: "8.3", LessThan: "8.4"}, {GreaterEqual: "801.11", LessThan: "801.12"}}},
 	},
 	"FG-IR-17-206": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}}},
+		{Product: "FortiOS", Versions: []string{"5.4.0", "5.4.1", "5.4.2", "5.4.3", "5.4.4", "5.4.5"}},
 	},
 	"FG-IR-17-214": {
-		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "5.6.0"}}},
+		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
 		{Product: "FortiClientSSLVPN", Ranges: []supplementRange{{LessEqual: "4.4.2335"}}},
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "5.6.0"}}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
 	},
 	"FG-IR-17-231": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.15"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.8"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.8"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},
 	},
 	"FG-IR-17-242": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {LessEqual: "5.4.9"}}},
 	},
 	"FG-IR-17-245": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.2.15"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.8"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.8"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},
 	},
 	"FG-IR-17-259": {
 		{Product: "FortiCloud", Ranges: []supplementRange{{LessEqual: "3.2.0"}}},
 	},
 	"FG-IR-17-262": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.2.15"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.7"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.7"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.2"}}},
 	},
 	"FG-IR-17-274": {
 		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "7.0.0", LessEqual: "7.0.11"}, {GreaterEqual: "8.0.0", LessEqual: "8.3.3"}}},
@@ -488,40 +488,40 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.6", LessEqual: "5.4.9"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 	},
 	"FG-IR-17-305": {
-		{Product: "FortiAnalyzer", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.4"}}},
-		{Product: "FortiManager", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.4"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.4"}}},
+		{Product: "FortiManager", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.4"}}},
 	},
 	"FG-IR-18-006": {
-		{Product: "FortiManager", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.6"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
 	},
 	"FG-IR-18-013": {
-		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}, {LessEqual: "3.6.8"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.6.0", LessEqual: "3.6.8"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 	},
 	"FG-IR-18-014": {
-		{Product: "FortiAnalyzer", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.5"}}},
-		{Product: "FortiManager", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.5"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
 	},
 	"FG-IR-18-016": {
-		{Product: "FortiManager", Ranges: []supplementRange{{LessEqual: "6.0.1"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 	},
 	"FG-IR-18-018": {
 		{Product: "FortiOS", Versions: []string{"5.6.0"}},
 	},
 	"FG-IR-18-022": {
-		{Product: "FortiAnalyzer", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.5"}}},
-		{Product: "FortiManager", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.5"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
 	},
 	"FG-IR-18-024": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "2.4.0", LessEqual: "2.4.1"}, {GreaterEqual: "2.5.0", LessEqual: "2.5.2"}}},
+		{Product: "FortiSandbox", Versions: []string{"2.4.0", "2.4.1", "2.5.0", "2.5.1", "2.5.2"}},
 	},
 	"FG-IR-18-026": {
 		{Product: "FortiCloud", Ranges: []supplementRange{{LessEqual: "3.2.1"}}},
 	},
 	"FG-IR-18-027": {
-		{Product: "FortiOS", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.5"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.0"}}},
 	},
 	"FG-IR-18-051": {
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.7"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.1"}}},
+		{Product: "FortiManager", Versions: []string{"5.4.0", "5.4.1"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.7"}}},
 	},
 	"FG-IR-18-059": {
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessThan: "5.3.0"}}},
@@ -533,7 +533,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}, {LessEqual: "5.6.5"}}},
 	},
 	"FG-IR-18-092": {
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.0.2"}}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.2"}}},
 	},
 	"FG-IR-18-100": {
 		{Product: "FortiClientMac", Ranges: []supplementRange{{LessThan: "6.2.2"}}},
@@ -541,26 +541,26 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessThan: "6.0.8"}, {LessThan: "5.6.12"}}},
 	},
 	"FG-IR-18-101": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}, {LessEqual: "5.6.7"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 	},
 	"FG-IR-18-108": {
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-18-121": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessEqual: "5.6.0"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{LessEqual: "5.6.0"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.0"}}},
 	},
 	"FG-IR-18-157": {
 		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.0"}, {LessEqual: "5.4.4"}}},
 		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.2"}}},
 	},
 	"FG-IR-18-173": {
-		{Product: "FortiOS", Versions: []string{"6.2.3"}, Ranges: []supplementRange{{LessEqual: "6.2.0"}}},
+		{Product: "FortiOS", Versions: []string{"6.2.3"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
 	},
 	"FG-IR-18-232": {
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
-		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.2"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.6"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.8"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.9"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.1", LessThan: "4.2"}, {GreaterEqual: "4.2", LessThan: "4.3"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.9"}}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.10"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
 	},
 	"FG-IR-18-325": {
@@ -571,23 +571,23 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessThan: "6.0.4"}, {LessThan: "5.6.4"}}},
 	},
 	"FG-IR-18-382": {
-		{Product: "FortiSIEM", Ranges: []supplementRange{{LessEqual: "5.2.0"}}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.0"}}},
 	},
 	"FG-IR-18-383": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {LessEqual: "5.2.15"}}},
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.8"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.3"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-18-384": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.6", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.3", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-18-387": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {LessEqual: "5.4.13"}}},
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.8"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "5.5"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-18-388": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.14"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.8"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-18-389": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.1", LessEqual: "5.4.10"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.8"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
@@ -603,13 +603,13 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientMac", Versions: []string{"6.0.1", "6.0.2", "6.0.3", "6.0.4"}},
 	},
 	"FG-IR-19-007": {
-		{Product: "FortiOS", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{LessEqual: "6.2.4"}}},
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessEqual: "6.2.3"}}},
+		{Product: "FortiOS", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.4"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
 	},
 	"FG-IR-19-013": {
-		{Product: "FortiOS", Versions: []string{"5.2.7"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.13"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
-		{Product: "FortiAP-S", Ranges: []supplementRange{{LessThan: "6.2.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiAP-S", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessThan: "6.2.2"}}},
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{LessThan: "6.2.2"}}},
 		{Product: "FortiAnalyzer", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{LessThan: "7.0.4"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{LessThan: "6.2.3"}}},
@@ -619,26 +619,26 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-19-037": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.2.0"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
 	},
 	"FG-IR-19-043": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessThan: "6.0.4"}, {GreaterEqual: "6.2.0", LessThan: "6.2.3"}}},
 	},
 	"FG-IR-19-060": {
-		{Product: "FortiClientEMS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
+		{Product: "FortiClientEMS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 		{Product: "FortiClientWindows", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-19-070": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.0.2"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.2"}}},
 	},
 	"FG-IR-19-072": {
-		{Product: "FortiClientEMS", Versions: []string{"6.2.0"}},
+		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
 	},
 	"FG-IR-19-099": {
-		{Product: "FortiOS", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}}},
+		{Product: "FortiOS", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}}},
 	},
 	"FG-IR-19-100": {
-		{Product: "FortiSIEM", Ranges: []supplementRange{{LessEqual: "5.2.2"}}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.2"}}},
 	},
 	"FG-IR-19-104": {
 		{Product: "FortiAuthenticator", Versions: []string{"6.0.0"}},
@@ -647,15 +647,15 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-19-110": {
-		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.2.0"}}},
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.2.0"}}},
+		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
 	},
 	"FG-IR-19-111": {
 		{Product: "FortiOS", Versions: []string{"6.2.0"}},
 	},
 	"FG-IR-19-134": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
-		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.3"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.4"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
+		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2", LessThan: "1.3"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.4"}}},
 	},
 	"FG-IR-19-140": {
 		{Product: "FortiNAC", Versions: []string{"8.5.0"}, Ranges: []supplementRange{{GreaterEqual: "8.3.0", LessEqual: "8.3.6"}}},
@@ -664,10 +664,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}}},
 	},
 	"FG-IR-19-148": {
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.2.1"}}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 	},
 	"FG-IR-19-179": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
+		{Product: "FortiOS", Versions: []string{"6.2.0", "6.2.1"}},
 	},
 	"FG-IR-19-184": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
@@ -676,35 +676,35 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiRecorder", Ranges: []supplementRange{{LessThan: "2.7.4"}}},
 	},
 	"FG-IR-19-186": {
-		{Product: "FortiOS", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{LessEqual: "6.0.8"}}},
+		{Product: "FortiOS", Versions: []string{"6.2.0", "6.2.1"}},
 	},
 	"FG-IR-19-191": {
-		{Product: "FortiManager", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{LessEqual: "6.0.6"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 	},
 	"FG-IR-19-194": {
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessThan: "6.4.0"}}},
 	},
 	"FG-IR-19-195": {
-		{Product: "FortiSIEM", Ranges: []supplementRange{{LessEqual: "5.2.5"}}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.5"}}},
 	},
 	"FG-IR-19-197": {
-		{Product: "FortiSIEM", Ranges: []supplementRange{{LessEqual: "5.2.5"}}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.5"}}},
 	},
 	"FG-IR-19-209": {
-		{Product: "FortiAP", Ranges: []supplementRange{{LessEqual: "6.0.5"}}},
-		{Product: "FortiAP-S", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{LessEqual: "6.0.5"}}},
+		{Product: "FortiAP", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}}},
+		{Product: "FortiAP-S", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}}},
 		{Product: "FortiAP-U", Ranges: []supplementRange{{LessEqual: "6.0.5"}}},
 		{Product: "FortiAP-W2", Versions: []string{"6.2.0", "6.2.1"}, Ranges: []supplementRange{{LessEqual: "6.0.5"}}},
 	},
 	"FG-IR-19-210": {
-		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.2.1"}}},
+		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 	},
 	"FG-IR-19-217": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.6.13"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.9"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.13"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.9"}}},
 	},
 	"FG-IR-19-220": {
-		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "5.3.3"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.3.0", LessEqual: "5.3.3"}}},
 	},
 	"FG-IR-19-223": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
@@ -717,71 +717,71 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.2.0"}}},
 	},
 	"FG-IR-19-236": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 	},
 	"FG-IR-19-237": {
-		{Product: "FortiMail", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {LessEqual: "5.4.10"}}},
+		{Product: "FortiMail", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}}},
 	},
 	"FG-IR-19-238": {
 		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-19-240": {
-		{Product: "FortiSIEM", Ranges: []supplementRange{{LessEqual: "5.2.5"}}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.5"}}},
 	},
 	"FG-IR-19-244": {
-		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "5.3.7"}}},
-		{Product: "FortiADCManager", Ranges: []supplementRange{{LessEqual: "5.2.1"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.0"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.3.0", LessEqual: "5.3.7"}}},
+		{Product: "FortiADCManager", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.1"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.0"}}},
 	},
 	"FG-IR-19-248": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.0"}}},
 	},
 	"FG-IR-19-258": {
 		{Product: "FortiPresence", Ranges: []supplementRange{{LessEqual: "2.1.0"}}},
 	},
 	"FG-IR-19-265": {
-		{Product: "FortiWeb", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{LessEqual: "6.0.5"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.1"}}},
+		{Product: "FortiWeb", Versions: []string{"6.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.1"}}},
 	},
 	"FG-IR-19-269": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.2.0"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
 	},
 	"FG-IR-19-270": {
-		{Product: "FortiIsolator", Ranges: []supplementRange{{LessEqual: "1.2.2"}}},
+		{Product: "FortiIsolator", Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.2"}}},
 	},
 	"FG-IR-19-271": {
-		{Product: "FortiManager", Ranges: []supplementRange{{LessEqual: "6.2.1"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 	},
 	"FG-IR-19-281": {
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.2.2"}}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-19-283": {
 		{Product: "FortiOS", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
 	},
 	"FG-IR-19-292": {
 		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.4"}}},
-		{Product: "FortiAP-C", Ranges: []supplementRange{{LessEqual: "5.4.2"}}},
-		{Product: "FortiAP-S", Ranges: []supplementRange{{LessEqual: "6.2.3"}}},
-		{Product: "FortiAP-U", Ranges: []supplementRange{{LessEqual: "6.0.1"}}},
+		{Product: "FortiAP-C", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.2"}}},
+		{Product: "FortiAP-S", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
+		{Product: "FortiAP-U", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{LessEqual: "6.2.3"}}},
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
-		{Product: "FortiDDoS", Ranges: []supplementRange{{LessEqual: "5.2.0"}}},
-		{Product: "FortiExtender", Ranges: []supplementRange{{LessEqual: "4.2.0"}}},
+		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.0"}}},
+		{Product: "FortiExtender", Ranges: []supplementRange{{GreaterEqual: "4.2.0", LessEqual: "4.2.0"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "5.2.4"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.2"}}},
-		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.1", LessThan: "6.3"}}},
-		{Product: "FortiWAN", Ranges: []supplementRange{{LessEqual: "4.5.7"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.4"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.2"}}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}}},
+		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.5.0", LessEqual: "4.5.7"}}},
 		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.5.1", LessEqual: "8.5.5"}}},
 	},
 	"FG-IR-19-294": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {LessEqual: "6.0.8"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {LessEqual: "6.0.8"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
 	},
 	"FG-IR-19-296": {
-		{Product: "FortiSIEM", Ranges: []supplementRange{{LessEqual: "5.2.6"}}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.6"}}},
 	},
 	"FG-IR-19-298": {
-		{Product: "FortiAP-S", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}, {LessEqual: "6.0.5"}}},
-		{Product: "FortiAP-U", Ranges: []supplementRange{{LessEqual: "6.0.1"}}},
+		{Product: "FortiAP-S", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.5"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiAP-U", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}, {LessEqual: "6.0.5"}}},
 	},
 	"FG-IR-19-301": {
@@ -791,94 +791,94 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiGate Cloud", Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "4.5"}}},
 	},
 	"FG-IR-20-001": {
-		{Product: "FortiWeb", Versions: []string{"6.3.0"}, Ranges: []supplementRange{{LessEqual: "6.2.2"}}},
+		{Product: "FortiWeb", Versions: []string{"6.3.0"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-20-002": {
 		{Product: "FortiNAC", Ranges: []supplementRange{{LessEqual: "8.7.2"}}},
 	},
 	"FG-IR-20-003": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessEqual: "6.2.3"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
 	},
 	"FG-IR-20-005": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.6"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.6"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6"}},
+		{Product: "FortiManager", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6"}},
 	},
 	"FG-IR-20-006": {
-		{Product: "FortiDeceptor", Ranges: []supplementRange{{LessEqual: "3.0.0"}}},
+		{Product: "FortiDeceptor", Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.0"}}},
 	},
 	"FG-IR-20-009": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.4"}}},
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.9"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.4"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.9"}}},
 	},
 	"FG-IR-20-011": {
-		{Product: "FortiIsolator", Ranges: []supplementRange{{LessEqual: "2.0.1"}}},
+		{Product: "FortiIsolator", Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-20-012": {
 		{Product: "FortiADC", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.3", LessThan: "5.4"}, {LessThan: "5.3.5"}}},
 	},
 	"FG-IR-20-013": {
-		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "5.3.4"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.3.0", LessEqual: "5.3.4"}}},
 	},
 	"FG-IR-20-014": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.13"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
-		{Product: "FortiAuthenticator", Versions: []string{"5.5.0", "6.1.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
+		{Product: "FortiAuthenticator", Versions: []string{"6.1.0"}, Ranges: []supplementRange{{GreaterEqual: "5.5", LessThan: "5.6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-20-016": {
-		{Product: "FortiWLC", Ranges: []supplementRange{{LessEqual: "8.5.1"}}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.5.0", LessEqual: "8.5.1"}}},
 	},
 	"FG-IR-20-021": {
-		{Product: "FortiSIEMWindowsAgent", Ranges: []supplementRange{{LessEqual: "3.1.2"}}},
+		{Product: "FortiSIEMWindowsAgent", Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.2"}}},
 	},
 	"FG-IR-20-027": {
-		{Product: "FortiWebManager", Versions: []string{"6.0.2", "6.2.3"}},
+		{Product: "FortiWebManager", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
 	},
 	"FG-IR-20-033": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.5"}}},
 	},
 	"FG-IR-20-035": {
-		{Product: "FortiAP-U", Ranges: []supplementRange{{LessEqual: "6.0.2"}}},
-		{Product: "Meru AP", Ranges: []supplementRange{{LessEqual: "8.4.6"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.1"}}},
+		{Product: "FortiAP-U", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.2"}}},
+		{Product: "Meru AP", Ranges: []supplementRange{{GreaterEqual: "8.4.0", LessEqual: "8.4.6"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.1"}}},
 	},
 	"FG-IR-20-036": {
-		{Product: "FortiAnalyzer", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{LessEqual: "6.2.3"}}}, // FortiRecorder-management models only, which version data cannot express
+		{Product: "FortiAnalyzer", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}}, // FortiRecorder-management models only, which version data cannot express
 	},
 	"FG-IR-20-037": {
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}}},
 	},
 	"FG-IR-20-038": {
-		{Product: "FortiNAC", Ranges: []supplementRange{{LessEqual: "8.8.1"}}},
+		{Product: "FortiNAC", Ranges: []supplementRange{{GreaterEqual: "8.8.0", LessEqual: "8.8.1"}}},
 	},
 	"FG-IR-20-040": {
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 	},
 	"FG-IR-20-041": {
-		{Product: "FortiSIEM", Ranges: []supplementRange{{LessEqual: "5.2.8"}}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.8"}}},
 	},
 	"FG-IR-20-044": {
 		{Product: "FortiADC", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
-		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.5"}}},
-		{Product: "FortiDDoS-F", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.2"}}},
+		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}}},
+		{Product: "FortiDDoS-F", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}}},
 		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "6", LessThan: "6.3"}}},
 	},
 	"FG-IR-20-045": {
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
-		{Product: "FortiVoice", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessThan: "5.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
+		{Product: "FortiVoice", Ranges: []supplementRange{{GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.1"}}},
 	},
 	"FG-IR-20-049": {
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessThan: "6.3.0"}}},
 	},
 	"FG-IR-20-054": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessEqual: "6.2.5"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"6.2.5"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessThan: "6.2.5"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 		{Product: "FortiTester", Ranges: []supplementRange{{LessThan: "3.9.0"}}},
 	},
 	"FG-IR-20-061": {
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-20-066": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.2"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.6"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.6"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-20-067": {
-		{Product: "FortiClientEMS", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.8", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.6", "6.2.7", "6.2.8", "6.2.9", "6.4.0", "6.4.1"}},
+		{Product: "FortiClientEMS", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.8", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.6", "6.2.7", "6.2.8", "6.2.9"}, Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-20-068": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.2", LessEqual: "6.2.5"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
@@ -890,33 +890,33 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessEqual: "3.2.1"}}},
 	},
 	"FG-IR-20-072": {
-		{Product: "FortiClientEMS", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.6", "6.2.7", "6.2.8", "6.4.0", "6.4.1", "6.4.2"}},
+		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 	},
 	"FG-IR-20-074": {
-		{Product: "FortiClientEMS", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.6", "6.2.7", "6.2.8", "6.4.0", "6.4.1"}},
+		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-20-076": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.2.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.4"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.4"}}},
 	},
 	"FG-IR-20-078": {
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "5.4", LessThan: "5.6"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3", LessThan: "6.4"}, {GreaterEqual: "6.4", LessThan: "6.5"}}},
-		{Product: "FortiDeceptor", Versions: []string{"1.1.0", "2.0.0", "2.1.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.1"}, {GreaterEqual: "3.0.0", LessEqual: "3.0.2"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.1"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "5.5", LessThan: "5.6"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3", LessThan: "6.4"}, {GreaterEqual: "6.4", LessThan: "6.5"}}},
+		{Product: "FortiDeceptor", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "2.0", LessThan: "2.1"}, {GreaterEqual: "2.1", LessThan: "2.2"}, {GreaterEqual: "3.0", LessThan: "3.1"}, {GreaterEqual: "3.1", LessThan: "3.2"}}},
 		{Product: "FortiMail", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.9"}, {GreaterEqual: "6.2.1", LessEqual: "6.2.4"}}},
 	},
 	"FG-IR-20-079": {
-		{Product: "FortiClientWindows", Versions: []string{"6.4.0", "6.4.1", "6.4.2", "7.0.0", "7.0.1"}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.2"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-20-082": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.6.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.4"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-20-083": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.6.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}}},
 	},
 	"FG-IR-20-091": {
 		{Product: "FortiOS", Versions: []string{"5.6.0", "5.6.1", "5.6.2", "5.6.3", "5.6.4", "5.6.5", "5.6.6", "5.6.7", "5.6.8", "5.6.9", "5.6.10", "5.6.11", "5.6.12", "5.6.13", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.0.11", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.4.0", "6.4.1", "6.4.2", "6.4.3"}},
 	},
 	"FG-IR-20-092": {
-		{Product: "FortiAnalyzer", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.4.4"}},
+		{Product: "FortiAnalyzer", Versions: []string{"6.4.4"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}}},
 	},
 	"FG-IR-20-098": {
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
@@ -931,32 +931,32 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.9", LessThan: "5.10"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.7"}}},
 	},
 	"FG-IR-20-122": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.7"}, {LessThan: "6.2.4"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessThan: "6.2.4"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.7"}}},
 	},
 	"FG-IR-20-123": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.5"}}},
 	},
 	"FG-IR-20-124": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.7"}, {LessThan: "6.2.4"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessThan: "6.2.4"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.7"}}},
 	},
 	"FG-IR-20-125": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.2.4"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.9"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.4"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.9"}}},
 	},
 	"FG-IR-20-126": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.7"}, {LessThan: "6.2.4"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessThan: "6.2.4"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.7"}}},
 	},
 	"FG-IR-20-127": {
-		{Product: "FortiClientWindows", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.2.8", "6.4.0", "6.4.1", "6.4.2", "6.4.3", "6.4.4", "6.4.5", "6.4.6", "7.0.0"}},
+		{Product: "FortiClientWindows", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-20-131": {
-		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
+		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 		{Product: "FortiProxy", Ranges: []supplementRange{{LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-20-137": {
 		{Product: "FortiWLC", Versions: []string{"8.3.3", "8.6.0"}, Ranges: []supplementRange{{GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.4.4", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.3"}}},
 	},
 	"FG-IR-20-138": {
-		{Product: "FortiWLC", Versions: []string{"8.1.3", "8.6.0"}, Ranges: []supplementRange{{GreaterEqual: "8.2.4", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.4.4", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.3"}}},
+		{Product: "FortiWLC", Versions: []string{"8.1.3"}, Ranges: []supplementRange{{GreaterEqual: "8.2.4", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.4.4", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.3"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.0"}}},
 	},
 	"FG-IR-20-147": {
 		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.2.6", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.2", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.4.4", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}}},
@@ -1015,10 +1015,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-20-202": {
-		{Product: "FortiSandbox", Versions: []string{"3.1.0", "3.1.1", "3.1.2", "3.1.3", "3.1.4", "3.2.0", "3.2.1", "3.2.2"}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}}},
 	},
 	"FG-IR-20-206": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.2.4"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.14"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.4"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.14"}}},
 	},
 	"FG-IR-20-209": {
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "4.0.0"}}},
@@ -1036,27 +1036,27 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-20-222": {
 		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
-		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "5.6"}}},
+		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "4.5"}, {GreaterEqual: "4.5", LessThan: "4.6"}, {GreaterEqual: "4.6", LessThan: "4.7"}, {GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "5.5", LessThan: "5.6"}}},
 		{Product: "FortiDDoS-F", Versions: []string{"6.3.0"}, Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.4"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 		{Product: "FortiMail", Ranges: []supplementRange{{LessEqual: "7.0.1"}}},
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "4.0.1"}}},
 		{Product: "FortiWeb", Ranges: []supplementRange{{LessThan: "6.3.12"}}},
 	},
 	"FG-IR-20-224": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}, {LessEqual: "6.0.9"}}},
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.9"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}}},
 	},
 	"FG-IR-20-226": {
 		{Product: "FortiOS", Versions: []string{"5.6.12"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.9"}}},
 	},
 	"FG-IR-20-229": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {LessEqual: "5.2.14"}}},
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.8"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.14"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-20-230": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {LessEqual: "5.2"}}},
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.8"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-20-231": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.1", LessEqual: "5.4.10"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.8"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
@@ -1064,7 +1064,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-20-232": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {LessEqual: "5.4"}}},
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.8"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.8"}}},
 	},
 	"FG-IR-20-233": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.4.6", LessEqual: "5.4.12"}, {GreaterEqual: "5.6.3", LessEqual: "5.6.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
@@ -1074,14 +1074,14 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSandbox", Versions: []string{"4.0.0"}, Ranges: []supplementRange{{LessEqual: "3.2.2"}}},
 	},
 	"FG-IR-20-235": {
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.9"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}}},
 	},
 	"FG-IR-20-236": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.2.4"}}},
-		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.9"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.4"}}},
+		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}}},
 	},
 	"FG-IR-20-241": {
-		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
+		{Product: "FortiClientLinux", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 	},
 	"FG-IR-20-243": {
 		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
@@ -1099,16 +1099,16 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "7.0.0"}}},
 	},
 	"FG-IR-21-004": {
-		{Product: "Meru AP", Versions: []string{"8.5.0", "8.5.1", "8.5.2", "8.5.3", "8.5.4", "8.5.5", "8.6.0", "8.6.1"}},
+		{Product: "Meru AP", Ranges: []supplementRange{{GreaterEqual: "8.5.0", LessEqual: "8.5.5"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.1"}}},
 	},
 	"FG-IR-21-005": {
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "3.2.2"}}},
 	},
 	"FG-IR-21-006": {
-		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
+		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-21-007": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-21-008": {
@@ -1132,11 +1132,11 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "6.4.4"}}},
 	},
 	"FG-IR-21-022": {
-		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.4.3"}}},
+		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-21-023": {
-		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.7"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.10"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.10"}, {GreaterEqual: "5.3.12", LessEqual: "5.3.13"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
-		{Product: "FortiNDR", Ranges: []supplementRange{{LessEqual: "7.2.1"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.7"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.10"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.10"}, {GreaterEqual: "5.3.12", LessEqual: "5.3.13"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessThan: "6.4.5"}}},
+		{Product: "FortiNDR", Ranges: []supplementRange{{GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2", LessThan: "1.3"}, {GreaterEqual: "1.3", LessThan: "1.4"}, {GreaterEqual: "1.4", LessThan: "1.5"}, {GreaterEqual: "1.5", LessThan: "1.6"}, {GreaterEqual: "7.0", LessThan: "7.1"}, {GreaterEqual: "7.1", LessThan: "7.2"}, {GreaterEqual: "7.2.0", LessEqual: "7.2.1"}}},
 	},
 	"FG-IR-21-026": {
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.6", LessThan: "3.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
@@ -1148,18 +1148,18 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "7.0.1"}}},
 	},
 	"FG-IR-21-031": {
-		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.2.0", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
 	},
 	"FG-IR-21-037": {
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-21-039": {
-		{Product: "FortiWeb", Versions: []string{"3.0.0", "4.0.2", "4.1.0", "4.1.1", "4.1.2", "4.2.0", "4.2.2", "4.2.3", "4.2.4", "4.3.1", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "4.3.6", "4.3.7", "4.4.0", "4.4.1", "4.4.2", "4.4.3", "4.4.4", "4.4.5", "4.4.6", "4.4.7", "5.0.0", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6", "5.1.0", "5.1.1", "5.1.2", "5.1.3", "5.1.4", "5.2.0", "5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.3.0", "5.3.1", "5.3.2", "5.3.3", "5.3.4", "5.3.5", "5.3.6", "5.3.7", "5.3.8", "5.3.9", "5.4.0", "5.4.1", "5.5.0", "5.5.1", "5.5.2", "5.5.3", "5.5.4", "5.5.5", "5.5.6", "5.5.7", "5.6.0", "5.6.1", "5.6.2", "5.7.0", "5.7.1", "5.7.2", "5.7.3", "5.8.0", "5.8.1", "5.8.2", "5.8.3", "5.8.5", "5.8.6", "5.8.7", "5.9.0", "5.9.1", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0"}},
+		{Product: "FortiWeb", Versions: []string{"3.0.0", "4.0.2", "4.1.0", "4.1.1", "4.1.2", "4.2.0", "4.2.2", "4.2.3", "4.2.4", "4.3.1", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "4.3.6", "4.3.7", "4.4.0", "4.4.1", "4.4.2", "4.4.3", "4.4.4", "4.4.5", "4.4.6", "4.4.7", "5.0.0", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6", "5.1.0", "5.1.1", "5.1.2", "5.1.3", "5.1.4", "5.2.0", "5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.3.0", "5.3.1", "5.3.2", "5.3.3", "5.3.4", "5.3.5", "5.3.6", "5.3.7", "5.3.8", "5.3.9", "5.4.0", "5.4.1", "5.5.0", "5.5.1", "5.5.2", "5.5.3", "5.5.4", "5.5.5", "5.5.6", "5.5.7", "5.6.0", "5.6.1", "5.6.2", "5.7.0", "5.7.1", "5.7.2", "5.7.3", "5.8.0", "5.8.1", "5.8.2", "5.8.3", "5.8.5", "5.8.6", "5.8.7", "5.9.0", "5.9.1", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.4.0"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.5"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}}},
 	},
 	"FG-IR-21-040": {
-		{Product: "FortiIsolator", Versions: []string{"2.3.0", "2.3.1", "2.3.2"}},
+		{Product: "FortiIsolator", Ranges: []supplementRange{{GreaterEqual: "2.3.0", LessEqual: "2.3.2"}}},
 	},
 	"FG-IR-21-042": {
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
@@ -1168,14 +1168,14 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Versions: []string{"6.4.4", "6.4.5"}},
 	},
 	"FG-IR-21-047": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.2.4"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.13"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.4"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.13"}}},
 	},
 	"FG-IR-21-049": {
-		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}, {GreaterEqual: "7.0.0", LessThan: "7.0.1"}}},
 	},
 	"FG-IR-21-050": {
-		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
-		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-21-051": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.13"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
@@ -1186,54 +1186,54 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-21-059": {
-		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-21-060": {
-		{Product: "FortiWAN", Ranges: []supplementRange{{LessThan: "4.5.9"}}},
+		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.5.0", LessThan: "4.5.9"}}},
 	},
 	"FG-IR-21-062": {
-		{Product: "FortiWAN", Ranges: []supplementRange{{LessThan: "4.5.9"}}},
+		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.5.0", LessThan: "4.5.9"}}},
 	},
 	"FG-IR-21-063": {
-		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
-		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
+		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-21-064": {
-		{Product: "FortiWAN", Ranges: []supplementRange{{LessThan: "4.5.9"}}},
+		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.5.0", LessThan: "4.5.9"}}},
 	},
 	"FG-IR-21-065": {
-		{Product: "FortiWAN", Ranges: []supplementRange{{LessThan: "4.5.9"}}},
+		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.5.0", LessThan: "4.5.9"}}},
 	},
 	"FG-IR-21-068": {
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessThan: "6.3.1"}}},
 	},
 	"FG-IR-21-069": {
-		{Product: "FortiWAN", Ranges: []supplementRange{{LessEqual: "4.5.7"}}},
+		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.6"}, {GreaterEqual: "4.1.1", LessEqual: "4.1.3"}, {GreaterEqual: "4.2.1", LessEqual: "4.2.2"}, {GreaterEqual: "4.2.5", LessEqual: "4.2.7"}, {GreaterEqual: "4.3.0", LessEqual: "4.3.1"}, {GreaterEqual: "4.4.0", LessEqual: "4.4.1"}, {GreaterEqual: "4.5.0", LessEqual: "4.5.7"}}},
 	},
 	"FG-IR-21-070": {
-		{Product: "FortiWAN", Ranges: []supplementRange{{LessThan: "4.5.9"}}},
+		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.5.0", LessThan: "4.5.9"}}},
 	},
 	"FG-IR-21-074": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-075": {
-		{Product: "FortiClientEMS", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
-		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
-		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiClientLinux", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-077": {
-		{Product: "FortiPortal", Versions: []string{"5.0.0", "5.0.1", "5.0.2", "5.0.3", "5.1.0", "5.1.1", "5.1.2", "5.2.0", "5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.2.5", "5.3.0", "5.3.1", "5.3.2", "5.3.3", "5.3.4", "5.3.5", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4"}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-21-078": {
-		{Product: "FortiWAN", Ranges: []supplementRange{{LessThan: "4.5.9"}}},
+		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.5.0", LessThan: "4.5.9"}}},
 	},
 	"FG-IR-21-079": {
-		{Product: "FortiClientMac", Versions: []string{"6.4.0", "6.4.1", "6.4.2", "6.4.3", "6.4.4", "6.4.5", "7.0.0"}},
+		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.0"}}},
 	},
 	"FG-IR-21-084": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-21-085": {
 		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
@@ -1246,10 +1246,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-21-092": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-21-094": {
-		{Product: "FortiPortal", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4"}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-21-096": {
 		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
@@ -1273,42 +1273,42 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWLM", Versions: []string{"8.2.2"}, Ranges: []supplementRange{{GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
 	},
 	"FG-IR-21-107": {
-		{Product: "FortiWLM", Versions: []string{"8.2.2", "8.3.0", "8.3.1", "8.3.2", "8.4.0", "8.4.1", "8.4.2", "8.5.0", "8.5.1", "8.5.2", "8.6.0", "8.6.1"}},
+		{Product: "FortiWLM", Versions: []string{"8.2.2", "8.3.0", "8.3.1", "8.3.2", "8.4.0", "8.4.1", "8.4.2", "8.5.0", "8.5.1", "8.5.2"}, Ranges: []supplementRange{{GreaterEqual: "8.6.0", LessEqual: "8.6.1"}}},
 	},
 	"FG-IR-21-109": {
 		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
 	},
 	"FG-IR-21-110": {
-		{Product: "FortiWLM", Versions: []string{"8.2.2", "8.3.0", "8.3.1", "8.3.2", "8.4.0", "8.4.1", "8.4.2", "8.5.0", "8.5.1", "8.5.2", "8.6.0", "8.6.1"}},
+		{Product: "FortiWLM", Versions: []string{"8.2.2", "8.3.0", "8.3.1", "8.3.2", "8.4.0", "8.4.1", "8.4.2", "8.5.0", "8.5.1", "8.5.2"}, Ranges: []supplementRange{{GreaterEqual: "8.6.0", LessEqual: "8.6.1"}}},
 	},
 	"FG-IR-21-111": {
-		{Product: "FortiWLM", Ranges: []supplementRange{{LessEqual: "8.6.2"}}},
+		{Product: "FortiWLM", Ranges: []supplementRange{{GreaterEqual: "8.2", LessThan: "8.3"}, {GreaterEqual: "8.3", LessThan: "8.4"}, {GreaterEqual: "8.4", LessThan: "8.5"}, {GreaterEqual: "8.5", LessThan: "8.6"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
 	},
 	"FG-IR-21-112": {
-		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "6.4.6"}}},
-		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "6.4.6"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
+		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-21-114": {
-		{Product: "FortiWLM", Ranges: []supplementRange{{LessEqual: "8.6.1"}}},
+		{Product: "FortiWLM", Ranges: []supplementRange{{GreaterEqual: "8.2", LessThan: "8.3"}, {GreaterEqual: "8.3", LessThan: "8.4"}, {GreaterEqual: "8.4", LessThan: "8.5"}, {GreaterEqual: "8.5", LessThan: "8.6"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.1"}}},
 	},
 	"FG-IR-21-115": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.13"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 		{Product: "FortiOS-6K7K", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-21-118": {
-		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-119": {
-		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0"}},
+		{Product: "FortiWeb", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.5"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}}},
 	},
 	"FG-IR-21-120": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.2.5"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.8", LessThan: "5.9"}, {GreaterEqual: "5.9", LessThan: "5.10"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.5"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-122": {
-		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-123": {
-		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-126": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
@@ -1317,44 +1317,44 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4", LessThan: "6.5"}}},
 	},
 	"FG-IR-21-128": {
-		{Product: "FortiWLM", Ranges: []supplementRange{{LessEqual: "8.4.2"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
+		{Product: "FortiWLM", Versions: []string{"8.2.2", "8.3.0", "8.3.1", "8.3.2"}, Ranges: []supplementRange{{GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
 	},
 	"FG-IR-21-129": {
 		{Product: "FortiWLM", Ranges: []supplementRange{{LessEqual: "8.6.1"}}},
 	},
 	"FG-IR-21-130": {
-		{Product: "FortiWeb", Versions: []string{"6.4.0", "6.4.1"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}}},
-		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "6.2.4"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.4"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-21-131": {
-		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.5"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-132": {
-		{Product: "FortiADC", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.4"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.7"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.8"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.7"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
-		{Product: "FortiDDoS", Versions: []string{"4.5.0", "4.6.0", "4.7.0", "5.0.0", "5.1.0", "5.2.0", "5.7.0"}, Ranges: []supplementRange{{GreaterEqual: "4.4.0", LessEqual: "4.4.2"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.2"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.3"}, {GreaterEqual: "5.5.0", LessEqual: "5.5.1"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.1"}}},
-		{Product: "FortiDDoS-CM", Versions: []string{"4.7.0", "5.0.0", "5.1.0", "5.2.0"}, Ranges: []supplementRange{{GreaterEqual: "5.3.0", LessEqual: "5.3.1"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.3"}, {GreaterEqual: "5.5.0", LessEqual: "5.5.1"}}},
+		{Product: "FortiADC", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiDDoS", Versions: []string{"5.7.0"}, Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "4.5"}, {GreaterEqual: "4.5", LessThan: "4.6"}, {GreaterEqual: "4.6", LessThan: "4.7"}, {GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.2"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.3"}, {GreaterEqual: "5.5.0", LessEqual: "5.5.1"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.1"}}},
+		{Product: "FortiDDoS-CM", Ranges: []supplementRange{{GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.1"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.3"}, {GreaterEqual: "5.5.0", LessEqual: "5.5.1"}}},
 		{Product: "FortiDDoS-F", Versions: []string{"6.3.0"}, Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.4"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 		{Product: "FortiFone", Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.11"}}},
-		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
-		{Product: "FortiNDR", Versions: []string{"1.1.0", "1.2.0", "1.4.0"}, Ranges: []supplementRange{{GreaterEqual: "1.3.0", LessEqual: "1.3.1"}, {GreaterEqual: "1.5.0", LessEqual: "1.5.3"}}},
-		{Product: "FortiRecorder", Ranges: []supplementRange{{GreaterEqual: "2.6.0", LessEqual: "2.6.3"}, {GreaterEqual: "2.7.0", LessEqual: "2.7.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiNDR", Ranges: []supplementRange{{GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2", LessThan: "1.3"}, {GreaterEqual: "1.3", LessThan: "1.4"}, {GreaterEqual: "1.4", LessThan: "1.5"}, {GreaterEqual: "1.5", LessThan: "1.6"}}},
+		{Product: "FortiRecorder", Ranges: []supplementRange{{GreaterEqual: "2.6", LessThan: "2.7"}, {GreaterEqual: "2.7", LessThan: "2.8"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 		{Product: "FortiVoice", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-133": {
-		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-134": {
 		{Product: "FortiWeb", Versions: []string{"6.4.0", "6.4.1"}},
 	},
 	"FG-IR-21-138": {
-		{Product: "FortiWeb", Versions: []string{"6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-139": {
 		{Product: "FortiWeb", Versions: []string{"6.4.0", "6.4.1"}},
 	},
 	"FG-IR-21-140": {
-		{Product: "FortiClientEMS", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-147": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
@@ -1363,89 +1363,89 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiExtender", Ranges: []supplementRange{{LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-152": {
-		{Product: "FortiWeb", Versions: []string{"6.4.0", "6.4.1"}, Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-155": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiProxy", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2", LessThan: "1.3"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.6"}}},
-		{Product: "FortiRecorder", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
+		{Product: "FortiRecorder", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.9"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
-		{Product: "FortiVoice", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
+		{Product: "FortiVoice", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-21-156": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-157": {
-		{Product: "FortiWeb", Versions: []string{"6.4.0", "6.4.1"}, Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-158": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-160": {
-		{Product: "FortiWeb", Versions: []string{"6.4.0", "6.4.1"}, Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-163": {
-		{Product: "FortiAP", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
-		{Product: "FortiAP-S", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.4.7"}}},
-		{Product: "FortiAP-U", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "6.2.3"}}},
-		{Product: "FortiAP-W2", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
+		{Product: "FortiAP", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
+		{Product: "FortiAP-S", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.4.7"}}},
+		{Product: "FortiAP-U", Ranges: []supplementRange{{GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "5.4.0", LessEqual: "6.2.3"}}},
+		{Product: "FortiAP-W2", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-21-166": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-167": {
-		{Product: "FortiClientWindows", Versions: []string{"4.0.1", "4.0.2", "4.0.3", "4.0.4", "4.1.0", "4.1.1", "4.1.2", "4.1.3", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6", "4.2.7", "4.3.0", "4.3.1", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "5.0.0", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6", "5.0.7", "5.0.8", "5.0.9", "5.0.10", "5.0.11", "5.2.0", "5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.2.5", "5.2.6", "5.4.0", "5.4.1", "5.4.2", "5.4.3", "5.4.4", "5.4.5", "5.6.0", "5.6.1", "5.6.2", "5.6.3", "5.6.4", "5.6.5", "5.6.6", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.2.8", "6.2.9", "6.4.0", "6.4.1"}},
+		{Product: "FortiClientWindows", Versions: []string{"4.0.1", "4.0.2", "4.0.3", "4.0.4", "4.1.0", "4.1.1", "4.1.2", "4.1.3", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6", "4.2.7", "4.3.0", "4.3.1", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "5.0.0", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6", "5.0.7", "5.0.8", "5.0.9", "5.0.10", "5.0.11", "5.2.0", "5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.2.5", "5.2.6", "5.4.0", "5.4.1", "5.4.2", "5.4.3", "5.4.4", "5.4.5", "5.6.0", "5.6.1", "5.6.2", "5.6.3", "5.6.4", "5.6.5", "5.6.6", "6.4.0", "6.4.1"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}}},
 	},
 	"FG-IR-21-168": {
-		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-170": {
 		{Product: "FortiDeceptor", Versions: []string{"4.2.0"}, Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.2"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.1"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}, {GreaterEqual: "3.3.0", LessEqual: "3.3.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.1"}}},
 		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.5"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}}},
 	},
 	"FG-IR-21-175": {
-		{Product: "FortiSIEMWindowsAgent", Versions: []string{"3.1.0", "3.1.2", "3.2.0", "3.2.1", "3.2.2", "3.3.0", "4.0.0", "4.1.0", "4.1.1", "4.1.2", "4.1.3", "4.1.4"}},
+		{Product: "FortiSIEMWindowsAgent", Versions: []string{"3.3.0", "4.0.0"}, Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.4"}}},
 	},
 	"FG-IR-21-176": {
-		{Product: "FortiSIEMWindowsAgent", Versions: []string{"3.1.0", "3.1.2", "3.2.0", "3.2.1", "3.2.2", "3.3.0", "4.0.0", "4.1.0", "4.1.1", "4.1.2", "4.1.3", "4.1.4"}},
+		{Product: "FortiSIEMWindowsAgent", Versions: []string{"3.3.0", "4.0.0"}, Ranges: []supplementRange{{GreaterEqual: "3.1.0", LessEqual: "3.1.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.4"}}},
 	},
 	"FG-IR-21-178": {
-		{Product: "FortiNAC", Versions: []string{"8.8.0", "8.8.1", "8.8.2", "8.8.3", "8.8.4", "8.8.5", "8.8.6", "8.8.7", "8.8.8", "8.8.9", "9.1.0", "9.1.1", "9.1.2", "9.1.3", "9.2.0"}},
+		{Product: "FortiNAC", Ranges: []supplementRange{{GreaterEqual: "8.8.0", LessEqual: "8.8.9"}, {GreaterEqual: "9.1.0", LessEqual: "9.1.3"}, {GreaterEqual: "9.2.0", LessEqual: "9.2.0"}}},
 	},
 	"FG-IR-21-179": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
-		{Product: "FortiProxy", Ranges: []supplementRange{{LessThan: "2.0.8"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessThan: "7.0.4"}}},
+		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.13"}, {GreaterEqual: "2.0.0", LessThan: "2.0.8"}}},
 	},
 	"FG-IR-21-180": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.9.0", LessEqual: "5.9.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-181": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiOS", Versions: []string{"7.0.0", "7.0.1"}},
 		{Product: "FortiProxy", Versions: []string{"7.0.0"}},
 	},
 	"FG-IR-21-182": {
-		{Product: "FortiNAC", Versions: []string{"8.8.0", "8.8.1", "8.8.2", "8.8.3", "8.8.4", "8.8.5", "8.8.6", "8.8.7", "8.8.8", "9.1.0", "9.1.1", "9.1.2"}},
+		{Product: "FortiNAC", Ranges: []supplementRange{{GreaterEqual: "8.8.0", LessEqual: "8.8.8"}, {GreaterEqual: "9.1.0", LessEqual: "9.1.2"}}},
 	},
 	"FG-IR-21-185": {
-		{Product: "FortiMail", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.0.11", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.4.0", "6.4.1", "6.4.2", "6.4.3", "6.4.4", "6.4.5", "7.0.0", "7.0.1"}},
+		{Product: "FortiMail", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.0.11"}, Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-186": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4", LessThan: "6.5"}}},
 	},
 	"FG-IR-21-188": {
-		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.3.16", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-189": {
-		{Product: "FortiWLM", Ranges: []supplementRange{{LessEqual: "8.3.2"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
+		{Product: "FortiWLM", Versions: []string{"8.2.2"}, Ranges: []supplementRange{{GreaterEqual: "8.3.0", LessEqual: "8.3.2"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
 	},
 	"FG-IR-21-192": {
-		{Product: "FortiClientEMS", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.6", "6.2.7", "6.2.8", "6.2.9", "6.4.0", "6.4.1", "6.4.2", "6.4.3", "6.4.4", "7.0.0", "7.0.1"}},
+		{Product: "FortiClientEMS", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.6", "6.2.7", "6.2.8", "6.2.9"}, Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.4"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-200": {
-		{Product: "FortiWLC", Ranges: []supplementRange{{LessEqual: "8.6.1"}}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.0", LessThan: "8.1"}, {GreaterEqual: "8.1", LessThan: "8.2"}, {GreaterEqual: "8.2", LessThan: "8.3"}, {GreaterEqual: "8.3", LessThan: "8.4"}, {GreaterEqual: "8.4", LessThan: "8.5"}, {GreaterEqual: "8.5", LessThan: "8.6"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.1"}}},
 	},
 	"FG-IR-21-201": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.13"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.13"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessThan: "7.0.3"}}},
 	},
 	"FG-IR-21-206": {
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
@@ -1454,13 +1454,13 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.13"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-21-213": {
-		{Product: "FortiDeceptor", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessThan: "3.3"}, {GreaterEqual: "3.3.0", LessEqual: "3.3.2"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.1"}}},
+		{Product: "FortiDeceptor", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "3.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}, {GreaterEqual: "3.3.0", LessEqual: "3.3.2"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.1"}}},
 	},
 	"FG-IR-21-214": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "5.7", LessThan: "5.8"}, {GreaterEqual: "5.8", LessThan: "5.9"}, {GreaterEqual: "5.9.0", LessEqual: "5.9.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4", LessThan: "6.5"}}},
 	},
 	"FG-IR-21-218": {
-		{Product: "FortiRecorder", Ranges: []supplementRange{{GreaterEqual: "2.7.0", LessEqual: "2.7.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
+		{Product: "FortiRecorder", Ranges: []supplementRange{{GreaterEqual: "2.7", LessThan: "2.8"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.17"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-222": {
@@ -1468,7 +1468,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
 	},
 	"FG-IR-21-226": {
-		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiClientLinux", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-21-227": {
 		{Product: "FortiAP-C", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.1"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.3"}}},
@@ -1482,7 +1482,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-232": {
-		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiClientLinux", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-21-233": {
 		{Product: "FortiIsolator", Versions: []string{"1.0.0", "1.1.0", "2.2.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.2"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.2"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.4"}}},
@@ -1498,7 +1498,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-21-238": {
-		{Product: "FortiClientWindows", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.2.8", "6.2.9", "6.4.0", "6.4.1", "6.4.2", "6.4.3", "6.4.4", "6.4.5", "6.4.6", "6.4.7", "7.0.0", "7.0.1", "7.0.2"}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-21-239": {
 		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}}},
@@ -1507,8 +1507,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-21-255": {
-		{Product: "FortiAnalyzer", Versions: []string{"5.6.0", "5.6.1", "5.6.2", "5.6.3", "5.6.4", "5.6.5", "5.6.6", "5.6.7", "5.6.8", "5.6.9", "5.6.10", "5.6.11", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.0.11", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.2.8", "6.2.9", "6.4.0", "6.4.1", "6.4.2", "6.4.3", "6.4.4", "6.4.5", "6.4.6", "6.4.7", "7.0.0", "7.0.1", "7.0.2"}},
-		{Product: "FortiManager", Versions: []string{"5.6.0", "5.6.1", "5.6.2", "5.6.3", "5.6.4", "5.6.5", "5.6.6", "5.6.7", "5.6.8", "5.6.9", "5.6.10", "5.6.11", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.0.11", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.2.8", "6.2.9", "6.4.0", "6.4.1", "6.4.2", "6.4.3", "6.4.4", "6.4.5", "6.4.6", "6.4.7", "7.0.0", "7.0.1", "7.0.2"}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-22-007": {
 		{Product: "FortiFone", Ranges: []supplementRange{{LessEqual: "3.0.11"}}},
@@ -1538,8 +1538,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiEDR", Versions: []string{"4.0.0", "4.2.2"}, Ranges: []supplementRange{{GreaterEqual: "4.1.0", LessEqual: "4.1.1"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.2"}}},
 	},
 	"FG-IR-22-056": {
-		{Product: "FortiDeceptor", Versions: []string{"1.1.0", "2.0.0", "2.1.0", "4.1.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.1"}, {GreaterEqual: "3.0.0", LessEqual: "3.0.2"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.1"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}, {GreaterEqual: "3.3.0", LessEqual: "3.3.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}}},
-		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "2.5.0", LessEqual: "2.5.2"}, {GreaterEqual: "3.0.0", LessEqual: "3.0.7"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.5"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.2"}}},
+		{Product: "FortiDeceptor", Versions: []string{"4.1.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "2.0", LessThan: "2.1"}, {GreaterEqual: "2.1", LessThan: "2.2"}, {GreaterEqual: "3.0", LessThan: "3.1"}, {GreaterEqual: "3.1", LessThan: "3.2"}, {GreaterEqual: "3.2", LessThan: "3.3"}, {GreaterEqual: "3.3.0", LessEqual: "3.3.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{GreaterEqual: "2.5", LessThan: "2.6"}, {GreaterEqual: "3.0", LessThan: "3.1"}, {GreaterEqual: "3.1", LessThan: "3.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.2"}}},
 	},
 	"FG-IR-22-058": {
 		{Product: "FortiNAC", Versions: []string{"8.5.4", "8.6.0"}, Ranges: []supplementRange{{GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.2", LessEqual: "8.6.5"}, {GreaterEqual: "8.7.0", LessEqual: "8.7.6"}, {GreaterEqual: "8.8.0", LessEqual: "8.8.11"}, {GreaterEqual: "9.1.0", LessEqual: "9.1.5"}, {GreaterEqual: "9.2.0", LessEqual: "9.2.3"}, {LessEqual: "8.3.7"}}},
@@ -1547,21 +1547,21 @@ var supplementTable = map[string][]supplementProduct{
 	"FG-IR-22-059": {
 		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 		{Product: "FortiADCManager", Ranges: []supplementRange{{LessThan: "7.0.0"}}},
-		{Product: "FortiAIOps", Ranges: []supplementRange{{LessThan: "1.1.0"}}},
-		{Product: "FortiAP", Ranges: []supplementRange{{LessThan: "7.2.1"}}},
-		{Product: "FortiAP-W2", Ranges: []supplementRange{{LessThan: "7.2.1"}}},
+		{Product: "FortiAIOps", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}}},
+		{Product: "FortiAP", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.4", LessThan: "6.5"}, {GreaterEqual: "7.0", LessThan: "7.1"}}},
+		{Product: "FortiAP-W2", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.4", LessThan: "6.5"}, {GreaterEqual: "7.0", LessThan: "7.1"}}},
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3", LessThan: "6.4"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 		{Product: "FortiClientAndroid", Ranges: []supplementRange{{LessThan: "7.0.3"}}},
-		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
-		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessThan: "7.0.6"}}},
-		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.5"}}},
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
+		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
+		{Product: "FortiClientLinux", Ranges: []supplementRange{{GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4", LessThan: "6.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.5"}}},
+		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.5"}}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiClientiOS", Ranges: []supplementRange{{LessThan: "7.0.3"}}},
-		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "5.7"}}},
+		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "4.5", LessThan: "4.6"}, {GreaterEqual: "4.6", LessThan: "4.7"}, {GreaterEqual: "4.7", LessThan: "4.8"}, {GreaterEqual: "5.0", LessThan: "5.1"}, {GreaterEqual: "5.1", LessThan: "5.2"}, {GreaterEqual: "5.2", LessThan: "5.3"}, {GreaterEqual: "5.3", LessThan: "5.4"}, {GreaterEqual: "5.4", LessThan: "5.5"}, {GreaterEqual: "5.5", LessThan: "5.6"}, {GreaterEqual: "5.6", LessThan: "5.7"}}},
 		{Product: "FortiDDoS-F", Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.4"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.3"}}},
-		{Product: "FortiDeceptor", Versions: []string{"4.1.0"}, Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessThan: "4.0.0"}, {GreaterEqual: "4.0.0", LessThan: "4.1.0"}}},
-		{Product: "FortiIsolator", Versions: []string{"2.2.0", "2.4.0"}, Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.1"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.2"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.4"}}},
+		{Product: "FortiDeceptor", Versions: []string{"4.1.0"}, Ranges: []supplementRange{{GreaterEqual: "3", LessThan: "4"}, {GreaterEqual: "4.0", LessThan: "4.1"}}},
+		{Product: "FortiIsolator", Versions: []string{"2.4.0"}, Ranges: []supplementRange{{GreaterEqual: "2.0", LessThan: "2.1"}, {GreaterEqual: "2.1", LessThan: "2.2"}, {GreaterEqual: "2.2", LessThan: "2.3"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.4"}}},
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiNDR", Ranges: []supplementRange{{LessThan: "7.0.0"}}},
@@ -1572,11 +1572,11 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.10"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
 		{Product: "FortiTester", Ranges: []supplementRange{{LessEqual: "7.1.1"}}},
 		{Product: "FortiVoice", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
-		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.6"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.3"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.7"}, {GreaterEqual: "4.3.0", LessThan: "4.4"}, {GreaterEqual: "4.4.0", LessThan: "4.5"}, {GreaterEqual: "4.5.0", LessEqual: "4.5.9"}}},
+		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.3", LessThan: "4.4"}, {GreaterEqual: "4.4", LessThan: "4.5"}, {GreaterEqual: "4.5.0", LessEqual: "4.5.9"}}},
 		{Product: "FortiWeb", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.18"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 	},
 	"FG-IR-22-060": {
-		{Product: "FortiSandbox", Versions: []string{"4.2.0"}, Ranges: []supplementRange{{GreaterEqual: "3.0.1", LessEqual: "3.0.7"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.5"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}}},
+		{Product: "FortiSandbox", Versions: []string{"4.2.0"}, Ranges: []supplementRange{{GreaterEqual: "3.0.1", LessEqual: "3.0.7"}, {GreaterEqual: "3.1", LessThan: "3.2"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}}},
 	},
 	"FG-IR-22-061": {
 		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -403,7 +403,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.5"}}},
 	},
 	"FG-IR-17-104": {
-		{Product: "FortiOS", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.5"}, {LessEqual: "5.2.11"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "5.6.0"}}},
 	},
 	"FG-IR-17-106": {
 		{Product: "FortiWLC", Versions: []string{"6.1.2"}, Ranges: []supplementRange{{GreaterEqual: "6.1.4", LessEqual: "6.1.5"}, {GreaterEqual: "7.0.7", LessEqual: "7.0.10"}, {GreaterEqual: "8.0.0", LessEqual: "8.3.2"}}},
@@ -429,7 +429,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "6.1.2", LessEqual: "6.1.5"}, {GreaterEqual: "7.0.7", LessEqual: "7.0.10"}, {GreaterEqual: "8.0.0", LessEqual: "8.3.2"}}},
 	},
 	"FG-IR-17-127": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.11"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.4"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.4.4"}}},
 	},
 	"FG-IR-17-131": {
 		{Product: "FortiWeb", Versions: []string{"5.8.0"}, Ranges: []supplementRange{{LessEqual: "5.7.1"}}},
@@ -608,7 +608,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Versions: []string{"5.2.7"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.13"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 		{Product: "FortiAP-S", Ranges: []supplementRange{{LessThan: "6.2.2"}}},
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{LessThan: "6.2.2"}}},
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessThan: "6.2.3"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{LessThan: "7.0.4"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{LessThan: "6.2.3"}}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{LessThan: "3.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 	},
@@ -720,7 +720,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-19-240": {
-		{Product: "FortiSIEM", Versions: []string{"5.2.5"}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{LessEqual: "5.2.5"}}},
 	},
 	"FG-IR-19-244": {
 		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "5.3.7"}}},
@@ -939,7 +939,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSandbox", Versions: []string{"3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.1.0", "3.1.1", "3.1.2", "3.1.3", "3.1.4", "3.2.0", "3.2.1"}},
 	},
 	"FG-IR-20-171": {
-		{Product: "FortiSandbox", Ranges: []supplementRange{{LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.1"}}},
+		{Product: "FortiSandbox", Ranges: []supplementRange{{LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}}},
 	},
 	"FG-IR-20-172": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.2.5"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
@@ -1004,7 +1004,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "4.0.0"}}},
 	},
 	"FG-IR-20-222": {
-		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.0"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 		{Product: "FortiMail", Ranges: []supplementRange{{LessEqual: "7.0.1"}}},
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "4.0.1"}}},
 		{Product: "FortiWeb", Ranges: []supplementRange{{LessThan: "6.3.12"}}},
@@ -1076,7 +1076,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-21-007": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {LessEqual: "6.2.2"}}},
-		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {LessEqual: "1.2.9"}, {LessEqual: "2.0.0"}}},
+		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {LessEqual: "1.2.9"}, {LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-21-008": {
 		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "7.0.1"}}},
@@ -1101,7 +1101,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-21-023": {
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.7"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.10"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.10"}, {GreaterEqual: "5.3.12", LessEqual: "5.3.13"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}, {LessThan: "6.4.5"}}},
-		{Product: "FortiNDR", Ranges: []supplementRange{{LessEqual: "7.2.0"}}},
+		{Product: "FortiNDR", Ranges: []supplementRange{{LessEqual: "7.2.1"}}},
 	},
 	"FG-IR-21-026": {
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.6", LessThan: "3.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
@@ -1259,7 +1259,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS-6K7K", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-21-118": {
-		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
 	},
 	"FG-IR-21-119": {
 		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0"}},
@@ -1268,10 +1268,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.2.5"}, {LessEqual: "6.3.15"}, {LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-122": {
-		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
 	},
 	"FG-IR-21-123": {
-		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
 	},
 	"FG-IR-21-126": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
@@ -1305,7 +1305,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-133": {
-		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
 	},
 	"FG-IR-21-134": {
 		{Product: "FortiWeb", Versions: []string{"6.4.0", "6.4.1"}},
@@ -1360,7 +1360,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientWindows", Versions: []string{"4.0.1", "4.0.2", "4.0.3", "4.0.4", "4.1.0", "4.1.1", "4.1.2", "4.1.3", "4.2.0", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6", "4.2.7", "4.3.0", "4.3.1", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "5.0.0", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6", "5.0.7", "5.0.8", "5.0.9", "5.0.10", "5.0.11", "5.2.0", "5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.2.5", "5.2.6", "5.4.0", "5.4.1", "5.4.2", "5.4.3", "5.4.4", "5.4.5", "5.6.0", "5.6.1", "5.6.2", "5.6.3", "5.6.4", "5.6.5", "5.6.6", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.2.8", "6.2.9", "6.4.0", "6.4.1"}},
 	},
 	"FG-IR-21-168": {
-		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
+		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
 	},
 	"FG-IR-21-170": {
 		{Product: "FortiDeceptor", Versions: []string{"4.2.0"}, Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessEqual: "3.0.2"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.1"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}, {GreaterEqual: "3.3.0", LessEqual: "3.3.3"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.2"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.1"}}},

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -146,7 +146,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.3", LessEqual: "5.2.3"}}},
 	},
 	"FG-IR-15-010": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.3.4"}, {LessThan: "5.3.5"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.3.4"}, {GreaterEqual: "5.3.0", LessThan: "5.3.5"}}},
 	},
 	"FG-IR-15-011": {
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.10"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.1"}}},
@@ -267,7 +267,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAP", Versions: []string{"5.4.0"}},
 		{Product: "FortiAnalyzer", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{LessEqual: "5.2.2"}, {LessEqual: "5.2.7"}}},
 		{Product: "FortiOS", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.3"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.7"}, {LessEqual: "5.0.12"}, {LessEqual: "5.0.13"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{LessEqual: "3.3.3"}, {LessEqual: "3.4.1"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{LessEqual: "3.3.3"}, {GreaterEqual: "3.4.0", LessEqual: "3.4.1"}}},
 	},
 	"FG-IR-16-029": {
 		{Product: "FortiWLC", Versions: []string{"7.0.9.1", "7.0.10.0", "8.0.5.0", "8.1.2.0", "8.2.4.0"}, Ranges: []supplementRange{{LessEqual: "6.1.2.29"}}},
@@ -724,11 +724,11 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-19-244": {
 		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "5.3.7"}}},
-		{Product: "FortiADCManager", Ranges: []supplementRange{{LessEqual: "5.2.1"}, {LessEqual: "5.3.0"}}},
+		{Product: "FortiADCManager", Ranges: []supplementRange{{LessEqual: "5.2.1"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.0"}}},
 	},
 	"FG-IR-19-248": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
-		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {LessEqual: "1.2.9"}, {LessEqual: "2.0.0"}}},
+		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.0"}}},
 	},
 	"FG-IR-19-258": {
 		{Product: "FortiPresence", Ranges: []supplementRange{{LessEqual: "2.1.0"}}},
@@ -821,7 +821,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiNAC", Ranges: []supplementRange{{LessEqual: "8.8.1"}}},
 	},
 	"FG-IR-20-040": {
-		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.0.9"}, {LessEqual: "6.2.1"}}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 	},
 	"FG-IR-20-041": {
 		{Product: "FortiSIEM", Ranges: []supplementRange{{LessEqual: "5.2.8"}}},
@@ -844,7 +844,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-20-066": {
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "4.0.4"}, {LessEqual: "4.1.2"}, {LessEqual: "4.2.2"}, {LessEqual: "5.0.3"}, {LessEqual: "5.1.2"}, {LessEqual: "5.2.6"}, {LessEqual: "5.3.6"}, {LessEqual: "6.0.4"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.2"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.6"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-20-067": {
 		{Product: "FortiClientEMS", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.8", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.6", "6.2.7", "6.2.8", "6.2.9", "6.4.0", "6.4.1"}},
@@ -897,7 +897,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientLinux", Versions: []string{"6.0.8", "6.4.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.4"}, {GreaterEqual: "6.2.6", LessEqual: "6.2.7"}}},
 	},
 	"FG-IR-20-120": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.9", LessThan: "5.10"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {LessEqual: "6.2.3"}, {LessEqual: "6.3.7"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.9", LessThan: "5.10"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.7"}}},
 	},
 	"FG-IR-20-122": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.7"}, {LessThan: "6.2.4"}}},
@@ -973,8 +973,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiGate Cloud", Ranges: []supplementRange{{LessEqual: "20.3"}}},
 	},
 	"FG-IR-20-194": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {LessEqual: "6.2.7"}, {LessEqual: "6.4.5"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {LessEqual: "6.2.7"}, {LessEqual: "6.4.5"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-20-198": {
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessEqual: "3.0.6"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.4"}, {GreaterEqual: "3.2.0", LessEqual: "3.2.2"}}},
@@ -1048,7 +1048,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{LessEqual: "1.2.9"}}},
 	},
 	"FG-IR-20-241": {
-		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.2.8"}, {LessEqual: "6.4.2"}}},
+		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 	},
 	"FG-IR-20-243": {
 		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
@@ -1075,8 +1075,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-21-007": {
-		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {LessEqual: "6.2.2"}}},
-		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {LessEqual: "1.2.9"}, {LessEqual: "2.0.1"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.9"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}}},
 	},
 	"FG-IR-21-008": {
 		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "7.0.1"}}},
@@ -1100,7 +1100,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-21-023": {
-		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.7"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.10"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.10"}, {GreaterEqual: "5.3.12", LessEqual: "5.3.13"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}, {LessThan: "6.4.5"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.7"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.10"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.10"}, {GreaterEqual: "5.3.12", LessEqual: "5.3.13"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}, {GreaterEqual: "6.4.0", LessThan: "6.4.5"}}},
 		{Product: "FortiNDR", Ranges: []supplementRange{{LessEqual: "7.2.1"}}},
 	},
 	"FG-IR-21-026": {
@@ -1116,9 +1116,9 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.2.0", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
 	},
 	"FG-IR-21-037": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {LessEqual: "6.2.7"}, {LessEqual: "6.4.5"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {LessEqual: "6.2.7"}, {LessEqual: "6.4.5"}}},
-		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "5.2.5"}, {LessEqual: "5.3.5"}, {LessEqual: "6.0.4"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-21-039": {
 		{Product: "FortiWeb", Versions: []string{"3.0.0", "4.0.2", "4.1.0", "4.1.1", "4.1.2", "4.2.0", "4.2.2", "4.2.3", "4.2.4", "4.3.1", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "4.3.6", "4.3.7", "4.4.0", "4.4.1", "4.4.2", "4.4.3", "4.4.4", "4.4.5", "4.4.6", "4.4.7", "5.0.0", "5.0.1", "5.0.2", "5.0.3", "5.0.4", "5.0.5", "5.0.6", "5.1.0", "5.1.1", "5.1.2", "5.1.3", "5.1.4", "5.2.0", "5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.3.0", "5.3.1", "5.3.2", "5.3.3", "5.3.4", "5.3.5", "5.3.6", "5.3.7", "5.3.8", "5.3.9", "5.4.0", "5.4.1", "5.5.0", "5.5.1", "5.5.2", "5.5.3", "5.5.4", "5.5.5", "5.5.6", "5.5.7", "5.6.0", "5.6.1", "5.6.2", "5.7.0", "5.7.1", "5.7.2", "5.7.3", "5.8.0", "5.8.1", "5.8.2", "5.8.3", "5.8.5", "5.8.6", "5.8.7", "5.9.0", "5.9.1", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0"}},
@@ -1183,8 +1183,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-075": {
-		{Product: "FortiClientEMS", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {LessEqual: "7.0.1"}}},
-		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {LessEqual: "7.0.1"}}},
+		{Product: "FortiClientEMS", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-077": {
 		{Product: "FortiPortal", Versions: []string{"5.0.0", "5.0.1", "5.0.2", "5.0.3", "5.1.0", "5.1.1", "5.1.2", "5.2.0", "5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.2.5", "5.3.0", "5.3.1", "5.3.2", "5.3.3", "5.3.4", "5.3.5", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4"}},
@@ -1202,8 +1202,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-21-088": {
-		{Product: "FortiClientEMS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {LessEqual: "6.4.6"}}},
-		{Product: "FortiClientWindows", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {LessEqual: "6.4.6"}}},
+		{Product: "FortiClientEMS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
+		{Product: "FortiClientWindows", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-21-091": {
 		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
@@ -1227,13 +1227,13 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
 	},
 	"FG-IR-21-103": {
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-104": {
 		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
 	},
 	"FG-IR-21-106": {
-		{Product: "FortiWLM", Versions: []string{"8.2.2"}, Ranges: []supplementRange{{LessEqual: "8.3.3"}, {LessEqual: "8.4.2"}, {LessEqual: "8.5.2"}, {LessEqual: "8.6.2"}}},
+		{Product: "FortiWLM", Versions: []string{"8.2.2"}, Ranges: []supplementRange{{GreaterEqual: "8.3.0", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
 	},
 	"FG-IR-21-107": {
 		{Product: "FortiWLM", Versions: []string{"8.2.2", "8.3.0", "8.3.1", "8.3.2", "8.4.0", "8.4.1", "8.4.2", "8.5.0", "8.5.1", "8.5.2", "8.6.0", "8.6.1"}},
@@ -1265,7 +1265,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0"}},
 	},
 	"FG-IR-21-120": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.2.5"}, {LessEqual: "6.3.15"}, {LessEqual: "6.4.1"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.2.5"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-122": {
 		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
@@ -1330,10 +1330,10 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-21-155": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
-		{Product: "FortiProxy", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2", LessThan: "1.3"}, {LessEqual: "2.0.6"}}},
-		{Product: "FortiRecorder", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {LessEqual: "6.4.2"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {LessEqual: "6.4.9"}, {LessEqual: "7.0.2"}}},
-		{Product: "FortiVoice", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {LessEqual: "6.4.3"}}},
+		{Product: "FortiProxy", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2", LessThan: "1.3"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.6"}}},
+		{Product: "FortiRecorder", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.9"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
+		{Product: "FortiVoice", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-21-156": {
 		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
@@ -1431,7 +1431,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
 	},
 	"FG-IR-21-226": {
-		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.2.9"}, {LessEqual: "6.4.7"}, {LessEqual: "7.0.2"}}},
+		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-21-227": {
 		{Product: "FortiAP-C", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.1"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.3"}}},
@@ -1445,7 +1445,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-232": {
-		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.0.8"}, {LessEqual: "6.2.9"}, {LessEqual: "6.4.7"}, {LessEqual: "7.0.2"}}},
+		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-21-233": {
 		{Product: "FortiIsolator", Versions: []string{"1.0.0", "1.1.0", "2.2.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.2"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.2"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.4"}}},
@@ -1484,7 +1484,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4", LessThan: "6.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-22-041": {
-		{Product: "FortiSOAR PaaS", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.2.2"}, {LessEqual: "6.4.4"}, {LessEqual: "7.0.2"}}},
+		{Product: "FortiSOAR PaaS", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.2.2"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-22-044": {
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -113,7 +113,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.2"}, {LessEqual: "5.0.11"}}},
 	},
 	"FG-IR-15-003": {
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessThan: "3.2.0"}, {LessThan: "3.2.1"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessThan: "3.2.1"}}},
 	},
 	"FG-IR-15-004": {
 		{Product: "FortiClientAndroid", Ranges: []supplementRange{{LessThan: "5.2.6"}}},
@@ -157,7 +157,7 @@ var supplementTable = map[string][]supplementProduct{
 	"FG-IR-15-014": {
 		{Product: "AscenLink", Ranges: []supplementRange{{LessEqual: "7.2.4"}}},
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessEqual: "5.2.2"}}},
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessEqual: "4.0.0"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{LessThan: "4.0"}}},
 		{Product: "FortiClientAndroid", Ranges: []supplementRange{{LessEqual: "5.2.5"}}},
 		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "5.2.3"}}},
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "5.2.3"}}},
@@ -183,7 +183,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.3"}}},
 	},
 	"FG-IR-15-022": {
-		{Product: "FortiManager", Ranges: []supplementRange{{LessEqual: "5.2.2"}, {LessEqual: "5.2.3"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{LessEqual: "5.2.3"}}},
 	},
 	"FG-IR-15-023": {
 		{Product: "FortiADC", Ranges: []supplementRange{{LessThan: "4.4.0"}}},
@@ -265,8 +265,8 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-16-026": {
 		{Product: "FortiAP", Versions: []string{"5.4.0"}},
-		{Product: "FortiAnalyzer", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{LessEqual: "5.2.2"}, {LessEqual: "5.2.7"}}},
-		{Product: "FortiOS", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.3"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.7"}, {LessEqual: "5.0.12"}, {LessEqual: "5.0.13"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{LessEqual: "5.2.7"}}},
+		{Product: "FortiOS", Versions: []string{"5.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.7"}, {LessEqual: "5.0.13"}}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{LessEqual: "3.3.3"}, {GreaterEqual: "3.4.0", LessEqual: "3.4.1"}}},
 	},
 	"FG-IR-16-029": {
@@ -460,7 +460,7 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-17-214": {
 		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "5.6.0"}}},
-		{Product: "FortiClientSSLVPN", Ranges: []supplementRange{{LessEqual: "4.4.2334"}, {LessEqual: "4.4.2335"}}},
+		{Product: "FortiClientSSLVPN", Ranges: []supplementRange{{LessEqual: "4.4.2335"}}},
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "5.6.0"}}},
 	},
 	"FG-IR-17-231": {
@@ -644,7 +644,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAuthenticator", Versions: []string{"6.0.0"}},
 	},
 	"FG-IR-19-107": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 	},
 	"FG-IR-19-110": {
 		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.2.0"}}},
@@ -1135,7 +1135,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-21-023": {
-		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.7"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.10"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.10"}, {GreaterEqual: "5.3.12", LessEqual: "5.3.13"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}, {GreaterEqual: "6.4.0", LessThan: "6.4.5"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.11"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.7"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.10"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.10"}, {GreaterEqual: "5.3.12", LessEqual: "5.3.13"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
 		{Product: "FortiNDR", Ranges: []supplementRange{{LessEqual: "7.2.1"}}},
 	},
 	"FG-IR-21-026": {
@@ -1151,8 +1151,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.2.0", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
 	},
 	"FG-IR-21-037": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
 	},
 	"FG-IR-21-039": {

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -353,6 +353,9 @@ var supplementTable = map[string][]supplementProduct{
 	"FG-IR-16-088": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.14"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.15"}}},
 	},
+	"FG-IR-16-090": {
+		{Product: "FortiOS"}, // whole product, audited: advisory: FortiOS all versions, when TCP timestamp is enabled (the default)
+	},
 	"FG-IR-16-095": {
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "5.4.1", LessEqual: "5.4.2"}}},
 	},
@@ -707,6 +710,9 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
 		{Product: "FortiProxy", Versions: []string{"2.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.9"}}},
 	},
+	"FG-IR-19-224": {
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}}}, // 424E/426E/448E with bluetooth enabled only, which version data cannot express
+	},
 	"FG-IR-19-227": {
 		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.2.0"}}},
 	},
@@ -750,6 +756,21 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-19-283": {
 		{Product: "FortiOS", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
+	},
+	"FG-IR-19-292": {
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.4"}}},
+		{Product: "FortiAP-C", Ranges: []supplementRange{{LessEqual: "5.4.2"}}},
+		{Product: "FortiAP-S", Ranges: []supplementRange{{LessEqual: "6.2.3"}}},
+		{Product: "FortiAP-U", Ranges: []supplementRange{{LessEqual: "6.0.1"}}},
+		{Product: "FortiAP-W2", Ranges: []supplementRange{{LessEqual: "6.2.3"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
+		{Product: "FortiDDoS", Ranges: []supplementRange{{LessEqual: "5.2.0"}}},
+		{Product: "FortiExtender", Ranges: []supplementRange{{LessEqual: "4.2.0"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}}},
+		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "5.2.4"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.2"}}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.1", LessThan: "6.3"}}},
+		{Product: "FortiWAN", Ranges: []supplementRange{{LessEqual: "4.5.7"}}},
+		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.5.1", LessEqual: "8.5.5"}}},
 	},
 	"FG-IR-19-294": {
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {LessEqual: "6.0.8"}}},
@@ -813,6 +834,13 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-20-033": {
 		{Product: "FortiOS", Ranges: []supplementRange{{LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.5"}}},
+	},
+	"FG-IR-20-035": {
+		{Product: "FortiAP-U", Ranges: []supplementRange{{LessEqual: "6.0.2"}}},
+		{Product: "Meru AP", Ranges: []supplementRange{{LessEqual: "8.4.6"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.1"}}},
+	},
+	"FG-IR-20-036": {
+		{Product: "FortiAnalyzer", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{LessEqual: "6.2.3"}}}, // FortiRecorder-management models only, which version data cannot express
 	},
 	"FG-IR-20-037": {
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}}},

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -828,6 +828,9 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-20-044": {
 		{Product: "FortiADC", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{LessEqual: "5.4.3"}}},
+		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "5.0", LessThan: "5.5"}}},
+		{Product: "FortiDDoS-F", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.2"}}},
+		{Product: "FortiSIEM", Ranges: []supplementRange{{GreaterEqual: "6", LessThan: "6.3"}}},
 	},
 	"FG-IR-20-045": {
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.10"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
@@ -1005,6 +1008,8 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-20-222": {
 		{Product: "FortiADC", Ranges: []supplementRange{{LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}}},
+		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "5.6"}}},
+		{Product: "FortiDDoS-F", Versions: []string{"6.3.0"}, Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.4"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 		{Product: "FortiMail", Ranges: []supplementRange{{LessEqual: "7.0.1"}}},
 		{Product: "FortiSandbox", Ranges: []supplementRange{{LessThan: "4.0.1"}}},
 		{Product: "FortiWeb", Ranges: []supplementRange{{LessThan: "6.3.12"}}},
@@ -1086,6 +1091,8 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-21-014": {
 		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "6.4.4"}}},
+		{Product: "FortiNDR", Versions: []string{"1.1.0", "1.2.0", "1.4.0"}, Ranges: []supplementRange{{GreaterEqual: "1.3.0", LessEqual: "1.3.1"}, {GreaterEqual: "1.5.0", LessEqual: "1.5.3"}}},
+		{Product: "FortiWeb", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.9.0", LessEqual: "5.9.2"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.17"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 	},
 	"FG-IR-21-018": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.4.2", LessEqual: "6.4.4"}}},
@@ -1184,7 +1191,9 @@ var supplementTable = map[string][]supplementProduct{
 	},
 	"FG-IR-21-075": {
 		{Product: "FortiClientEMS", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 		{Product: "FortiClientMac", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiClientWindows", Ranges: []supplementRange{{LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-077": {
 		{Product: "FortiPortal", Versions: []string{"5.0.0", "5.0.1", "5.0.2", "5.0.3", "5.1.0", "5.1.1", "5.1.2", "5.2.0", "5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.2.5", "5.3.0", "5.3.1", "5.3.2", "5.3.3", "5.3.4", "5.3.5", "6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4"}},
@@ -1521,6 +1530,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientMac", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.5"}}},
 		{Product: "FortiClientWindows", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiClientiOS", Ranges: []supplementRange{{LessThan: "7.0.3"}}},
+		{Product: "FortiDDoS", Ranges: []supplementRange{{GreaterEqual: "4.4", LessThan: "5.7"}}},
+		{Product: "FortiDDoS-F", Ranges: []supplementRange{{GreaterEqual: "6.1.0", LessEqual: "6.1.4"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.3"}}},
 		{Product: "FortiDeceptor", Versions: []string{"4.1.0"}, Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessThan: "4.0.0"}, {GreaterEqual: "4.0.0", LessThan: "4.1.0"}}},
 		{Product: "FortiIsolator", Versions: []string{"2.2.0", "2.4.0"}, Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.1"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.2"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.4"}}},
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -605,7 +605,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessEqual: "6.2.3"}}},
 	},
 	"FG-IR-19-013": {
-		{Product: "FortiOS", Versions: []string{"5.2.7"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.13"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.17"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
+		{Product: "FortiOS", Versions: []string{"5.2.7"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.13"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.2"}}},
 		{Product: "FortiAP-S", Ranges: []supplementRange{{LessThan: "6.2.2"}}},
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{LessThan: "6.2.2"}}},
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{LessThan: "6.2.3"}}},
@@ -868,7 +868,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Ranges: []supplementRange{{LessEqual: "6.2.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.4"}}},
 	},
 	"FG-IR-20-078": {
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.1"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "5.4", LessThan: "5.6"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "5.4", LessThan: "5.6"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3", LessThan: "6.4"}, {GreaterEqual: "6.4", LessThan: "6.5"}}},
 		{Product: "FortiDeceptor", Versions: []string{"1.1.0", "2.0.0", "2.1.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.1"}, {GreaterEqual: "3.0.0", LessEqual: "3.0.2"}, {GreaterEqual: "3.1.0", LessEqual: "3.1.1"}}},
 		{Product: "FortiMail", Versions: []string{"6.4.0"}, Ranges: []supplementRange{{GreaterEqual: "5.4.0", LessEqual: "5.4.12"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.9"}, {GreaterEqual: "6.2.1", LessEqual: "6.2.4"}}},
 	},
@@ -888,7 +888,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAnalyzer", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.4.4"}},
 	},
 	"FG-IR-20-098": {
-		{Product: "FortiAnalyzer", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.4.0", "6.4.1", "6.4.2", "6.4.3"}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
 	},
 	"FG-IR-20-103": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.4"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
@@ -931,7 +931,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWLC", Ranges: []supplementRange{{GreaterEqual: "8.2.6", LessEqual: "8.2.7"}, {GreaterEqual: "8.3.2", LessEqual: "8.3.3"}, {GreaterEqual: "8.4.0", LessEqual: "8.4.2"}, {GreaterEqual: "8.4.4", LessEqual: "8.4.8"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}}},
 	},
 	"FG-IR-20-158": {
-		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
+		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 		{Product: "FortiProxy", Ranges: []supplementRange{{LessEqual: "2.0.3"}}},
 	},
 	"FG-IR-20-170": {
@@ -1051,7 +1051,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessEqual: "6.2.8"}, {LessEqual: "6.4.2"}}},
 	},
 	"FG-IR-20-243": {
-		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.17"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
+		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-20-244": {
 		{Product: "FortiMail", Ranges: []supplementRange{{LessThan: "7.0.0"}}},
@@ -1104,7 +1104,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiNDR", Ranges: []supplementRange{{LessEqual: "7.2.0"}}},
 	},
 	"FG-IR-21-026": {
-		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.6"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {LessEqual: "3.6.11"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "3.6", LessThan: "3.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-21-027": {
 		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
@@ -1139,8 +1139,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-21-050": {
-		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {LessEqual: "6.0.11"}, {LessEqual: "6.2.7"}, {LessEqual: "6.4.5"}}},
-		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {LessEqual: "6.0.11"}, {LessEqual: "6.2.7"}, {LessEqual: "6.4.5"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-21-051": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.13"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
@@ -1151,8 +1151,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-21-059": {
-		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {LessEqual: "6.0.11"}, {LessEqual: "6.2.8"}, {LessEqual: "6.4.5"}}},
-		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {LessEqual: "6.0.11"}, {LessEqual: "6.2.8"}, {LessEqual: "6.4.5"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
+		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.5"}}},
 	},
 	"FG-IR-21-060": {
 		{Product: "FortiWAN", Ranges: []supplementRange{{LessThan: "4.5.9"}}},
@@ -1161,8 +1161,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWAN", Ranges: []supplementRange{{LessThan: "4.5.9"}}},
 	},
 	"FG-IR-21-063": {
-		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {LessEqual: "6.0.11"}, {LessEqual: "6.2.8"}, {LessEqual: "6.4.6"}}},
-		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {LessEqual: "6.0.11"}, {LessEqual: "6.2.8"}, {LessEqual: "6.4.6"}}},
+		{Product: "FortiAnalyzer", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
+		{Product: "FortiManager", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{LessEqual: "5.6.11"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-21-064": {
 		{Product: "FortiWAN", Ranges: []supplementRange{{LessThan: "4.5.9"}}},
@@ -1206,7 +1206,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientWindows", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-21-091": {
-		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.17"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
+		{Product: "FortiOS", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}}},
 	},
 	"FG-IR-21-092": {
 		{Product: "FortiPortal", Ranges: []supplementRange{{LessEqual: "4.0.4"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.2"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.4"}, {GreaterEqual: "5.0.0", LessEqual: "5.0.3"}, {GreaterEqual: "5.1.0", LessEqual: "5.1.2"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.5"}, {GreaterEqual: "5.3.0", LessEqual: "5.3.5"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.4"}}},
@@ -1227,7 +1227,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
 	},
 	"FG-IR-21-103": {
-		{Product: "FortiManager", Versions: []string{"5.6.0"}, Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {LessEqual: "6.4.6"}, {LessEqual: "7.0.1"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 	},
 	"FG-IR-21-104": {
 		{Product: "FortiPortal", Ranges: []supplementRange{{LessThan: "6.0.6"}}},
@@ -1274,10 +1274,10 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.1.0", "6.1.1", "6.1.2", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.4.0", "6.4.1"}},
 	},
 	"FG-IR-21-126": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.17"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.15"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
-		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessEqual: "1.0.7"}, {GreaterEqual: "1.1.0", LessEqual: "1.1.6"}, {GreaterEqual: "1.2.0", LessEqual: "1.2.13"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.10"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
+		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2", LessThan: "1.3"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.10"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4", LessThan: "6.5"}}},
 	},
 	"FG-IR-21-128": {
 		{Product: "FortiWLM", Ranges: []supplementRange{{LessEqual: "8.4.2"}, {GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.0", LessEqual: "8.6.2"}}},
@@ -1329,7 +1329,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiWeb", Versions: []string{"6.4.0", "6.4.1"}, Ranges: []supplementRange{{GreaterEqual: "6.3.0", LessEqual: "6.3.15"}}},
 	},
 	"FG-IR-21-155": {
-		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.17"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
+		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiProxy", Versions: []string{"7.0.0"}, Ranges: []supplementRange{{GreaterEqual: "1.0", LessThan: "1.1"}, {GreaterEqual: "1.1", LessThan: "1.2"}, {GreaterEqual: "1.2", LessThan: "1.3"}, {LessEqual: "2.0.6"}}},
 		{Product: "FortiRecorder", Ranges: []supplementRange{{LessEqual: "6.0.10"}, {LessEqual: "6.4.2"}}},
 		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {LessEqual: "6.4.9"}, {LessEqual: "7.0.2"}}},
@@ -1393,7 +1393,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiMail", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.0.11", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.4.0", "6.4.1", "6.4.2", "6.4.3", "6.4.4", "6.4.5", "7.0.0", "7.0.1"}},
 	},
 	"FG-IR-21-186": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.2"}, {GreaterEqual: "5.6.0", LessThan: "5.7"}, {GreaterEqual: "5.7.0", LessEqual: "5.7.3"}, {GreaterEqual: "5.7.0", LessThan: "5.8"}, {GreaterEqual: "5.8.0", LessEqual: "5.8.3"}, {GreaterEqual: "5.8.0", LessThan: "5.9"}, {GreaterEqual: "5.8.5", LessEqual: "5.8.7"}, {GreaterEqual: "5.9.0", LessEqual: "5.9.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5", LessThan: "6"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4", LessThan: "6.5"}}},
 	},
 	"FG-IR-21-188": {
 		{Product: "FortiWeb", Versions: []string{"6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.3.0", "6.3.1", "6.3.2", "6.3.3", "6.3.4", "6.3.5", "6.3.6", "6.3.7", "6.3.8", "6.3.9", "6.3.10", "6.3.11", "6.3.12", "6.3.13", "6.3.14", "6.3.15", "6.3.16", "6.4.0", "6.4.1"}},
@@ -1420,11 +1420,11 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiDeceptor", Ranges: []supplementRange{{GreaterEqual: "1.0.0", LessThan: "3.3"}, {GreaterEqual: "3.3.0", LessEqual: "3.3.2"}, {GreaterEqual: "4.0.0", LessEqual: "4.0.1"}}},
 	},
 	"FG-IR-21-214": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.2"}, {GreaterEqual: "5.7.0", LessEqual: "5.7.3"}, {GreaterEqual: "5.8.0", LessEqual: "5.8.3"}, {GreaterEqual: "5.8.5", LessEqual: "5.8.7"}, {GreaterEqual: "5.9.0", LessEqual: "5.9.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "5.7", LessThan: "5.8"}, {GreaterEqual: "5.8", LessThan: "5.9"}, {GreaterEqual: "5.9.0", LessEqual: "5.9.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.16"}, {GreaterEqual: "6.4", LessThan: "6.5"}}},
 	},
 	"FG-IR-21-218": {
 		{Product: "FortiRecorder", Ranges: []supplementRange{{GreaterEqual: "2.7.0", LessEqual: "2.7.7"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.12"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.3"}}},
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.8"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.3"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.17"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.17"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 	},
 	"FG-IR-21-222": {
 		{Product: "FortiOS", Versions: []string{"7.2.0"}, Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.9"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.5"}}},
@@ -1437,8 +1437,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAP-C", Ranges: []supplementRange{{GreaterEqual: "5.2.0", LessEqual: "5.2.1"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.3"}}},
 	},
 	"FG-IR-21-228": {
-		{Product: "FortiAnalyzer", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.0.11", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.2.8", "6.2.9", "6.4.0", "6.4.1", "6.4.2", "6.4.3", "6.4.4", "6.4.5", "6.4.6", "6.4.7", "6.4.8", "7.0.0", "7.0.1", "7.0.2", "7.0.3", "7.0.4"}},
-		{Product: "FortiManager", Versions: []string{"6.0.0", "6.0.1", "6.0.2", "6.0.3", "6.0.4", "6.0.5", "6.0.6", "6.0.7", "6.0.8", "6.0.9", "6.0.10", "6.0.11", "6.2.0", "6.2.1", "6.2.2", "6.2.3", "6.2.4", "6.2.5", "6.2.6", "6.2.7", "6.2.8", "6.2.9", "6.4.0", "6.4.1", "6.4.2", "6.4.3", "6.4.4", "6.4.5", "6.4.6", "6.4.7", "6.4.8", "7.0.0", "7.0.1", "7.0.2", "7.0.3", "7.0.4"}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
 	},
 	"FG-IR-21-230": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
@@ -1451,7 +1451,7 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiIsolator", Versions: []string{"1.0.0", "1.1.0", "2.2.0"}, Ranges: []supplementRange{{GreaterEqual: "1.2.0", LessEqual: "1.2.2"}, {GreaterEqual: "2.0.0", LessEqual: "2.0.1"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.2"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.4"}}},
 	},
 	"FG-IR-21-234": {
-		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.2"}, {GreaterEqual: "5.7.0", LessEqual: "5.7.3"}, {GreaterEqual: "5.8.0", LessEqual: "5.8.3"}, {GreaterEqual: "5.8.5", LessEqual: "5.8.7"}, {GreaterEqual: "5.9.0", LessEqual: "5.9.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.17"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
+		{Product: "FortiWeb", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "5.7", LessThan: "5.8"}, {GreaterEqual: "5.8", LessThan: "5.9"}, {GreaterEqual: "5.9.0", LessEqual: "5.9.1"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.6"}, {GreaterEqual: "6.3.0", LessEqual: "6.3.17"}, {GreaterEqual: "6.4", LessThan: "6.5"}}},
 	},
 	"FG-IR-21-235": {
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.0.14"}, {GreaterEqual: "5.2.0", LessEqual: "5.2.15"}, {GreaterEqual: "5.4.0", LessEqual: "5.4.13"}, {GreaterEqual: "5.6.0", LessEqual: "5.6.14"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
@@ -1480,8 +1480,8 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.2"}}},
 	},
 	"FG-IR-22-026": {
-		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.11"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
-		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6.0", LessEqual: "5.6.11"}, {GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.11"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
+		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4", LessThan: "6.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
+		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "5.6", LessThan: "5.7"}, {GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4", LessThan: "6.5"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 	},
 	"FG-IR-22-041": {
 		{Product: "FortiSOAR PaaS", Versions: []string{"6.0.0"}, Ranges: []supplementRange{{GreaterEqual: "5.0.0", LessEqual: "5.2.2"}, {LessEqual: "6.4.4"}, {LessEqual: "7.0.2"}}},
@@ -1508,13 +1508,13 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiNAC", Versions: []string{"8.5.4", "8.6.0"}, Ranges: []supplementRange{{GreaterEqual: "8.5.0", LessEqual: "8.5.2"}, {GreaterEqual: "8.6.2", LessEqual: "8.6.5"}, {GreaterEqual: "8.7.0", LessEqual: "8.7.6"}, {GreaterEqual: "8.8.0", LessEqual: "8.8.11"}, {GreaterEqual: "9.1.0", LessEqual: "9.1.5"}, {GreaterEqual: "9.2.0", LessEqual: "9.2.3"}, {LessEqual: "8.3.7"}}},
 	},
 	"FG-IR-22-059": {
-		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.4"}, {GreaterEqual: "6.1.0", LessEqual: "6.1.4"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
+		{Product: "FortiADC", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.3"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.1"}}},
 		{Product: "FortiADCManager", Ranges: []supplementRange{{LessThan: "7.0.0"}}},
 		{Product: "FortiAIOps", Ranges: []supplementRange{{LessThan: "1.1.0"}}},
 		{Product: "FortiAP", Ranges: []supplementRange{{LessThan: "7.2.1"}}},
 		{Product: "FortiAP-W2", Ranges: []supplementRange{{LessThan: "7.2.1"}}},
 		{Product: "FortiAnalyzer", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
-		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.4.1"}}},
+		{Product: "FortiAuthenticator", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.1", LessThan: "6.2"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.3", LessThan: "6.4"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.1"}}},
 		{Product: "FortiClientAndroid", Ranges: []supplementRange{{LessThan: "7.0.3"}}},
 		{Product: "FortiClientEMS", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiClientLinux", Ranges: []supplementRange{{LessThan: "7.0.6"}}},
@@ -1523,14 +1523,14 @@ var supplementTable = map[string][]supplementProduct{
 		{Product: "FortiClientiOS", Ranges: []supplementRange{{LessThan: "7.0.3"}}},
 		{Product: "FortiDeceptor", Versions: []string{"4.1.0"}, Ranges: []supplementRange{{GreaterEqual: "3.0.0", LessThan: "4.0.0"}, {GreaterEqual: "4.0.0", LessThan: "4.1.0"}}},
 		{Product: "FortiIsolator", Versions: []string{"2.2.0", "2.4.0"}, Ranges: []supplementRange{{GreaterEqual: "2.0.0", LessEqual: "2.0.1"}, {GreaterEqual: "2.1.0", LessEqual: "2.1.2"}, {GreaterEqual: "2.3.0", LessEqual: "2.3.4"}}},
-		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.9"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
+		{Product: "FortiMail", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.8"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.6"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiManager", Ranges: []supplementRange{{GreaterEqual: "6.2.0", LessEqual: "6.2.9"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.7"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiNDR", Ranges: []supplementRange{{LessThan: "7.0.0"}}},
 		{Product: "FortiOS", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.14"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.8"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.5"}}},
 		{Product: "FortiProxy", Ranges: []supplementRange{{GreaterEqual: "7.0.0", LessEqual: "7.0.3"}}},
 		{Product: "FortiRecorder", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.10"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.2"}}},
 		{Product: "FortiSIEM", Ranges: []supplementRange{{LessThan: "6.4.0"}}},
-		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.7"}, {GreaterEqual: "6.2.0", LessEqual: "6.2.7"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.10"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
+		{Product: "FortiSwitch", Ranges: []supplementRange{{GreaterEqual: "6.0", LessThan: "6.1"}, {GreaterEqual: "6.2", LessThan: "6.3"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.10"}, {GreaterEqual: "7.0.0", LessEqual: "7.0.4"}}},
 		{Product: "FortiTester", Ranges: []supplementRange{{LessEqual: "7.1.1"}}},
 		{Product: "FortiVoice", Ranges: []supplementRange{{GreaterEqual: "6.0.0", LessEqual: "6.0.11"}, {GreaterEqual: "6.4.0", LessEqual: "6.4.4"}}},
 		{Product: "FortiWAN", Ranges: []supplementRange{{GreaterEqual: "4.0.0", LessEqual: "4.0.6"}, {GreaterEqual: "4.1.0", LessEqual: "4.1.3"}, {GreaterEqual: "4.2.0", LessEqual: "4.2.7"}, {GreaterEqual: "4.3.0", LessThan: "4.4"}, {GreaterEqual: "4.4.0", LessThan: "4.5"}, {GreaterEqual: "4.5.0", LessEqual: "4.5.9"}}},

--- a/pkg/extract/fortinet/cvrf/supplement_data.go
+++ b/pkg/extract/fortinet/cvrf/supplement_data.go
@@ -1,7 +1,8 @@
-// The initial content of this table was machine-generated from the
-// legacy handmade dataset, Fortinet's CNA records and the advisory
-// notes, then arbitrated by hand; it is maintained as ordinary source.
-// See supplement.go for what this table is and how it was derived.
+// The rows state what each advisory's Affected Products note says, plus
+// what the Fortinet CNA record for the same CVEs adds; they are generated
+// from those two sources and arbitrated by hand, and maintained as
+// ordinary source. See supplement.go for the wording conventions and for
+// why the legacy handmade dataset is not a source.
 
 package cvrf
 

--- a/pkg/extract/fortinet/cvrf/testdata/golden/data/2012/FG-IR-012-003.json
+++ b/pkg/extract/fortinet/cvrf/testdata/golden/data/2012/FG-IR-012-003.json
@@ -51,8 +51,8 @@
 									"cpe": "cpe:2.3:o:fortinet:fortios:*:*:*:*:*:*:*:*",
 									"range": {
 										"type": "fortinet-fortios",
-										"ge": "4.2.0",
-										"le": "4.2.16"
+										"ge": "4.2",
+										"lt": "4.3"
 									}
 								}
 							},


### PR DESCRIPTION
## What

Re-sources `supplement_data.go` — the affected-product table for the 2012–2022 CVRF advisories that ship with empty `product_statuses` — from the advisories themselves, and fixes the detection errors the previous sourcing left behind.

| | | rows |
|---|---|---|
| A | `"<train> all versions"` → train ranges (`ge "6.0", lt "6.1"`) | 31 |
| B | bounds raised to the version the advisory states | 13 |
| C | open-ended caps bounded to the train they belong to | 30 |
| D | rows added for products only the advisory text names | +11 |
| E | advisories added whose affected set only their text carries | +5 advisories |
| F | ranges dropped that a sibling already covers | 10 |
| G | rows rebuilt from the advisory note ∪ the Fortinet CNA record | 298 |
| H | the rows G could not decide, settled one by one | 121 |

## Why

The table was seeded from the legacy `vuls-data-raw-fortinet` (handmade) dataset, which reads Fortinet's wording in two ways the advisories do not support:

**`"<train> all versions"` was frozen at the release that existed when the dataset was curated.** FG-IR-21-091 says *"FortiGate 6.0 all versions"* and ships no 6.0 fix, but the row stopped at `le 6.0.17` while the 6.0 train ends at 6.0.18 — so a 6.0.18 device did not match. Across 16 advisories that pattern missed **81 releases** (FG-IR-22-026 missed 16, FG-IR-20-078 missed 10, FG-IR-19-013 missed all of FortiAnalyzer 6.4.x).

**`"<v> and below"` was stored without a lower bound**, so the highest cap in a row also matched every later release of the older trains that same row caps lower: FG-IR-21-103 reported FortiManager 6.4.7–6.4.15 as affected although the advisory stops at 6.4.6. That was **140 releases over 29 rows**.

Fortinet's own structured data settles the second reading: across the CNA records for these advisories, **58 entries bound their lowest affected train explicitly against 4 that leave it open** (e.g. FG-IR-20-082 → `5.6.0 <= 5.6.12`).

Five advisories also listed products with versions that no row covered (FortiSIEM/FortiDDoS/FortiDDoS-F in FG-IR-20-044, FortiWeb/FortiNDR in FG-IR-21-014, FortiClientWindows/Linux in FG-IR-21-075, …), and five advisories with a versioned affected set had no entry at all (FG-IR-19-292 alone names 13 products) — they produced no detection.

## How

Row content is now the advisory's Affected Products note, unioned with the Fortinet CNA record for the same CVEs; handmade is only the seed and no longer a source. Of the 721 rows, 549 have a version in their note, 34 rest on a CNA record alone, and 138 have neither and keep what they had.

Wording conventions (written down in `supplement.go`):

- `"<v> and below/earlier"` → `ge <train>.0, le <v>`
- `"<train> all versions"` / `"<train>.x"` → the `product.TrainRange` shape the CSAF extractor already emits, so a later release of an EOL train cannot fall out of range
- `"all versions below <v>"` → open-ended below; `"<a> through <b>"` → exactly that

Notes whose scope versions cannot express (hardware models in FG-IR-19-224 / FG-IR-20-036, the default TCP timestamp setting in FG-IR-16-090, which is an audited whole-product row) carry the version bound the note gives and say so in a comment.

121 rows could not be rewritten unattended — dash-versioned FortiWLC releases (`7.0-10`), `4.x prior to 4.3.7`, `5.4 branch:` headings, an advisory that writes its range backwards (`6.0.14 to 6.0.0`) — and were settled individually: 75 took the note's reading, 14 are hand-written, 32 keep what they had.

## Rows left as they are

**31 rows the note-vs-row comparison flagged and I kept.** Each is a case where the generated reading would have been wrong, not a case of skipping work:

| Advisory | Product | Row | Why it stays |
|---|---|---|---|
| `FG-IR-012-001` | FortiOS | `≥ 4.3.0 ≤ 4.3.5` | the row is already the note ("v4.3 through FOS 4.3.5") |
| `FG-IR-13-008` | FortiClient Lite | `= 4.3.3.445 / ≥ 2.0 < 2.1` | "FortiClient 4.0.2 for MacOS" in the note belongs to the FortiClientMac row |
| `FG-IR-13-018` | FortiAnalyzer | `≥ 4.0.0 < 4.3.7 / ≥ 5.0.0 < 5.0.5` | "4.x prior to 4.3.7, 5.x prior to 5.0.5" is what the row already says |
| `FG-IR-14-034` | FortiOS | `≥ 5.0.0 ≤ 5.0.10 / ≥ 5.2.0 ≤ 5.2.2` | the note's other numbers are TLS versions (v1.0, v1.1, v1.2) |
| `FG-IR-16-080` | Connect | `≥ 14.10.0.0 < 14.10.0.5 / ≥ 14.2.0.0 < 14.2.0.12 / ≥ 15.10.0.0 < 15.10.0.3 / ≥ 16.7.0.0 < 16.7.0.1` | bounds come from the patch list in Solutions (14.2.0.12, 14.10.0.5, …), finer than the note's train names |
| `FG-IR-17-104` | FortiOS | `≤ 5.6.0` | "versions upto 5.6.0" (note) and "5.6.0 and earlier" (CNA) are open-ended below |
| `FG-IR-17-106` | FortiWLC | `= 6.1.2 / ≥ 6.1.4 ≤ 6.1.5 / ≥ 7.0.7 ≤ 7.0.10 / ≥ 8.0.0 ≤ 8.3.2` | the note versions releases with dashes (6.1-2 … 7.0-10); the row maps them to dotted versions |
| `FG-IR-17-113` | FortiOS | `= 5.6.0 / ≥ 5.4.0 ≤ 5.4.5` | "Branch 5.4: 5.4.0 to 5.4.5" — the heading is not a train claim, and the CNA agrees |
| `FG-IR-17-196` | FortiAP | `= 5.6.0 / ≥ 5.4.0 ≤ 5.4.3 / ≤ 5.2.6` | already the note's per-branch reading, including "Previous branches: All versions" |
| `FG-IR-17-259` | FortiCloud | `≤ 3.2.0` | hosted service versioned linearly — no maintenance train to bound to |
| `FG-IR-17-274` | FortiWLC | `≥ 7.0.0 ≤ 7.0.11 / ≥ 8.0.0 ≤ 8.3.3` | "7.0.11 and lower in the 7.x branch" / "8.3.3 and lower in the 8.x branch" is the row |
| `FG-IR-17-279` | FortiWeb | `≥ 5.6.0 < 6.1.0` | "all versions below 6.1.0, starting from 5.6.0" keeps the exclusive upper bound |
| `FG-IR-18-026` | FortiCloud | `≤ 3.2.1` | hosted service versioned linearly — no maintenance train to bound to |
| `FG-IR-18-074` | FortiCloud | `≤ 3.2.1` | hosted service versioned linearly — no maintenance train to bound to |
| `FG-IR-18-100` | FortiClientMac | `< 6.2.2` | "All versions below X" is open-ended by wording |
| `FG-IR-18-100` | FortiClientWindows | `< 6.2.0` | "All versions below X" is open-ended by wording |
| `FG-IR-18-100` | FortiOS | `≥ 6.0.0 < 6.0.8 / < 5.6.12` | "All versions below X" is open-ended by wording |
| `FG-IR-18-384` | FortiOS | `≥ 5.4.6 ≤ 5.4.12 / ≥ 5.6.3 ≤ 5.6.7 / ≥ 6.0.0 ≤ 6.0.4` | "6.0 - 6.0.0 to 6.0.4" — the "6.0 -" is a label, not a train claim |
| `FG-IR-18-388` | FortiOS | `≥ 5.2.0 ≤ 5.2.14 / ≥ 5.4.0 ≤ 5.4.12 / ≥ 5.6.0 ≤ 5.6.10 / ≥ 6.0.0 ≤ 6.0.4` | "Branch lower than 5.2 not been assessed" is not an affected claim |
| `FG-IR-19-034` | FortiOS | `≥ 5.2.0 ≤ 5.6.10 / ≥ 6.0.0 ≤ 6.0.4` | the note's two ranges are tighter than the CNA's spanning "5.2.0 to 6.0.4" |
| `FG-IR-19-104` | FortiAuthenticator | `= 6.0.0` | the note's "v1.5 and below" is the Outlook Web Access agent, a different product; the row is the CNA's 6.0.0 |
| `FG-IR-19-145` | FortiOS | `= 6.2.0 / ≥ 5.6.0 ≤ 5.6.10 / ≥ 6.0.0 ≤ 6.0.8` | the note gives IPS Engine versions, not FortiOS ones |
| `FG-IR-20-044` | FortiSIEM | `≥ 6 < 6.3` | "6.x" with the fix at 6.3.0 — bounded at < 6.3, not < 7 |
| `FG-IR-20-170` | FortiAuthenticator | `< 6.0.6` | the CNA's "before 6.0.6" already covers every release the note enumerates |
| `FG-IR-20-191` | FSSO | `≤ 5.0.295` | the note's 7.0.0 / 6.4.5 are the FortiOS bundle versions, not FSSO's |
| `FG-IR-20-193` | FortiGate Cloud | `≤ 20.3` | hosted service versioned linearly — no maintenance train to bound to |
| `FG-IR-21-018` | FortiOS | `≥ 6.4.2 ≤ 6.4.4` | the note excludes 6.4.0/6.4.1, which the CNA's "6.4.0 to 6.4.4" would pull back in |
| `FG-IR-21-051` | FortiOS | `≥ 5.6.0 ≤ 5.6.13 / ≥ 6.0.0 ≤ 6.0.12 / ≥ 6.2.0 ≤ 6.2.8 / ≥ 6.4.0 ≤ 6.4.5` | the note's per-train caps are tighter than the CNA's "before 7.0.1" |
| `FG-IR-21-085` | FortiPortal | `≤ 5.2.5 / ≥ 5.3.0 ≤ 5.3.5 / ≥ 6.0.0 ≤ 6.0.4` | ≤ 5.2.5 already equals the CNA enumeration down to 4.0.0 |
| `FG-IR-21-230` | FortiOS | `≥ 6.0.0 ≤ 6.0.14 / ≥ 6.2.0 ≤ 6.2.10 / ≥ 6.4.0 ≤ 6.4.8 / ≥ 7.0.0 ≤ 7.0.3` | the note writes its range backwards ("6.0.14 to 6.0.0"); the row has it the right way round |
| `FG-IR-21-230` | FortiProxy | `≥ 2.0.0 ≤ 2.0.7 / ≥ 7.0.0 ≤ 7.0.1` | the note writes its range backwards ("2.0.7 to 2.0.0"); the row has it the right way round |

**132 rows with no version to check against.** Their advisory names the product without a version (98) or has no Affected Products note at all (34), and the CVEs' CNA records carry nothing for that product either — so they still hold what the handmade dataset seeded. Keeping them is deliberate: whole-product rows would flag every release of the product, and dropping them would take away the only detection those advisories have.

<details>
<summary>132 rows resting on the seed</summary>

| Advisory | Product | Row | Why unverifiable |
|---|---|---|---|
| `FG-IR-012-007` | FortiDB | `< 4.4.2` | note names no version |
| `FG-IR-012-008` | FortiWeb | `< 4.4.4` | note names no version |
| `FG-IR-013-001` | FortiMail | `< 4.3.4` | note names no version |
| `FG-IR-13-008` | FortiClientMac | `= 4.0.2` | note names no version |
| `FG-IR-13-008` | FortiClientWindows | `= 4.3.3.445` | note names no version |
| `FG-IR-13-016` | FortiAuthenticator | `≥ 1.0.0 ≤ 1.3.1 / ≥ 2.0.0 ≤ 2.2.0` | note names no version |
| `FG-IR-14-010` | FortiBalancer | `(whole product)` | note names no version |
| `FG-IR-14-011` | FortiADC | `≥ 3.0 < 4.0` | note names no version |
| `FG-IR-14-018` | AscenLink | `≥ 7.1 < 7.2` | note names no version |
| `FG-IR-14-031` | FortiADC | `(whole product)` | note names no version |
| `FG-IR-14-031` | FortiAnalyzer | `= 5.0.9, 5.2.1` | note names no version |
| `FG-IR-14-031` | FortiAuthenticator | `≥ 3.0.0 ≤ 3.0.3` | note names no version |
| `FG-IR-14-031` | FortiCache | `≥ 2.2.0 ≤ 3.0.8` | note names no version |
| `FG-IR-14-031` | FortiClientWindows | `(whole product)` | note names no version |
| `FG-IR-14-031` | FortiDB | `(whole product)` | note names no version |
| `FG-IR-14-031` | FortiDDoS | `< 4.1.3` | note names no version |
| `FG-IR-14-031` | FortiMail | `(whole product)` | note names no version |
| `FG-IR-14-031` | FortiOS | `(whole product)` | note names no version |
| `FG-IR-14-031` | FortiRecorder | `(whole product)` | note names no version |
| `FG-IR-14-031` | FortiSwitch | `(whole product)` | note names no version |
| `FG-IR-14-031` | FortiVoice | `(whole product)` | note names no version |
| `FG-IR-14-031` | FortiWeb | `≥ 5.2.0 ≤ 5.2.4 / ≥ 5.3.0 ≤ 5.3.2` | note names no version |
| `FG-IR-14-033` | FortiManager | `< 5.0.7` | note names no version |
| `FG-IR-15-004` | FortiClientAndroid | `< 5.2.6` | note names no version |
| `FG-IR-15-004` | FortiClientiOS | `< 5.2.1` | note names no version |
| `FG-IR-15-005` | FortiADC | `< 4.2.0` | note names no version |
| `FG-IR-15-005` | FortiAnalyzer | `≥ 5.0.0 ≤ 5.0.10 / ≥ 5.2.0 ≤ 5.2.1` | note names no version |
| `FG-IR-15-005` | FortiMail | `≥ 5.0.0 < 5.0.8 / ≥ 5.1.0 < 5.1.5 / ≥ 5.2.0 < 5.2.3 / < 4.3.9` | note names no version |
| `FG-IR-15-005` | FortiManager | `≥ 5.0.3 ≤ 5.0.10 / ≥ 5.2.0 ≤ 5.2.1` | note names no version |
| `FG-IR-15-005` | FortiOS | `≥ 5.2.0 < 5.2.3` | note names no version |
| `FG-IR-15-005` | FortiWeb | `≥ 5.1.2 ≤ 5.3.4` | note names no version |
| `FG-IR-15-006` | FSSO | `< 5.0.0237` | note names no version |
| `FG-IR-15-007` | FortiMail | `(whole product)` | note names no version |
| `FG-IR-15-008` | FortiADC | `< 4.2.2` | note names no version |
| `FG-IR-15-008` | FortiClientAndroid | `< 5.2.6` | note names no version |
| `FG-IR-15-008` | FortiClientMac | `< 5.2.4` | note names no version |
| `FG-IR-15-008` | FortiClientWindows | `< 5.2.4` | note names no version |
| `FG-IR-15-008` | FortiClientiOS | `< 5.2.1` | note names no version |
| `FG-IR-15-009` | FortiMail | `≥ 5.0.3 ≤ 5.2.3` | note names no version |
| `FG-IR-15-014` | AscenLink | `≤ 7.2.4` | no Affected Products note |
| `FG-IR-15-014` | FortiAnalyzer | `≤ 5.2.2` | no Affected Products note |
| `FG-IR-15-014` | FortiAuthenticator | `< 4.0` | no Affected Products note |
| `FG-IR-15-014` | FortiClientAndroid | `≤ 5.2.5` | no Affected Products note |
| `FG-IR-15-014` | FortiClientMac | `≤ 5.2.3` | no Affected Products note |
| `FG-IR-15-014` | FortiClientWindows | `≤ 5.2.3` | no Affected Products note |
| `FG-IR-15-014` | FortiMail | `≥ 5.1.0 ≤ 5.1.5 / ≥ 5.2.0 ≤ 5.2.4 / ≤ 5.0.8` | no Affected Products note |
| `FG-IR-15-014` | FortiManager | `≤ 5.2.2` | no Affected Products note |
| `FG-IR-15-014` | FortiOS | `≤ 5.2.3` | no Affected Products note |
| `FG-IR-15-014` | FortiRecorder | `≤ 2.0.0` | no Affected Products note |
| `FG-IR-15-014` | FortiWAN | `≤ 4.0.2` | no Affected Products note |
| `FG-IR-15-017` | FortiClientSSLVPN | `≤ 4.0.2312` | note names no version |
| `FG-IR-15-023` | FortiADC | `< 4.4.0` | no Affected Products note |
| `FG-IR-15-023` | FortiAP | `< 5.4.0` | no Affected Products note |
| `FG-IR-15-023` | FortiAnalyzer | `≥ 5.4.0 < 5.4.1 / < 5.2.5` | no Affected Products note |
| `FG-IR-15-023` | FortiAuthenticator | `< 4.1.0` | no Affected Products note |
| `FG-IR-15-023` | FortiCache | `< 5.2.6` | no Affected Products note |
| `FG-IR-15-023` | FortiClientAndroid | `< 5.2.8` | no Affected Products note |
| `FG-IR-15-023` | FortiClientMac | `< 5.4.1` | no Affected Products note |
| `FG-IR-15-023` | FortiClientWindows | `< 5.4.1` | no Affected Products note |
| `FG-IR-15-023` | FortiClientiOS | `< 5.2.3` | no Affected Products note |
| `FG-IR-15-023` | FortiDB | `< 5.2.0` | no Affected Products note |
| `FG-IR-15-023` | FortiDDoS | `< 4.1.11` | no Affected Products note |
| `FG-IR-15-023` | FortiExplorer | `< 2.7.0` | no Affected Products note |
| `FG-IR-15-023` | FortiExtender | `< 2.0.3` | no Affected Products note |
| `FG-IR-15-023` | FortiMail | `≥ 5.1.0 < 5.1.6 / ≥ 5.2.0 < 5.2.7 / ≥ 5.3.0 < 5.3.1 / < 5.0.9` | no Affected Products note |
| `FG-IR-15-023` | FortiManager | `≥ 5.4.0 < 5.4.1 / < 5.2.5` | no Affected Products note |
| `FG-IR-15-023` | FortiOS | `< 5.2.6` | no Affected Products note |
| `FG-IR-15-023` | FortiRecorder | `< 2.3.0` | no Affected Products note |
| `FG-IR-15-023` | FortiSandbox | `< 2.2.0` | no Affected Products note |
| `FG-IR-15-023` | FortiSwitch | `< 3.4.0` | no Affected Products note |
| `FG-IR-15-023` | FortiSwitch-EFX | `< 3.4.0` | no Affected Products note |
| `FG-IR-15-023` | FortiVoice | `< 5.2.1.82` | no Affected Products note |
| `FG-IR-15-023` | FortiWAN | `< 4.1.2` | no Affected Products note |
| `FG-IR-15-023` | FortiWeb | `< 5.5.2` | no Affected Products note |
| `FG-IR-15-025` | FortiClientWindows | `≤ 5.2.3` | note names no version |
| `FG-IR-16-001` | FortiAnalyzer | `≥ 5.0.5 ≤ 5.0.11 / ≥ 5.2.0 ≤ 5.2.4` | note names no version |
| `FG-IR-16-001` | FortiCache | `≥ 3.0.0 ≤ 3.0.7` | note names no version |
| `FG-IR-16-001` | FortiOS | `≥ 4.1.0 ≤ 4.1.10 / ≥ 4.2.0 ≤ 4.2.15 / ≥ 4.3.0 ≤ 4.3.16 / ≥ 5.0.0 ≤ 5.0.7` | note names no version |
| `FG-IR-16-001` | FortiSwitch | `≥ 3.3.0 ≤ 3.3.2` | note names no version |
| `FG-IR-16-003` | FortiOS | `≥ 5.0.0 < 5.0.13 / ≥ 5.2.0 < 5.2.4` | note names no version |
| `FG-IR-16-004` | FortiOS | `≥ 5.0.0 < 5.0.13 / ≥ 5.2.0 < 5.2.3` | note names no version |
| `FG-IR-16-008` | FortiOS | `≥ 5.2.0 < 5.2.6 / < 5.0.13` | note names no version |
| `FG-IR-16-010` | FortiWeb | `< 5.5.3` | note names no version |
| `FG-IR-16-014` | FortiManager | `≥ 5.0.0 ≤ 5.0.11 / ≥ 5.2.0 ≤ 5.2.5` | note names no version |
| `FG-IR-16-021` | FortiClientWindows | `≤ 5.4.0` | note names no version |
| `FG-IR-16-041` | FortiClientSSLVPN | `(whole product)` | note names no version |
| `FG-IR-16-045` | FortiWAN | `≤ 4.2.4` | note names no version |
| `FG-IR-16-048` | AscenLink | `≥ 7.2.0 ≤ 7.2.16` | note names no version |
| `FG-IR-16-048` | FSSO CA | `= 0.4.20, 3.0.0, 4.1.2 / ≥ 4.0.0 ≤ 4.0.2 / ≥ 4.2.2 ≤ 4.2.9 / ≥ 4.3.0 ≤ 4.3.10 / ≥ 5.0.0 ≤ 5.0.9 / ≥ 5.2.0 ≤ 5.2.3 / ≥ 5.2.6 ≤ 5.2.9` | note names no version |
| `FG-IR-16-048` | FortiADC | `= 3.0.0, 3.1.0, 4.6.0 / ≥ 3.2.0 ≤ 3.2.2 / ≥ 4.0.0 ≤ 4.0.2 / ≥ 4.1.0 ≤ 4.1.1 / ≥ 4.2.0 ≤ 4.2.3 / ≥ 4.3.0 ≤ 4.3.2 / ≥ 4.4.0 ≤ 4.4.1 / ≥ 4.5.0 ≤ 4.5.4` | note names no version |
| `FG-IR-16-048` | FortiAP-W2 | `≥ 5.4.0 ≤ 5.4.1` | note names no version |
| `FG-IR-16-048` | FortiAuthenticator | `= 1.0.0, 1.1.0, 2.1.0, 2.2.0 / ≥ 1.2.0 ≤ 1.2.1 / ≥ 1.3.0 ≤ 1.3.1 / ≥ 3.0.0 ≤ 3.0.3 / ≥ 3.1.0 ≤ 3.1.2 / ≥ 3.2.0 ≤ 3.2.1 / ≥ 3.3.0 ≤ 3.3.2 / ≥ 4.0.0 ≤ 4.0.1 / ≥ 4.1.0 ≤ 4.1.2` | note names no version |
| `FG-IR-16-048` | FortiCache | `= 0.4.10, 1.0.0, 4.1.1 / ≥ 2.0.0 ≤ 2.0.1 / ≥ 2.1.0 ≤ 2.1.3 / ≥ 2.2.0 ≤ 2.2.4 / ≥ 2.3.0 ≤ 2.3.7 / ≥ 3.0.0 ≤ 3.0.8 / ≥ 3.1.0 ≤ 3.1.1 / ≥ 4.0.0 ≤ 4.0.4` | note names no version |
| `FG-IR-16-048` | FortiClientAndroid | `= 5.4.0` | note names no version |
| `FG-IR-16-048` | FortiClientEMS | `≥ 1.0.0 ≤ 1.0.2` | note names no version |
| `FG-IR-16-048` | FortiClientMac | `≥ 4.0.0 ≤ 4.0.3 / ≥ 5.0.0 ≤ 5.0.10 / ≥ 5.2.0 ≤ 5.2.6 / ≥ 5.4.0 ≤ 5.4.1` | note names no version |
| `FG-IR-16-048` | FortiClientSSLVPN | `= 4.0.2328` | note names no version |
| `FG-IR-16-048` | FortiClientWindows | `= 5.4.1` | note names no version |
| `FG-IR-16-048` | FortiDB | `= 0.4.10, 0.5.16, 2.0.2, 2.4.0, 4.3.2, 5.0.0 / ≥ 3.2.1 ≤ 3.2.7 / ≥ 4.0.0 ≤ 4.0.1 / ≥ 4.4.0 ≤ 4.4.3 / ≥ 5.1.0 ≤ 5.1.1 / ≥ 5.1.5 ≤ 5.1.10` | note names no version |
| `FG-IR-16-048` | FortiDDoS | `= 3.1.0, 3.2.0 / ≥ 0.4.10 ≤ 0.4.23 / ≥ 4.0.0 ≤ 4.0.1 / ≥ 4.1.0 ≤ 4.1.12 / ≥ 4.2.1 ≤ 4.2.2` | note names no version |
| `FG-IR-16-048` | FortiExplorer | `= 1.3.0, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0` | note names no version |
| `FG-IR-16-048` | FortiMail | `= 2.0.1 / ≥ 4.0.1 ≤ 4.0.5 / ≥ 4.1.0 ≤ 4.1.3 / ≥ 4.2.0 ≤ 4.2.4 / ≥ 4.3.0 ≤ 4.3.9 / ≥ 5.0.0 ≤ 5.0.11 / ≥ 5.1.0 ≤ 5.1.6 / ≥ 5.2.0 ≤ 5.2.8 / ≥ 5.3.0 ≤ 5.3.5` | note names no version |
| `FG-IR-16-048` | FortiManager | `≥ 4.0.0 ≤ 4.0.3 / ≥ 4.1.1 ≤ 4.1.4 / ≥ 4.2.0 ≤ 4.2.9 / ≥ 4.3.0 ≤ 4.3.8 / ≥ 5.0.0 ≤ 5.0.12 / ≥ 5.2.0 ≤ 5.2.9 / ≥ 5.4.0 ≤ 5.4.1` | note names no version |
| `FG-IR-16-048` | FortiRecorder | `= 1.0.0, 1.1.0, 1.2.0, 2.0.0, 2.3.0 / ≥ 1.3.0 ≤ 1.3.1 / ≥ 1.4.0 ≤ 1.4.1 / ≥ 2.1.0 ≤ 2.1.1 / ≥ 2.2.0 ≤ 2.2.2 / ≥ 2.4.0 ≤ 2.4.1` | note names no version |
| `FG-IR-16-048` | FortiSandbox | `= 1.1.0, 1.3.0 / ≥ 1.2.0 ≤ 1.2.3 / ≥ 1.4.0 ≤ 1.4.3 / ≥ 2.0.0 ≤ 2.0.3 / ≥ 2.1.0 ≤ 2.1.3 / ≥ 2.2.0 ≤ 2.2.2 / ≥ 2.3.0 ≤ 2.3.2` | note names no version |
| `FG-IR-16-048` | FortiTester | `= 2.3.0, 2.5.0, 2.6.0, 2.7.0 / ≥ 2.4.0 ≤ 2.4.1` | note names no version |
| `FG-IR-16-048` | FortiTokenIOS | `= 3.0.5` | note names no version |
| `FG-IR-16-048` | FortiVoice | `= 5.0.5, 5.3.3` | note names no version |
| `FG-IR-16-048` | FortiWAN | `≥ 0.4.10 ≤ 0.4.24 / ≥ 4.0.0 ≤ 4.0.6 / ≥ 4.1.1 ≤ 4.1.3 / ≥ 4.2.1 ≤ 4.2.5` | note names no version |
| `FG-IR-16-048` | FortiWeb | `= 3.0.0, 4.0.2, 5.6.0 / ≥ 4.1.0 ≤ 4.1.2 / ≥ 4.2.0 ≤ 4.2.4 / ≥ 4.3.1 ≤ 4.3.7 / ≥ 4.4.0 ≤ 4.4.7 / ≥ 5.0.0 ≤ 5.0.6 / ≥ 5.1.0 ≤ 5.1.4 / ≥ 5.2.0 ≤ 5.2.4 / ≥ 5.3.0 ≤ 5.3.9 / ≥ 5.4.0 ≤ 5.4.1 / ≥ 5.5.0 ≤ 5.5.7` | note names no version |
| `FG-IR-16-050` | FortiOS | `≥ 5.2.0 ≤ 5.2.9 / ≥ 5.4.0 ≤ 5.4.1` | note names no version |
| `FG-IR-16-069` | FortiClientSSLVPN | `(whole product)` | note names no version |
| `FG-IR-16-090` | FortiOS | `(whole product)` | note names no version |
| `FG-IR-17-214` | FortiClientSSLVPN | `≤ 4.4.2335` | note names no version |
| `FG-IR-17-302` | FortiOS | `≥ 5.4.6 ≤ 5.4.9 / ≥ 6.0.0 ≤ 6.0.1` | note names no version |
| `FG-IR-18-018` | FortiOS | `= 5.6.0` | note names no version |
| `FG-IR-18-059` | FortiAuthenticator | `≥ 4.0.0 < 5.3.0` | note names no version |
| `FG-IR-18-356` | FortiAP-S | `≥ 6.0.0 < 6.0.4 / < 5.6.4` | note names no version |
| `FG-IR-18-356` | FortiAP-W2 | `≥ 6.0.0 < 6.0.4 / < 5.6.4` | note names no version |
| `FG-IR-19-107` | FortiOS | `≥ 6.2.0 ≤ 6.2.2` | note names no version |
| `FG-IR-19-111` | FortiOS | `= 6.2.0` | note names no version |
| `FG-IR-19-224` | FortiSwitch | `≥ 6.0 < 6.1 / ≥ 6.2 < 6.3` | note names no version |
| `FG-IR-19-292` | FortiADC | `≥ 5.2.0 ≤ 5.2.5 / ≥ 5.3.0 ≤ 5.3.4` | note names no version |
| `FG-IR-19-292` | FortiAnalyzer | `≥ 5 < 6 / ≥ 6.0.0 ≤ 6.0.8 / ≥ 6.2.0 ≤ 6.2.3` | note names no version |
| `FG-IR-19-292` | FortiManager | `≥ 5 < 6 / ≥ 6.0.0 ≤ 6.0.8 / ≥ 6.2.0 ≤ 6.2.3` | note names no version |
| `FG-IR-19-306` | FortiGate Cloud | `≥ 4.4 < 4.5` | note names no version |
| `FG-IR-20-191` | FSSO CA | `≤ 5.0.295` | note names no version |
| `FG-IR-21-051` | FortiOS-6K7K | `= 6.4.2 / ≥ 6.2.0 ≤ 6.2.6` | note names no version |
| `FG-IR-22-007` | FortiFone | `≤ 3.0.11` | note names no version |
| `FG-IR-22-041` | FortiSOAR PaaS | `= 6.0.0 / ≥ 5.0.0 ≤ 5.2.2 / ≥ 6.4.0 ≤ 6.4.4 / ≥ 7.0.0 ≤ 7.0.2` | note names no version |
| `FG-IR-22-059` | FortiADCManager | `< 7.0.0` | note names no version |
| `FG-IR-22-059` | FortiNDR | `< 7.0.0` | note names no version |

</details>

## Review round

**Copilot** — the package comment read as if 2022 were a clean cutoff while also claiming 2022 advisories need supplementing. There is no cutoff: filled documents go back to FG-IR-16-035, through 2021 they are the exception (21 filled against 123 empty), 2022 is where it flips (155 against 13), and FG-IR-23-* on is entirely filled. Reworded in `ad538b6d`.

**Review of the rebuilt rows** — 18 rows where the rebuild stopped matching its own advisory, all verified against the raw CVRF documents and corrected in `ce509b69`:

| | Rows | What was wrong |
|---|---|---|
| Ranges the note states, dropped | FG-IR-19-179, FG-IR-19-099, FG-IR-15-007 | `"6.0.8 and below versions until 5.4.0"`, `"5.6.0 to 5.6.10"`, and the 5.0 train whose fix the Solutions note gives as 5.0.11 |
| Notes misread | FG-IR-14-033, FG-IR-17-119, FG-IR-17-196 ×2, FG-IR-14-032 | `"< version 5.0.7"` became the exact version 5.0.7 — the fixed release marked affected, every vulnerable one missed; `"8.0 -> 8.2"` as `le "8.2"` dropped 8.2.1–8.2.7 although the 8.x fix is 8.3.3; the `"801.11r"` typo became a version train that can never match, and FortiWLC/Meru AP were bounded at 7.0 although that note says `"Previous branches: All versions"`; `"10.2.0a for Coyote Point"` — another product — landed in the FortiADC row |
| Fixed release inside its own range | FG-IR-20-170, FG-IR-18-108, FG-IR-20-171, FG-IR-17-073, FG-IR-20-222 | each caps a product at the very release its own Solutions note hands out |
| `FortiAP-S/W2` names two products | FG-IR-19-292, FG-IR-17-118 ×2, FG-IR-19-209, FG-IR-19-298 | the -W2 rows kept a floorless seed bound while the -S rows had the note's |

Two policies are now written down in `supplement.go` rather than left implicit:

- **A release the advisory calls a fix is never inside its own affected range.** Where the Affected Products note and the Solutions note collide, the fix wins and the cap is the release before it. FG-IR-20-171 says *"3.2.2 and earlier"* against *"Upgrade to 3.2.2 or later"*, and the same note's other pair — *"3.1.4 and earlier"* against *"upgrade to 3.1.5"* — shows which half is the slip.
- **A CNA record may add versions the note is silent about** — typically an EOL train Fortinet stopped enumerating — **but never a release the same advisory calls a fix.** That is what pulled 3.2.2 and 7.0.2 into rows above.

Also folded the 37 ranges whose two bounds are the same release into the exact version they mean.

**Second pass over the rebuilt rows** — six rows still capped a product at the release its own advisory hands out, including FG-IR-21-023, which the rule's comment names as an example. Corrected in `9adae3ec`:

| Advisory | Product | Was | Is | The advisory's own fix |
|---|---|---|---|---|
| `FG-IR-21-023` | FortiNDR | `≤ 7.2.1` | `= 7.2.0` | "upgrade to FortiNDR version 7.2.1 or above" |
| `FG-IR-22-046` | FortiADC | `≤ 7.0.2` | `≤ 7.0.1` | "upgrade to FortiADC version 7.0.2 or above" |
| `FG-IR-22-061` | FortiADC | `≤ 7.0.2` | `≤ 7.0.1` | "upgrade to FortiADC 7.0.2 or above" |
| `FG-IR-21-132` | FortiDDoS | `≤ 5.3.2`, `≤ 5.4.3` | `≤ 5.3.1`, `≤ 5.4.2` | "upgrade to FortiDDoS version 5.3.2 / 5.4.3 or above" |
| `FG-IR-21-132` | FortiDDoS-CM | `≤ 5.4.3` | `≤ 5.4.2` | "upgrade to FortiDDoS-CM version 5.4.3 or above" |

Running the rule across the whole table also turned up `FG-IR-14-031` FortiAnalyzer, spanning 5.0.0–5.0.9 and 5.2.0–5.2.1 where the note names two releases — *"version 5.0.9 and version 5.2.1 in their default configuration"* — and the FortiManager row of the same advisory already carried them as exact versions. It now reads the same way.

Seven rows still match a version their advisory calls an upgrade target, and are meant to. The comment records which and why, so the next pass does not re-derive it:

- **per-CVE scoping** — a release fixed for one CVE is affected by another in the same advisory (`FG-IR-17-214`, `FG-IR-19-107`, `FG-IR-19-238`)
- **the remediation is a setting, not a release** — `FG-IR-14-031`'s *"Upgrade to 5.0.9 or 5.2.1 and apply the settings"* (POODLE)
- **a target given for particular hardware** — `FG-IR-20-131` and `FG-IR-21-049` send the high-end F-series models to 6.2.9 while 6.2.9 is affected elsewhere


## Testing

- `go test ./pkg/extract/fortinet/...` — ok; `gofmt -l`, `go vet` — clean
- Goldens regenerated where the change is intentional: `FG-IR-21-085` (FortiPortal 5.2 cap gains its train's lower bound) and `FG-IR-012-003` (FortiOS 4.2 becomes the train the note describes)
- `TestSupplementCriterions` pinned FG-IR-21-040 as its enumerated-versions example, which is now a range; it points at FG-IR-19-003, whose advisory really does enumerate (*"FortiClientMAC 6.0.1, 6.0.2, 6.0.3 and 6.0.4"*)
- Re-audited the whole table against the CVRF notes, the CNA records and the release lists in Fortinet's own 2022+ `product_tree`s: the 81 missed releases and the 140 over-matched ones are gone, and no row is empty or inverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
